### PR TITLE
fix(Card): fix clearfix interference with flex/grid card layouts

### DIFF
--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -343,6 +343,14 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
         padding: bodyPadding,
         borderRadius: `0 0 ${unit(token.borderRadiusLG)} ${unit(token.borderRadiusLG)}`,
         ...clearFix(),
+
+        // Remove clearFix pseudo-elements when using flex/grid layouts to avoid interference with gap calculations
+        '&[style*="display: flex"], &[style*="display:flex"], &[style*="display: grid"], &[style*="display:grid"]':
+          {
+            '&::before, &::after': {
+              content: 'none',
+            },
+          },
       },
 
       [`${componentCls}-grid`]: genCardGridStyle(token),

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -342,14 +342,6 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
       [`${componentCls}-body`]: {
         padding: bodyPadding,
         borderRadius: `0 0 ${unit(token.borderRadiusLG)} ${unit(token.borderRadiusLG)}`,
-        ...clearFix(),
-
-        // Remove clearFix pseudo-elements when using flex/grid layouts to avoid interference with gap calculations
-        '&[style*="display: flex"], &[style*="display: grid"]': {
-          '&::before, &::after': {
-            content: 'none',
-          },
-        },
       },
 
       [`${componentCls}-grid`]: genCardGridStyle(token),

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -345,12 +345,11 @@ const genCardStyle: GenerateStyle<CardToken> = (token): CSSObject => {
         ...clearFix(),
 
         // Remove clearFix pseudo-elements when using flex/grid layouts to avoid interference with gap calculations
-        '&[style*="display: flex"], &[style*="display:flex"], &[style*="display: grid"], &[style*="display:grid"]':
-          {
-            '&::before, &::after': {
-              content: 'none',
-            },
+        '&[style*="display: flex"], &[style*="display: grid"]': {
+          '&::before, &::after': {
+            content: 'none',
           },
+        },
       },
 
       [`${componentCls}-grid`]: genCardGridStyle(token),


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...
- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
close https://github.com/ant-design/ant-design/issues/54952

### 💡 Background and Solution
The ::after and ::before pseudo-elements inside ant-card-body are being included in gap calculations
The clearFix function is affecting it; simply set the content to none to fix it

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Card body extra padding when adding `gap` style. |
| 🇨🇳 Chinese | 修复 Card body 增加 `gap` 样式时有多余 padding 的问题。 |
