### PR TITLE
feat(date-picker): Add suffix icon and separator color configuration.

### DIFF
--- a/components/date-picker/demo/component-token.tsx
+++ b/components/date-picker/demo/component-token.tsx
@@ -24,6 +24,8 @@ const App: React.FC = () => (
             cellHeight: 40,
             textHeight: 45,
             withoutTimeCellHeight: 70,
+            suffixIconColor: 'blue',
+            separatorColor: 'green',
           },
         },
       }}

--- a/components/date-picker/style/index.ts
+++ b/components/date-picker/style/index.ts
@@ -88,6 +88,8 @@ const genPickerStyle: GenerateStyle<PickerToken> = (token) => {
     boxShadowPopoverArrow,
     fontHeight,
     lineHeightLG,
+    suffixIconColor,
+    separatorColor,
   } = token;
 
   return [
@@ -174,7 +176,7 @@ const genPickerStyle: GenerateStyle<PickerToken> = (token) => {
           flex: 'none',
           alignSelf: 'center',
           marginInlineStart: token.calc(paddingXS).div(2).equal(),
-          color: colorTextDisabled,
+          color: suffixIconColor,
           lineHeight: 1,
           pointerEvents: 'none',
           transition: `opacity ${motionDurationMid}, color ${motionDurationMid}`,
@@ -225,7 +227,7 @@ const genPickerStyle: GenerateStyle<PickerToken> = (token) => {
           display: 'inline-block',
           width: '1em',
           height: fontSizeLG,
-          color: colorTextDisabled,
+          color: separatorColor,
           fontSize: fontSizeLG,
           verticalAlign: 'top',
           cursor: 'default',

--- a/components/date-picker/style/token.ts
+++ b/components/date-picker/style/token.ts
@@ -94,6 +94,16 @@ export interface ComponentToken
    * @descEN z-index of popup
    */
   zIndexPopup: number;
+  /**
+   * @desc 后缀日期图标颜色
+   * @descEN Color of suffix icon
+   */
+  suffixIconColor: string;
+  /**
+   * @desc 分隔符颜色
+   * @descEN Color of separator
+   */
+  separatorColor: string;
 }
 
 export type PickerPanelToken = {
@@ -205,4 +215,6 @@ export const prepareComponentToken: GetDefaultToken<'DatePicker'> = (token) => (
   presetsWidth: 120,
   presetsMaxWidth: 200,
   zIndexPopup: token.zIndexPopupBase + 50,
+  suffixIconColor: token.colorTextDisabled,
+  separatorColor: token.colorTextDisabled,
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
close #55024 
> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution
新增两个token属性
- suffixIconColor 后缀日期图标颜色 Color of suffix icon
- separatorColor 分隔符颜色 Color of separator

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Add suffix icon and separator color configuration   |
| 🇨🇳 Chinese |  增加分隔符颜色跟后缀日期图标颜色配置   |
