### PR TITLE
chore: bump jsdom from 26 to 27

### DIFF
--- a/package.json
+++ b/package.json
@@ -270,7 +270,7 @@
     "jest-image-snapshot": "^6.4.0",
     "jest-puppeteer": "^11.0.0",
     "jquery": "^3.7.1",
-    "jsdom": "^26.0.0",
+    "jsdom": "^27.0.0",
     "jsonml-to-react-element": "^1.1.11",
     "jsonml.js": "^0.1.0",
     "lint-staged": "^16.0.0",
@@ -351,16 +351,5 @@
   "title": "Ant Design",
   "tnpm": {
     "mode": "npm"
-  },
-  "pnpm": {
-    "overrides": {
-      "nwsapi": "2.2.22"
-    }
-  },
-  "overrides": {
-    "nwsapi": "2.2.22"
-  },
-  "resolutions": {
-    "nwsapi": "2.2.22"
   }
 }


### PR DESCRIPTION


### 🤔 This is a ...


- [ ] ❓ Other (about what?)

### 🔗 Related Issues

https://github.com/jsdom/jsdom/releases/tag/27.0.0


### 💡 Background and Solution

升级一下试试 ci 结果，看起来修复了很多 css 选择器的问题，尤其是苦 nswapi 久矣。

<img width="1641" height="1404" alt="image" src="https://github.com/user-attachments/assets/087f5400-d290-408f-88c8-48129333eea0" />


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        -   |
| 🇨🇳 Chinese |       -    |
