### PR TITLE
refactor(list/card): use some replace forEach

### DIFF
--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -159,13 +159,8 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
   };
 
   const isContainGrid = React.useMemo<boolean>(() => {
-    let containGrid = false;
-    React.Children.forEach(children as React.ReactElement, (element: React.JSX.Element) => {
-      if (element?.type === Grid) {
-        containGrid = true;
-      }
-    });
-    return containGrid;
+    const childrenArray = React.Children.toArray(children);
+    return childrenArray.some((child) => React.isValidElement(child) && child.type === Grid);
   }, [children]);
 
   const prefixCls = getPrefixCls('card', customizePrefixCls);

--- a/components/list/Item.tsx
+++ b/components/list/Item.tsx
@@ -1,5 +1,5 @@
-import type { CSSProperties, FC, HTMLAttributes, ReactElement, ReactNode } from 'react';
-import React, { Children, useContext } from 'react';
+import type { CSSProperties, HTMLAttributes, ReactNode } from 'react';
+import React, { useContext } from 'react';
 import { clsx } from 'clsx';
 
 import type { SemanticClassNames, SemanticStyles } from '../_util/hooks/useMergeSemantic';
@@ -35,7 +35,7 @@ export interface ListItemMetaProps {
 type ListItemClassNamesModule = keyof Exclude<ListItemProps['classNames'], undefined>;
 type ListItemStylesModule = keyof Exclude<ListItemProps['styles'], undefined>;
 
-export const Meta: FC<ListItemMetaProps> = ({
+export const Meta: React.FC<ListItemMetaProps> = ({
   prefixCls: customizePrefixCls,
   className,
   avatar,
@@ -87,13 +87,9 @@ const InternalItem = React.forwardRef<HTMLDivElement, ListItemProps>((props, ref
   });
 
   const isItemContainsTextNodeAndNotSingular = () => {
-    let result = false;
-    Children.forEach(children as ReactElement, (element) => {
-      if (typeof element === 'string') {
-        result = true;
-      }
-    });
-    return result && Children.count(children) > 1;
+    const childrenArray = React.Children.toArray(children);
+    const hasTextNode = childrenArray.some((node) => typeof node === 'string');
+    return hasTextNode && childrenArray.length > 1;
   };
 
   const isFlexMode = () => {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] ❓ Other (about what?)

### 🔗 Related Issues

### 💡 Background and Solution

https://react.dev/reference/react/Children#children-toarray
这边的场景就是要找数组中有一个符合条件的， 看起来用 some 更简洁方便


（react/no-children-for-each）：

forEach 强调副作用，常见写法要借助外部可变变量（如 containGrid），在渲染期做可变赋值不利于静态分析与可读性。
不能短路，找到目标后仍遍历全部 children，易写出脆弱代码。
对 null/boolean/fragment/嵌套数组等 children 形态可读性差，易遗漏边界。
使用返回值导向的方法（some/every/map/filter）更声明式，便于类型推断与优化。



### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |          - |
| 🇨🇳 Chinese |          - |
