### PR TITLE
refactor[Table]: Replace useMergedState to useControlledState

### DIFF
--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -2999,7 +2999,7 @@ describe('Table.filter', () => {
     expect(container.querySelector<HTMLInputElement>('input[type="checkbox"]')!.checked).toEqual(
       true,
     );
-
+    fireEvent.click(container.querySelector('.ant-btn-primary')!);
     // Table data changes while the dropdown is open and a user is setting filters.
     rerender(createTable({ ...tableProps, dataSource: [{ name: 'Foo' }] }));
 

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -7,7 +7,7 @@ import type { DataNode, GetCheckDisabled } from '@rc-component/tree/lib/interfac
 import { arrAdd, arrDel } from '@rc-component/tree/lib/util';
 import { conductCheck } from '@rc-component/tree/lib/utils/conductUtil';
 import { convertDataToEntities } from '@rc-component/tree/lib/utils/treeUtil';
-import { useMergedState } from '@rc-component/util';
+import { useControlledState } from '@rc-component/util';
 import classNames from 'classnames';
 
 import useMultipleSelect from '../../_util/hooks/useMultipleSelect';
@@ -117,11 +117,9 @@ const useSelection = <RecordType extends AnyObject = AnyObject>(
   );
 
   // ========================= Keys =========================
-  const [mergedSelectedKeys, setMergedSelectedKeys] = useMergedState(
-    selectedRowKeys || defaultSelectedRowKeys || EMPTY_LIST,
-    {
-      value: selectedRowKeys,
-    },
+  const [mergedSelectedKeys, setMergedSelectedKeys] = useControlledState(
+    defaultSelectedRowKeys || EMPTY_LIST,
+    selectedRowKeys,
   );
   // const [mergedSelectedKeys, setMergedSelectedKeys] = useControlledState(
   //   selectedRowKeys || defaultSelectedRowKeys || EMPTY_LIST,

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -121,10 +121,6 @@ const useSelection = <RecordType extends AnyObject = AnyObject>(
     defaultSelectedRowKeys || EMPTY_LIST,
     selectedRowKeys,
   );
-  // const [mergedSelectedKeys, setMergedSelectedKeys] = useControlledState(
-  //   selectedRowKeys || defaultSelectedRowKeys || EMPTY_LIST,
-  //   selectedRowKeys,
-  // );
 
   // ======================== Caches ========================
   const preserveRecordsRef = React.useRef(new Map<Key, RecordType>());


### PR DESCRIPTION


### 🤔 This is a ...

- [X] 🛠 Refactoring


### 🔗 Related Issues
close https://github.com/ant-design/ant-design/issues/54854

### 💡 Background and Solution

https://github.com/react-component/util/pull/673

### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     refactor[Table]: Replace useMergedState to useControlledState       |
| 🇨🇳 Chinese |     Table 组件中使用的 useMergedState 替换为 useControlledState     |
