### PR TITLE
fix: restrict Pagination QuickJumper to numeric input only

### DIFF
--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -74,53 +74,42 @@ const Pagination: React.FC<PaginationProps> = (props) => {
   } = useComponentConfig('pagination');
   const prefixCls = getPrefixCls('pagination', customizePrefixCls);
 
-  // Handle QuickJumper input to only accept numbers
-  React.useEffect(() => {
-    if (!showQuickJumper && !simple) {
-      return;
-    }
+  // Handle QuickJumper input to only accept numbers using React event handler
+  const handleContainerInput = React.useCallback(
+    (e: React.FormEvent<HTMLDivElement>) => {
+      if (!showQuickJumper && !simple) {
+        return;
+      }
 
-    const handleInput = (e: Event) => {
       const target = e.target;
       // Type guard for better type safety
       if (!(target instanceof HTMLInputElement)) {
         return;
       }
-      const input = target;
 
       // Check if this is a QuickJumper input
       const isQuickJumperInput =
-        input.closest(`.${prefixCls}-options-quick-jumper`) ||
-        input.closest(`.${prefixCls}-simple-pager`);
+        target.closest(`.${prefixCls}-options-quick-jumper`) ||
+        target.closest(`.${prefixCls}-simple-pager`);
 
       if (isQuickJumperInput) {
         // Store the original value
-        const originalValue = input.value;
+        const originalValue = target.value;
         // Only allow digits
         const numericValue = originalValue.replace(/\D/g, '');
 
         if (originalValue !== numericValue) {
-          // Stop event propagation
-          e.stopPropagation();
-
           // Set the filtered value
-          input.value = numericValue;
+          target.value = numericValue;
 
-          // Dispatch a new input event to notify rc-pagination
-          input.dispatchEvent(new Event('input', { bubbles: true }));
+          // Trigger a new input event to notify rc-pagination
+          const inputEvent = new Event('input', { bubbles: true });
+          target.dispatchEvent(inputEvent);
         }
       }
-    };
-
-    // Add event listener for input events
-    const container = paginationRef.current;
-    if (container) {
-      container.addEventListener('input', handleInput, true);
-      return () => {
-        container.removeEventListener('input', handleInput, true);
-      };
-    }
-  }, [prefixCls, showQuickJumper, simple]);
+    },
+    [prefixCls, showQuickJumper, simple],
+  );
 
   // Style
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
@@ -265,7 +254,7 @@ const Pagination: React.FC<PaginationProps> = (props) => {
   const mergedStyle: React.CSSProperties = { ...contextStyle, ...style };
 
   return wrapCSSVar(
-    <div ref={paginationRef}>
+    <div ref={paginationRef} onInput={handleContainerInput}>
       {token.wireframe && <BorderedStyle prefixCls={prefixCls} />}
       <RcPagination
         {...iconsProps}

--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -57,10 +57,13 @@ const Pagination: React.FC<PaginationProps> = (props) => {
     showSizeChanger,
     selectComponentClass,
     pageSizeOptions,
+    showQuickJumper,
+    simple,
     ...restProps
   } = props;
   const { xs } = useBreakpoint(responsive);
   const [, token] = useToken();
+  const paginationRef = React.useRef<HTMLDivElement>(null);
 
   const {
     getPrefixCls,
@@ -70,6 +73,54 @@ const Pagination: React.FC<PaginationProps> = (props) => {
     style: contextStyle,
   } = useComponentConfig('pagination');
   const prefixCls = getPrefixCls('pagination', customizePrefixCls);
+
+  // Handle QuickJumper input to only accept numbers
+  React.useEffect(() => {
+    if (!showQuickJumper && !simple) {
+      return;
+    }
+
+    const handleInput = (e: Event) => {
+      const target = e.target;
+      // Type guard for better type safety
+      if (!(target instanceof HTMLInputElement)) {
+        return;
+      }
+      const input = target;
+
+      // Check if this is a QuickJumper input
+      const isQuickJumperInput =
+        input.closest(`.${prefixCls}-options-quick-jumper`) ||
+        input.closest(`.${prefixCls}-simple-pager`);
+
+      if (isQuickJumperInput) {
+        // Store the original value
+        const originalValue = input.value;
+        // Only allow digits
+        const numericValue = originalValue.replace(/\D/g, '');
+
+        if (originalValue !== numericValue) {
+          // Stop event propagation
+          e.stopPropagation();
+
+          // Set the filtered value
+          input.value = numericValue;
+
+          // Dispatch a new input event to notify rc-pagination
+          input.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+      }
+    };
+
+    // Add event listener for input events
+    const container = paginationRef.current;
+    if (container) {
+      container.addEventListener('input', handleInput, true);
+      return () => {
+        container.removeEventListener('input', handleInput, true);
+      };
+    }
+  }, [prefixCls, showQuickJumper, simple]);
 
   // Style
   const [wrapCSSVar, hashId, cssVarCls] = useStyle(prefixCls);
@@ -214,7 +265,7 @@ const Pagination: React.FC<PaginationProps> = (props) => {
   const mergedStyle: React.CSSProperties = { ...contextStyle, ...style };
 
   return wrapCSSVar(
-    <>
+    <div ref={paginationRef}>
       {token.wireframe && <BorderedStyle prefixCls={prefixCls} />}
       <RcPagination
         {...iconsProps}
@@ -227,8 +278,10 @@ const Pagination: React.FC<PaginationProps> = (props) => {
         pageSizeOptions={mergedPageSizeOptions}
         showSizeChanger={mergedShowSizeChanger}
         sizeChangerRender={sizeChangerRender}
+        showQuickJumper={showQuickJumper}
+        simple={simple}
       />
-    </>,
+    </div>,
   );
 };
 

--- a/components/pagination/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/pagination/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,307 +1,29 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Pagination ConfigProvider should be rendered correctly in RTL 1`] = `
-<ul
-  class="ant-pagination ant-pagination-rtl"
->
-  <li
-    aria-disabled="true"
-    class="ant-pagination-prev ant-pagination-disabled"
-    title="Previous Page"
+<div>
+  <ul
+    class="ant-pagination ant-pagination-rtl"
   >
-    <button
-      class="ant-pagination-item-link"
-      disabled=""
-      tabindex="-1"
-      type="button"
+    <li
+      aria-disabled="true"
+      class="ant-pagination-prev ant-pagination-disabled"
+      title="Previous Page"
     >
-      <span
-        aria-label="right"
-        class="anticon anticon-right"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="right"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-          />
-        </svg>
-      </span>
-    </button>
-  </li>
-  <li
-    class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
-    tabindex="0"
-    title="1"
-  >
-    <a
-      rel="nofollow"
-    >
-      1
-    </a>
-  </li>
-  <li
-    class="ant-pagination-item ant-pagination-item-2"
-    tabindex="0"
-    title="2"
-  >
-    <a
-      rel="nofollow"
-    >
-      2
-    </a>
-  </li>
-  <li
-    class="ant-pagination-item ant-pagination-item-3"
-    tabindex="0"
-    title="3"
-  >
-    <a
-      rel="nofollow"
-    >
-      3
-    </a>
-  </li>
-  <li
-    class="ant-pagination-item ant-pagination-item-4"
-    tabindex="0"
-    title="4"
-  >
-    <a
-      rel="nofollow"
-    >
-      4
-    </a>
-  </li>
-  <li
-    class="ant-pagination-item ant-pagination-item-5"
-    tabindex="0"
-    title="5"
-  >
-    <a
-      rel="nofollow"
-    >
-      5
-    </a>
-  </li>
-  <li
-    aria-disabled="false"
-    class="ant-pagination-next"
-    tabindex="0"
-    title="Next Page"
-  >
-    <button
-      class="ant-pagination-item-link"
-      tabindex="-1"
-      type="button"
-    >
-      <span
-        aria-label="left"
-        class="anticon anticon-left"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="left"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
-          />
-        </svg>
-      </span>
-    </button>
-  </li>
-</ul>
-`;
-
-exports[`Pagination ConfigProvider should be rendered correctly when componentSize is large 1`] = `
-<ul
-  class="ant-pagination"
->
-  <li
-    aria-disabled="true"
-    class="ant-pagination-prev ant-pagination-disabled"
-    title="Previous Page"
-  >
-    <button
-      class="ant-pagination-item-link"
-      disabled=""
-      tabindex="-1"
-      type="button"
-    >
-      <span
-        aria-label="left"
-        class="anticon anticon-left"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="left"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
-          />
-        </svg>
-      </span>
-    </button>
-  </li>
-  <li
-    class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
-    tabindex="0"
-    title="1"
-  >
-    <a
-      rel="nofollow"
-    >
-      1
-    </a>
-  </li>
-  <li
-    class="ant-pagination-item ant-pagination-item-2"
-    tabindex="0"
-    title="2"
-  >
-    <a
-      rel="nofollow"
-    >
-      2
-    </a>
-  </li>
-  <li
-    class="ant-pagination-item ant-pagination-item-3"
-    tabindex="0"
-    title="3"
-  >
-    <a
-      rel="nofollow"
-    >
-      3
-    </a>
-  </li>
-  <li
-    class="ant-pagination-item ant-pagination-item-4"
-    tabindex="0"
-    title="4"
-  >
-    <a
-      rel="nofollow"
-    >
-      4
-    </a>
-  </li>
-  <li
-    class="ant-pagination-item ant-pagination-item-5"
-    tabindex="0"
-    title="5"
-  >
-    <a
-      rel="nofollow"
-    >
-      5
-    </a>
-  </li>
-  <li
-    aria-disabled="false"
-    class="ant-pagination-next"
-    tabindex="0"
-    title="Next Page"
-  >
-    <button
-      class="ant-pagination-item-link"
-      tabindex="-1"
-      type="button"
-    >
-      <span
-        aria-label="right"
-        class="anticon anticon-right"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="right"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-          />
-        </svg>
-      </span>
-    </button>
-  </li>
-  <li
-    class="ant-pagination-options"
-  >
-    <div
-      aria-label="Page Size"
-      class="ant-select ant-select-outlined ant-pagination-options-size-changer ant-select-single ant-select-show-arrow ant-select-show-search"
-    >
-      <div
-        class="ant-select-selector"
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
       >
         <span
-          class="ant-select-selection-wrap"
-        >
-          <span
-            class="ant-select-selection-search"
-          >
-            <input
-              aria-autocomplete="list"
-              aria-controls="rc_select_TEST_OR_SSR_list"
-              aria-expanded="false"
-              aria-haspopup="listbox"
-              aria-label="Page Size"
-              aria-owns="rc_select_TEST_OR_SSR_list"
-              autocomplete="off"
-              class="ant-select-selection-search-input"
-              id="rc_select_TEST_OR_SSR"
-              role="combobox"
-              type="search"
-              value=""
-            />
-          </span>
-          <span
-            class="ant-select-selection-item"
-            title="10 / page"
-          >
-            10 / page
-          </span>
-        </span>
-      </div>
-      <span
-        aria-hidden="true"
-        class="ant-select-arrow"
-        style="user-select: none;"
-        unselectable="on"
-      >
-        <span
-          aria-label="down"
-          class="anticon anticon-down ant-select-suffix"
+          aria-label="right"
+          class="anticon anticon-right"
           role="img"
         >
           <svg
             aria-hidden="true"
-            data-icon="down"
+            data-icon="right"
             fill="currentColor"
             focusable="false"
             height="1em"
@@ -309,94 +31,378 @@ exports[`Pagination ConfigProvider should be rendered correctly when componentSi
             width="1em"
           >
             <path
-              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
             />
           </svg>
         </span>
-      </span>
-    </div>
-  </li>
-</ul>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+      tabindex="0"
+      title="1"
+    >
+      <a
+        rel="nofollow"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-2"
+      tabindex="0"
+      title="2"
+    >
+      <a
+        rel="nofollow"
+      >
+        2
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-3"
+      tabindex="0"
+      title="3"
+    >
+      <a
+        rel="nofollow"
+      >
+        3
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-4"
+      tabindex="0"
+      title="4"
+    >
+      <a
+        rel="nofollow"
+      >
+        4
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-5"
+      tabindex="0"
+      title="5"
+    >
+      <a
+        rel="nofollow"
+      >
+        5
+      </a>
+    </li>
+    <li
+      aria-disabled="false"
+      class="ant-pagination-next"
+      tabindex="0"
+      title="Next Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Pagination ConfigProvider should be rendered correctly when componentSize is large 1`] = `
+<div>
+  <ul
+    class="ant-pagination"
+  >
+    <li
+      aria-disabled="true"
+      class="ant-pagination-prev ant-pagination-disabled"
+      title="Previous Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+      tabindex="0"
+      title="1"
+    >
+      <a
+        rel="nofollow"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-2"
+      tabindex="0"
+      title="2"
+    >
+      <a
+        rel="nofollow"
+      >
+        2
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-3"
+      tabindex="0"
+      title="3"
+    >
+      <a
+        rel="nofollow"
+      >
+        3
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-4"
+      tabindex="0"
+      title="4"
+    >
+      <a
+        rel="nofollow"
+      >
+        4
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-5"
+      tabindex="0"
+      title="5"
+    >
+      <a
+        rel="nofollow"
+      >
+        5
+      </a>
+    </li>
+    <li
+      aria-disabled="false"
+      class="ant-pagination-next"
+      tabindex="0"
+      title="Next Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-options"
+    >
+      <div
+        aria-label="Page Size"
+        class="ant-select ant-select-outlined ant-pagination-options-size-changer ant-select-single ant-select-show-arrow ant-select-show-search"
+      >
+        <div
+          class="ant-select-selector"
+        >
+          <span
+            class="ant-select-selection-wrap"
+          >
+            <span
+              class="ant-select-selection-search"
+            >
+              <input
+                aria-autocomplete="list"
+                aria-controls="rc_select_TEST_OR_SSR_list"
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-label="Page Size"
+                aria-owns="rc_select_TEST_OR_SSR_list"
+                autocomplete="off"
+                class="ant-select-selection-search-input"
+                id="rc_select_TEST_OR_SSR"
+                role="combobox"
+                type="search"
+                value=""
+              />
+            </span>
+            <span
+              class="ant-select-selection-item"
+              title="10 / page"
+            >
+              10 / page
+            </span>
+          </span>
+        </div>
+        <span
+          aria-hidden="true"
+          class="ant-select-arrow"
+          style="user-select: none;"
+          unselectable="on"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down ant-select-suffix"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </li>
+  </ul>
+</div>
 `;
 
 exports[`Pagination rtl render component should be rendered correctly in RTL direction 1`] = `
-<ul
-  class="ant-pagination ant-pagination-rtl"
->
-  <li
-    aria-disabled="true"
-    class="ant-pagination-prev ant-pagination-disabled"
-    title="Previous Page"
+<div>
+  <ul
+    class="ant-pagination ant-pagination-rtl"
   >
-    <button
-      class="ant-pagination-item-link"
-      disabled=""
-      tabindex="-1"
-      type="button"
+    <li
+      aria-disabled="true"
+      class="ant-pagination-prev ant-pagination-disabled"
+      title="Previous Page"
     >
-      <span
-        aria-label="right"
-        class="anticon anticon-right"
-        role="img"
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="right"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
+        <span
+          aria-label="right"
+          class="anticon anticon-right"
+          role="img"
         >
-          <path
-            d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-          />
-        </svg>
-      </span>
-    </button>
-  </li>
-  <li
-    class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-disabled"
-    tabindex="0"
-    title="1"
-  >
-    <a
-      rel="nofollow"
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-disabled"
+      tabindex="0"
+      title="1"
     >
-      1
-    </a>
-  </li>
-  <li
-    aria-disabled="true"
-    class="ant-pagination-next ant-pagination-disabled"
-    title="Next Page"
-  >
-    <button
-      class="ant-pagination-item-link"
-      disabled=""
-      tabindex="-1"
-      type="button"
-    >
-      <span
-        aria-label="left"
-        class="anticon anticon-left"
-        role="img"
+      <a
+        rel="nofollow"
       >
-        <svg
-          aria-hidden="true"
-          data-icon="left"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
+        1
+      </a>
+    </li>
+    <li
+      aria-disabled="true"
+      class="ant-pagination-next ant-pagination-disabled"
+      title="Next Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
         >
-          <path
-            d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
-          />
-        </svg>
-      </span>
-    </button>
-  </li>
-</ul>
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+  </ul>
+</div>
 `;

--- a/components/pagination/__tests__/index.test.tsx
+++ b/components/pagination/__tests__/index.test.tsx
@@ -126,4 +126,64 @@ describe('Pagination', () => {
     // Expect `input` is `readonly`
     expect(container.querySelector('.ant-select input')).toHaveAttribute('readonly');
   });
+
+  // https://github.com/ant-design/ant-design/issues/55637
+  describe('QuickJumper should only accept numeric input', () => {
+    it('should filter non-numeric characters in QuickJumper input', () => {
+      const { container } = render(<Pagination total={100} showQuickJumper />);
+
+      const input = container.querySelector(
+        '.ant-pagination-options-quick-jumper input',
+      ) as HTMLInputElement;
+
+      expect(input).toBeTruthy();
+
+      // Try to input letters
+      fireEvent.input(input, { target: { value: 'abc' } });
+      expect(input.value).toBe('');
+
+      // Try to input mixed alphanumeric
+      fireEvent.input(input, { target: { value: '12abc34' } });
+      expect(input.value).toBe('1234');
+
+      // Normal numeric input should work
+      fireEvent.input(input, { target: { value: '5' } });
+      expect(input.value).toBe('5');
+    });
+
+    it('should filter non-numeric characters in simple mode', () => {
+      const { container } = render(<Pagination simple total={100} />);
+
+      const input = container.querySelector('.ant-pagination-simple input') as HTMLInputElement;
+
+      expect(input).toBeTruthy();
+
+      // Initial value should be "1"
+      expect(input.value).toBe('1');
+
+      // Try to input letters - should filter them to empty string
+      fireEvent.input(input, { target: { value: 'test' } });
+      expect(input.value).toBe('');
+
+      // Try to input mixed alphanumeric - only numbers should remain
+      fireEvent.input(input, { target: { value: '3abc' } });
+      expect(input.value).toBe('3');
+
+      // Normal numeric input should work
+      fireEvent.input(input, { target: { value: '7' } });
+      expect(input.value).toBe('7');
+    });
+
+    it('should handle paste with non-numeric content', () => {
+      const { container } = render(<Pagination total={100} showQuickJumper />);
+
+      const input = container.querySelector(
+        '.ant-pagination-options-quick-jumper input',
+      ) as HTMLInputElement;
+
+      // Simulate paste with mixed content
+      fireEvent.input(input, { target: { value: 'page123' } });
+      expect(input.value).toBe('123');
+    });
+  });
 });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Closes #55637 

### 💡 Background and Solution

**Problem:**
The Pagination component's QuickJumper and simple mode page input fields currently accept any string input (letters, special characters, etc.) instead of restricting input to numbers only. This can lead to confusion and unexpected behavior when users accidentally type non-numeric characters.

**Solution:**
Added input filtering logic at the antd Pagination component level using DOM event interception. The solution:
- Intercepts `input` events in the capture phase before they reach `rc-pagination`
- Filters out all non-numeric characters using regex `/\D/g`
- Applies to both QuickJumper mode and simple mode
- Handles keyboard input and paste operations

**Implementation:**
- Added a `useEffect` hook to attach an event listener to the pagination container
- The event listener filters non-numeric characters from input values in real-time
- Wrapped `RcPagination` with a `div` container to enable event handling via ref

before: 
![PixPin_2025-11-10_15-56-47](https://github.com/user-attachments/assets/5724819d-b577-4a2f-a65e-1036e93c4a39)

after:
![PixPin_2025-11-10_15-57-45](https://github.com/user-attachments/assets/9efd4c4e-73f2-4a98-8712-d282f1fbc59a)


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Pagination QuickJumper to only accept numeric input. |
| 🇨🇳 Chinese | 🐞 修复 Pagination 快速跳转输入框为只接受数字输入。 |
