### PR TITLE
fix: Fixed the issue of carousel dot being unclickable

### DIFF
--- a/components/carousel/style/index.ts
+++ b/components/carousel/style/index.ts
@@ -233,10 +233,10 @@ const genDotsStyle: GenerateStyle<CarouselToken> = (token) => {
 
   const animation = new Keyframes(`${token.prefixCls}-dot-animation`, {
     from: {
-      transform: `translate3d(-100%, 0, 0)`,
+      width: 0,
     },
     to: {
-      transform: `translate3d(0%, 0, 0)`,
+      width: token.dotActiveWidth,
     },
   });
 
@@ -284,7 +284,7 @@ const genDotsStyle: GenerateStyle<CarouselToken> = (token) => {
             position: 'absolute',
             top: 0,
             insetInlineStart: 0,
-            width: '100%',
+            width: 0,
             height: dotHeight,
             content: '""',
             background: 'transparent',


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- fix https://github.com/ant-design/ant-design/issues/55755

### 💡 Background and Solution

横向和竖向的动画样式实现不同 上次改漏了 
现在统一成 height width 了

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     修复横向标识点无法点击切换问题      |
| 🇨🇳 Chinese |      Fixed the issue of carousel dot being unclickable.     |
