### PR TITLE
fix: float button & float button group disabled prop type

### DIFF
--- a/components/float-button/interface.ts
+++ b/components/float-button/interface.ts
@@ -37,6 +37,7 @@ export interface FloatButtonProps extends React.DOMAttributes<FloatButtonElement
    */
   htmlType?: ButtonHTMLType;
   'aria-label'?: React.HtmlHTMLAttributes<HTMLElement>['aria-label'];
+  disabled?: boolean;
 }
 
 export interface FloatButtonContentProps extends React.DOMAttributes<HTMLDivElement> {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

N/A

### 💡 Background and Solution

disabled prop is missing in type definition but still works

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  fix type not found error |
| 🇨🇳 Chinese |           |
