### PR TITLE
feat: add editAreaClassName and editAreaStyle props for Typography

### DIFF
--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -52,6 +52,8 @@ interface EditConfig {
   triggerType?: ('icon' | 'text')[];
   enterIcon?: React.ReactNode;
   tabIndex?: number;
+  editAreaClassName?: string;
+  editAreaStyle?: React.CSSProperties;
 }
 
 export interface EllipsisConfig {
@@ -342,6 +344,8 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
         maxLength={editConfig.maxLength}
         autoSize={editConfig.autoSize}
         enterIcon={editConfig.enterIcon}
+        textAreaClassName={editConfig.editAreaClassName}
+        textAreaStyle={editConfig.editAreaStyle}
       />
     );
   }

--- a/components/typography/Editable.tsx
+++ b/components/typography/Editable.tsx
@@ -24,6 +24,8 @@ interface EditableProps {
   autoSize?: TextAreaProps['autoSize'];
   enterIcon?: React.ReactNode;
   component?: string;
+  textAreaClassName?: string;
+  textAreaStyle?: React.CSSProperties;
 }
 
 const Editable: React.FC<EditableProps> = (props) => {
@@ -40,6 +42,8 @@ const Editable: React.FC<EditableProps> = (props) => {
     onCancel,
     onEnd,
     component,
+    textAreaClassName: externalTextAreaClassName,
+    textAreaStyle,
     enterIcon = <EnterOutlined />,
   } = props;
   const ref = React.useRef<TextAreaRef>(null);
@@ -145,6 +149,8 @@ const Editable: React.FC<EditableProps> = (props) => {
         aria-label={ariaLabel}
         rows={1}
         autoSize={autoSize}
+        className={externalTextAreaClassName}
+        style={textAreaStyle}
       />
       {enterIcon !== null
         ? cloneElement(enterIcon, { className: `${prefixCls}-edit-content-confirm` })

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1232,6 +1232,57 @@ Array [
       </div>
     </div>
   </div>,
+  <div
+    class="ant-typography"
+  >
+    Customized edit area.
+    <button
+      aria-describedby="test-id"
+      aria-label="Edit"
+      class="ant-typography-edit"
+      type="button"
+    >
+      <span
+        aria-label="edit"
+        class="anticon anticon-edit"
+        role="button"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="edit"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+          />
+        </svg>
+      </span>
+    </button>
+    <div
+      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-placement-top"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+    >
+      <div
+        class="ant-tooltip-arrow"
+        style="position: absolute; bottom: 0px; left: 0px;"
+      />
+      <div
+        class="ant-tooltip-content"
+      >
+        <div
+          class="ant-tooltip-inner"
+          id="test-id"
+          role="tooltip"
+        >
+          Edit
+        </div>
+      </div>
+    </div>
+  </div>,
   <h1
     class="ant-typography"
     style="margin: 0px;"

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -955,6 +955,37 @@ Array [
       </span>
     </button>
   </div>,
+  <div
+    class="ant-typography"
+  >
+    Customized edit area.
+    <button
+      aria-describedby="test-id"
+      aria-label="Edit"
+      class="ant-typography-edit"
+      type="button"
+    >
+      <span
+        aria-label="edit"
+        class="anticon anticon-edit"
+        role="button"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="edit"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>,
   <h1
     class="ant-typography"
     style="margin:0"

--- a/components/typography/demo/editable.tsx
+++ b/components/typography/demo/editable.tsx
@@ -28,6 +28,7 @@ const App: React.FC = () => {
   const [lengthLimitedStr, setLengthLimitedStr] = useState(
     'This is an editable text with limited length.',
   );
+  const [styleEditAreaStr, setStyleEditAreaStr] = useState('Customized edit area.');
 
   const radioToState = (input: string): ('icon' | 'text')[] => {
     switch (input) {
@@ -121,6 +122,14 @@ const App: React.FC = () => {
         }}
       >
         {lengthLimitedStr}
+      </Paragraph>
+      <Paragraph
+        editable={{
+          onChange: setStyleEditAreaStr,
+          editAreaStyle: { backgroundColor: 'green' },
+        }}
+      >
+        {styleEditAreaStr}
       </Paragraph>
       <Typography.Title editable level={1} style={{ margin: 0 }}>
         h1. Ant Design

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -120,6 +120,8 @@ Common props ref：[Common props](/docs/react/common-props)
       triggerType: ('icon' | 'text')[],
       enterIcon: ReactNode,
       tabIndex: number,
+      editAreaClassName: string,
+      editAreaStyle: React.CSSProperties,
     }
 
 | Property | Description | Type | Default | Version |
@@ -137,6 +139,8 @@ Common props ref：[Common props](/docs/react/common-props)
 | triggerType | Edit mode trigger - icon, text or both (not specifying icon as trigger hides it) | Array&lt;`icon`\|`text`> | \[`icon`] |  |
 | enterIcon | Custom "enter" icon in the edit field (passing `null` removes the icon) | ReactNode | `<EnterOutlined />` | 4.17.0 |
 | tabIndex | Set tabIndex of the edit button | number | 0 | 5.17.0 |
+| editAreaClassName | Custom class name for the editing textarea | string | - | 5.29.0 |
+| editAreaStyle | Custom style for the editing textarea | React.CSSProperties | - | 5.29.0 |
 
 ### ellipsis
 

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -121,6 +121,8 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
       triggerType: ('icon' | 'text')[],
       enterIcon: ReactNode,
       tabIndex: number,
+      editAreaClassName: string,
+      editAreaStyle: React.CSSProperties,
     }
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
@@ -138,6 +140,8 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 | triggerType | 编辑模式触发器类型，图标、文本或者两者都设置（不设置图标作为触发器时它会隐藏） | Array&lt;`icon`\|`text`> | \[`icon`] |  |
 | enterIcon | 在编辑段中自定义“enter”图标（传递“null”将删除图标） | ReactNode | `<EnterOutlined />` | 4.17.0 |
 | tabIndex | 自定义编辑按钮的 tabIndex | number | 0 | 5.17.0 |
+| editAreaClassName | 编辑文本域的自定义类名 | string | - | 5.29.0 |
+| editAreaStyle | 编辑文本域的自定义样式 | React.CSSProperties | - | 5.29.0 |
 
 ### ellipsis
 


### PR DESCRIPTION
### 🤔 This is a ...

-  🆕 New feature

### 🔗 Related Issues

> - Issue, that I made this:  #55640

### 💡 Background and Solution

> - Problem happens, when I tried to change view of editing component, that appear when I want to change Typography - there's no props to customize TextArea,

> - My changes: 
>  <img width="1871" height="915" alt="image" src="https://github.com/user-attachments/assets/bdf6c772-512b-4f4a-bd65-f4e0dbd5ecbe" />


### 📝 Change Log

>### Added
> ```js
>      editAreaClassName: string,
>      editAreaStyle: React.CSSProperties,
>```
>

