### PR TITLE
fix: remove infinite loop in theme transition

### DIFF
--- a/.dumi/hooks/useThemeAnimation.ts
+++ b/.dumi/hooks/useThemeAnimation.ts
@@ -85,10 +85,6 @@ const useThemeAnimation = () => {
     );
     document
       .startViewTransition(async () => {
-        // wait for theme change end
-        while (colorBgElevated === animateRef.current.colorBgElevated) {
-          await new Promise<void>((resolve) => setTimeout(resolve, 1000 / 60));
-        }
         const root = document.documentElement;
         root.classList.remove(isDark ? 'dark' : 'light');
         root.classList.add(isDark ? 'light' : 'dark');

--- a/.dumi/theme/common/ThemeSwitch/index.tsx
+++ b/.dumi/theme/common/ThemeSwitch/index.tsx
@@ -137,9 +137,9 @@ const ThemeSwitch: React.FC<ThemeSwitchProps> = () => {
       const filteredTheme = theme.filter((t) => !['light', 'dark', 'auto'].includes(t));
       const newTheme = [...filteredTheme, themeKey];
 
-      updateSiteConfig({ theme: newTheme });
-
       setTheme(themeKey);
+
+      updateSiteConfig({ theme: newTheme });
     } else {
       // 其他主题选项是开关式的
       const hasTheme = theme.includes(themeKey);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close #55525

### 💡 Background and Solution

如 issue 所述，在主题切换时会卡住浏览器几秒。删除这个 while 可以避免此问题，调慢动画观察也暂未发现带来其他问题。

另外验证中顺便发现另外一个问题也一起修复了：如果当前选中的是深色，修改为「跟随系统」时第一次不会生效，只会让地址栏的 `?theme=dark` 消失，选中的还是深色项，页面颜色也是深色。再点一次「跟随系统」才能切成跟系统一样的浅色。

这个问题原因是：

1. `updateSiteConfig` 触发 URL 参数变化（删除 `?theme=dark`）
2. GlobalLayout 的 `useEffect` 监听到 URL 变化，调用 `getFinalTheme` 重新计算主题
3. 但此时 localStorage 还是旧值 'dark'，导致重新计算后又回到了 `['dark']`
4. 最后 `setTheme(themeKey)` 才执行，读到的是深色

交换了执行顺序确保当 GlobalLayout 响应 URL 变化时，localStorage 已经是最新值，避免了状态不一致的问题。

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     docs site theme switch no longer freezes browser     |
| 🇨🇳 Chinese |      修复文档站点主题切换卡住浏览器的问题     |
