### PR TITLE
fix: use dotActiveWidth token

### DIFF
--- a/components/carousel/style/index.ts
+++ b/components/carousel/style/index.ts
@@ -351,7 +351,7 @@ const genCarouselVerticalStyle: GenerateStyle<CarouselToken> = (token) => {
       height: 0,
     },
     to: {
-      height: token.dotWidth,
+      height: token.dotActiveWidth,
     },
   });
 
@@ -416,8 +416,12 @@ const genCarouselVerticalStyle: GenerateStyle<CarouselToken> = (token) => {
 
           '&.slick-active': {
             ...reverseSizeOfDot,
+            height: token.dotActiveWidth,
 
-            button: reverseSizeOfDot,
+            button: {
+              ...reverseSizeOfDot,
+              height: token.dotActiveWidth,
+            },
 
             '&::after': {
               ...reverseSizeOfDot,


### PR DESCRIPTION
- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- close https://github.com/ant-design/ant-design/issues/55614

### 💡 Background and Solution

<img width="705" height="444" alt="image" src="https://github.com/user-attachments/assets/e5997371-dd83-44fb-b1ad-6823b7f853b4" />

竖排标识符没有使用 dotActiveWidth

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      修复竖排标识符激活态宽度异常     |
| 🇨🇳 Chinese |      修复了激活状态下垂直标识符宽度异常的问题。     |
