### PR TITLE
chore(masonry): fix Dynamic demo key calculte error

### DIFF
--- a/components/masonry/demo/dynamic.tsx
+++ b/components/masonry/demo/dynamic.tsx
@@ -31,7 +31,7 @@ const Update: React.FC = () => {
     setItems((prevItems) => [
       ...prevItems,
       {
-        key: (prevItems[prevItems.length - 1]?.key || 0) + 1,
+        key: prevItems.length ? prevItems[prevItems.length - 1].key + 1 : 0,
         data: Math.floor(Math.random() * 100) + 50,
       },
     ]);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #55623

### 💡 Background and Solution

When adding a new item, if the current item array is empty, the key starts from 0; otherwise, it is set to the key of the last item in the array plus 1.
### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Modify the key calculation logic of the dynamic update demo for the masonry component      |
| 🇨🇳 Chinese |    修改瀑布流组件动态更新 demo 的 key 计算逻辑      |
