### PR TITLE
fix: Remove unwanted space in between arrow head and arrow body

### DIFF
--- a/components/style/placementArrow.ts
+++ b/components/style/placementArrow.ts
@@ -85,7 +85,7 @@ export default function getArrowStyle<
           `&-placement-topRight > ${componentCls}-arrow`,
         ].join(',')]: {
           bottom: arrowDistance,
-          transform: 'translateY(100%) rotate(180deg)',
+          transform: 'translateY(95%) rotate(180deg)',
         },
 
         [`&-placement-top > ${componentCls}-arrow`]: {
@@ -93,7 +93,7 @@ export default function getArrowStyle<
             _skip_check_: true,
             value: '50%',
           },
-          transform: 'translateX(-50%) translateY(100%) rotate(180deg)',
+          transform: 'translateX(-50%) translateY(95%) rotate(180deg)',
         },
 
         '&-placement-topLeft': {
@@ -127,7 +127,7 @@ export default function getArrowStyle<
           `&-placement-bottomRight > ${componentCls}-arrow`,
         ].join(',')]: {
           top: arrowDistance,
-          transform: `translateY(-100%)`,
+          transform: `translateY(-95%)`,
         },
 
         [`&-placement-bottom > ${componentCls}-arrow`]: {
@@ -135,7 +135,7 @@ export default function getArrowStyle<
             _skip_check_: true,
             value: '50%',
           },
-          transform: `translateX(-50%) translateY(-100%)`,
+          transform: `translateX(-50%) translateY(-95%)`,
         },
 
         '&-placement-bottomLeft': {
@@ -172,7 +172,7 @@ export default function getArrowStyle<
             _skip_check_: true,
             value: arrowDistance,
           },
-          transform: 'translateX(100%) rotate(90deg)',
+          transform: 'translateX(95%) rotate(90deg)',
         },
 
         [`&-placement-left > ${componentCls}-arrow`]: {
@@ -180,7 +180,7 @@ export default function getArrowStyle<
             _skip_check_: true,
             value: '50%',
           },
-          transform: 'translateY(-50%) translateX(100%) rotate(90deg)',
+          transform: 'translateY(-50%) translateX(95%) rotate(90deg)',
         },
 
         [`&-placement-leftTop > ${componentCls}-arrow`]: {
@@ -203,7 +203,7 @@ export default function getArrowStyle<
             _skip_check_: true,
             value: arrowDistance,
           },
-          transform: 'translateX(-100%) rotate(-90deg)',
+          transform: 'translateX(-95%) rotate(-90deg)',
         },
 
         [`&-placement-right > ${componentCls}-arrow`]: {
@@ -211,7 +211,7 @@ export default function getArrowStyle<
             _skip_check_: true,
             value: '50%',
           },
-          transform: 'translateY(-50%) translateX(-100%) rotate(-90deg)',
+          transform: 'translateY(-50%) translateX(-95%) rotate(-90deg)',
         },
 
         [`&-placement-rightTop > ${componentCls}-arrow`]: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx
fix #55038 

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.
- There was transform property applied on the arrow, which was moving it more than expected, So, I have decreased the value of the transform

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix: Ensure there is no space between arrow and popover of a tooltip and other related components even after scaling |
| 🇨🇳 Chinese | 修复：确保即使在缩放后，工具提示的箭头和弹出窗口与其他相关组件之间也没有空格 |
