### PR TITLE
chore: bump eslint-plugin-react-refresh from 0.4.14 to 0.4.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
     "eslint-plugin-jest": "^29.0.1",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "eslint-plugin-react-refresh": "^0.4.14",
+    "eslint-plugin-react-refresh": "^0.4.22",
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",
     "gh-pages": "^6.2.0",


### PR DESCRIPTION


### 🤔 This is a ...


- [ ] ❓ Other (about what?)


### 💡 Background and Solution

理论上 antd 没锁包，不需要做这样子的 bump，但是为了验证一个功能，和处理一个强迫症错误。

很奇怪，rerun 多次无果，为了避免 master 的 ci 错误起到干扰作用，还是提个 PR 测试一下 ci 能不能正常通过。


<img width="1448" height="286" alt="image" src="https://github.com/user-attachments/assets/85a01317-e39b-4322-a93f-fbf7797c6b76" />



https://github.com/ant-design/ant-design/pull/55174#issuecomment-3342369424


<img width="1429" height="1348" alt="image" src="https://github.com/user-attachments/assets/e7da8a86-1e66-40ae-9156-f2885630c020" />


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        -   |
| 🇨🇳 Chinese |     -      |
