### PR TITLE
fix(Select): The height in the small size under the Multiple mode does not match the expectation.

### DIFF
--- a/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4512,7 +4512,7 @@ exports[`renders components/select/demo/filled-debug.tsx extend context correctl
   >
     <div
       class="ant-select ant-select-filled ant-select-single ant-select-show-arrow ant-select-disabled"
-      style="flex: 1 1 0%;"
+      style="flex: 1;"
     >
       <div
         class="ant-select-selector"
@@ -4675,7 +4675,7 @@ exports[`renders components/select/demo/filled-debug.tsx extend context correctl
     </div>
     <div
       class="ant-select ant-select-filled ant-select-multiple ant-select-show-arrow ant-select-disabled ant-select-show-search"
-      style="flex: 1 1 0%;"
+      style="flex: 1;"
     >
       <div
         class="ant-select-selector"
@@ -4875,7 +4875,7 @@ exports[`renders components/select/demo/filled-debug.tsx extend context correctl
   >
     <div
       class="ant-select ant-select-filled ant-select-status-error ant-select-single ant-select-show-arrow"
-      style="flex: 1 1 0%;"
+      style="flex: 1;"
     >
       <div
         class="ant-select-selector"
@@ -5037,7 +5037,7 @@ exports[`renders components/select/demo/filled-debug.tsx extend context correctl
     </div>
     <div
       class="ant-select ant-select-filled ant-select-status-error ant-select-multiple ant-select-show-arrow ant-select-show-search"
-      style="flex: 1 1 0%;"
+      style="flex: 1;"
     >
       <div
         class="ant-select-selector"
@@ -5263,7 +5263,7 @@ exports[`renders components/select/demo/filled-debug.tsx extend context correctl
   >
     <div
       class="ant-select ant-select-filled ant-select-status-error ant-select-single ant-select-show-arrow ant-select-disabled"
-      style="flex: 1 1 0%;"
+      style="flex: 1;"
     >
       <div
         class="ant-select-selector"
@@ -5426,7 +5426,7 @@ exports[`renders components/select/demo/filled-debug.tsx extend context correctl
     </div>
     <div
       class="ant-select ant-select-filled ant-select-status-error ant-select-multiple ant-select-show-arrow ant-select-disabled ant-select-show-search"
-      style="flex: 1 1 0%;"
+      style="flex: 1;"
     >
       <div
         class="ant-select-selector"
@@ -18238,7 +18238,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
   >
     <div
       class="ant-select ant-select-outlined ant-select-single ant-select-show-arrow"
-      style="flex: 1 1 0%;"
+      style="flex: 1;"
     >
       <div
         class="ant-select-selector"
@@ -18399,7 +18399,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
     </div>
     <div
       class="ant-select ant-select-outlined ant-select-multiple ant-select-show-arrow ant-select-show-search"
-      style="flex: 1 1 0%;"
+      style="flex: 1;"
     >
       <div
         class="ant-select-selector"
@@ -18625,7 +18625,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
   >
     <div
       class="ant-select ant-select-filled ant-select-single ant-select-show-arrow"
-      style="flex: 1 1 0%;"
+      style="flex: 1;"
     >
       <div
         class="ant-select-selector"
@@ -18786,7 +18786,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
     </div>
     <div
       class="ant-select ant-select-filled ant-select-multiple ant-select-show-arrow ant-select-show-search"
-      style="flex: 1 1 0%;"
+      style="flex: 1;"
     >
       <div
         class="ant-select-selector"
@@ -19012,7 +19012,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
   >
     <div
       class="ant-select ant-select-borderless ant-select-single ant-select-show-arrow"
-      style="flex: 1 1 0%;"
+      style="flex: 1;"
     >
       <div
         class="ant-select-selector"
@@ -19173,7 +19173,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
     </div>
     <div
       class="ant-select ant-select-borderless ant-select-multiple ant-select-show-arrow ant-select-show-search"
-      style="flex: 1 1 0%;"
+      style="flex: 1;"
     >
       <div
         class="ant-select-selector"
@@ -19399,7 +19399,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
   >
     <div
       class="ant-select ant-select-underlined ant-select-single ant-select-show-arrow"
-      style="flex: 1 1 0%;"
+      style="flex: 1;"
     >
       <div
         class="ant-select-selector"
@@ -19560,7 +19560,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
     </div>
     <div
       class="ant-select ant-select-underlined ant-select-multiple ant-select-show-arrow ant-select-show-search"
-      style="flex: 1 1 0%;"
+      style="flex: 1;"
     >
       <div
         class="ant-select-selector"

--- a/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4512,7 +4512,7 @@ exports[`renders components/select/demo/filled-debug.tsx extend context correctl
   >
     <div
       class="ant-select ant-select-filled ant-select-single ant-select-show-arrow ant-select-disabled"
-      style="flex: 1;"
+      style="flex: 1 1 0%;"
     >
       <div
         class="ant-select-selector"
@@ -4675,7 +4675,7 @@ exports[`renders components/select/demo/filled-debug.tsx extend context correctl
     </div>
     <div
       class="ant-select ant-select-filled ant-select-multiple ant-select-show-arrow ant-select-disabled ant-select-show-search"
-      style="flex: 1;"
+      style="flex: 1 1 0%;"
     >
       <div
         class="ant-select-selector"
@@ -4875,7 +4875,7 @@ exports[`renders components/select/demo/filled-debug.tsx extend context correctl
   >
     <div
       class="ant-select ant-select-filled ant-select-status-error ant-select-single ant-select-show-arrow"
-      style="flex: 1;"
+      style="flex: 1 1 0%;"
     >
       <div
         class="ant-select-selector"
@@ -5037,7 +5037,7 @@ exports[`renders components/select/demo/filled-debug.tsx extend context correctl
     </div>
     <div
       class="ant-select ant-select-filled ant-select-status-error ant-select-multiple ant-select-show-arrow ant-select-show-search"
-      style="flex: 1;"
+      style="flex: 1 1 0%;"
     >
       <div
         class="ant-select-selector"
@@ -5263,7 +5263,7 @@ exports[`renders components/select/demo/filled-debug.tsx extend context correctl
   >
     <div
       class="ant-select ant-select-filled ant-select-status-error ant-select-single ant-select-show-arrow ant-select-disabled"
-      style="flex: 1;"
+      style="flex: 1 1 0%;"
     >
       <div
         class="ant-select-selector"
@@ -5426,7 +5426,7 @@ exports[`renders components/select/demo/filled-debug.tsx extend context correctl
     </div>
     <div
       class="ant-select ant-select-filled ant-select-status-error ant-select-multiple ant-select-show-arrow ant-select-disabled ant-select-show-search"
-      style="flex: 1;"
+      style="flex: 1 1 0%;"
     >
       <div
         class="ant-select-selector"
@@ -18238,7 +18238,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
   >
     <div
       class="ant-select ant-select-outlined ant-select-single ant-select-show-arrow"
-      style="flex: 1;"
+      style="flex: 1 1 0%;"
     >
       <div
         class="ant-select-selector"
@@ -18399,7 +18399,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
     </div>
     <div
       class="ant-select ant-select-outlined ant-select-multiple ant-select-show-arrow ant-select-show-search"
-      style="flex: 1;"
+      style="flex: 1 1 0%;"
     >
       <div
         class="ant-select-selector"
@@ -18625,7 +18625,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
   >
     <div
       class="ant-select ant-select-filled ant-select-single ant-select-show-arrow"
-      style="flex: 1;"
+      style="flex: 1 1 0%;"
     >
       <div
         class="ant-select-selector"
@@ -18786,7 +18786,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
     </div>
     <div
       class="ant-select ant-select-filled ant-select-multiple ant-select-show-arrow ant-select-show-search"
-      style="flex: 1;"
+      style="flex: 1 1 0%;"
     >
       <div
         class="ant-select-selector"
@@ -19012,7 +19012,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
   >
     <div
       class="ant-select ant-select-borderless ant-select-single ant-select-show-arrow"
-      style="flex: 1;"
+      style="flex: 1 1 0%;"
     >
       <div
         class="ant-select-selector"
@@ -19173,7 +19173,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
     </div>
     <div
       class="ant-select ant-select-borderless ant-select-multiple ant-select-show-arrow ant-select-show-search"
-      style="flex: 1;"
+      style="flex: 1 1 0%;"
     >
       <div
         class="ant-select-selector"
@@ -19399,7 +19399,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
   >
     <div
       class="ant-select ant-select-underlined ant-select-single ant-select-show-arrow"
-      style="flex: 1;"
+      style="flex: 1 1 0%;"
     >
       <div
         class="ant-select-selector"
@@ -19560,7 +19560,7 @@ exports[`renders components/select/demo/variant.tsx extend context correctly 1`]
     </div>
     <div
       class="ant-select ant-select-underlined ant-select-multiple ant-select-show-arrow ant-select-show-search"
-      style="flex: 1;"
+      style="flex: 1 1 0%;"
     >
       <div
         class="ant-select-selector"

--- a/components/select/style/multiple.ts
+++ b/components/select/style/multiple.ts
@@ -275,41 +275,39 @@ const genSelectionStyle = (
         marginBlock: INTERNAL_FIXED_ITEM_MARGIN,
       },
 
-      [`${selectOverflowPrefixCls} ${selectOverflowPrefixCls}-item ${componentCls}-selection-search`]:
-        {
-          display: 'inline-flex',
-          position: 'relative',
-          maxWidth: '100%',
-          marginInlineStart: token
-            .calc(token.inputPaddingHorizontalBase)
-            .sub(selectItemDist)
-            .equal(),
+      [`${selectOverflowPrefixCls} 
+        ${selectOverflowPrefixCls}-item 
+        ${componentCls}-selection-search`]: {
+        display: 'inline-flex',
+        position: 'relative',
+        maxWidth: '100%',
+        marginInlineStart: token.calc(token.inputPaddingHorizontalBase).sub(selectItemDist).equal(),
 
-          [`
+        [`
           &-input,
           &-mirror
         `]: {
-            height: selectItemHeight,
-            fontFamily: token.fontFamily,
-            lineHeight: unit(selectItemHeight),
-            transition: `all ${token.motionDurationSlow}`,
-          },
-
-          '&-input': {
-            width: '100%',
-            minWidth: 4.1, // fix search cursor missing
-          },
-
-          '&-mirror': {
-            position: 'absolute',
-            top: 0,
-            insetInlineStart: 0,
-            insetInlineEnd: 'auto',
-            zIndex: 999,
-            whiteSpace: 'pre', // fix whitespace wrapping caused width calculation bug
-            visibility: 'hidden',
-          },
+          height: selectItemHeight,
+          fontFamily: token.fontFamily,
+          lineHeight: unit(selectItemHeight),
+          transition: `all ${token.motionDurationSlow}`,
         },
+
+        '&-input': {
+          width: '100%',
+          minWidth: 4.1, // fix search cursor missing
+        },
+
+        '&-mirror': {
+          position: 'absolute',
+          top: 0,
+          insetInlineStart: 0,
+          insetInlineEnd: 'auto',
+          zIndex: 999,
+          whiteSpace: 'pre', // fix whitespace wrapping caused width calculation bug
+          visibility: 'hidden',
+        },
+      },
 
       // ======================= Placeholder =======================
       [`${componentCls}-selection-placeholder`]: {

--- a/components/select/style/multiple.ts
+++ b/components/select/style/multiple.ts
@@ -275,37 +275,41 @@ const genSelectionStyle = (
         marginBlock: INTERNAL_FIXED_ITEM_MARGIN,
       },
 
-      [`${componentCls}-selection-search`]: {
-        display: 'inline-flex',
-        position: 'relative',
-        maxWidth: '100%',
-        marginInlineStart: token.calc(token.inputPaddingHorizontalBase).sub(selectItemDist).equal(),
+      [`${selectOverflowPrefixCls} ${selectOverflowPrefixCls}-item ${componentCls}-selection-search`]:
+        {
+          display: 'inline-flex',
+          position: 'relative',
+          maxWidth: '100%',
+          marginInlineStart: token
+            .calc(token.inputPaddingHorizontalBase)
+            .sub(selectItemDist)
+            .equal(),
 
-        [`
+          [`
           &-input,
           &-mirror
         `]: {
-          height: selectItemHeight,
-          fontFamily: token.fontFamily,
-          lineHeight: unit(selectItemHeight),
-          transition: `all ${token.motionDurationSlow}`,
-        },
+            height: selectItemHeight,
+            fontFamily: token.fontFamily,
+            lineHeight: unit(selectItemHeight),
+            transition: `all ${token.motionDurationSlow}`,
+          },
 
-        '&-input': {
-          width: '100%',
-          minWidth: 4.1, // fix search cursor missing
-        },
+          '&-input': {
+            width: '100%',
+            minWidth: 4.1, // fix search cursor missing
+          },
 
-        '&-mirror': {
-          position: 'absolute',
-          top: 0,
-          insetInlineStart: 0,
-          insetInlineEnd: 'auto',
-          zIndex: 999,
-          whiteSpace: 'pre', // fix whitespace wrapping caused width calculation bug
-          visibility: 'hidden',
+          '&-mirror': {
+            position: 'absolute',
+            top: 0,
+            insetInlineStart: 0,
+            insetInlineEnd: 'auto',
+            zIndex: 999,
+            whiteSpace: 'pre', // fix whitespace wrapping caused width calculation bug
+            visibility: 'hidden',
+          },
         },
-      },
 
       // ======================= Placeholder =======================
       [`${componentCls}-selection-placeholder`]: {

--- a/components/select/style/multiple.ts
+++ b/components/select/style/multiple.ts
@@ -66,17 +66,6 @@ export const getMultipleSelectorUnit = (
   };
 };
 
-const getSelectItemStyle = (token: SelectItemToken): number | string => {
-  const { multipleSelectItemHeight, selectHeight, lineWidth } = token;
-  const selectItemDist = token
-    .calc(selectHeight)
-    .sub(multipleSelectItemHeight)
-    .div(2)
-    .sub(lineWidth)
-    .equal();
-  return selectItemDist;
-};
-
 /**
  * Get the `rc-overflow` needed style.
  * It's a share style which means not affected by `size`.
@@ -196,7 +185,6 @@ const genSelectionStyle = (
   const selectOverflowPrefixCls = `${componentCls}-selection-overflow`;
 
   const selectItemHeight = token.multipleSelectItemHeight;
-  const selectItemDist = getSelectItemStyle(token);
 
   const suffixCls = suffix ? `${componentCls}-${suffix}` : '';
 
@@ -281,7 +269,6 @@ const genSelectionStyle = (
         display: 'inline-flex',
         position: 'relative',
         maxWidth: '100%',
-        marginInlineStart: token.calc(token.inputPaddingHorizontalBase).sub(selectItemDist).equal(),
 
         [`
           &-input,

--- a/components/select/style/multiple.ts
+++ b/components/select/style/multiple.ts
@@ -66,6 +66,17 @@ export const getMultipleSelectorUnit = (
   };
 };
 
+const getSelectItemStyle = (token: SelectItemToken): number | string => {
+  const { multipleSelectItemHeight, selectHeight, lineWidth } = token;
+  const selectItemDist = token
+    .calc(selectHeight)
+    .sub(multipleSelectItemHeight)
+    .div(2)
+    .sub(lineWidth)
+    .equal();
+  return selectItemDist;
+};
+
 /**
  * Get the `rc-overflow` needed style.
  * It's a share style which means not affected by `size`.
@@ -185,6 +196,7 @@ const genSelectionStyle = (
   const selectOverflowPrefixCls = `${componentCls}-selection-overflow`;
 
   const selectItemHeight = token.multipleSelectItemHeight;
+  const selectItemDist = getSelectItemStyle(token);
 
   const suffixCls = suffix ? `${componentCls}-${suffix}` : '';
 
@@ -263,22 +275,11 @@ const genSelectionStyle = (
         marginBlock: INTERNAL_FIXED_ITEM_MARGIN,
       },
 
-      [`${selectOverflowPrefixCls} 
-        ${selectOverflowPrefixCls}-item 
-        ${componentCls}-selection-search`]: {
+      [`${componentCls}-selection-search`]: {
         display: 'inline-flex',
         position: 'relative',
         maxWidth: '100%',
-
-        [`
-          &-input,
-          &-mirror
-        `]: {
-          height: selectItemHeight,
-          fontFamily: token.fontFamily,
-          lineHeight: unit(selectItemHeight),
-          transition: `all ${token.motionDurationSlow}`,
-        },
+        marginInlineStart: token.calc(token.inputPaddingHorizontalBase).sub(selectItemDist).equal(),
 
         '&-input': {
           width: '100%',
@@ -293,6 +294,22 @@ const genSelectionStyle = (
           zIndex: 999,
           whiteSpace: 'pre', // fix whitespace wrapping caused width calculation bug
           visibility: 'hidden',
+        },
+      },
+
+      // fix: https://github.com/ant-design/ant-design/issues/54971
+      // Selector priority is low and CSS is overridden.
+      [`${selectOverflowPrefixCls} 
+        ${selectOverflowPrefixCls}-item 
+        ${componentCls}-selection-search`]: {
+        [`
+          &-input,
+          &-mirror
+        `]: {
+          height: selectItemHeight,
+          fontFamily: token.fontFamily,
+          lineHeight: unit(selectItemHeight),
+          transition: `all ${token.motionDurationSlow}`,
         },
       },
 


### PR DESCRIPTION
…s not match the expectation.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 💄 Component style improvement

### 🔗 Related Issues

close https://github.com/ant-design/ant-design/issues/54971

### 💡 Background and Solution
<img width="848" height="130" alt="image" src="https://github.com/user-attachments/assets/ab0832e0-f0f8-406f-8e35-ee01a06fc460" />

已确认是bug

选择器1：.ant-select-show-search.ant-select:not(.ant-select-customize-input) .ant-select-selector input 
选择器2：.ant-select-multiple.ant-select-sm .ant-select-selection-search-input, .ant-select-multiple.ant-select-sm .ant-select-selection-search-mirror
选择器1的优先级是10+10+10+10+1=41，选择器的优先级是10+10+10=30

选择器1覆盖了选择器2的样式，
解决方式：给选择器2添加增加嵌套层级

### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      The height in the small size under the Multiple mode does not match the expectation.     |
| 🇨🇳 Chinese |     Multiple 模式下 small 尺寸下的高度与预期不符      |
