### PR TITLE
feat: Add defaultRequest to customRequest

### DIFF
--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -53,7 +53,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | accept | File types that can be accepted. See [input accept Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) | string | - |  |
 | action | Uploading URL | string \| (file) => Promise&lt;string> | - |  |
 | beforeUpload | Hook function which will be executed before uploading. Uploading will be stopped with `false` or a rejected Promise returned. When returned value is `Upload.LIST_IGNORE`, the list of files that have been uploaded will ignore it. **Warning：this function is not supported in IE9** | (file, fileList) => boolean \| Promise&lt;File> \| `Upload.LIST_IGNORE` | - |  |
-| customRequest | Override for the default xhr behavior allowing for additional customization and the ability to implement your own XMLHttpRequest | ( options: RequestOptions, info: { defaultRequest: (option: RequestOptions) => void; } ) => void | - |  |
+| customRequest | Override for the default xhr behavior allowing for additional customization and the ability to implement your own XMLHttpRequest | ( options: [RequestOptions](#requestoptions), info: { defaultRequest: (option: [RequestOptions](#requestoptions)) => void; } ) => void | - |  |
 | data | Uploading extra params or function which can return uploading extra params | object \| (file) => object \| Promise&lt;object> | - |  |
 | defaultFileList | Default list of files that have been uploaded | object\[] | - |  |
 | directory | Support upload whole directory ([caniuse](https://caniuse.com/#feat=input-file-directory)) | boolean | false |  |

--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -94,6 +94,21 @@ Extends File with additional props.
 | uid | unique id. Will auto-generate when not provided | string | - | - |
 | url | Download url | string | - | - |
 
+### RequestOptions
+
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| action | Uploading URL | string | - | - |
+| data | Uploading extra params or function which can return uploading extra params | Record<string, unknown> | - | 4.20.0 |
+| filename | file name | string | - | - |
+| file | File object containing upload information | [UploadFile](#uploadfile) | - | - |
+| withCredentials | The ajax upload with cookie sent | boolean | - | - |
+| headers | Set request headers, valid above IE10 | Record<string, string> | - | - |
+| method | The http method of upload request | string | - | - |
+| onProgress | Progress event callback | (event: object, file:UploadFile ) => void | - | - |
+| onError | Error callback when upload fails | (event: object, body?: object) => void | - | - |
+| onSuccess | Success callback when upload completes | (body: object, fileOrXhr?: UploadFile \| XMLHttpRequest) | - | - |
+
 ### onChange
 
 > 💡 The function will be called when uploading is in progress, completed, or failed.

--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -53,7 +53,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | accept | File types that can be accepted. See [input accept Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) | string | - |  |
 | action | Uploading URL | string \| (file) => Promise&lt;string> | - |  |
 | beforeUpload | Hook function which will be executed before uploading. Uploading will be stopped with `false` or a rejected Promise returned. When returned value is `Upload.LIST_IGNORE`, the list of files that have been uploaded will ignore it. **Warning：this function is not supported in IE9** | (file, fileList) => boolean \| Promise&lt;File> \| `Upload.LIST_IGNORE` | - |  |
-| customRequest | Override for the default xhr behavior allowing for additional customization and the ability to implement your own XMLHttpRequest | function | - |  |
+| customRequest | Override for the default xhr behavior allowing for additional customization and the ability to implement your own XMLHttpRequest | ( options: RequestOptions, info: { defaultRequest: (option: RequestOptions) => void; } ) => void | - |  |
 | data | Uploading extra params or function which can return uploading extra params | object \| (file) => object \| Promise&lt;object> | - |  |
 | defaultFileList | Default list of files that have been uploaded | object\[] | - |  |
 | directory | Support upload whole directory ([caniuse](https://caniuse.com/#feat=input-file-directory)) | boolean | false |  |

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -54,7 +54,7 @@ demo:
 | accept | 接受上传的文件类型，详见 [input accept Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) | string | - |  |
 | action | 上传的地址 | string \| (file) => Promise&lt;string> | - |  |
 | beforeUpload | 上传文件之前的钩子，参数为上传的文件，若返回 `false` 则停止上传。支持返回一个 Promise 对象，Promise 对象 reject 时则停止上传，resolve 时开始上传（ resolve 传入 `File` 或 `Blob` 对象则上传 resolve 传入对象）；也可以返回 `Upload.LIST_IGNORE`，此时列表中将不展示此文件。 **注意：IE9 不支持该方法** | (file, fileList) => boolean \| Promise&lt;File> \| `Upload.LIST_IGNORE` | - |  |
-| customRequest | 通过覆盖默认的上传行为，可以自定义自己的上传实现 | function | - |  |
+| customRequest | 通过覆盖默认的上传行为，可以自定义自己的上传实现 | ( options: RequestOptions, info: { defaultRequest: (option: RequestOptions) => void; }, ) => void | - |  |
 | data | 上传所需额外参数或返回上传额外参数的方法 | object\|(file) => object \| Promise&lt;object> | - |  |
 | defaultFileList | 默认已经上传的文件列表 | object\[] | - |  |
 | directory | 支持上传文件夹（[caniuse](https://caniuse.com/#feat=input-file-directory)） | boolean | false |  |
@@ -94,6 +94,21 @@ demo:
 | thumbUrl | 缩略图地址 | string | - | - |
 | uid | 唯一标识符，不设置时会自动生成 | string | - | - |
 | url | 下载地址 | string | - | - |
+
+### RequestOptions
+
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| action | 上传的地址 | string | - | - |
+| data | CORS 属性设置 | Record<string, unknown> | - | - |
+| filename | 文件名 | string | - | - |
+| file | 文件信息 | [UploadFile](#uploadfile) | - | - |
+| withCredentials | 上传请求时是否携带 cookie | boolean | - | - |
+| headers | 上传的请求头部 | Record<string, string> | - | - |
+| method | 上传请求的 http method | string | - | - |
+| onProgress | 上传进度回调 | (event: object, file:UploadFile ) => void | - | - |
+| onError | 上传失败回调 | (event: object, body?: object) => void | - | - |
+| onSuccess | 上传成功回调 | (body: object, fileOrXhr?: UploadFile \| XMLHttpRequest) | - | - |
 
 ### onChange
 

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -54,7 +54,7 @@ demo:
 | accept | 接受上传的文件类型，详见 [input accept Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) | string | - |  |
 | action | 上传的地址 | string \| (file) => Promise&lt;string> | - |  |
 | beforeUpload | 上传文件之前的钩子，参数为上传的文件，若返回 `false` 则停止上传。支持返回一个 Promise 对象，Promise 对象 reject 时则停止上传，resolve 时开始上传（ resolve 传入 `File` 或 `Blob` 对象则上传 resolve 传入对象）；也可以返回 `Upload.LIST_IGNORE`，此时列表中将不展示此文件。 **注意：IE9 不支持该方法** | (file, fileList) => boolean \| Promise&lt;File> \| `Upload.LIST_IGNORE` | - |  |
-| customRequest | 通过覆盖默认的上传行为，可以自定义自己的上传实现 | ( options: RequestOptions, info: { defaultRequest: (option: RequestOptions) => void; } ) => void | - |  |
+| customRequest | 通过覆盖默认的上传行为，可以自定义自己的上传实现 | ( options: [RequestOptions](#requestoptions), info: { defaultRequest: (option: [RequestOptions](#requestoptions)) => void; } ) => void | - |  |
 | data | 上传所需额外参数或返回上传额外参数的方法 | object\|(file) => object \| Promise&lt;object> | - |  |
 | defaultFileList | 默认已经上传的文件列表 | object\[] | - |  |
 | directory | 支持上传文件夹（[caniuse](https://caniuse.com/#feat=input-file-directory)） | boolean | false |  |

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -54,7 +54,7 @@ demo:
 | accept | 接受上传的文件类型，详见 [input accept Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) | string | - |  |
 | action | 上传的地址 | string \| (file) => Promise&lt;string> | - |  |
 | beforeUpload | 上传文件之前的钩子，参数为上传的文件，若返回 `false` 则停止上传。支持返回一个 Promise 对象，Promise 对象 reject 时则停止上传，resolve 时开始上传（ resolve 传入 `File` 或 `Blob` 对象则上传 resolve 传入对象）；也可以返回 `Upload.LIST_IGNORE`，此时列表中将不展示此文件。 **注意：IE9 不支持该方法** | (file, fileList) => boolean \| Promise&lt;File> \| `Upload.LIST_IGNORE` | - |  |
-| customRequest | 通过覆盖默认的上传行为，可以自定义自己的上传实现 | ( options: RequestOptions, info: { defaultRequest: (option: RequestOptions) => void; }, ) => void | - |  |
+| customRequest | 通过覆盖默认的上传行为，可以自定义自己的上传实现 | ( options: RequestOptions, info: { defaultRequest: (option: RequestOptions) => void; } ) => void | - |  |
 | data | 上传所需额外参数或返回上传额外参数的方法 | object\|(file) => object \| Promise&lt;object> | - |  |
 | defaultFileList | 默认已经上传的文件列表 | object\[] | - |  |
 | directory | 支持上传文件夹（[caniuse](https://caniuse.com/#feat=input-file-directory)） | boolean | false |  |

--- a/components/upload/interface.ts
+++ b/components/upload/interface.ts
@@ -120,7 +120,12 @@ export interface UploadProps<T = any>
   style?: React.CSSProperties;
   disabled?: boolean;
   prefixCls?: string;
-  customRequest?: (options: RcCustomRequestOptions<T>) => void;
+  customRequest?: (
+    options: RcCustomRequestOptions<T>,
+    info: {
+      defaultRequest: (option: RcCustomRequestOptions) => void;
+    },
+  ) => void;
   withCredentials?: boolean;
   openFileDialogOnClick?: boolean;
   locale?: UploadLocale;

--- a/components/upload/interface.ts
+++ b/components/upload/interface.ts
@@ -123,7 +123,7 @@ export interface UploadProps<T = any>
   customRequest?: (
     options: RcCustomRequestOptions<T>,
     info: {
-      defaultRequest: (option: RcCustomRequestOptions) => void;
+      defaultRequest: (option: RcCustomRequestOptions<T>) => void;
     },
   ) => void;
   withCredentials?: boolean;

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "rc-tooltip": "~6.4.0",
     "rc-tree": "~5.13.1",
     "rc-tree-select": "~5.27.0",
-    "rc-upload": "~4.9.2",
+    "rc-upload": "~4.11.0",
     "rc-util": "^5.44.4",
     "scroll-into-view-if-needed": "^3.1.0",
     "throttle-debounce": "^5.0.2"

--- a/scripts/__snapshots__/check-site.ts.snap
+++ b/scripts/__snapshots__/check-site.ts.snap
@@ -268,9 +268,9 @@ exports[`site test Component components/typography en Page 1`] = `6`;
 
 exports[`site test Component components/typography zh Page 1`] = `6`;
 
-exports[`site test Component components/upload en Page 1`] = `2`;
+exports[`site test Component components/upload en Page 1`] = `3`;
 
-exports[`site test Component components/upload zh Page 1`] = `2`;
+exports[`site test Component components/upload zh Page 1`] = `3`;
 
 exports[`site test Component components/watermark en Page 1`] = `2`;
 


### PR DESCRIPTION
### 🤔 This is a ...

- [X] 🆕 New feature


### 🔗 Related Issues
close https://github.com/ant-design/ant-design/issues/54457

### 💡 Background and Solution


### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Add info.defaultRequest to the customRequest parameter     |
| 🇨🇳 Chinese |      在customRequest 参数中增加 info.defaultRequest     |
