### PR TITLE
refactor: Use indexOf instead of findIndex for index lookup

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -47,7 +47,6 @@
       "complexity": {
         "useDateNow": "off",
         "noImportantStyles": "off",
-        "useIndexOf": "off",
         "useOptionalChain": "off"
       },
       "correctness": {

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -278,7 +278,7 @@ const useFilter = <RecordType extends AnyObject = AnyObject>(
       return filterStates
         .filter(({ key }) => keyList.includes(key))
         .map((item) => {
-          const col = mergedColumns[keyList.findIndex((key) => key === item.key)];
+          const col = mergedColumns[keyList.indexOf(item.key)];
           return {
             ...item,
             column: {

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -564,7 +564,7 @@ const useSelection = <RecordType extends AnyObject = AnyObject>(
                 onChange={(event) => {
                   const { nativeEvent } = event;
                   const { shiftKey } = nativeEvent;
-                  const currentSelectedIndex = recordKeys.findIndex((item) => item === key);
+                  const currentSelectedIndex = recordKeys.indexOf(key);
                   const isMultiple = derivedSelectedKeys.some((item) => recordKeys.includes(item));
 
                   if (shiftKey && checkStrictly && isMultiple) {


### PR DESCRIPTION


### 🤔 This is a ...

- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

```
  ℹ Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.

    565 │                   const { nativeEvent } = event;
    566 │                   const { shiftKey } = nativeEvent;
  > 567 │                   const currentSelectedIndex = recordKeys.findIndex((item) => item === key);
        │                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    568 │                   const isMultiple = derivedSelectedKeys.some((item) => recordKeys.includes(item));        
    569 │ 

ead.
```

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      -     |
| 🇨🇳 Chinese |      -     |
