### PR TITLE
fix: Modify Segmented to import tooltips from  antd

### DIFF
--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -7,7 +7,6 @@ import type {
 } from '@rc-component/segmented';
 import RcSegmented from '@rc-component/segmented';
 import useId from '@rc-component/util/lib/hooks/useId';
-import { Tooltip, TooltipProps } from 'antd';
 import classNames from 'classnames';
 
 import useMergeSemantic from '../_util/hooks/useMergeSemantic';
@@ -16,6 +15,7 @@ import type { Orientation } from '../_util/hooks/useOrientation';
 import { useComponentConfig } from '../config-provider/context';
 import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';
+import Tooltip, { TooltipProps } from '../tooltip';
 import useStyle from './style';
 
 export type { SegmentedValue } from '@rc-component/segmented';

--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -15,7 +15,8 @@ import type { Orientation } from '../_util/hooks/useOrientation';
 import { useComponentConfig } from '../config-provider/context';
 import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';
-import Tooltip, { TooltipProps } from '../tooltip';
+import Tooltip from '../tooltip';
+import type { TooltipProps } from '../tooltip';
 import useStyle from './style';
 
 export type { SegmentedValue } from '@rc-component/segmented';


### PR DESCRIPTION


### 🤔 This is a ...

- [X] 🐞 Bug fix


### 🔗 Related Issues



### 💡 Background and Solution

<img width="2910" height="1116" alt="image" src="https://github.com/user-attachments/assets/3f0140af-0556-4e22-8036-1510e1389586" />


### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Modify Segmented to import tooltips from  antd      |
| 🇨🇳 Chinese |     修复Segmented从antd顶层引入Tooltip导致的错误      |
