### PR TITLE
revert: "fix(upload): handle maxCount negative value validation"

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -125,7 +125,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
     // Cut to match count
     if (maxCount === 1) {
       cloneList = cloneList.slice(-1);
-    } else if (typeof maxCount === 'number' && Number.isFinite(maxCount) && maxCount > 0) {
+    } else if (maxCount) {
       exceedMaxCount = cloneList.length > maxCount;
       cloneList = cloneList.slice(0, maxCount);
     }


### PR DESCRIPTION
Reverts ant-design/ant-design#55129

Ant Design Collaborators 讨论后认为负数非文档或 demo 的示例用法，原本也是非预期的传入值，所以不需要做过度防御，故进行 revert