### PR TITLE
fix: uses correct style for content rendering

### DIFF
--- a/components/descriptions/Cell.tsx
+++ b/components/descriptions/Cell.tsx
@@ -49,6 +49,9 @@ const Cell: React.FC<CellProps> = (props) => {
   const descContext = React.useContext(DescriptionsContext);
   const { classNames: descriptionsClassNames } = descContext;
 
+  const mergedLabelStyle: React.CSSProperties = { ...labelStyle, ...styles?.label };
+  const mergedContentStyle: React.CSSProperties = { ...contentStyle, ...styles?.content };
+
   if (bordered) {
     return (
       <Component
@@ -64,10 +67,8 @@ const Cell: React.FC<CellProps> = (props) => {
         style={style}
         colSpan={span}
       >
-        {notEmpty(label) && <span style={{ ...labelStyle, ...styles?.label }}>{label}</span>}
-        {notEmpty(content) && (
-          <span style={{ ...contentStyle, ...styles?.content }}>{content}</span>
-        )}
+        {notEmpty(label) && <span style={mergedLabelStyle}>{label}</span>}
+        {notEmpty(content) && <span style={mergedContentStyle}>{content}</span>}
       </Component>
     );
   }
@@ -84,7 +85,7 @@ const Cell: React.FC<CellProps> = (props) => {
             className={classNames(`${itemPrefixCls}-item-label`, descriptionsClassNames?.label, {
               [`${itemPrefixCls}-item-no-colon`]: !colon,
             })}
-            style={{ ...labelStyle, ...styles?.label }}
+            style={mergedLabelStyle}
           >
             {label}
           </span>
@@ -92,7 +93,7 @@ const Cell: React.FC<CellProps> = (props) => {
         {(content || content === 0) && (
           <span
             className={classNames(`${itemPrefixCls}-item-content`, descriptionsClassNames?.content)}
-            style={{ ...contentStyle, ...styles?.content }}
+            style={mergedContentStyle}
           >
             {content}
           </span>

--- a/components/descriptions/Cell.tsx
+++ b/components/descriptions/Cell.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { JSX } from 'react';
 import classNames from 'classnames';
+
 import DescriptionsContext from './DescriptionsContext';
 import type { SemanticName } from './DescriptionsContext';
 
@@ -64,7 +65,9 @@ const Cell: React.FC<CellProps> = (props) => {
         colSpan={span}
       >
         {notEmpty(label) && <span style={{ ...labelStyle, ...styles?.label }}>{label}</span>}
-        {notEmpty(content) && <span style={{ ...labelStyle, ...styles?.content }}>{content}</span>}
+        {notEmpty(content) && (
+          <span style={{ ...contentStyle, ...styles?.content }}>{content}</span>
+        )}
       </Component>
     );
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 把错误的 `labelStyle` 换成 `contentStyle`，顺便把公共的样式抽出来 |
| 🇨🇳 Chinese | 把错误的 `labelStyle` 换成 `contentStyle`，顺便把公共的样式抽出来 |