### PR TITLE
docs(AutoComplete): add underlined variant demo

### DIFF
--- a/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3130,6 +3130,53 @@ exports[`renders components/auto-complete/demo/variant.tsx extend context correc
       </div>
     </div>
   </div>
+   <div
+    class="ant-select ant-select-underlined ant-select-auto-complete ant-select-single ant-select-show-search"
+    style="width: 200px;"
+  >
+    <div
+      class="ant-select-selector"
+    >
+      <span
+        class="ant-select-selection-wrap"
+      >
+        <span
+          class="ant-select-selection-search"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-controls="rc_select_TEST_OR_SSR_list"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-owns="rc_select_TEST_OR_SSR_list"
+            autocomplete="off"
+            class="ant-select-selection-search-input"
+            id="rc_select_TEST_OR_SSR"
+            role="combobox"
+            type="search"
+            value=""
+          />
+        </span>
+        <span
+          class="ant-select-selection-placeholder"
+        >
+          Underlined
+        </span>
+      </span>
+    </div>
+    <div
+      class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-select-dropdown-empty ant-select-dropdown-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+    >
+      <div>
+        <div
+          class="ant-select-item-empty"
+          id="rc_select_TEST_OR_SSR_list"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
 </div>
 `;
 

--- a/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3130,7 +3130,7 @@ exports[`renders components/auto-complete/demo/variant.tsx extend context correc
       </div>
     </div>
   </div>
-   <div
+  <div
     class="ant-select ant-select-underlined ant-select-auto-complete ant-select-single ant-select-show-search"
     style="width: 200px;"
   >

--- a/components/auto-complete/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1850,5 +1850,39 @@ exports[`renders components/auto-complete/demo/variant.tsx correctly 1`] = `
       </span>
     </div>
   </div>
+  <div
+    class="ant-select ant-select-underlined ant-select-auto-complete ant-select-single ant-select-show-search"
+    style="width:200px"
+  >
+    <div
+      class="ant-select-selector"
+    >
+      <span
+        class="ant-select-selection-wrap"
+      >
+        <span
+          class="ant-select-selection-search"
+        >
+          <input
+            aria-autocomplete="list"
+            aria-controls="undefined_list"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-owns="undefined_list"
+            autocomplete="off"
+            class="ant-select-selection-search-input"
+            role="combobox"
+            type="search"
+            value=""
+          />
+        </span>
+        <span
+          class="ant-select-selection-placeholder"
+        >
+          Underlined
+        </span>
+      </span>
+    </div>
+  </div>
 </div>
 `;

--- a/components/auto-complete/demo/variant.md
+++ b/components/auto-complete/demo/variant.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-可选 `outlined` `filled` `borderless` 三种形态。
+可选 `outlined` `filled` `borderless` `underlined` 四种形态。
 
 ## en-US
 
-There are `outlined` `filled` and `borderless`, totally three variants to choose from.
+There are `outlined` `filled` `borderless` and `underlined`, totally four variants to choose from.

--- a/components/auto-complete/demo/variant.md
+++ b/components/auto-complete/demo/variant.md
@@ -4,4 +4,4 @@
 
 ## en-US
 
-There are `outlined` `filled` `borderless` and `underlined`, totally four variants to choose from.
+There are `outlined`, `filled`, `borderless`, and `underlined` variants to choose from.

--- a/components/auto-complete/demo/variant.tsx
+++ b/components/auto-complete/demo/variant.tsx
@@ -37,6 +37,14 @@ const App: React.FC = () => {
         onSelect={globalThis.console.log}
         variant="borderless"
       />
+      <AutoComplete
+        options={options}
+        style={{ width: 200 }}
+        placeholder="Underlined"
+        onSearch={(text) => setOptions(getPanelValue(text))}
+        onSelect={globalThis.console.log}
+        variant="underlined"
+      />
     </Flex>
   );
 };

--- a/components/auto-complete/index.en-US.md
+++ b/components/auto-complete/index.en-US.md
@@ -68,7 +68,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | size | The size of the input box | `large` \| `middle` \| `small` | - |  |
 | value | Selected option | string | - |  |
 | styles | Semantic DOM style | [Record<SemanticDOM, CSSProperties>](#semantic-dom) | - | 5.25.0 |
-| variant | Variants of input | `outlined` \| `borderless` \| `filled` | `outlined` | 5.13.0 |
+| variant | Variants of input | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 |
 | virtual | Disable virtual scroll when set to false | boolean | true | 4.1.0 |
 | onBlur | Called when leaving the component | function() | - |  |
 | onChange | Called when selecting an option or changing an input value | function(value) | - |  |

--- a/components/auto-complete/index.zh-CN.md
+++ b/components/auto-complete/index.zh-CN.md
@@ -69,7 +69,7 @@ demo:
 | size | 控件大小 | `large` \| `middle` \| `small` | - |  |
 | styles | 语义化结构 style | [Record<SemanticDOM, CSSProperties>](#semantic-dom) | - | 5.25.0 |
 | value | 指定当前选中的条目 | string | - |  |
-| variant | 形态变体 | `outlined` \| `borderless` \| `filled` | `outlined` | 5.13.0 |
+| variant | 形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 |
 | virtual | 设置 false 时关闭虚拟滚动 | boolean | true | 4.1.0 |
 | onBlur | 失去焦点时的回调 | function() | - |  |
 | onChange | 选中 option，或 input 的 value 变化时，调用此函数 | function(value) | - |  |


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

none

### 💡 Background and Solution

AutoComplete 组件基于 Select 组件实现，后者支持 `underlined` 变体，AutoComplete 实际上也支持 `underlined` 变体。故在文档上透出 `underlined` 变体的 demo。

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Add underlined variant demo  |
| 🇨🇳 Chinese | 补充 underlined 变体的代码示例  |
