### PR TITLE
perf: keep LoadingIcon in memo

### DIFF
--- a/components/cascader/hooks/useColumnIcons.tsx
+++ b/components/cascader/hooks/useColumnIcons.tsx
@@ -9,10 +9,13 @@ const useColumnIcons = (prefixCls: string, rtl: boolean, expandIcon?: React.Reac
     mergedExpandIcon = rtl ? <LeftOutlined /> : <RightOutlined />;
   }
 
-  const loadingIcon = (
-    <span className={`${prefixCls}-menu-item-loading-icon`}>
-      <LoadingOutlined spin />
-    </span>
+  const loadingIcon = React.useMemo(
+    () => (
+      <span className={`${prefixCls}-menu-item-loading-icon`}>
+        <LoadingOutlined spin />
+      </span>
+    ),
+    [prefixCls],
   );
 
   return React.useMemo<Readonly<[React.ReactNode, React.ReactNode]>>(


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [x] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

在上一个 PR #55273 中给 memo 添加了遗漏的依赖，但是看 coderabbitai 评论担心会存在 JSX 对象重新计算的问题，所以把 LoadingIcon 也丢进 memo 里面缓存起来

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | perf: keep LoadingIcon in memo |
| 🇨🇳 Chinese | perf: keep LoadingIcon in memo |