### PR TITLE
fix(list): adjust bordered list overflow styling

### DIFF
--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -94,10 +94,10 @@ const genBorderedStyle = (token: ListToken): CSSObject => {
   } = token;
 
   // Inner radius = Outer radius - border width; this prevents white gaps from appearing at the top corners.
-  const topCornerBorderRadius = `${unit(token.calc(borderRadiusLG).sub(token.lineWidth).equal())}`;
+  const topCornerBorderRadius = unit(token.calc(borderRadiusLG).sub(token.lineWidth).equal());
 
   // Inner radius = Outer radius - border width; this prevents white gaps from appearing at the bottom corners.
-  const bottomCornerBorderRadius = `${unit(token.calc(borderRadiusLG).sub(token.lineWidth).equal())}`;
+  const bottomCornerBorderRadius = unit(token.calc(borderRadiusLG).sub(token.lineWidth).equal());
 
   return {
     [listBorderedCls]: {

--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -94,9 +94,20 @@ const genBorderedStyle = (token: ListToken): CSSObject => {
   } = token;
   return {
     [listBorderedCls]: {
-      overflow: 'hidden',
       border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
       borderRadius: borderRadiusLG,
+      // Inner radius = Outer radius - border width; this prevents white gaps from appearing at the top corners.
+      [`${componentCls}-header`]: {
+        borderTopLeftRadius: token.calc(borderRadiusLG).sub(token.lineWidth).equal(),
+        borderTopRightRadius: token.calc(borderRadiusLG).sub(token.lineWidth).equal(),
+      },
+
+      // Inner radius = Outer radius - border width; this prevents white gaps from appearing at the bottom corners.
+      [`${componentCls}-footer`]: {
+        borderBottomLeftRadius: token.calc(borderRadiusLG).sub(token.lineWidth).equal(),
+        borderBottomRightRadius: token.calc(borderRadiusLG).sub(token.lineWidth).equal(),
+      },
+
       [`${componentCls}-header,${componentCls}-footer,${componentCls}-item`]: {
         paddingInline: paddingLG,
       },

--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -92,20 +92,23 @@ const genBorderedStyle = (token: ListToken): CSSObject => {
     marginLG,
     borderRadiusLG,
   } = token;
+
+  // Inner radius = Outer radius - border width; this prevents white gaps from appearing at the top corners.
+  const topCornerBorderRadius = `${unit(token.calc(borderRadiusLG).sub(token.lineWidth).equal())}`;
+
+  // Inner radius = Outer radius - border width; this prevents white gaps from appearing at the bottom corners.
+  const bottomCornerBorderRadius = `${unit(token.calc(borderRadiusLG).sub(token.lineWidth).equal())}`;
+
   return {
     [listBorderedCls]: {
       border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
       borderRadius: borderRadiusLG,
-      // Inner radius = Outer radius - border width; this prevents white gaps from appearing at the top corners.
       [`${componentCls}-header`]: {
-        borderTopLeftRadius: token.calc(borderRadiusLG).sub(token.lineWidth).equal(),
-        borderTopRightRadius: token.calc(borderRadiusLG).sub(token.lineWidth).equal(),
+        borderRadius: `${topCornerBorderRadius} ${topCornerBorderRadius} 0 0`,
       },
 
-      // Inner radius = Outer radius - border width; this prevents white gaps from appearing at the bottom corners.
       [`${componentCls}-footer`]: {
-        borderBottomLeftRadius: token.calc(borderRadiusLG).sub(token.lineWidth).equal(),
-        borderBottomRightRadius: token.calc(borderRadiusLG).sub(token.lineWidth).equal(),
+        borderRadius: `0 0 ${bottomCornerBorderRadius} ${bottomCornerBorderRadius}`,
       },
 
       [`${componentCls}-header,${componentCls}-footer,${componentCls}-item`]: {

--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -94,6 +94,7 @@ const genBorderedStyle = (token: ListToken): CSSObject => {
   } = token;
   return {
     [listBorderedCls]: {
+      overflow: 'hidden',
       border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
       borderRadius: borderRadiusLG,
       [`${componentCls}-header,${componentCls}-footer,${componentCls}-item`]: {


### PR DESCRIPTION
### 🤔 This is a ...

- [X] 💄 Component style improvement

### 🔗 Related Issues

None

### 💡 Background and Solution

> - List with `bordered` has overflow issue styling with it's `header` and `footer`

**Solution:**
Apply overflow hidden to `bordered` List to avoid this issue

**Before**
<img width="1751" height="97" alt="image" src="https://github.com/user-attachments/assets/82b4a548-8541-451d-bcba-1f2c40a8be83" />
<img width="1739" height="87" alt="image" src="https://github.com/user-attachments/assets/f032dda8-4717-445c-94d4-65c4793d4a6d" />


**After**
<img width="1754" height="100" alt="image" src="https://github.com/user-attachments/assets/68bacf11-8b58-42ef-ab5a-6c894fcf2a20" />
<img width="1746" height="108" alt="image" src="https://github.com/user-attachments/assets/3886357f-87a7-4df8-95fe-1c1eb3626443" />




### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix(list): adjust bordered list overflow styling   |
| 🇨🇳 Chinese |  修复（列表）：调整有边框的列表溢出样式     |
