### PR TITLE
docs: fix auto theme mode

### DIFF
--- a/.dumi/pages/index/components/PreviewBanner/index.tsx
+++ b/.dumi/pages/index/components/PreviewBanner/index.tsx
@@ -36,7 +36,7 @@ const useStyle = createStyles(({ token, css, cx }, siteConfig: SiteContextProps)
     inset: 0;
     backdrop-filter: blur(2px);
     opacity: 1;
-    background-color: 'rgba(255, 255, 255, 0.2)';
+    background-color: rgba(255, 255, 255, 0.2);
     transition: all 1s ease;
     pointer-events: none;
     [data-prefers-color='dark'] & {

--- a/.dumi/pages/index/components/PreviewBanner/index.tsx
+++ b/.dumi/pages/index/components/PreviewBanner/index.tsx
@@ -31,15 +31,17 @@ const locales = {
 
 const useStyle = createStyles(({ token, css, cx }, siteConfig: SiteContextProps) => {
   const textShadow = `0 0 4px ${token.colorBgContainer}`;
-  const isDark = siteConfig.theme.includes('dark');
   const mask = cx(css`
     position: absolute;
     inset: 0;
     backdrop-filter: blur(2px);
     opacity: 1;
-    background-color: ${isDark ? 'rgba(0, 0, 0, 0.2)' : 'rgba(255, 255, 255, 0.2)'};
+    background-color: 'rgba(255, 255, 255, 0.2)';
     transition: all 1s ease;
     pointer-events: none;
+    [data-prefers-color='dark'] & {
+      background-color: rgba(0, 0, 0, 0.2);
+    }
   `);
 
   const block = cx(css`

--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -50,6 +50,7 @@ if (typeof window !== 'undefined') {
 const getAlgorithm = (themes: ThemeName[] = [], systemTheme: 'dark' | 'light') =>
   themes
     .map((theme) => {
+      // auto 模式下根据系统主题切换
       if (theme === 'auto' && systemTheme === 'dark') {
         return antdTheme.darkAlgorithm;
       }
@@ -135,7 +136,7 @@ const GlobalLayout: React.FC = () => {
         setSearchParams(nextSearchParams);
       }
     },
-    [searchParams, setSearchParams, systemTheme],
+    [searchParams, setSearchParams],
   );
 
   const updateMobileMode = useCallback(() => {
@@ -192,12 +193,6 @@ const GlobalLayout: React.FC = () => {
       // bannerVisible:
       //   hasBannerContent && (storedBannerVisibleLastTime ? !!storedBannerVisible : true),
     });
-
-    // 设置 data-prefers-color 属性
-    const colorTheme = finalTheme.find((t) => ['light', 'dark'].includes(t));
-    if (colorTheme) {
-      document.documentElement.setAttribute('data-prefers-color', colorTheme);
-    }
 
     // Handle isMobile
     updateMobileMode();


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

[文档主题切换，实例代码块背景颜色异常](https://github.com/ant-design/ant-design/issues/55339)

现在站点主题存在以下问题
> - "跟随系统"模式无法正常工作
> - 文档主题切换时代码块背景颜色异常

### 💡 需求背景和解决方案

> - [#Issue 54450](https://github.com/ant-design/ant-design/pull/54450)之前，默认两种主题和浏览器主题对齐。后续进行调整，引入了auto主题，但是，auto功能没有实装，监听功能也未生效
> - 站点主题使用./theme/themes/dark生成对应样式以及‘data-prefers-color’两套逻辑同时控制，但是，之前的代码中使用auto主题后没有相应修改‘data-prefers-color’，导致这部分内容控制的代码块颜色出现异常
> - 站点Index页面直接读取siteConfig.theme.includes('dark')，当主题为auto时会出现不一致
> - 本次修改新增维护系统主题，修改原主题逻辑，修改原'data-prefers-color' 属性设置方法，修改Index页面背景颜色取法

### 📝 更新日志

> - 本次更新为站点改动，对开发者无影响

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix site auto theme mode issue     |
| 🇨🇳 Chinese |  站点自动主题异常修复         |

### 更改测试
代码块颜色异常测试
![code bg color20251021_130220](https://github.com/user-attachments/assets/095ff78a-716c-444a-ad3b-d7a6c38247ac)
主题随系统更改测试
![auto mode20251021_130341](https://github.com/user-attachments/assets/16913dbc-f45b-46e7-ad52-72593d287065)

烦请Code Review，感谢