### PR TITLE
chore: turn on react-hooks/static-components

### DIFF
--- a/components/form/FormItem/StatusProvider.tsx
+++ b/components/form/FormItem/StatusProvider.tsx
@@ -12,10 +12,10 @@ import type { FormItemStatusContextProps } from '../context';
 import { getStatus } from '../util';
 
 const iconMap = {
-  success: <CheckCircleFilled />,
-  warning: <ExclamationCircleFilled />,
-  error: <CloseCircleFilled />,
-  validating: <LoadingOutlined />,
+  success: CheckCircleFilled,
+  warning: ExclamationCircleFilled,
+  error: CloseCircleFilled,
+  validating: LoadingOutlined,
 };
 
 export interface StatusProviderProps {
@@ -78,7 +78,7 @@ export default function StatusProvider({
               `${itemPrefixCls}-feedback-icon-${mergedValidateStatus}`,
             )}
           >
-            {customIconNode || IconNode}
+            {customIconNode || React.createElement(IconNode)}
           </span>
         ) : null;
     }

--- a/components/form/FormItem/StatusProvider.tsx
+++ b/components/form/FormItem/StatusProvider.tsx
@@ -69,7 +69,7 @@ export default function StatusProvider({
       const customIconNode =
         mergedValidateStatus &&
         customIcons?.({ status: mergedValidateStatus, errors, warnings })?.[mergedValidateStatus];
-      const IconNode = mergedValidateStatus && iconMap[mergedValidateStatus];
+      const IconNode = mergedValidateStatus ? iconMap[mergedValidateStatus] : null;
       feedbackIcon =
         customIconNode !== false && IconNode ? (
           <span
@@ -78,7 +78,7 @@ export default function StatusProvider({
               `${itemPrefixCls}-feedback-icon-${mergedValidateStatus}`,
             )}
           >
-            {customIconNode || React.createElement(IconNode)}
+            {customIconNode || <IconNode />}
           </span>
         ) : null;
     }

--- a/components/form/FormItem/StatusProvider.tsx
+++ b/components/form/FormItem/StatusProvider.tsx
@@ -12,10 +12,10 @@ import type { FormItemStatusContextProps } from '../context';
 import { getStatus } from '../util';
 
 const iconMap = {
-  success: CheckCircleFilled,
-  warning: ExclamationCircleFilled,
-  error: CloseCircleFilled,
-  validating: LoadingOutlined,
+  success: <CheckCircleFilled />,
+  warning: <ExclamationCircleFilled />,
+  error: <CloseCircleFilled />,
+  validating: <LoadingOutlined />,
 };
 
 export interface StatusProviderProps {
@@ -78,7 +78,7 @@ export default function StatusProvider({
               `${itemPrefixCls}-feedback-icon-${mergedValidateStatus}`,
             )}
           >
-            {customIconNode || <IconNode />}
+            {customIconNode || IconNode}
           </span>
         ) : null;
     }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -67,7 +67,6 @@ export default antfu(
       'react-hooks/preserve-manual-memoization': 'off',
       'react-hooks/set-state-in-effect': 'off',
       'react-hooks/refs': 'off',
-      'react-hooks/static-components': 'off',
     },
   },
   compat.configs['flat/recommended'],


### PR DESCRIPTION
### 🤔 This is a ...


- [ ] ❓ Other (about what?)


### 💡 Background and Solution
 ESLint 的 react-hooks/static-components 静态规则会把 render 里以大写变量（例如 `<IconNode />`）形式使用的 JSX 误判为“在 render 中创建组件类型”
https://react.dev/reference/eslint-plugin-react-hooks/lints/static-components

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        -   |
| 🇨🇳 Chinese |      -     |
