### PR TITLE
docs: Fix custom storage sync event 

### DIFF
--- a/.dumi/hooks/useLocalStorage.ts
+++ b/.dumi/hooks/useLocalStorage.ts
@@ -83,9 +83,15 @@ const useLocalStorage = <T>(key: string, options: Options<T> = {}) => {
     [key],
   );
 
+  const shouldSyncCustomEvent = (ev: CustomEvent) => {
+    return ev && ev.detail && ev.detail.key === key && ev.detail.storageArea === storage;
+  };
+
   const onCustomStorage = useCallback(
     (event: Event) => {
-      if (shouldSync(event as StorageEvent)) {
+      const customEvent = event as CustomEvent;
+
+      if (shouldSyncCustomEvent(customEvent)) {
         setState(getStoredValue());
       }
     },

--- a/.dumi/hooks/useLocalStorage.ts
+++ b/.dumi/hooks/useLocalStorage.ts
@@ -83,8 +83,8 @@ const useLocalStorage = <T>(key: string, options: Options<T> = {}) => {
     [key],
   );
 
-  const shouldSyncCustomEvent = (ev: CustomEvent) => {
-    return ev && ev.detail && ev.detail.key === key && ev.detail.storageArea === storage;
+  const shouldSyncCustomEvent = (ev: CustomEvent<{ key: string; storageArea: Storage }>) => {
+    return ev?.detail?.key === key && ev?.detail?.storageArea === storage;
   };
 
   const onCustomStorage = useCallback(


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

https://github.com/ant-design/ant-design/issues/55750

### 💡 需求背景和解决方案

> 站点Local Storage监听Native Storage和Custom Storage两个结构，当前代码里，两个结构使用同样的同步判断事件
```ts
const shouldSync = (ev: StorageEvent) => {
    return ev && ev.key === key && ev.storageArea === storage;
  };
```
然而，Custom事件的结构为
```ts
CustomEvent(ANT_SYNC_STORAGE_EVENT_KEY, {
          detail: { key, newValue, oldValue, storageArea: storage },
        })
```
<img width="1850" height="985" alt="image" src="https://github.com/user-attachments/assets/773a569e-b61f-44bd-8deb-c33c3915c371" />

即有一层detail包装，这个问题导致使用到Custom Storage的部分无法正常监听更新，因此，主题获取出现问题

> 本次修改新增对Custom Storage结构同步事件的支持

### 📝 更新日志

> 站点级更新，对用户无影响

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   Fix custom storage sync event        |
| 🇨🇳 中文 |    站点数据存储事件修复      |

### 测试
![fix20251117_235116](https://github.com/user-attachments/assets/5101c7e9-7ab4-41d4-b544-0f424fbc9985)
