### PR TITLE
fix: input underlined hover color

### DIFF
--- a/components/input/style/variants.ts
+++ b/components/input/style/variants.ts
@@ -369,7 +369,7 @@ export const genBaseUnderlinedStyle = (
   borderColor: `transparent transparent ${options.borderColor} transparent`,
   borderRadius: 0,
   '&:hover': {
-    borderColor: `transparent transparent ${options.borderColor} transparent`,
+    borderColor: `transparent transparent ${options.hoverBorderColor} transparent`,
     backgroundColor: token.hoverBg,
   },
 


### PR DESCRIPTION
to #55608

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
fix #55608 

### 💡 Background and Solution

Input 组件开启 underlined 后，增加鼠标 hover 时的边框颜色

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | When the `underlined` property is enabled for the Input component, the border color changes on mouse hover |
| 🇨🇳 Chinese | Input 组件开启 underlined 后，增加鼠标 hover 时的边框颜色 |
