### PR TITLE
chore: bump eslint-plugin-react-hooks@7.0.1

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -104,6 +104,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
 
   // Control mode will auto fill file uid if not provided
   React.useMemo(() => {
+    // eslint-disable-next-line react-hooks/purity
     const timestamp = Date.now();
     (fileList || []).forEach((file, index) => {
       if (!file.uid && !Object.isFrozen(file)) {

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -104,7 +104,6 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
 
   // Control mode will auto fill file uid if not provided
   React.useMemo(() => {
-    // eslint-disable-next-line react-hooks/purity
     const timestamp = Date.now();
     (fileList || []).forEach((file, index) => {
       if (!file.uid && !Object.isFrozen(file)) {

--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "eslint-plugin-compat": "^6.0.1",
     "eslint-plugin-jest": "^29.0.1",
     "eslint-plugin-jsx-a11y": "^6.10.0",
-    "eslint-plugin-react-hooks": "^7.0.0",
+    "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.22",
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

这行留着反而有 warning，删了倒没有 warning，是不是可以去掉
<img width="1239" height="217" alt="image" src="https://github.com/user-attachments/assets/6cacf623-9fbf-4d62-b527-b2061f40390f" />


破案了，pnpm lock 住7.0.0 没更新上去，得清除缓存，或者卸载重装，直接 pnpm install 还不行，要不然抬一下版本，显式标注一下，也方便后期版本compare？


<img width="662" height="360" alt="image" src="https://github.com/user-attachments/assets/29c51994-5b4b-4bac-854d-3b6347ce9f35" />

### 📝 Change Log


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    -      |
| 🇨🇳 Chinese |      -     |
