### PR TITLE
refactor: use rc-utils's toArray replace React's Children legacy api

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -142,7 +142,7 @@ const InternalCompoundedButton = React.forwardRef<
     autoFocus,
     ...rest
   } = props;
-  const childNodes: React.ReactElement[] = toArray(children);
+  const childNodes: React.ReactNode[] = toArray(children);
   // https://github.com/ant-design/ant-design/issues/47605
   // Compatible with original `type` behavior
   const mergedType = type || 'default';

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -1,5 +1,5 @@
-import React, { Children, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { omit, useComposeRef } from '@rc-component/util';
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { omit, toArray, useComposeRef } from '@rc-component/util';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import { clsx } from 'clsx';
 
@@ -142,7 +142,7 @@ const InternalCompoundedButton = React.forwardRef<
     autoFocus,
     ...rest
   } = props;
-
+  const childNodes: React.ReactElement[] = toArray(children);
   // https://github.com/ant-design/ant-design/issues/47605
   // Compatible with original `type` behavior
   const mergedType = type || 'default';
@@ -216,7 +216,7 @@ const InternalCompoundedButton = React.forwardRef<
   const mergedRef = useComposeRef(ref, buttonRef);
 
   const needInserted =
-    Children.count(children) === 1 && !icon && !isUnBorderedButtonVariant(mergedVariant);
+    childNodes.length === 1 && !icon && !isUnBorderedButtonVariant(mergedVariant);
 
   // ========================= Mount ==========================
   // Record for mount status.

--- a/components/button/buttonHelpers.tsx
+++ b/components/button/buttonHelpers.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { toArray } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { cloneElement, isFragment } from '../_util/reactNode';
@@ -88,8 +89,8 @@ export function spaceChildren(
 ) {
   let isPrevChildPure = false;
   const childList: React.ReactNode[] = [];
-
-  React.Children.forEach(children, (child) => {
+  const childNodes: React.ReactElement[] = toArray(children);
+  childNodes.forEach((child) => {
     const type = typeof child;
     const isCurrentChildPure = type === 'string' || type === 'number';
     if (isPrevChildPure && isCurrentChildPure) {

--- a/components/button/buttonHelpers.tsx
+++ b/components/button/buttonHelpers.tsx
@@ -89,7 +89,7 @@ export function spaceChildren(
 ) {
   let isPrevChildPure = false;
   const childList: React.ReactNode[] = [];
-  const childNodes: React.ReactElement[] = toArray(children);
+  const childNodes: React.ReactNode[] = toArray(children);
   childNodes.forEach((child) => {
     const type = typeof child;
     const isCurrentChildPure = type === 'string' || type === 'number';

--- a/components/button/buttonHelpers.tsx
+++ b/components/button/buttonHelpers.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { toArray } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { cloneElement, isFragment } from '../_util/reactNode';
@@ -89,8 +88,8 @@ export function spaceChildren(
 ) {
   let isPrevChildPure = false;
   const childList: React.ReactNode[] = [];
-  const childNodes: React.ReactElement[] = toArray(children);
-  childNodes.forEach((child) => {
+
+  React.Children.forEach(children, (child) => {
     const type = typeof child;
     const isCurrentChildPure = type === 'string' || type === 'number';
     if (isPrevChildPure && isCurrentChildPure) {

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -159,7 +159,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
   };
 
   const isContainGrid = React.useMemo<boolean>(() => {
-    const childNodes: React.ReactElement[] = toArray(children);
+    const childNodes: React.ReactNode[] = toArray(children);
     return childNodes.some((child) => React.isValidElement(child) && child.type === Grid);
   }, [children]);
 

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import type { Tab, TabBarExtraContent } from '@rc-component/tabs/lib/interface';
-import omit from '@rc-component/util/lib/omit';
+import { omit, toArray } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import useMergeSemantic from '../_util/hooks/useMergeSemantic';
@@ -159,8 +159,8 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
   };
 
   const isContainGrid = React.useMemo<boolean>(() => {
-    const childrenArray = React.Children.toArray(children);
-    return childrenArray.some((child) => React.isValidElement(child) && child.type === Grid);
+    const childNodes: React.ReactElement[] = toArray(children);
+    return childNodes.some((child) => React.isValidElement(child) && child.type === Grid);
   }, [children]);
 
   const prefixCls = getPrefixCls('card', customizePrefixCls);

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { Settings } from '@ant-design/react-slick';
 import SlickCarousel from '@ant-design/react-slick';
+import { toArray } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { devUseWarning } from '../_util/warning';
@@ -104,7 +105,8 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>((props, ref) => {
     [slickRef.current],
   );
   const { children, initialSlide = 0 } = props;
-  const count = React.Children.count(children);
+  const childNodes: React.ReactElement[] = toArray(children);
+  const count = childNodes.length;
   const isRTL = (rtl ?? direction === 'rtl') && !vertical;
 
   React.useEffect(() => {

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -105,7 +105,7 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>((props, ref) => {
     [slickRef.current],
   );
   const { children, initialSlide = 0 } = props;
-  const childNodes: React.ReactElement[] = toArray(children);
+  const childNodes: React.ReactNode[] = toArray(children);
   const count = childNodes.length;
   const isRTL = (rtl ?? direction === 'rtl') && !vertical;
 

--- a/components/list/Item.tsx
+++ b/components/list/Item.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, HTMLAttributes, ReactNode } from 'react';
 import React, { useContext } from 'react';
+import { toArray } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { SemanticClassNames, SemanticStyles } from '../_util/hooks/useMergeSemantic';
@@ -87,9 +88,9 @@ const InternalItem = React.forwardRef<HTMLDivElement, ListItemProps>((props, ref
   });
 
   const isItemContainsTextNodeAndNotSingular = () => {
-    const childrenArray = React.Children.toArray(children);
-    const hasTextNode = childrenArray.some((node) => typeof node === 'string');
-    return hasTextNode && childrenArray.length > 1;
+    const childNodes: React.ReactElement[] = toArray(children);
+    const hasTextNode = childNodes.some((node) => typeof node === 'string');
+    return hasTextNode && childNodes.length > 1;
   };
 
   const isFlexMode = () => {

--- a/components/list/Item.tsx
+++ b/components/list/Item.tsx
@@ -88,7 +88,7 @@ const InternalItem = React.forwardRef<HTMLDivElement, ListItemProps>((props, ref
   });
 
   const isItemContainsTextNodeAndNotSingular = () => {
-    const childNodes: React.ReactElement[] = toArray(children);
+    const childNodes: React.ReactNode[] = toArray(children);
     const hasTextNode = childNodes.some((node) => typeof node === 'string');
     return hasTextNode && childNodes.length > 1;
   };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,8 +43,6 @@ export default antfu(
       'react-hooks/exhaustive-deps': 'off',
       'react-refresh/only-export-components': 'off', // TODO: remove this
       'react/no-clone-element': 'off',
-      'react/no-children-for-each': 'off',
-      'react/no-children-count': 'off',
       'react/no-children-map': 'off',
       'react/no-children-only': 'off',
       'react/no-unstable-default-props': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,9 +43,9 @@ export default antfu(
       'react-hooks/exhaustive-deps': 'off',
       'react-refresh/only-export-components': 'off', // TODO: remove this
       'react/no-clone-element': 'off',
+      'react/no-children-for-each': 'off',
       'react/no-children-map': 'off',
       'react/no-children-only': 'off',
-      'react/no-children-for-each': 'off',
       'react/no-unstable-default-props': 'off',
       'react/no-create-ref': 'off', // TODO: remove this
       'react-hooks-extra/prefer-use-state-lazy-initialization': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,7 @@ export default antfu(
       'react/no-clone-element': 'off',
       'react/no-children-map': 'off',
       'react/no-children-only': 'off',
+      'react/no-children-for-each': 'off',
       'react/no-unstable-default-props': 'off',
       'react/no-create-ref': 'off', // TODO: remove this
       'react-hooks-extra/prefer-use-state-lazy-initialization': 'off',


### PR DESCRIPTION
### 🤔 This is a ...


- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution
 react lagacy 不知道什么时候会废弃，好像也标记三年了，换成 rc 自己的吧，用着放心踏实（虽然内部实现 api 也差不多，但是以后兜底的话只用那边一改，这边就不用换了）
https://github.com/react-component/util/blob/33ca7f79e92865a6089afcb27cab65f1d31cb2dd/src/Children/toArray.ts

<img width="1206" height="336" alt="image" src="https://github.com/user-attachments/assets/5e08d530-55c5-41d3-ac0b-f8d246517322" />
<img width="1667" height="621" alt="image" src="https://github.com/user-attachments/assets/756ec47d-c71d-4f83-82f5-26ea0cd3b500" />


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      -     |
| 🇨🇳 Chinese |     -      |
