### PR TITLE
fix(wave): make wave effect work with tailwind disabled variant

### DIFF
--- a/components/_util/wave/index.ts
+++ b/components/_util/wave/index.ts
@@ -44,7 +44,8 @@ const Wave: React.FC<WaveProps> = (props) => {
         !node.getAttribute ||
         node.getAttribute('disabled') ||
         (node as HTMLInputElement).disabled ||
-        node.className.includes('disabled') ||
+        (node.className.includes('disabled') && !node.className.includes('disabled:')) ||
+        node.getAttribute('aria-disabled') === 'true' ||
         node.className.includes('-leave')
       ) {
         return;

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -106,7 +106,7 @@ const InternalSwitch = React.forwardRef<HTMLButtonElement, SwitchProps>((props, 
   };
 
   return wrapCSSVar(
-    <Wave component="Switch">
+    <Wave component="Switch" disabled={mergedDisabled}>
       <RcSwitch
         {...restProps}
         checked={checked}


### PR DESCRIPTION
### 🤔 This is a ...

- [X] 🐞 Bug fix

### 🔗 Related Issues

None

### 💡 Background and Solution

> - When using Tailwind's `disabled:` variant to style Ant Design components that feature wave effects (such as buttons), the wave animation fails to function properly.
> - The issue stems from the current implementation of the wave component, which performs a string-based check for the word "disabled" within the container's className. This approach incorrectly identifies Tailwind's disabled: variants as disabled states.
> - Example of problematic usage: 
```
<Button className="disabled:text-red-500">Hello</Button>
```


**Solution:** Remove the className-based disabled state detection from the wave component implementation. Instead, rely on the element's actual disabled attribute or aria states to determine whether wave effects should be applied.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix(wave): make wave effect work with tailwind disabled variant    |
| 🇨🇳 Chinese |  修复（波浪）：使波浪效果与顺风禁用变体一起工作         |
