### PR TITLE
fix(Input.Search): align the icon button within the input

### DIFF
--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -710,6 +710,10 @@ const genSearchInputStyle: GenerateStyle<InputToken> = (token: InputToken) => {
         },
       },
 
+      [`${componentCls}-group > input`]: {
+        height: token.controlHeight,
+      },
+
       [`${searchPrefixCls}-button`]: {
         height: token.controlHeight,
 
@@ -722,10 +726,16 @@ const genSearchInputStyle: GenerateStyle<InputToken> = (token: InputToken) => {
         [`${componentCls}-affix-wrapper, ${searchPrefixCls}-button`]: {
           height: token.controlHeightLG,
         },
+        [`${componentCls}-group > input`]: {
+          height: token.controlHeightLG,
+        },
       },
 
       '&-small': {
         [`${componentCls}-affix-wrapper, ${searchPrefixCls}-button`]: {
+          height: token.controlHeightSM,
+        },
+        [`${componentCls}-group > input`]: {
           height: token.controlHeightSM,
         },
       },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 💄 Component style improvement


### 🔗 Related Issues


### 💡 Background and Solution

<img width="793" height="600" alt="image" src="https://github.com/user-attachments/assets/94bb4999-a06a-4bd9-96a8-bf6368ab634c" />
修复输入框和 search 按钮没对齐的问题

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     align the icon button within the input      |
| 🇨🇳 Chinese |     修复输入框和 search 按钮没对齐的问题      |
