### PR TITLE
Fix/fix select underlined height

### DIFF
--- a/components/select/style/variants.ts
+++ b/components/select/style/variants.ts
@@ -251,11 +251,11 @@ const genBaseUnderlinedStyle = (
     [`&:not(${componentCls}-disabled):not(${componentCls}-customize-input):not(${antCls}-pagination-size-changer)`]:
       {
         [`&:hover ${componentCls}-selector`]: {
-          borderColor: `transparent transparent ${options.borderColor} transparent`,
+          borderColor: `transparent transparent ${options.hoverBorderHover} transparent`,
         },
 
         [`${componentCls}-focused& ${componentCls}-selector`]: {
-          borderColor: `transparent transparent ${options.borderColor} transparent`,
+          borderColor: `transparent transparent ${options.activeBorderColor} transparent`,
           outline: 0,
         },
         [`${componentCls}-prefix`]: {

--- a/components/select/style/variants.ts
+++ b/components/select/style/variants.ts
@@ -242,20 +242,20 @@ const genBaseUnderlinedStyle = (
 
   return {
     [`&:not(${componentCls}-customize-input) ${componentCls}-selector`]: {
-      borderWidth: `0 0 ${unit(token.lineWidth)} 0`,
-      borderStyle: `none none ${token.lineType} none`,
-      borderColor: options.borderColor,
+      borderWidth: `${unit(token.lineWidth)} 0`,
+      borderStyle: `${token.lineType} none`,
+      borderColor: `transparent transparent ${options.borderColor} transparent`,
       background: token.selectorBg,
       borderRadius: 0,
     },
     [`&:not(${componentCls}-disabled):not(${componentCls}-customize-input):not(${antCls}-pagination-size-changer)`]:
       {
         [`&:hover ${componentCls}-selector`]: {
-          borderColor: options.hoverBorderHover,
+          borderColor: `transparent transparent ${options.borderColor} transparent`,
         },
 
         [`${componentCls}-focused& ${componentCls}-selector`]: {
-          borderColor: options.activeBorderColor,
+          borderColor: `transparent transparent ${options.borderColor} transparent`,
           outline: 0,
         },
         [`${componentCls}-prefix`]: {


### PR DESCRIPTION
to #55601

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [✅ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
fix #55601 
### 💡 Background and Solution

调整 variant="underlined" 时 Select 组件高度为32px

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Adjust the height of the Select component to 32px when variant="underlined" |
| 🇨🇳 Chinese |  调整 variant="underlined" 时 Select 组件高度为32px  |
