### PR TITLE
fix: Splitter min & max not working for init limit

### DIFF
--- a/components/splitter/SplitBar.tsx
+++ b/components/splitter/SplitBar.tsx
@@ -31,7 +31,7 @@ export interface SplitBarProps {
 }
 
 function getValidNumber(num: number | undefined): number {
-  return typeof num === 'number' && !Number.isNaN(num) && isFinite(num) ? Math.round(num) : 0;
+  return typeof num === 'number' && !Number.isNaN(num) && Number.isFinite(num) ? Math.round(num) : 0;
 }
 
 const SplitBar: React.FC<SplitBarProps> = (props) => {

--- a/components/splitter/SplitBar.tsx
+++ b/components/splitter/SplitBar.tsx
@@ -30,7 +30,7 @@ export interface SplitBarProps {
   containerSize: number;
 }
 
-function getValidNumber(num: number | undefined): number {
+function getValidNumber(num?: number): number {
   return typeof num === 'number' && !Number.isNaN(num) && Number.isFinite(num) ? Math.round(num) : 0;
 }
 

--- a/components/splitter/SplitBar.tsx
+++ b/components/splitter/SplitBar.tsx
@@ -31,7 +31,7 @@ export interface SplitBarProps {
 }
 
 function getValidNumber(num: number | undefined): number {
-  return typeof num === 'number' && !Number.isNaN(num) ? Math.round(num) : 0;
+  return typeof num === 'number' && !Number.isNaN(num) && isFinite(num) ? Math.round(num) : 0;
 }
 
 const SplitBar: React.FC<SplitBarProps> = (props) => {

--- a/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -394,7 +394,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
     <div
       aria-valuemax="0"
       aria-valuemin="0"
-      aria-valuenow="50"
+      aria-valuenow="0"
       class="ant-splitter-bar"
       role="separator"
     >
@@ -474,7 +474,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
     <div
       aria-valuemax="0"
       aria-valuemin="0"
-      aria-valuenow="50"
+      aria-valuenow="0"
       class="ant-splitter-bar"
       role="separator"
     >
@@ -554,12 +554,12 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
     <div
       aria-valuemax="0"
       aria-valuemin="0"
-      aria-valuenow="50"
+      aria-valuenow="0"
       class="ant-splitter-bar"
       role="separator"
     >
       <div
-        class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        class="ant-splitter-bar-dragger"
       />
     </div>
     <div

--- a/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
@@ -390,7 +390,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
     <div
       aria-valuemax="0"
       aria-valuemin="0"
-      aria-valuenow="50"
+      aria-valuenow="0"
       class="ant-splitter-bar"
       role="separator"
     >
@@ -476,7 +476,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
     <div
       aria-valuemax="0"
       aria-valuemin="0"
-      aria-valuenow="50"
+      aria-valuenow="0"
       class="ant-splitter-bar"
       role="separator"
     >
@@ -562,12 +562,12 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
     <div
       aria-valuemax="0"
       aria-valuemin="0"
-      aria-valuenow="50"
+      aria-valuenow="0"
       class="ant-splitter-bar"
       role="separator"
     >
       <div
-        class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        class="ant-splitter-bar-dragger"
       />
     </div>
     <div

--- a/components/splitter/__tests__/demo-extend.test.ts
+++ b/components/splitter/__tests__/demo-extend.test.ts
@@ -1,3 +1,3 @@
 import { extendTest } from '../../../tests/shared/demoTest';
 
-extendTest('splitter');
+extendTest('splitter', { skip: ['size-mix'] });

--- a/components/splitter/__tests__/demo.test.ts
+++ b/components/splitter/__tests__/demo.test.ts
@@ -1,3 +1,3 @@
 import demoTest from '../../../tests/shared/demoTest';
 
-demoTest('splitter');
+demoTest('splitter', { skip: ['size-mix'] });

--- a/components/splitter/__tests__/image.test.ts
+++ b/components/splitter/__tests__/image.test.ts
@@ -1,5 +1,5 @@
 import { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Splitter image', () => {
-  imageDemoTest('splitter');
+  imageDemoTest('splitter', { skip: ['size-mix'] });
 });

--- a/components/splitter/__tests__/size.test.tsx
+++ b/components/splitter/__tests__/size.test.tsx
@@ -58,4 +58,21 @@ describe('useSizes', () => {
     // Check post pixel sizes
     expect(postPxSizes).toEqual([200, 200, 600]);
   });
+
+  it('case 4: impossible case, just average fill', () => {
+    // This case triggers the impossible condition where sumMin > 1 and sumMax < 1
+    // sumMin = 0.6 + 0.4 + 0.6 = 1.6 > 1
+    // sumMax = 0.3 + 0.2 + 0.3 = 0.8 < 1
+    const items = [
+      { min: 600, max: 300 }, // min=0.6, max=0.3
+      { min: 400, max: 200 }, // min=0.4, max=0.2
+      { min: 600, max: 300 }, // min=0.6, max=0.3
+    ];
+
+    const { result } = renderHook(() => useSizes(items, containerSize));
+    const [, postPxSizes] = result.current;
+
+    // In impossible case, should average fill (1000 / 3 = 333.33... for each)
+    expect(postPxSizes).toEqual([1000 / 3, 1000 / 3, 1000 / 3]);
+  });
 });

--- a/components/splitter/__tests__/size.test.tsx
+++ b/components/splitter/__tests__/size.test.tsx
@@ -1,5 +1,4 @@
-import { renderHook } from '@testing-library/react';
-
+import { renderHook } from '../../../tests/utils';
 import useSizes from '../hooks/useSizes';
 
 describe('useSizes', () => {
@@ -22,7 +21,7 @@ describe('useSizes', () => {
     ];
 
     const { result } = renderHook(() => useSizes(items, containerSize));
-    const [, postPxSizes] = result.current;
+    const [, postPxSizes] = result.current!;
 
     // Check post pixel sizes
     expect(postPxSizes).toEqual([100, 200, 700]);

--- a/components/splitter/__tests__/size.test.tsx
+++ b/components/splitter/__tests__/size.test.tsx
@@ -21,7 +21,7 @@ describe('useSizes', () => {
     ];
 
     const { result } = renderHook(() => useSizes(items, containerSize));
-    const [, postPxSizes] = result.current!;
+    const [, postPxSizes] = result.current;
 
     // Check post pixel sizes
     expect(postPxSizes).toEqual([100, 200, 700]);

--- a/components/splitter/__tests__/size.test.tsx
+++ b/components/splitter/__tests__/size.test.tsx
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react';
+
+import useSizes from '../hooks/useSizes';
+
+describe('useSizes', () => {
+  const containerSize = 1000;
+
+  it('case 1: mixed size, min, max values', () => {
+    const items = [
+      {
+        size: 100,
+        min: 100,
+        max: 200,
+      },
+      {
+        min: 100,
+        max: 200,
+      },
+      {
+        min: '20%',
+      },
+    ];
+
+    const { result } = renderHook(() => useSizes(items, containerSize));
+    const [, postPxSizes] = result.current;
+
+    // Check post pixel sizes
+    expect(postPxSizes).toEqual([100, 200, 700]);
+  });
+
+  it('case 2: all items with min values', () => {
+    const items = [
+      {
+        min: 300,
+      },
+      {
+        min: 100,
+        max: 200,
+      },
+      {
+        min: 600,
+      },
+    ];
+
+    const { result } = renderHook(() => useSizes(items, containerSize));
+    const [, postPxSizes] = result.current;
+
+    // Check post pixel sizes
+    expect(postPxSizes).toEqual([300, 100, 600]);
+  });
+
+  it('case 3: items with min and max values', () => {
+    const items = [{ min: 100, max: 200 }, { min: 100, max: 200 }, { min: 400 }];
+
+    const { result } = renderHook(() => useSizes(items, containerSize));
+    const [, postPxSizes] = result.current;
+
+    // Check post pixel sizes
+    expect(postPxSizes).toEqual([200, 200, 600]);
+  });
+});

--- a/components/splitter/demo/size-mix.tsx
+++ b/components/splitter/demo/size-mix.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Flex, Splitter, Typography } from 'antd';
+
+const Desc: React.FC<Readonly<{ text?: string | number }>> = (props) => (
+  <Flex justify="center" align="center" style={{ height: '100%' }}>
+    <Typography.Title type="secondary" level={5} style={{ whiteSpace: 'nowrap' }}>
+      {props.text}
+    </Typography.Title>
+  </Flex>
+);
+
+const App: React.FC = () => (
+  <Splitter
+    style={{
+      height: 300,
+      width: 1000,
+      boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)',
+    }}
+  >
+    <Splitter.Panel defaultSize={100} min={100} max={200}>
+      <Desc text="First" />
+    </Splitter.Panel>
+    <Splitter.Panel min={100} max={200}>
+      <Desc text="Second" />
+    </Splitter.Panel>
+    <Splitter.Panel min="20%">
+      <Desc text="Second" />
+    </Splitter.Panel>
+  </Splitter>
+);
+
+export default App;

--- a/components/splitter/demo/size-mix.tsx
+++ b/components/splitter/demo/size-mix.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Flex, Splitter, Typography } from 'antd';
-import { size } from 'lodash';
 
 const Desc: React.FC<Readonly<{ text?: string | number }>> = (props) => (
   <Flex justify="center" align="center" style={{ height: '100%' }}>
@@ -10,33 +9,33 @@ const Desc: React.FC<Readonly<{ text?: string | number }>> = (props) => (
   </Flex>
 );
 
-// const SIZE_BUCKETS = [
-//   {
-//     defaultSize: 100,
-//     min: 100,
-//     max: 200,
-//   },
-//   {
-//     min: 100,
-//     max: 200,
-//   },
-//   {
-//     min: '20%',
-//   },
-// ] as const;
-
 const SIZE_BUCKETS = [
   {
-    min: 300,
+    defaultSize: 100,
+    min: 100,
+    max: 200,
   },
   {
     min: 100,
     max: 200,
   },
   {
-    min: 600,
+    min: '20%',
   },
 ] as const;
+
+// const SIZE_BUCKETS = [
+//   {
+//     min: 300,
+//   },
+//   {
+//     min: 100,
+//     max: 200,
+//   },
+//   {
+//     min: 600,
+//   },
+// ] as const;
 
 const App: React.FC = () => (
   <Splitter

--- a/components/splitter/demo/size-mix.tsx
+++ b/components/splitter/demo/size-mix.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Flex, Splitter, Typography } from 'antd';
+import React, { useState } from 'react';
+import { Flex, Radio, Splitter, Typography } from 'antd';
 
 const Desc: React.FC<Readonly<{ text?: string | number }>> = (props) => (
   <Flex justify="center" align="center" style={{ height: '100%' }}>
@@ -9,7 +9,7 @@ const Desc: React.FC<Readonly<{ text?: string | number }>> = (props) => (
   </Flex>
 );
 
-const SIZE_BUCKETS = [
+const SIZE_BUCKETS_1 = [
   {
     defaultSize: 100,
     min: 100,
@@ -24,37 +24,54 @@ const SIZE_BUCKETS = [
   },
 ] as const;
 
-// const SIZE_BUCKETS = [
-//   {
-//     min: 300,
-//   },
-//   {
-//     min: 100,
-//     max: 200,
-//   },
-//   {
-//     min: 600,
-//   },
-// ] as const;
+const SIZE_BUCKETS_2 = [
+  {
+    min: 300,
+  },
+  {
+    min: 100,
+    max: 200,
+  },
+  {
+    min: 600,
+  },
+] as const;
 
-const App: React.FC = () => (
-  <Splitter
-    style={{
-      height: 300,
-      width: 1000,
-      boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)',
-    }}
-  >
-    <Splitter.Panel {...SIZE_BUCKETS[0]}>
-      <Desc text="First" />
-    </Splitter.Panel>
-    <Splitter.Panel {...SIZE_BUCKETS[1]}>
-      <Desc text="Second" />
-    </Splitter.Panel>
-    <Splitter.Panel {...SIZE_BUCKETS[2]}>
-      <Desc text="Third" />
-    </Splitter.Panel>
-  </Splitter>
-);
+const App: React.FC = () => {
+  const [sizeBucket, setSizeBucket] = useState(1);
+
+  const SIZE_BUCKETS = sizeBucket === 1 ? SIZE_BUCKETS_1 : SIZE_BUCKETS_2;
+
+  return (
+    <>
+      <Radio.Group
+        onChange={(e) => setSizeBucket(e.target.value)}
+        value={sizeBucket}
+        style={{ marginBottom: 16 }}
+      >
+        <Radio.Button value={1}>Size Bucket 1</Radio.Button>
+        <Radio.Button value={2}>Size Bucket 2</Radio.Button>
+      </Radio.Group>
+      <Splitter
+        key={sizeBucket}
+        style={{
+          height: 300,
+          width: 1000,
+          boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)',
+        }}
+      >
+        <Splitter.Panel {...SIZE_BUCKETS[0]}>
+          <Desc text="First" />
+        </Splitter.Panel>
+        <Splitter.Panel {...SIZE_BUCKETS[1]}>
+          <Desc text="Second" />
+        </Splitter.Panel>
+        <Splitter.Panel {...SIZE_BUCKETS[2]}>
+          <Desc text="Third" />
+        </Splitter.Panel>
+      </Splitter>
+    </>
+  );
+};
 
 export default App;

--- a/components/splitter/demo/size-mix.tsx
+++ b/components/splitter/demo/size-mix.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Flex, Splitter, Typography } from 'antd';
+import { size } from 'lodash';
 
 const Desc: React.FC<Readonly<{ text?: string | number }>> = (props) => (
   <Flex justify="center" align="center" style={{ height: '100%' }}>
@@ -9,6 +10,34 @@ const Desc: React.FC<Readonly<{ text?: string | number }>> = (props) => (
   </Flex>
 );
 
+// const SIZE_BUCKETS = [
+//   {
+//     defaultSize: 100,
+//     min: 100,
+//     max: 200,
+//   },
+//   {
+//     min: 100,
+//     max: 200,
+//   },
+//   {
+//     min: '20%',
+//   },
+// ] as const;
+
+const SIZE_BUCKETS = [
+  {
+    min: 300,
+  },
+  {
+    min: 100,
+    max: 200,
+  },
+  {
+    min: 600,
+  },
+] as const;
+
 const App: React.FC = () => (
   <Splitter
     style={{
@@ -17,14 +46,14 @@ const App: React.FC = () => (
       boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)',
     }}
   >
-    <Splitter.Panel defaultSize={100} min={100} max={200}>
+    <Splitter.Panel {...SIZE_BUCKETS[0]}>
       <Desc text="First" />
     </Splitter.Panel>
-    <Splitter.Panel min={100} max={200}>
+    <Splitter.Panel {...SIZE_BUCKETS[1]}>
       <Desc text="Second" />
     </Splitter.Panel>
-    <Splitter.Panel min="20%">
-      <Desc text="Second" />
+    <Splitter.Panel {...SIZE_BUCKETS[2]}>
+      <Desc text="Third" />
     </Splitter.Panel>
   </Splitter>
 );

--- a/components/splitter/hooks/sizeUtil.ts
+++ b/components/splitter/hooks/sizeUtil.ts
@@ -1,11 +1,62 @@
 type SizeUnit = number | undefined;
 
-/**
- * TODO: 自动分配百分比尺寸：
- * 1. ptgSizes 中如果有数字值则不处理。
- * 2. ptgSizes 中如果有 undefined 则进行自动分配：
- * - 如果 undefined 的槽有 min 或 max 限制，则优先对其进行分配。
- * - 如果 undefined 的槽没有 min 和 max 限制，则均分剩余空间。
- */
-export function autoPtgSizes(ptgSizes: SizeUnit[], minPtgSizes: SizeUnit[], maxPtgSizes: SizeUnit[]) {
+export function autoPtgSizes(
+  ptgSizes: SizeUnit[],
+  minPtgSizes: SizeUnit[],
+  maxPtgSizes: SizeUnit[],
+): number[] {
+  const result = [...ptgSizes] as number[];
+
+  // Static current data
+  let currentTotalPtg = 0;
+  const undefinedIndexes: number[] = [];
+  ptgSizes.forEach((size, index) => {
+    if (size === undefined) {
+      undefinedIndexes.push(index);
+    } else {
+      currentTotalPtg += size;
+    }
+  });
+
+  const restPtg = 1 - currentTotalPtg;
+
+  // Fill if exceed
+  if (restPtg < 0) {
+    const scale = 1 / currentTotalPtg;
+    return ptgSizes.map((size) => (size === undefined ? 0 : size * scale));
+  }
+
+  // Check if limit exists
+  let sumMin = 0;
+  let sumMax = 0;
+  for (const index of undefinedIndexes) {
+    const min = minPtgSizes[index] || 0;
+    const max = maxPtgSizes[index] || 1;
+    sumMin += min;
+    sumMax += max;
+  }
+
+  // Impossible case, just average fill
+  if (sumMin > 1 && sumMax < 1) {
+    const avg = 1 / undefinedIndexes.length;
+    return ptgSizes.map((size) => (size === undefined ? avg : size));
+  }
+
+  // Greedy algorithm
+  let remain = restPtg - sumMin;
+
+  for (let i = 0; i < undefinedIndexes.length; i += 1) {
+    const index = undefinedIndexes[i];
+    const min = minPtgSizes[index] || 0;
+    const max = maxPtgSizes[index] || 1;
+
+    result[index] = min;
+
+    const canAdd = max - min;
+    const add = Math.min(canAdd, remain);
+    result[index] += add;
+    remain -= add;
+  }
+
+  return result;
 }

--- a/components/splitter/hooks/sizeUtil.ts
+++ b/components/splitter/hooks/sizeUtil.ts
@@ -1,0 +1,11 @@
+type SizeUnit = number | undefined;
+
+/**
+ * TODO: 自动分配百分比尺寸：
+ * 1. ptgSizes 中如果有数字值则不处理。
+ * 2. ptgSizes 中如果有 undefined 则进行自动分配：
+ * - 如果 undefined 的槽有 min 或 max 限制，则优先对其进行分配。
+ * - 如果 undefined 的槽没有 min 和 max 限制，则均分剩余空间。
+ */
+export function autoPtgSizes(ptgSizes: SizeUnit[], minPtgSizes: SizeUnit[], maxPtgSizes: SizeUnit[]) {
+}

--- a/components/splitter/hooks/sizeUtil.ts
+++ b/components/splitter/hooks/sizeUtil.ts
@@ -5,8 +5,6 @@ export function autoPtgSizes(
   minPtgSizes: SizeUnit[],
   maxPtgSizes: SizeUnit[],
 ): number[] {
-  const result = [...ptgSizes] as number[];
-
   // Static current data
   let currentTotalPtg = 0;
   const undefinedIndexes: number[] = [];
@@ -19,6 +17,7 @@ export function autoPtgSizes(
   });
 
   const restPtg = 1 - currentTotalPtg;
+  const undefinedCount = undefinedIndexes.length;
 
   // Fill if exceed
   if (restPtg < 0) {
@@ -29,23 +28,34 @@ export function autoPtgSizes(
   // Check if limit exists
   let sumMin = 0;
   let sumMax = 0;
+  let limitMin = 0;
+  let limitMax = 1;
   for (const index of undefinedIndexes) {
     const min = minPtgSizes[index] || 0;
     const max = maxPtgSizes[index] || 1;
     sumMin += min;
     sumMax += max;
+    limitMin = Math.max(limitMin, min);
+    limitMax = Math.min(limitMax, max);
   }
 
   // Impossible case, just average fill
   if (sumMin > 1 && sumMax < 1) {
-    const avg = 1 / undefinedIndexes.length;
+    const avg = 1 / undefinedCount;
     return ptgSizes.map((size) => (size === undefined ? avg : size));
   }
 
+  // Quickly fill if can
+  const restAvg = restPtg / undefinedCount;
+  if (limitMin <= restAvg && restAvg <= limitMax) {
+    return ptgSizes.map((size) => (size === undefined ? restAvg : size));
+  }
+
   // Greedy algorithm
+  const result = [...ptgSizes] as number[];
   let remain = restPtg - sumMin;
 
-  for (let i = 0; i < undefinedIndexes.length; i += 1) {
+  for (let i = 0; i < undefinedCount; i += 1) {
     const index = undefinedIndexes[i];
     const min = minPtgSizes[index] || 0;
     const max = maxPtgSizes[index] || 1;

--- a/components/splitter/hooks/useSizes.ts
+++ b/components/splitter/hooks/useSizes.ts
@@ -94,8 +94,6 @@ export default function useSizes(items: PanelProps[], containerSize?: number) {
     } else {
       // Loop to calculate the rest size.
       const calcRestSize = (forceFill = false) => {
-        let success = true;
-
         // If total percentage is smaller than 1, we will fill the rest.
         const avgRest = (1 - getTotalPtg()) / emptyCount;
 
@@ -110,13 +108,11 @@ export default function useSizes(items: PanelProps[], containerSize?: number) {
           const maxPtg = postPercentMaxSizes[index];
 
           if (avgRest < minPtg) {
-            success = false;
             emptyCount -= 1;
             return minPtg;
           }
 
           if (avgRest > maxPtg) {
-            success = false;
             emptyCount -= 1;
             return maxPtg;
           }
@@ -124,7 +120,7 @@ export default function useSizes(items: PanelProps[], containerSize?: number) {
           return ptg;
         });
 
-        return success;
+        return emptyCount <= 0;
       };
 
       // If size over the maxSize or under the minSize, we need recalculate again.

--- a/components/splitter/index.en-US.md
+++ b/components/splitter/index.en-US.md
@@ -29,6 +29,7 @@ Can be used to separate areas horizontally or vertically. When you need to freel
 <code src="./demo/nested-in-tabs.tsx" debug>Nested in tabs</code>
 <code src="./demo/lazy.tsx" version="5.23.0">Lazy</code>
 <code src="./demo/debug.tsx" debug>Debug</code>
+<code src="./demo/size-mix.tsx" debug>Size Mix</code>
 
 ## API
 

--- a/components/splitter/index.zh-CN.md
+++ b/components/splitter/index.zh-CN.md
@@ -30,6 +30,7 @@ tag: 5.21.0
 <code src="./demo/nested-in-tabs.tsx" debug>标签页中嵌套</code>
 <code src="./demo/lazy.tsx" version="5.23.0">延迟渲染模式</code>
 <code src="./demo/debug.tsx" debug>调试</code>
+<code src="./demo/size-mix.tsx" debug>尺寸混合</code>
 
 ## API
 

--- a/tests/utils.tsx
+++ b/tests/utils.tsx
@@ -32,18 +32,18 @@ export const sleep = async (timeout = 0) => {
 const customRender = (ui: ReactElement, options?: Partial<RenderOptions>) =>
   render(ui, { wrapper: StrictMode, ...options });
 
-export function renderHook<T>(func: () => T): { result: React.RefObject<T | null> } {
-  const result = createRef<T>();
+export function renderHook<T>(func: () => T): { result: React.RefObject<T> } {
+  const result = createRef<any>();
 
   const Demo: React.FC = () => {
-    (result as any).current = func();
+    result.current = func();
 
     return null;
   };
 
   customRender(<Demo />);
 
-  return { result };
+  return { result: result as React.RefObject<T> };
 }
 
 /**


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #54931

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Splitter `minSize` & `maxSize` not take effect when first mount without controlled mode.      |
| 🇨🇳 Chinese |    修复 Splitter `minSize` 和 `maxSize` 在初始化非受控下不生效的问题。         |
