### PR TITLE
fix: clicking does nothing after occur error in actionFn

### DIFF
--- a/components/_util/ActionButton.tsx
+++ b/components/_util/ActionButton.tsx
@@ -99,7 +99,14 @@ const ActionButton: React.FC<ActionButtonProps> = (props) => {
     }
     let returnValueOfOnOk: PromiseLike<any>;
     if (emitEvent) {
-      returnValueOfOnOk = actionFn(e);
+      // if actionFn has been throw error, just reset clickedRef
+      try {
+        returnValueOfOnOk = actionFn(e);
+      } catch {
+        clickedRef.current = false;
+        return;
+      }
+
       if (quitOnNullishReturnValue && !isThenable(returnValueOfOnOk)) {
         clickedRef.current = false;
         onInternalClose(e);

--- a/components/_util/ActionButton.tsx
+++ b/components/_util/ActionButton.tsx
@@ -98,12 +98,19 @@ const ActionButton: React.FC<ActionButtonProps> = (props) => {
       return;
     }
     let returnValueOfOnOk: PromiseLike<any>;
+    // Currently only Popconfirm passes `emitEvent` as true
     if (emitEvent) {
       // if actionFn has been throw error, just reset clickedRef
       try {
         returnValueOfOnOk = actionFn(e);
-      } catch {
+      } catch (error) {
         clickedRef.current = false;
+
+        // Log error for debugging unless in silent mode
+        if (!isSilent?.()) {
+          console.error('Error in actionFn:', error);
+        }
+
         return;
       }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

This requirement stems from the Popconfirm component; onConfirm props wants to close the Popover component under specific conditions.
Therefore, try-catch is used to indicate that confirmation success has not yet been achieved.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       fix: clicking does nothing after occur error in actionFn    |
| 🇨🇳 Chinese |       fix: 当 actionFn 函数调用发生异常后 ，点击没有任何反应   |
