### PR TITLE
docs: Update React documentation links from reactjs.org to react.dev

### DIFF
--- a/components/alert/demo/error-boundary.md
+++ b/components/alert/demo/error-boundary.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-友好的 [React 错误处理](https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html) 包裹组件。
+友好的 [React 错误处理](https://zh-hans.react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) 包裹组件。
 
 ## en-US
 
-ErrorBoundary Component for making error handling easier in [React](https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html).
+ErrorBoundary Component for making error handling easier in [React](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary).

--- a/components/form/demo/control-hooks.md
+++ b/components/form/demo/control-hooks.md
@@ -2,7 +2,7 @@
 
 通过 `Form.useForm` 对表单数据域进行交互。
 
-> 注意 `useForm` 是 [React Hooks](https://zh-hans.react.dev/reference/react/hooksl) 的实现，只能用于函数组件。如果是在 Class Component 下，你也可以通过 `ref` 获取数据域：https://codesandbox.io/p/sandbox/ngtjtm
+> 注意 `useForm` 是 [React Hooks](https://zh-hans.react.dev/reference/react/hooks) 的实现，只能用于函数组件。如果是在 Class Component 下，你也可以通过 `ref` 获取数据域：https://codesandbox.io/p/sandbox/ngtjtm
 
 ## en-US
 

--- a/components/form/demo/control-hooks.md
+++ b/components/form/demo/control-hooks.md
@@ -2,10 +2,10 @@
 
 通过 `Form.useForm` 对表单数据域进行交互。
 
-> 注意 `useForm` 是 [React Hooks](https://reactjs.org/docs/hooks-intro.html) 的实现，只能用于函数组件。如果是在 Class Component 下，你也可以通过 `ref` 获取数据域：https://codesandbox.io/p/sandbox/ngtjtm
+> 注意 `useForm` 是 [React Hooks](https://zh-hans.react.dev/reference/react/hooksl) 的实现，只能用于函数组件。如果是在 Class Component 下，你也可以通过 `ref` 获取数据域：https://codesandbox.io/p/sandbox/ngtjtm
 
 ## en-US
 
 Call form method with `Form.useForm`.
 
-> Note that `useForm` is a [React Hooks](https://reactjs.org/docs/hooks-intro.html) that only works in functional component. You can also use `ref` to get the form instance in class component: https://codesandbox.io/p/sandbox-ngtjtm
+> Note that `useForm` is a [React Hooks](https://react.dev/reference/react/hooks) that only works in functional component. You can also use `ref` to get the form instance in class component: https://codesandbox.io/p/sandbox-ngtjtm

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -599,7 +599,7 @@ Components inside Form.Item with name property will turn into controlled mode, w
 
 ### Why can not call `ref` of Form at first time?
 
-`ref` only receives the mounted instance. please ref React official doc: <https://reactjs.org/docs/refs-and-the-dom.html#accessing-refs>
+`ref` only receives the mounted instance. please ref React official doc: <https://react.dev/learn/manipulating-the-dom-with-refs#when-react-attaches-the-refs>
 
 ### Why will `resetFields` re-mount component?
 

--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -598,7 +598,7 @@ Form.Item 默认绑定值属性到 `value` 上，而 Switch、Checkbox 等组件
 
 ### 为什么第一次调用 `ref` 的 Form 为空？
 
-`ref` 仅在节点被加载时才会被赋值，请参考 React 官方文档：<https://reactjs.org/docs/refs-and-the-dom.html#accessing-refs>
+`ref` 仅在节点被加载时才会被赋值，请参考 React 官方文档：<https://zh-hans.react.dev/learn/manipulating-the-dom-with-refs#when-react-attaches-the-refs>
 
 ### 为什么 `resetFields` 会重新 mount 组件？
 

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -76,7 +76,7 @@ Common props ref：[Common props](/docs/react/common-props)
 
 > When `Input` is used in a `Form.Item` context, if the `Form.Item` has the `id` props defined then `value`, `defaultValue`, and `id` props of `Input` are automatically set.
 
-The rest of the props of Input are exactly the same as the original [input](https://reactjs.org/docs/dom-elements.html#all-supported-html-attributes).
+The rest of the props of Input are exactly the same as the original [input](https://react.dev/reference/react-dom/components/input).
 
 #### CountConfig
 

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -77,7 +77,7 @@ demo:
 
 > 如果 `Input` 在 `Form.Item` 内，并且 `Form.Item` 设置了 `id` 属性，则 `value` `defaultValue` 和 `id` 属性会被自动设置。
 
-Input 的其他属性和 React 自带的 [input](https://reactjs.org/docs/dom-elements.html#all-supported-html-attributes) 一致。
+Input 的其他属性和 React 自带的 [input](https://zh-hans.react.dev/reference/react-dom/components/input) 一致。
 
 #### CountConfig
 
@@ -148,10 +148,10 @@ interface CountConfig {
 
 #### VisibilityToggle
 
-| 参数            | 说明                 | 类型                | 默认值 | 版本 |
-| --------------- | -------------------- | ------------------- | ------ | ---- |
-| visible         | 用于手动控制密码显隐 | boolean             | false  | 4.24 |
-| onVisibleChange | 显隐密码的回调       | (visible) => void   | -      | 4.24 |
+| 参数            | 说明                 | 类型              | 默认值 | 版本 |
+| --------------- | -------------------- | ----------------- | ------ | ---- |
+| visible         | 用于手动控制密码显隐 | boolean           | false  | 4.24 |
+| onVisibleChange | 显隐密码的回调       | (visible) => void | -      | 4.24 |
 
 #### Input Methods
 

--- a/docs/react/faq.en-US.md
+++ b/docs/react/faq.en-US.md
@@ -73,7 +73,7 @@ The `defaultXxxx` (e.g. `defaultValue`) of `Input`/`Select`(etc...) only works o
 
 ## Why does modifying props in mutable way not trigger a component update?
 
-antd use shallow compare of props to optimize performance. You should always pass the new object when updating the state. Please ref [React's document](https://reactjs.org/docs/thinking-in-react.html)
+antd use shallow compare of props to optimize performance. You should always pass the new object when updating the state. Please ref [React's document](https://react.dev/learn/thinking-in-react)
 
 ## After I set the `value` of an `Input`/`Select`(etc.) component, the value cannot be changed by user's action.
 
@@ -181,7 +181,7 @@ Static methods like message/notification/Modal.confirm are not using the same re
 
 ## Why shouldn't I use component internal props or state with ref?
 
-You should only access the API by official doc with ref. Directly access internal `props` or `state` is not recommended which will make your code strong coupling with current version. Any refactor will break your code like refactor with [Hooks](https://reactjs.org/docs/hooks-intro.html) version, delete or rename internal `props` or `state`, adjust internal node constructor, etc.
+You should only access the API by official doc with ref. Directly access internal `props` or `state` is not recommended which will make your code strong coupling with current version. Any refactor will break your code like refactor with [Hooks](https://react.dev/reference/react/hooks) version, delete or rename internal `props` or `state`, adjust internal node constructor, etc.
 
 <div id="why-open"></div>
 

--- a/docs/react/faq.zh-CN.md
+++ b/docs/react/faq.zh-CN.md
@@ -73,7 +73,7 @@ antd 在 minor 和 patch 版本迭代中会避免引入破坏性变更，遵从�
 
 ## 为什么修改组件传入的对象或数组属性组件不会更新？
 
-antd 内部会对 props 进行浅比较实现性能优化。当状态变更，你总是应该传递一个新的对象。具体请参考 [React 的文档](https://zh-hans.reactjs.org/docs/thinking-in-react.html)
+antd 内部会对 props 进行浅比较实现性能优化。当状态变更，你总是应该传递一个新的对象。具体请参考 [React 的文档](https://zh-hans.react.dev/learn/thinking-in-react)
 
 ## 当我设置了 `Input`/`Select` 等的 `value` 时它就无法修改了。
 
@@ -204,7 +204,7 @@ message/notification/Modal.confirm 等静态方法不同于 `<Button />` 的渲�
 
 ## 为什么我不应该通过 ref 访问组件内部的 props 和 state？
 
-你通过 ref 获得引用时只应该使用文档提供的方法。直接读取组件内部的 `props` 和 `state` 不是一个好的设计，这会使你的代码与组件版本强耦合。任何重构都可能会使你的代码无法工作，其中重构包括且不仅限于改造成 [Hooks](https://reactjs.org/docs/hooks-intro.html) 版本、移除 / 更名内部 `props` 与 `state`、调整内部 React 节点结构等等。
+你通过 ref 获得引用时只应该使用文档提供的方法。直接读取组件内部的 `props` 和 `state` 不是一个好的设计，这会使你的代码与组件版本强耦合。任何重构都可能会使你的代码无法工作，其中重构包括且不仅限于改造成 [Hooks](https://zh-hans.react.dev/reference/react/hooks) 版本、移除 / 更名内部 `props` 与 `state`、调整内部 React 节点结构等等。
 
 <div id="why-open"></div>
 

--- a/docs/spec/introduce.en-US.md
+++ b/docs/spec/introduce.en-US.md
@@ -30,7 +30,7 @@ We provide comprehensive design guidelines, best practices, resources, and tools
 
 ## Front-end Implementation
 
-[React](http://facebook.github.io/react/) is used to encapsulate a library of components which embody our design language. We welcome the community to implement [our design system](/docs/spec/introduce) in other front-end frameworks of their choice.
+[React](https://react.dev/) is used to encapsulate a library of components which embody our design language. We welcome the community to implement [our design system](/docs/spec/introduce) in other front-end frameworks of their choice.
 
 - [Ant Design of React](/docs/react/introduce)（official implementation）
 - [NG-ZORRO - Ant Design of Angular](http://ng.ant.design)

--- a/docs/spec/introduce.zh-CN.md
+++ b/docs/spec/introduce.zh-CN.md
@@ -30,7 +30,7 @@ title: 介绍
 
 ## 前端实现
 
-我们采用 [React](https://reactjs.org) 封装了一套 Ant Design 的组件库，也欢迎社区其他框架的实现版本。
+我们采用 [React](https://zh-hans.react.dev/) 封装了一套 Ant Design 的组件库，也欢迎社区其他框架的实现版本。
 
 - [Ant Design of React](/docs/react/introduce)（官方实现）
 - [NG-ZORRO - Ant Design of Angular](http://ng.ant.design)（社区实现）


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 📝 Site / documentation improvement

### 🔗 Related Issues

close https://github.com/ant-design/ant-design/issues/55386

### 💡 Background and Solution

将项目中React文档链接，从reactjs.org到react.dev
**博客中的React文档链接除外，博客中的链接应该由作者来更新**

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Update React documentation links from reactjs.org to react.dev     |
| 🇨🇳 Chinese |      更新React文档链接，从reactjs.org到react.dev     |
