### PR TITLE
fix(Button): icon-only round button styles affected by theme token paddingInline / paddingInlineLG / paddingInlineSM

### DIFF
--- a/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1658,7 +1658,7 @@ Array [
     </div>
     <div
       class="ant-flex ant-flex-gap-small"
-      style="transform: scale(3); transform-origin: left top;"
+      style="transform: scale(3); transform-origin: left top; margin-bottom: 100px;"
     >
       <button
         class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg ant-btn-icon-only"
@@ -1728,6 +1728,288 @@ Array [
         </span>
       </button>
     </div>
+  </div>,
+  <div
+    class="ant-divider ant-divider-horizontal ant-divider-with-text ant-divider-with-text-center ant-divider-plain"
+    role="separator"
+  >
+    <span
+      class="ant-divider-inner-text"
+    >
+       paddingInline / paddingInlineLG / paddingInlineSM 
+    </span>
+  </div>,
+  <p
+    style="margin-bottom: 12px;"
+  >
+    Icon-only button should not be affected by paddingInline / paddingInlineLG / paddingInlineSM
+  </p>,
+  <div
+    class="ant-flex"
+    style="margin-bottom: 12px; gap: 8px;"
+  >
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-round ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-circle ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+  </div>,
+  <div
+    class="ant-flex"
+    style="margin-bottom: 12px; gap: 8px;"
+  >
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-round ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-circle ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+  </div>,
+  <div
+    class="ant-flex"
+    style="margin-bottom: 12px; gap: 8px;"
+  >
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-round ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-circle ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
   </div>,
 ]
 `;

--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -1562,7 +1562,7 @@ Array [
     </div>
     <div
       class="ant-flex ant-flex-gap-small"
-      style="transform:scale(3);transform-origin:left top"
+      style="transform:scale(3);transform-origin:left top;margin-bottom:100px"
     >
       <button
         class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg ant-btn-icon-only"
@@ -1632,6 +1632,288 @@ Array [
         </span>
       </button>
     </div>
+  </div>,
+  <div
+    class="ant-divider ant-divider-horizontal ant-divider-with-text ant-divider-with-text-center ant-divider-plain"
+    role="separator"
+  >
+    <span
+      class="ant-divider-inner-text"
+    >
+       paddingInline / paddingInlineLG / paddingInlineSM 
+    </span>
+  </div>,
+  <p
+    style="margin-bottom:12px"
+  >
+    Icon-only button should not be affected by paddingInline / paddingInlineLG / paddingInlineSM
+  </p>,
+  <div
+    class="ant-flex"
+    style="margin-bottom:12px;gap:8px"
+  >
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-round ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-circle ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+  </div>,
+  <div
+    class="ant-flex"
+    style="margin-bottom:12px;gap:8px"
+  >
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-round ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-circle ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+  </div>,
+  <div
+    class="ant-flex"
+    style="margin-bottom:12px;gap:8px"
+  >
+    <button
+      class="ant-btn ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-round ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+    <button
+      class="ant-btn ant-btn-circle ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-lg ant-btn-icon-only"
+      type="button"
+    >
+      <span
+        class="ant-btn-icon"
+      >
+        <span
+          aria-label="arrow-down"
+          class="anticon anticon-arrow-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="arrow-down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0048.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
   </div>,
 ]
 `;

--- a/components/button/demo/debug-icon.tsx
+++ b/components/button/demo/debug-icon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { MinusSquareOutlined, SearchOutlined } from '@ant-design/icons';
-import { Button, ConfigProvider, Divider, Flex, Radio, Tooltip, Input } from 'antd';
+import { ArrowDownOutlined, MinusSquareOutlined, SearchOutlined } from '@ant-design/icons';
+import { Button, ConfigProvider, Divider, Flex, Input, Radio, Tooltip } from 'antd';
 import type { ConfigProviderProps } from 'antd';
 import { FiColumns } from 'react-icons/fi';
 
@@ -99,6 +99,7 @@ const App: React.FC = () => {
             style={{
               transform: 'scale(3)',
               transformOrigin: 'left top',
+              marginBottom: 100,
             }}
           >
             <Button icon={<MinusSquareOutlined />} />
@@ -106,6 +107,37 @@ const App: React.FC = () => {
             <Button icon={<Icon16Size />} />
             <Button icon={<IconIrregularSize />} />
           </Flex>
+        </Flex>
+      </ConfigProvider>
+
+      <ConfigProvider
+        theme={{
+          components: { Button: { paddingInline: 100, paddingInlineLG: 150, paddingInlineSM: 50 } },
+        }}
+      >
+        <Divider plain> paddingInline / paddingInlineLG / paddingInlineSM </Divider>
+
+        <p style={{ marginBottom: 12 }}>
+          Icon-only button should not be affected by paddingInline / paddingInlineLG /
+          paddingInlineSM
+        </p>
+
+        <Flex gap={8} style={{ marginBottom: 12 }}>
+          <Button size="small" shape="default" icon={<ArrowDownOutlined />} />
+          <Button size="small" shape="round" icon={<ArrowDownOutlined />} />
+          <Button size="small" shape="circle" icon={<ArrowDownOutlined />} />
+        </Flex>
+
+        <Flex gap={8} style={{ marginBottom: 12 }}>
+          <Button shape="default" icon={<ArrowDownOutlined />} />
+          <Button shape="round" icon={<ArrowDownOutlined />} />
+          <Button shape="circle" icon={<ArrowDownOutlined />} />
+        </Flex>
+
+        <Flex gap={8} style={{ marginBottom: 12 }}>
+          <Button size="large" shape="default" icon={<ArrowDownOutlined />} />
+          <Button size="large" shape="round" icon={<ArrowDownOutlined />} />
+          <Button size="large" shape="circle" icon={<ArrowDownOutlined />} />
         </Flex>
       </ConfigProvider>
     </>

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -74,10 +74,6 @@ const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token): CSS
         [`&${componentCls}-compact-item`]: {
           flex: 'none',
         },
-
-        [`&${componentCls}-round`]: {
-          width: 'auto',
-        },
       },
 
       // Loading
@@ -148,11 +144,6 @@ const genCircleButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => (
   minWidth: token.controlHeight,
   paddingInline: 0,
   borderRadius: '50%',
-});
-
-const genRoundButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
-  borderRadius: token.controlHeight,
-  paddingInline: token.buttonPaddingHorizontal ?? token.calc(token.controlHeight).div(2).equal(),
 });
 
 const genDisabledStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => ({
@@ -756,7 +747,12 @@ const genButtonStyle = (token: ButtonToken, prefixCls = ''): CSSInterpolation =>
       [`${componentCls}${componentCls}-circle${prefixCls}`]: genCircleButtonStyle(token),
     },
     {
-      [`${componentCls}${componentCls}-round${prefixCls}`]: genRoundButtonStyle(token),
+      [`${componentCls}${componentCls}-round${prefixCls}`]: {
+        borderRadius: token.controlHeight,
+        [`&:not(${componentCls}-icon-only)`]: {
+          paddingInline: token.buttonPaddingHorizontal,
+        },
+      },
     },
   ];
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

修复前

<img width="1194" height="506" alt="image" src="https://github.com/user-attachments/assets/b88b0437-81ef-4b6d-98f1-9ef1b594b8cd" />

修复后

<img width="1156" height="486" alt="image" src="https://github.com/user-attachments/assets/c2f6dd91-d918-4c3d-9949-435d5a1c8a33" />


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(Button): icon-only round button styles affected by theme token paddingInline / paddingInlineLG / paddingInlineSM |
| 🇨🇳 Chinese | fix(Button): 圆形仅图标按钮样式被主题变量 paddingInline / paddingInlineLG / paddingInlineSM 影响 |
