### PR TITLE
type(flex): fix missing preset size support for gap

### DIFF
--- a/components/_util/type.ts
+++ b/components/_util/type.ts
@@ -1,7 +1,7 @@
 import type React from 'react';
 
 /** https://github.com/Microsoft/TypeScript/issues/29729 */
-export type LiteralUnion<T extends string> = T | (string & {});
+export type LiteralUnion<T extends string | undefined> = T | (string & {});
 
 export type AnyObject = Record<PropertyKey, any>;
 

--- a/components/flex/demo/gap.tsx
+++ b/components/flex/demo/gap.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Button, Flex, Radio, Slider } from 'antd';
-
-import type { FlexProps } from '../interface';
+import type { FlexProps } from 'antd';
 
 const App: React.FC = () => {
   const [gapSize, setGapSize] = React.useState<FlexProps['gap']>('small');
@@ -22,6 +21,8 @@ const App: React.FC = () => {
         <Button type="dashed">Dashed</Button>
         <Button type="link">Link</Button>
       </Flex>
+
+      <Flex gap=""> 1</Flex>
     </Flex>
   );
 };

--- a/components/flex/demo/gap.tsx
+++ b/components/flex/demo/gap.tsx
@@ -21,8 +21,6 @@ const App: React.FC = () => {
         <Button type="dashed">Dashed</Button>
         <Button type="link">Link</Button>
       </Flex>
-
-      <Flex gap=""> 1</Flex>
     </Flex>
   );
 };

--- a/components/flex/demo/gap.tsx
+++ b/components/flex/demo/gap.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { Button, Flex, Radio, Slider } from 'antd';
-import type { ConfigProviderProps } from 'antd';
 
-type SizeType = ConfigProviderProps['componentSize'];
+import type { FlexProps } from '../interface';
 
 const App: React.FC = () => {
-  const [gapSize, setGapSize] = React.useState<SizeType | 'customize'>('small');
+  const [gapSize, setGapSize] = React.useState<FlexProps['gap']>('small');
   const [customGapSize, setCustomGapSize] = React.useState<number>(0);
   return (
     <Flex gap="middle" vertical>

--- a/components/flex/interface.ts
+++ b/components/flex/interface.ts
@@ -1,8 +1,7 @@
 import type React from 'react';
 
 import type { AnyObject, CustomComponent, LiteralUnion } from '../_util/type';
-
-export type GapSize = 'small' | 'middle' | 'large';
+import type { SizeType } from '../config-provider/SizeContext';
 
 export interface FlexProps<P = AnyObject> extends React.HTMLAttributes<HTMLElement> {
   prefixCls?: string;
@@ -12,6 +11,6 @@ export interface FlexProps<P = AnyObject> extends React.HTMLAttributes<HTMLEleme
   justify?: React.CSSProperties['justifyContent'];
   align?: React.CSSProperties['alignItems'];
   flex?: React.CSSProperties['flex'];
-  gap?: LiteralUnion<GapSize> | number;
+  gap?: LiteralUnion<SizeType> | number;
   component?: CustomComponent<P>;
 }

--- a/components/flex/interface.ts
+++ b/components/flex/interface.ts
@@ -1,7 +1,8 @@
 import type React from 'react';
 
-import type { AnyObject, CustomComponent } from '../_util/type';
-import type { SizeType } from '../config-provider/SizeContext';
+import type { AnyObject, CustomComponent, LiteralUnion } from '../_util/type';
+
+export type GapSize = 'small' | 'middle' | 'large';
 
 export interface FlexProps<P = AnyObject> extends React.HTMLAttributes<HTMLElement> {
   prefixCls?: string;
@@ -11,6 +12,6 @@ export interface FlexProps<P = AnyObject> extends React.HTMLAttributes<HTMLEleme
   justify?: React.CSSProperties['justifyContent'];
   align?: React.CSSProperties['alignItems'];
   flex?: React.CSSProperties['flex'];
-  gap?: React.CSSProperties['gap'] | SizeType;
+  gap?: LiteralUnion<GapSize> | number;
   component?: CustomComponent<P>;
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #47187

### 💡 Background and Solution

<img width="595" height="168" alt="image" src="https://github.com/user-attachments/assets/4ec3d4bf-bbca-4663-ad0d-0d21848da1c8" />

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix missing preset size support for `gap`      |
| 🇨🇳 Chinese |       修复 `gap` 缺少预设尺寸的问题     |
