### PR TITLE
fix: Min/max constraints should be respected when resizing

### DIFF
--- a/components/splitter/Panel.tsx
+++ b/components/splitter/Panel.tsx
@@ -27,6 +27,7 @@ export const InternalPanel = forwardRef<
         // Use auto when start from ssr
         flexBasis: hasSize ? size : 'auto',
         flexGrow: hasSize ? 0 : 1,
+        flexShrink: hasSize ? 0 : 1,
       }}
     >
       {children}

--- a/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -559,7 +559,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
       role="separator"
     >
       <div
-        class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        class="ant-splitter-bar-dragger"
       />
     </div>
     <div

--- a/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -10,7 +10,7 @@ exports[`renders components/splitter/demo/collapsible.tsx extend context correct
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis: auto; flex-grow: 1;"
+      style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -37,7 +37,7 @@ exports[`renders components/splitter/demo/collapsible.tsx extend context correct
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis: auto; flex-grow: 1;"
+      style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -58,7 +58,7 @@ exports[`renders components/splitter/demo/collapsible.tsx extend context correct
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis: auto; flex-grow: 1;"
+      style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -85,7 +85,7 @@ exports[`renders components/splitter/demo/collapsible.tsx extend context correct
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis: auto; flex-grow: 1;"
+      style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -195,7 +195,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx extend context cor
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis: auto; flex-grow: 1;"
+      style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -222,7 +222,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx extend context cor
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis: auto; flex-grow: 1;"
+      style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -249,7 +249,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx extend context cor
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis: auto; flex-grow: 1;"
+      style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -279,7 +279,7 @@ exports[`renders components/splitter/demo/control.tsx extend context correctly 1
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis: 50%; flex-grow: 0;"
+      style="flex-basis: 50%; flex-grow: 0; flex-shrink: 0;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -306,7 +306,7 @@ exports[`renders components/splitter/demo/control.tsx extend context correctly 1
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis: 50%; flex-grow: 0;"
+      style="flex-basis: 50%; flex-grow: 0; flex-shrink: 0;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -377,7 +377,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis: auto; flex-grow: 1;"
+      style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -404,7 +404,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
     </div>
     <div
       class="ant-splitter-panel ant-splitter-panel-hidden"
-      style="flex-basis: 0px; flex-grow: 0;"
+      style="flex-basis: 0px; flex-grow: 0; flex-shrink: 0;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -431,7 +431,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis: auto; flex-grow: 1;"
+      style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -457,7 +457,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis: auto; flex-grow: 1;"
+      style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -484,7 +484,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
     </div>
     <div
       class="ant-splitter-panel ant-splitter-panel-hidden"
-      style="flex-basis: 0px; flex-grow: 0;"
+      style="flex-basis: 0px; flex-grow: 0; flex-shrink: 0;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -511,7 +511,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis: auto; flex-grow: 1;"
+      style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -537,7 +537,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis: auto; flex-grow: 1;"
+      style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -564,7 +564,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis: auto; flex-grow: 1;"
+      style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -590,7 +590,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis: auto; flex-grow: 1;"
+      style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -617,7 +617,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis: auto; flex-grow: 1;"
+      style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -644,7 +644,7 @@ exports[`renders components/splitter/demo/group.tsx extend context correctly 1`]
 >
   <div
     class="ant-splitter-panel"
-    style="flex-basis: auto; flex-grow: 1;"
+    style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -671,14 +671,14 @@ exports[`renders components/splitter/demo/group.tsx extend context correctly 1`]
   </div>
   <div
     class="ant-splitter-panel"
-    style="flex-basis: auto; flex-grow: 1;"
+    style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
   >
     <div
       class="ant-splitter ant-splitter-vertical"
     >
       <div
         class="ant-splitter-panel"
-        style="flex-basis: auto; flex-grow: 1;"
+        style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
       >
         <div
           class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -705,7 +705,7 @@ exports[`renders components/splitter/demo/group.tsx extend context correctly 1`]
       </div>
       <div
         class="ant-splitter-panel"
-        style="flex-basis: auto; flex-grow: 1;"
+        style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
       >
         <div
           class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -740,7 +740,7 @@ exports[`renders components/splitter/demo/lazy.tsx extend context correctly 1`] 
     >
       <div
         class="ant-splitter-panel"
-        style="flex-basis: 40%; flex-grow: 0;"
+        style="flex-basis: 40%; flex-grow: 0; flex-shrink: 0;"
       >
         <div
           class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -771,7 +771,7 @@ exports[`renders components/splitter/demo/lazy.tsx extend context correctly 1`] 
       </div>
       <div
         class="ant-splitter-panel"
-        style="flex-basis: auto; flex-grow: 1;"
+        style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
       >
         <div
           class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -796,7 +796,7 @@ exports[`renders components/splitter/demo/lazy.tsx extend context correctly 1`] 
     >
       <div
         class="ant-splitter-panel"
-        style="flex-basis: 40%; flex-grow: 0;"
+        style="flex-basis: 40%; flex-grow: 0; flex-shrink: 0;"
       >
         <div
           class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -827,7 +827,7 @@ exports[`renders components/splitter/demo/lazy.tsx extend context correctly 1`] 
       </div>
       <div
         class="ant-splitter-panel"
-        style="flex-basis: auto; flex-grow: 1;"
+        style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
       >
         <div
           class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -855,7 +855,7 @@ exports[`renders components/splitter/demo/multiple.tsx extend context correctly 
 >
   <div
     class="ant-splitter-panel"
-    style="flex-basis: auto; flex-grow: 1;"
+    style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -882,7 +882,7 @@ exports[`renders components/splitter/demo/multiple.tsx extend context correctly 
   </div>
   <div
     class="ant-splitter-panel"
-    style="flex-basis: auto; flex-grow: 1;"
+    style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -909,7 +909,7 @@ exports[`renders components/splitter/demo/multiple.tsx extend context correctly 
   </div>
   <div
     class="ant-splitter-panel"
-    style="flex-basis: auto; flex-grow: 1;"
+    style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -1060,7 +1060,7 @@ exports[`renders components/splitter/demo/size.tsx extend context correctly 1`] 
 >
   <div
     class="ant-splitter-panel"
-    style="flex-basis: 40%; flex-grow: 0;"
+    style="flex-basis: 40%; flex-grow: 0; flex-shrink: 0;"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -1087,7 +1087,7 @@ exports[`renders components/splitter/demo/size.tsx extend context correctly 1`] 
   </div>
   <div
     class="ant-splitter-panel"
-    style="flex-basis: auto; flex-grow: 1;"
+    style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -1113,7 +1113,7 @@ exports[`renders components/splitter/demo/vertical.tsx extend context correctly 
 >
   <div
     class="ant-splitter-panel"
-    style="flex-basis: auto; flex-grow: 1;"
+    style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -1140,7 +1140,7 @@ exports[`renders components/splitter/demo/vertical.tsx extend context correctly 
   </div>
   <div
     class="ant-splitter-panel"
-    style="flex-basis: auto; flex-grow: 1;"
+    style="flex-basis: auto; flex-grow: 1; flex-shrink: 1;"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"

--- a/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
@@ -10,7 +10,7 @@ exports[`renders components/splitter/demo/collapsible.tsx correctly 1`] = `
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis:auto;flex-grow:1"
+      style="flex-basis:auto;flex-grow:1;flex-shrink:1"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -37,7 +37,7 @@ exports[`renders components/splitter/demo/collapsible.tsx correctly 1`] = `
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis:auto;flex-grow:1"
+      style="flex-basis:auto;flex-grow:1;flex-shrink:1"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -58,7 +58,7 @@ exports[`renders components/splitter/demo/collapsible.tsx correctly 1`] = `
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis:auto;flex-grow:1"
+      style="flex-basis:auto;flex-grow:1;flex-shrink:1"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -85,7 +85,7 @@ exports[`renders components/splitter/demo/collapsible.tsx correctly 1`] = `
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis:auto;flex-grow:1"
+      style="flex-basis:auto;flex-grow:1;flex-shrink:1"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -193,7 +193,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx correctly 1`] = `
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis:auto;flex-grow:1"
+      style="flex-basis:auto;flex-grow:1;flex-shrink:1"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -220,7 +220,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx correctly 1`] = `
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis:auto;flex-grow:1"
+      style="flex-basis:auto;flex-grow:1;flex-shrink:1"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -247,7 +247,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx correctly 1`] = `
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis:auto;flex-grow:1"
+      style="flex-basis:auto;flex-grow:1;flex-shrink:1"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -275,7 +275,7 @@ exports[`renders components/splitter/demo/control.tsx correctly 1`] = `
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis:50%;flex-grow:0"
+      style="flex-basis:50%;flex-grow:0;flex-shrink:0"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -302,7 +302,7 @@ exports[`renders components/splitter/demo/control.tsx correctly 1`] = `
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis:50%;flex-grow:0"
+      style="flex-basis:50%;flex-grow:0;flex-shrink:0"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -371,7 +371,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis:auto;flex-grow:1"
+      style="flex-basis:auto;flex-grow:1;flex-shrink:1"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -400,7 +400,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
     </div>
     <div
       class="ant-splitter-panel ant-splitter-panel-hidden"
-      style="flex-basis:0;flex-grow:0"
+      style="flex-basis:0;flex-grow:0;flex-shrink:0"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -429,7 +429,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis:auto;flex-grow:1"
+      style="flex-basis:auto;flex-grow:1;flex-shrink:1"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -457,7 +457,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis:auto;flex-grow:1"
+      style="flex-basis:auto;flex-grow:1;flex-shrink:1"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -486,7 +486,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
     </div>
     <div
       class="ant-splitter-panel ant-splitter-panel-hidden"
-      style="flex-basis:0;flex-grow:0"
+      style="flex-basis:0;flex-grow:0;flex-shrink:0"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -515,7 +515,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis:auto;flex-grow:1"
+      style="flex-basis:auto;flex-grow:1;flex-shrink:1"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -543,7 +543,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis:auto;flex-grow:1"
+      style="flex-basis:auto;flex-grow:1;flex-shrink:1"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -572,7 +572,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis:auto;flex-grow:1"
+      style="flex-basis:auto;flex-grow:1;flex-shrink:1"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -600,7 +600,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
   >
     <div
       class="ant-splitter-panel"
-      style="flex-basis:auto;flex-grow:1"
+      style="flex-basis:auto;flex-grow:1;flex-shrink:1"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -629,7 +629,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
     </div>
     <div
       class="ant-splitter-panel"
-      style="flex-basis:auto;flex-grow:1"
+      style="flex-basis:auto;flex-grow:1;flex-shrink:1"
     >
       <div
         class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -656,7 +656,7 @@ exports[`renders components/splitter/demo/group.tsx correctly 1`] = `
 >
   <div
     class="ant-splitter-panel"
-    style="flex-basis:auto;flex-grow:1"
+    style="flex-basis:auto;flex-grow:1;flex-shrink:1"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -683,14 +683,14 @@ exports[`renders components/splitter/demo/group.tsx correctly 1`] = `
   </div>
   <div
     class="ant-splitter-panel"
-    style="flex-basis:auto;flex-grow:1"
+    style="flex-basis:auto;flex-grow:1;flex-shrink:1"
   >
     <div
       class="ant-splitter ant-splitter-vertical"
     >
       <div
         class="ant-splitter-panel"
-        style="flex-basis:auto;flex-grow:1"
+        style="flex-basis:auto;flex-grow:1;flex-shrink:1"
       >
         <div
           class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -717,7 +717,7 @@ exports[`renders components/splitter/demo/group.tsx correctly 1`] = `
       </div>
       <div
         class="ant-splitter-panel"
-        style="flex-basis:auto;flex-grow:1"
+        style="flex-basis:auto;flex-grow:1;flex-shrink:1"
       >
         <div
           class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -750,7 +750,7 @@ exports[`renders components/splitter/demo/lazy.tsx correctly 1`] = `
     >
       <div
         class="ant-splitter-panel"
-        style="flex-basis:40%;flex-grow:0"
+        style="flex-basis:40%;flex-grow:0;flex-shrink:0"
       >
         <div
           class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -781,7 +781,7 @@ exports[`renders components/splitter/demo/lazy.tsx correctly 1`] = `
       </div>
       <div
         class="ant-splitter-panel"
-        style="flex-basis:auto;flex-grow:1"
+        style="flex-basis:auto;flex-grow:1;flex-shrink:1"
       >
         <div
           class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -806,7 +806,7 @@ exports[`renders components/splitter/demo/lazy.tsx correctly 1`] = `
     >
       <div
         class="ant-splitter-panel"
-        style="flex-basis:40%;flex-grow:0"
+        style="flex-basis:40%;flex-grow:0;flex-shrink:0"
       >
         <div
           class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -837,7 +837,7 @@ exports[`renders components/splitter/demo/lazy.tsx correctly 1`] = `
       </div>
       <div
         class="ant-splitter-panel"
-        style="flex-basis:auto;flex-grow:1"
+        style="flex-basis:auto;flex-grow:1;flex-shrink:1"
       >
         <div
           class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -863,7 +863,7 @@ exports[`renders components/splitter/demo/multiple.tsx correctly 1`] = `
 >
   <div
     class="ant-splitter-panel"
-    style="flex-basis:auto;flex-grow:1"
+    style="flex-basis:auto;flex-grow:1;flex-shrink:1"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -892,7 +892,7 @@ exports[`renders components/splitter/demo/multiple.tsx correctly 1`] = `
   </div>
   <div
     class="ant-splitter-panel"
-    style="flex-basis:auto;flex-grow:1"
+    style="flex-basis:auto;flex-grow:1;flex-shrink:1"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -921,7 +921,7 @@ exports[`renders components/splitter/demo/multiple.tsx correctly 1`] = `
   </div>
   <div
     class="ant-splitter-panel"
-    style="flex-basis:auto;flex-grow:1"
+    style="flex-basis:auto;flex-grow:1;flex-shrink:1"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -1047,7 +1047,7 @@ exports[`renders components/splitter/demo/size.tsx correctly 1`] = `
 >
   <div
     class="ant-splitter-panel"
-    style="flex-basis:40%;flex-grow:0"
+    style="flex-basis:40%;flex-grow:0;flex-shrink:0"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -1074,7 +1074,7 @@ exports[`renders components/splitter/demo/size.tsx correctly 1`] = `
   </div>
   <div
     class="ant-splitter-panel"
-    style="flex-basis:auto;flex-grow:1"
+    style="flex-basis:auto;flex-grow:1;flex-shrink:1"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -1098,7 +1098,7 @@ exports[`renders components/splitter/demo/vertical.tsx correctly 1`] = `
 >
   <div
     class="ant-splitter-panel"
-    style="flex-basis:auto;flex-grow:1"
+    style="flex-basis:auto;flex-grow:1;flex-shrink:1"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"
@@ -1125,7 +1125,7 @@ exports[`renders components/splitter/demo/vertical.tsx correctly 1`] = `
   </div>
   <div
     class="ant-splitter-panel"
-    style="flex-basis:auto;flex-grow:1"
+    style="flex-basis:auto;flex-grow:1;flex-shrink:1"
   >
     <div
       class="ant-flex ant-flex-align-center ant-flex-justify-center"

--- a/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
@@ -567,7 +567,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
       role="separator"
     >
       <div
-        class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        class="ant-splitter-bar-dragger"
       />
     </div>
     <div

--- a/components/splitter/hooks/useSizes.ts
+++ b/components/splitter/hooks/useSizes.ts
@@ -85,19 +85,20 @@ export default function useSizes(items: PanelProps[], containerSize?: number) {
         const max = items[idx].max;
 
         // collapsible panel can be 0px
-        if (px === 0) {
-          return px;
+        const explicitZero = sizes[idx] === 0;
+        if (px === 0 && explicitZero) {
+          return 0;
         }
 
         // resize should respect the min/max limit
-        if (min !== undefined && !isPtg(min) && px < min) {
-          return min;
+        let finalPx = px;
+        if (min !== undefined && !isPtg(min)) {
+          finalPx = Math.max(finalPx, Number(min));
         }
-        if (max !== undefined && !isPtg(max) && px > max) {
-          return max;
+        if (max !== undefined && !isPtg(max)) {
+          finalPx = Math.min(finalPx, Number(max));
         }
-
-        return px;
+        return finalPx;
       }),
     [postPercentSizes, mergedContainerSize],
   );

--- a/components/splitter/hooks/useSizes.ts
+++ b/components/splitter/hooks/useSizes.ts
@@ -78,7 +78,27 @@ export default function useSizes(items: PanelProps[], containerSize?: number) {
   }, [sizes, mergedContainerSize]);
 
   const postPxSizes = React.useMemo(
-    () => postPercentSizes.map(ptg2px),
+    () =>
+      postPercentSizes.map((item, idx) => {
+        const px = ptg2px(item);
+        const min = items[idx].min;
+        const max = items[idx].max;
+
+        // collapsible panel can be 0px
+        if (px === 0) {
+          return px;
+        }
+
+        // resize should respect the min/max limit
+        if (min !== undefined && !isPtg(min) && px < min) {
+          return min;
+        }
+        if (max !== undefined && !isPtg(max) && px > max) {
+          return max;
+        }
+
+        return px;
+      }),
     [postPercentSizes, mergedContainerSize],
   );
 


### PR DESCRIPTION
- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- fix https://github.com/ant-design/ant-design/issues/54921

### 💡 Background and Solution

缩放浏览器时 resize 时 应准遵守 min max 限制

### 📝 Change Log



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix the issue where the browser zooming function does not use the `min` and `max` restrictions.        |
| 🇨🇳 Chinese |    修复浏览器缩放时未使用 `min` \ `max` 限制       |
