### PR TITLE
docs: add classNames and styles to Tooltip shared API documentation

### DIFF
--- a/components/tooltip/shared/sharedProps.en-US.md
+++ b/components/tooltip/shared/sharedProps.en-US.md
@@ -6,6 +6,7 @@
 | align | Please refer to the settings [dom-align](https://github.com/yiminghe/dom-align) | object | - |  |
 | arrow | Change arrow's visible state and change whether the arrow is pointed at the center of target. | boolean \| { pointAtCenter: boolean } | true | 5.2.0 |
 | autoAdjustOverflow | Whether to adjust popup placement automatically when popup is off screen | boolean | true |  |
+| classNames | Semantic DOM class | [Record<SemanticDOM, string>](#semantic-dom) | - | 5.23.0 |
 | color | The background color | string | - | 4.3.0 |
 | defaultOpen | Whether the floating tooltip card is open by default | boolean | false | 4.23.0 |
 | ~~destroyTooltipOnHide~~ | Whether destroy dom when close | boolean | false |  |
@@ -18,6 +19,7 @@
 | ~~overlayStyle~~ | Style of the tooltip card, please use `styles={{ root: {} }}` | React.CSSProperties | - |  |
 | ~~overlayInnerStyle~~ | Style of the tooltip inner content, please use `styles={{ body: {} }}` | React.CSSProperties | - |  |
 | placement | The position of the tooltip relative to the target, which can be one of `top` `left` `right` `bottom` `topLeft` `topRight` `bottomLeft` `bottomRight` `leftTop` `leftBottom` `rightTop` `rightBottom` | string | `top` |  |
+| styles | Semantic DOM style | [Record<SemanticDOM, CSSProperties>](#semantic-dom) | - | 5.23.0 |
 | trigger | Tooltip trigger mode. Could be multiple by passing an array | `hover` \| `focus` \| `click` \| `contextMenu` \| Array&lt;string> | `hover` |  |
 | open | Whether the floating tooltip card is open or not. Use `visible` under 4.23.0 ([why?](/docs/react/faq#why-open)) | boolean | false | 4.23.0 |
 | zIndex | Config `z-index` of Tooltip | number | - |  |

--- a/components/tooltip/shared/sharedProps.zh-CN.md
+++ b/components/tooltip/shared/sharedProps.zh-CN.md
@@ -6,6 +6,7 @@
 | align | 请参考 [dom-align](https://github.com/yiminghe/dom-align) 进行配置 | object | - |  |
 | arrow | 修改箭头的显示状态以及修改箭头是否指向目标元素中心 | boolean \| { pointAtCenter: boolean } | true | 5.2.0 |
 | autoAdjustOverflow | 气泡被遮挡时自动调整位置 | boolean | true |  |
+| classNames | 语义化结构 class | [Record<SemanticDOM, string>](#semantic-dom) | - | 5.23.0 |
 | color | 背景颜色 | string | - | 4.3.0 |
 | defaultOpen | 默认是否显隐 | boolean | false | 4.23.0 |
 | ~~destroyTooltipOnHide~~ | 关闭后是否销毁 dom | boolean | false |  |
@@ -18,6 +19,7 @@
 | ~~overlayStyle~~ | 卡片样式, 请使用 `styles={{ root: {} }}` 替换| React.CSSProperties | - |  |
 | ~~overlayInnerStyle~~ | 卡片内容区域的样式对象, 请使用 `styles={{ body: {} }}` 替换 | React.CSSProperties | - |  |
 | placement | 气泡框位置，可选 `top` `left` `right` `bottom` `topLeft` `topRight` `bottomLeft` `bottomRight` `leftTop` `leftBottom` `rightTop` `rightBottom` | string | `top` |  |
+| styles | 语义化结构 style | [Record<SemanticDOM, CSSProperties>](#semantic-dom) | - | 5.23.0 |
 | trigger | 触发行为，可选 `hover` \| `focus` \| `click` \| `contextMenu`，可使用数组设置多个触发行为 | string \| string\[] | `hover` |  |
 | open | 用于手动控制浮层显隐，小于 4.23.0 使用 `visible`（[为什么?](/docs/react/faq#弹层类组件为什么要统一至-open-属性)） | boolean | false | 4.23.0 |
 | zIndex | 设置 Tooltip 的 `z-index` | number | - |  |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

 Closes #55641 

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

#### Problem
The shared API documentation for Tooltip, Popconfirm, and Popover components is missing descriptions for `classNames` and `styles` properties.

#### Solution
Added `classNames` and `styles` API documentation to both Chinese and English versions of the shared props file, following the Semantic DOM pattern used in other components.

#### Verification
These properties already exist in the source code (`tooltip/index.tsx:95-98`), they were just missing from the documentation.


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add `classNames` and `styles` API documentation to Tooltip, Popconfirm, and Popover shared API |
| 🇨🇳 Chinese | 为 Tooltip、Popconfirm 和 Popover 的共享 API 添加 `classNames` 和 `styles` 文档说明 |
