### PR TITLE
docs: add changelog 5.27.6

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -24,7 +24,7 @@ tag: vVERSION
   - 🛠 Refactor the useMemo capability of spinProps in Table. [#55344](https://github.com/ant-design/ant-design/pull/55344) 
 - 🛠 Refactor the useMemo capability of ConfirmDialog in Modal when using arrays. [#55376](https://github.com/ant-design/ant-design/pull/55376) 
 - TypeScript
-  - 🤖 Add then `Window` type definition in `getTargetContainer` of ConfigProvider. [#55313](https://github.com/ant-design/ant-design/pull/55313) 
+  - 🤖 Add the `Window` type definition in `getTargetContainer` of ConfigProvider. [#55313](https://github.com/ant-design/ant-design/pull/55313)
   - 🤖 Add the `ShadowRoot` type definition in ConfigProvider `getTargetContainer` `getPopupContainer`. [#55278](https://github.com/ant-design/ant-design/pull/55278) [@leshalv](https://github.com/leshalv)
   - 🤖 Improve type definition in Modal. [#55371](https://github.com/ant-design/ant-design/pull/55371) 
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,19 @@ tag: vVERSION
 
 ---
 
+## 5.27.6
+
+`2025-10-20`
+
+- Table
+  - 🐞 Fix Table `pagination.align` is not working. [#55316](https://github.com/ant-design/ant-design/pull/55316) 
+  - 🛠 Refactor the useMemo capability of spinProps in Table. [#55344](https://github.com/ant-design/ant-design/pull/55344) 
+- 🛠 Refactor the useMemo capability of ConfirmDialog in Modal when using arrays. [#55376](https://github.com/ant-design/ant-design/pull/55376) 
+- TypeScript
+  - 🤖 Add then `Window` type definition in `getTargetContainer` of ConfigProvider. [#55313](https://github.com/ant-design/ant-design/pull/55313) 
+  - 🤖 Add the `ShadowRoot` type definition in ConfigProvider `getTargetContainer` `getPopupContainer`. [#55278](https://github.com/ant-design/ant-design/pull/55278) [@leshalv](https://github.com/leshalv)
+  - 🤖 Improve type definition in Modal. [#55371](https://github.com/ant-design/ant-design/pull/55371) 
+
 ## 5.27.5
 
 `2025-10-14`

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -21,12 +21,12 @@ tag: vVERSION
 
 - Table
   - 🐞 Fix Table `pagination.align` is not working. [#55316](https://github.com/ant-design/ant-design/pull/55316) 
-  - 🛠 Refactor the useMemo capability of spinProps in Table. [#55344](https://github.com/ant-design/ant-design/pull/55344) 
-- 🛠 Refactor the useMemo capability of ConfirmDialog in Modal when using arrays. [#55376](https://github.com/ant-design/ant-design/pull/55376) 
+  - 🛠 Add Table missing useMemo capability to spinProps.  [#55344](https://github.com/ant-design/ant-design/pull/55344) 
+- 🛠 Refactor Modal useMemo of ConfirmDialog to resolve useMemo invalid where Object.values ​​generates a new array. [#55376](https://github.com/ant-design/ant-design/pull/55376) 
 - TypeScript
-  - 🤖 Add the `Window` type definition in `getTargetContainer` of ConfigProvider. [#55313](https://github.com/ant-design/ant-design/pull/55313)
-  - 🤖 Add the `ShadowRoot` type definition in ConfigProvider's `getTargetContainer` and `getPopupContainer`. [#55278](https://github.com/ant-design/ant-design/pull/55278) [@leshalv](https://github.com/leshalv)
-  - 🤖 Improve type definition in Modal. [#55371](https://github.com/ant-design/ant-design/pull/55371) 
+  - 🤖 Add ConfigProvider the `Window` type definition in `getTargetContainer` of . [#55313](https://github.com/ant-design/ant-design/pull/55313)
+  - 🤖 Add ConfigProvider the `ShadowRoot` type definition in `getTargetContainer` and `getPopupContainer`. [#55278](https://github.com/ant-design/ant-design/pull/55278) [@leshalv](https://github.com/leshalv)
+  - 🤖 Improve Modal type definition. [#55371](https://github.com/ant-design/ant-design/pull/55371) 
 
 ## 5.27.5
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -25,7 +25,7 @@ tag: vVERSION
 - 🛠 Refactor the useMemo capability of ConfirmDialog in Modal when using arrays. [#55376](https://github.com/ant-design/ant-design/pull/55376) 
 - TypeScript
   - 🤖 Add the `Window` type definition in `getTargetContainer` of ConfigProvider. [#55313](https://github.com/ant-design/ant-design/pull/55313)
-  - 🤖 Add the `ShadowRoot` type definition in ConfigProvider `getTargetContainer` `getPopupContainer`. [#55278](https://github.com/ant-design/ant-design/pull/55278) [@leshalv](https://github.com/leshalv)
+  - 🤖 Add the `ShadowRoot` type definition in ConfigProvider's `getTargetContainer` and `getPopupContainer`. [#55278](https://github.com/ant-design/ant-design/pull/55278) [@leshalv](https://github.com/leshalv)
   - 🤖 Improve type definition in Modal. [#55371](https://github.com/ant-design/ant-design/pull/55371) 
 
 ## 5.27.5

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,19 @@ tag: vVERSION
 
 ---
 
+## 5.27.6
+
+`2025-10-20`
+
+- Table
+  - 🐞 修复 Table `pagination.align` 属性失效的问题。[#55316](https://github.com/ant-design/ant-design/pull/55316) 
+  - 🛠 重构 Table 中 spinProps 的 useMemo 能力。[#55344](https://github.com/ant-design/ant-design/pull/55344) 
+- 🛠 重构 Modal 中 ConfirmDialog 使用数组时的 useMemo 能力。[#55376](https://github.com/ant-design/ant-design/pull/55376) 
+- TypeScript
+  - 🤖 补充 ConfigProvider `getTargetContainer` 中 `Window` 类型 定义。[#55313](https://github.com/ant-design/ant-design/pull/55313) 
+  - 🤖 补充 ConfigProvider `getTargetContainer` `getPopupContainer` 中 `ShadowRoot` 类型定义。[#55278](https://github.com/ant-design/ant-design/pull/55278) [@leshalv](https://github.com/leshalv)
+  - 🤖 优化 Modal 中类型定义。[#55371](https://github.com/ant-design/ant-design/pull/55371) 
+
 ## 5.27.5
 
 `2025-10-14`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -21,8 +21,8 @@ tag: vVERSION
 
 - Table
   - 🐞 修复 Table `pagination.align` 属性失效的问题。[#55316](https://github.com/ant-design/ant-design/pull/55316) 
-  - 🛠 重构 Table 中 spinProps 的 useMemo 能力。[#55344](https://github.com/ant-design/ant-design/pull/55344) 
-- 🛠 重构 Modal 中 ConfirmDialog 使用数组时的 useMemo 能力。[#55376](https://github.com/ant-design/ant-design/pull/55376) 
+  - 🛠 补充 Table 中 spinProps 的 useMemo 缺失能力。[#55344](https://github.com/ant-design/ant-design/pull/55344) 
+- 🛠 重构 Modal 中 ConfirmDialog 的 useMemo，以解决 Object.values 生成新数组导致 useMemo 失效的问题。[#55376](https://github.com/ant-design/ant-design/pull/55376) 
 - TypeScript
   - 🤖 补充 ConfigProvider `getTargetContainer` 中 `Window` 类型定义。[#55313](https://github.com/ant-design/ant-design/pull/55313)
   - 🤖 补充 ConfigProvider 的 `getTargetContainer` 和 `getPopupContainer` 中 `ShadowRoot` 类型定义。[#55278](https://github.com/ant-design/ant-design/pull/55278) [@leshalv](https://github.com/leshalv)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -24,7 +24,7 @@ tag: vVERSION
   - 🛠 重构 Table 中 spinProps 的 useMemo 能力。[#55344](https://github.com/ant-design/ant-design/pull/55344) 
 - 🛠 重构 Modal 中 ConfirmDialog 使用数组时的 useMemo 能力。[#55376](https://github.com/ant-design/ant-design/pull/55376) 
 - TypeScript
-  - 🤖 补充 ConfigProvider `getTargetContainer` 中 `Window` 类型 定义。[#55313](https://github.com/ant-design/ant-design/pull/55313) 
+  - 🤖 补充 ConfigProvider `getTargetContainer` 中 `Window` 类型定义。[#55313](https://github.com/ant-design/ant-design/pull/55313)
   - 🤖 补充 ConfigProvider `getTargetContainer` `getPopupContainer` 中 `ShadowRoot` 类型定义。[#55278](https://github.com/ant-design/ant-design/pull/55278) [@leshalv](https://github.com/leshalv)
   - 🤖 优化 Modal 中类型定义。[#55371](https://github.com/ant-design/ant-design/pull/55371) 
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -25,7 +25,7 @@ tag: vVERSION
 - 🛠 重构 Modal 中 ConfirmDialog 使用数组时的 useMemo 能力。[#55376](https://github.com/ant-design/ant-design/pull/55376) 
 - TypeScript
   - 🤖 补充 ConfigProvider `getTargetContainer` 中 `Window` 类型定义。[#55313](https://github.com/ant-design/ant-design/pull/55313)
-  - 🤖 补充 ConfigProvider `getTargetContainer` `getPopupContainer` 中 `ShadowRoot` 类型定义。[#55278](https://github.com/ant-design/ant-design/pull/55278) [@leshalv](https://github.com/leshalv)
+  - 🤖 补充 ConfigProvider 的 `getTargetContainer` 和 `getPopupContainer` 中 `ShadowRoot` 类型定义。[#55278](https://github.com/ant-design/ant-design/pull/55278) [@leshalv](https://github.com/leshalv)
   - 🤖 优化 Modal 中类型定义。[#55371](https://github.com/ant-design/ant-design/pull/55371) 
 
 ## 5.27.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "5.27.5",
+  "version": "5.27.6",
   "description": "An enterprise-class UI design language and React components implementation",
   "license": "MIT",
   "funding": {


### PR DESCRIPTION

- Table
  - 🐞 修复 Table `pagination.align` 属性失效的问题。[#55316](https://github.com/ant-design/ant-design/pull/55316) 
  - 🛠 重构 Table 中 spinProps 的 useMemo 能力。[#55344](https://github.com/ant-design/ant-design/pull/55344) 
- 🛠 重构 Modal 中 ConfirmDialog 使用数组时的 useMemo 能力。[#55376](https://github.com/ant-design/ant-design/pull/55376) 
- TypeScript
  - 🤖 补充 ConfigProvider `getTargetContainer` 中 `Window` 类型 定义。[#55313](https://github.com/ant-design/ant-design/pull/55313) 
  - 🤖 补充 ConfigProvider `getTargetContainer` `getPopupContainer` 中 `ShadowRoot` 类型定义。[#55278](https://github.com/ant-design/ant-design/pull/55278) [@leshalv](https://github.com/leshalv)
  - 🤖 优化 Modal 中类型定义。[#55371](https://github.com/ant-design/ant-design/pull/55371) 


----


- Table
  - 🐞 Fix Table `pagination.align` is not working. [#55316](https://github.com/ant-design/ant-design/pull/55316) 
  - 🛠 Refactor the useMemo capability of spinProps in Table. [#55344](https://github.com/ant-design/ant-design/pull/55344) 
- 🛠 Refactor the useMemo capability of ConfirmDialog in Modal when using arrays. [#55376](https://github.com/ant-design/ant-design/pull/55376) 
- TypeScript
  - 🤖 Add then `Window` type definition in `getTargetContainer` of ConfigProvider. [#55313](https://github.com/ant-design/ant-design/pull/55313) 
  - 🤖 Add the `ShadowRoot` type definition in ConfigProvider `getTargetContainer` `getPopupContainer`. [#55278](https://github.com/ant-design/ant-design/pull/55278) [@leshalv](https://github.com/leshalv)
  - 🤖 Improve type definition in Modal. [#55371](https://github.com/ant-design/ant-design/pull/55371) 