### PR TITLE
fix: support clipboard copy in non-https contexts

### DIFF
--- a/.dumi/theme/builtins/ComponentMeta/index.tsx
+++ b/.dumi/theme/builtins/ComponentMeta/index.tsx
@@ -83,8 +83,8 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
   // ========================= Copy =========================
   const [copied, setCopied] = React.useState(false);
 
-  const onCopy = () => {
-    copy(`import { ${component} } from "antd";`);
+  const onCopy = async () => {
+    await copy(`import { ${component} } from "antd";`);
     setCopied(true);
   };
 

--- a/.dumi/theme/builtins/IconSearch/CopyableIcon.tsx
+++ b/.dumi/theme/builtins/IconSearch/CopyableIcon.tsx
@@ -109,8 +109,8 @@ const CopyableIcon: React.FC<CopyableIconProps> = (props) => {
   const [locale] = useLocale(locales);
   const { styles } = useStyle();
 
-  const onCopy = (text: string) => {
-    const result = copy(text);
+  const onCopy = async (text: string) => {
+    const result = await copy(text);
     if (result) {
       onCopied(name, text);
     } else {

--- a/.dumi/theme/builtins/Previewer/DesignPreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/DesignPreviewer.tsx
@@ -83,7 +83,7 @@ const DesignPreviewer: FC<AntdPreviewerProps> = ({ children, title, description,
     try {
       if (demoRef.current) {
         const group = await nodeToGroup(demoRef.current);
-        copy(JSON.stringify(group.toSketchJSON()));
+        await copy(JSON.stringify(group.toSketchJSON()));
         setCopied(true);
         timerRef.current = setTimeout(() => {
           setCopied(false);

--- a/.dumi/theme/common/Color/ColorBlock.tsx
+++ b/.dumi/theme/common/Color/ColorBlock.tsx
@@ -21,8 +21,8 @@ const ColorBlock: React.FC<ColorBlockProps> = (props) => {
     };
   }, [color, dark, index]);
 
-  const onCopy = () => {
-    copy(color);
+  const onCopy = async () => {
+    await copy(color);
     message.success(`Copied: ${color}`);
   };
 

--- a/.dumi/theme/common/Color/Palette.tsx
+++ b/.dumi/theme/common/Color/Palette.tsx
@@ -51,8 +51,8 @@ const Palette: React.FC<PaletteProps> = (props) => {
     setHexColors(colors);
   }, []);
 
-  const onCopy = (colorText: string) => {
-    copy(hexColors[colorText]);
+  const onCopy = async (colorText: string) => {
+    await copy(hexColors[colorText]);
     message.success(`@${colorText} copied: ${hexColors[colorText]}`);
   };
 

--- a/components/_util/__tests__/copy.test.ts
+++ b/components/_util/__tests__/copy.test.ts
@@ -1,3 +1,4 @@
+import { fireEvent } from '../../../tests/utils';
 import copy from '../copy';
 
 describe('Test copy', () => {
@@ -9,6 +10,14 @@ describe('Test copy', () => {
           write: jest.fn(),
         },
       },
+      configurable: true,
+      writable: true,
+    });
+
+    Object.defineProperty(document, 'execCommand', {
+      value: jest.fn().mockImplementation(() => {
+        fireEvent.copy(document.body);
+      }),
       configurable: true,
       writable: true,
     });
@@ -63,6 +72,12 @@ describe('Test copy', () => {
     expect(result).toBe(true);
   });
 
+  it('copy succeed via execCommand, When there is no clipboard object', async () => {
+    delete (global.navigator as any).clipboard;
+    const result = copy('test copy');
+    expect(result).toBe(true);
+  });
+
   it('copy failed, When the cutting object is not a string', async () => {
     const mockWrite = jest.fn().mockImplementation(() => Promise.resolve());
     navigator.clipboard.write = mockWrite;
@@ -73,16 +88,10 @@ describe('Test copy', () => {
     expect(result).toBe(false);
   });
 
-  it('copy failed, When there is no clipboard object', async () => {
-    delete (global.navigator as any).clipboard;
-    const result = copy('test copy');
-    expect((console.error as any).mock.lastCall[0]).toContain('Clipboard API failed');
-    expect(result).toBe(undefined);
-  });
-
   afterEach(() => {
     delete (global as any).navigator;
     delete (global as any).ClipboardItem;
+    delete (document as any).execCommand;
     jest.restoreAllMocks();
   });
 });

--- a/components/_util/__tests__/copy.test.ts
+++ b/components/_util/__tests__/copy.test.ts
@@ -72,10 +72,18 @@ describe('Test copy', () => {
     expect(result).toBe(true);
   });
 
-  it('copy succeed via execCommand, When there is no clipboard object', async () => {
+  it('format!=text/html via execCommand, When there is no clipboard object', async () => {
     delete (global.navigator as any).clipboard;
     const result = copy('test copy');
     expect(result).toBe(true);
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('format=text/html via execCommand, When there is no clipboard object', async () => {
+    delete (global.navigator as any).clipboard;
+    const result = copy('test copy');
+    expect(result).toBe(true);
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
   });
 
   it('copy failed, When the cutting object is not a string', async () => {

--- a/components/_util/__tests__/copy.test.ts
+++ b/components/_util/__tests__/copy.test.ts
@@ -81,7 +81,9 @@ describe('Test copy', () => {
 
   it('format=text/html via execCommand, When there is no clipboard object', async () => {
     delete (global.navigator as any).clipboard;
-    const result = await copy('test copy');
+    const result = await copy('<div>test copy</div>', {
+      format: 'text/html',
+    });
     expect(result).toBe(true);
     expect(document.execCommand).toHaveBeenCalledWith('copy');
   });

--- a/components/_util/__tests__/copy.test.ts
+++ b/components/_util/__tests__/copy.test.ts
@@ -51,7 +51,7 @@ describe('Test copy', () => {
 
     global.navigator.clipboard.writeText = mockWriteText;
 
-    const result = copy('Test Text', {});
+    const result = await copy('Test Text', {});
 
     expect(result).toBe(true);
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Test Text');
@@ -60,7 +60,7 @@ describe('Test copy', () => {
   it('format=text/html ,use navigator.clipboard.write', async () => {
     const mockWrite = jest.fn().mockImplementation(() => Promise.resolve());
     navigator.clipboard.write = mockWrite;
-    const result = copy('<div>Text</div>', {
+    const result = await copy('<div>Text</div>', {
       format: 'text/html',
     });
 
@@ -74,14 +74,14 @@ describe('Test copy', () => {
 
   it('format!=text/html via execCommand, When there is no clipboard object', async () => {
     delete (global.navigator as any).clipboard;
-    const result = copy('test copy');
+    const result = await copy('test copy');
     expect(result).toBe(true);
     expect(document.execCommand).toHaveBeenCalledWith('copy');
   });
 
   it('format=text/html via execCommand, When there is no clipboard object', async () => {
     delete (global.navigator as any).clipboard;
-    const result = copy('test copy');
+    const result = await copy('test copy');
     expect(result).toBe(true);
     expect(document.execCommand).toHaveBeenCalledWith('copy');
   });
@@ -89,7 +89,7 @@ describe('Test copy', () => {
   it('copy failed, When the cutting object is not a string', async () => {
     const mockWrite = jest.fn().mockImplementation(() => Promise.resolve());
     navigator.clipboard.write = mockWrite;
-    const result = copy(0 as any);
+    const result = await copy(0 as any);
     expect((console.error as any).mock.lastCall[0]).toContain(
       'The clipboard content must be of string type',
     );

--- a/components/_util/copy.ts
+++ b/components/_util/copy.ts
@@ -43,7 +43,7 @@ const asyncCopy = (text: string, isHtmlFormat: boolean) => {
   }
 };
 
-function copy(text: string, config?: { format?: 'text/plain' | 'text/html' }) {
+async function copy(text: string, config?: { format?: 'text/plain' | 'text/html' }) {
   if (typeof text !== 'string') {
     warning(false, 'The clipboard content must be of string type', '');
     return false;
@@ -51,7 +51,7 @@ function copy(text: string, config?: { format?: 'text/plain' | 'text/html' }) {
 
   const isHtmlFormat = config?.format === 'text/html';
 
-  if (asyncCopy(text, isHtmlFormat)) {
+  if (await asyncCopy(text, isHtmlFormat)) {
     return true;
   }
 

--- a/components/_util/copy.ts
+++ b/components/_util/copy.ts
@@ -25,17 +25,17 @@ const execCopy = (text: string, isHtmlFormat: boolean) => {
   }
 };
 
-const asyncCopy = (text: string, isHtmlFormat: boolean) => {
+const asyncCopy = async (text: string, isHtmlFormat: boolean) => {
   try {
     if (isHtmlFormat) {
-      navigator.clipboard.write([
+      await navigator.clipboard.write([
         new ClipboardItem({
           'text/html': new Blob([text], { type: 'text/html' }),
           'text/plain': new Blob([text], { type: 'text/plain' }),
         }),
       ]);
     } else {
-      navigator.clipboard.writeText(text);
+      await navigator.clipboard.writeText(text);
     }
     return true;
   } catch {

--- a/components/_util/copy.ts
+++ b/components/_util/copy.ts
@@ -1,28 +1,65 @@
 import warning from './warning';
 
-function copy(text: string, config?: { format?: 'text/plain' | 'text/html' }) {
-  const format = config?.format;
+const execCopy = (text: string, isHtmlFormat: boolean) => {
+  let copySuccess = false;
 
+  const onCopy = (event: ClipboardEvent) => {
+    event.stopPropagation();
+    event.preventDefault();
+    event.clipboardData?.clearData();
+    event.clipboardData?.setData('text/plain', text);
+    if (isHtmlFormat) {
+      event.clipboardData?.setData('text/html', text);
+    }
+    copySuccess = true;
+  };
+
+  try {
+    document.addEventListener('copy', onCopy, { capture: true });
+    document.execCommand('copy');
+    return copySuccess;
+  } catch {
+    return false;
+  } finally {
+    document.removeEventListener('copy', onCopy, { capture: true });
+  }
+};
+
+const asyncCopy = (text: string, isHtmlFormat: boolean) => {
+  try {
+    if (isHtmlFormat) {
+      navigator.clipboard.write([
+        new ClipboardItem({
+          'text/html': new Blob([text], { type: 'text/html' }),
+          'text/plain': new Blob([text], { type: 'text/plain' }),
+        }),
+      ]);
+    } else {
+      navigator.clipboard.writeText(text);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+function copy(text: string, config?: { format?: 'text/plain' | 'text/html' }) {
   if (typeof text !== 'string') {
     warning(false, 'The clipboard content must be of string type', '');
     return false;
   }
 
-  try {
-    if (format === 'text/html') {
-      const item = new ClipboardItem({
-        [format]: new Blob([text], { type: format }),
-        'text/plain': new Blob([text], { type: 'text/plain' }),
-      });
-      navigator.clipboard.write([item]);
-    } else {
-      navigator.clipboard.writeText(text);
-    }
+  const isHtmlFormat = config?.format === 'text/html';
 
+  if (asyncCopy(text, isHtmlFormat)) {
     return true;
-  } catch (err) {
-    warning(false, 'Clipboard API failed:', String(err));
   }
+
+  if (execCopy(text, isHtmlFormat)) {
+    return true;
+  }
+
+  return false;
 }
 
 export default copy;

--- a/components/typography/hooks/useCopyClick.ts
+++ b/components/typography/hooks/useCopyClick.ts
@@ -39,7 +39,7 @@ const useCopyClick = ({
     try {
       const text =
         typeof copyConfig.text === 'function' ? await copyConfig.text() : copyConfig.text;
-      copy(text || toList(children, true).join('') || '', copyOptions);
+      await copy(text || toList(children, true).join('') || '', copyOptions);
       setCopyLoading(false);
 
       setCopied(true);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [X] 🐞 Bug fix

### 🔗 Related Issues

Update for #53383

在 #53427 中，使用 [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard) 替换了 `copy-to-clipboard` 后，HTTP 网站上的剪贴板复制功能将失效（Clipboard API 只可在安全上下文中使用）。

### 💡 Solution

在非安全上下文及其它不支持 Clipboard API 的环境中，将复制方案降级为 execCommand('copy')  方案

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |Support clipboard copy on HTTP sites|
| 🇨🇳 Chinese |支持在 HTTP 网站上使用剪贴板复制功能|
