### PR TITLE
fix(notification): prevent colorful background when CSS variables are disabled

### DIFF
--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -156,21 +156,11 @@ export const genNoticeStyle = (token: NotificationToken): CSSObject => {
       wordWrap: 'break-word',
       borderRadius: borderRadiusLG,
       overflow: 'hidden',
-
       // Type-specific background colors
-      ...Object.entries({
-        success: colorSuccessBg,
-        error: colorErrorBg,
-        info: colorInfoBg,
-        warning: colorWarningBg,
-      }).reduce<CSSObject>((acc, [type, color]) => {
-        if (color) {
-          acc[`&-${type}`] = {
-            background: color,
-          };
-        }
-        return acc;
-      }, {}),
+      '&-success': colorSuccessBg ? { background: colorSuccessBg } : {},
+      '&-error': colorErrorBg ? { background: colorErrorBg } : {},
+      '&-info': colorInfoBg ? { background: colorInfoBg } : {},
+      '&-warning': colorWarningBg ? { background: colorWarningBg } : {},
     },
 
     [`${noticeCls}-message`]: {

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -158,18 +158,26 @@ export const genNoticeStyle = (token: NotificationToken): CSSObject => {
       overflow: 'hidden',
 
       // Type-specific background colors
-      '&-success': {
-        background: colorSuccessBg,
-      },
-      '&-error': {
-        background: colorErrorBg,
-      },
-      '&-info': {
-        background: colorInfoBg,
-      },
-      '&-warning': {
-        background: colorWarningBg,
-      },
+      ...(colorSuccessBg && {
+        '&-success': {
+          background: colorSuccessBg,
+        },
+      }),
+      ...(colorErrorBg && {
+        '&-error': {
+          background: colorErrorBg,
+        },
+      }),
+      ...(colorInfoBg && {
+        '&-info': {
+          background: colorInfoBg,
+        },
+      }),
+      ...(colorWarningBg && {
+        '&-warning': {
+          background: colorWarningBg,
+        },
+      }),
     },
 
     [`${noticeCls}-message`]: {

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -158,26 +158,19 @@ export const genNoticeStyle = (token: NotificationToken): CSSObject => {
       overflow: 'hidden',
 
       // Type-specific background colors
-      ...(colorSuccessBg && {
-        '&-success': {
-          background: colorSuccessBg,
-        },
-      }),
-      ...(colorErrorBg && {
-        '&-error': {
-          background: colorErrorBg,
-        },
-      }),
-      ...(colorInfoBg && {
-        '&-info': {
-          background: colorInfoBg,
-        },
-      }),
-      ...(colorWarningBg && {
-        '&-warning': {
-          background: colorWarningBg,
-        },
-      }),
+      ...Object.entries({
+        success: colorSuccessBg,
+        error: colorErrorBg,
+        info: colorInfoBg,
+        warning: colorWarningBg,
+      }).reduce<CSSObject>((acc, [type, color]) => {
+        if (color) {
+          acc[`&-${type}`] = {
+            background: color,
+          };
+        }
+        return acc;
+      }, {}),
     },
 
     [`${noticeCls}-message`]: {


### PR DESCRIPTION
## Summary

This PR fixes issue #55765 where the notification component displays unexpected colorful backgrounds when CSS variables are disabled (`cssVar: false`).

### Changes

Modified `components/notification/style/index.ts` to conditionally apply type-specific background colors (success, error, info, warning) only when the color values exist. This prevents colorful backgrounds from appearing when CSS variables are disabled.

**Before:** Background colors were always applied regardless of CSS variable settings.
**After:** Background colors are only applied when the color token values are available.

### Technical Details

The fix uses spread operators with conditional checks:
```typescript
...(colorSuccessBg && {
  '&-success': {
    background: colorSuccessBg,
  },
}),
```

This ensures that when CSS variables are disabled and these color values are undefined or invalid, the background styles are not applied at all.

### Testing

- Tested the notification component with `cssVar: false` in ConfigProvider
- Verified that notifications no longer show unexpected colorful backgrounds
- Confirmed that notifications with CSS variables enabled still work correctly

## Reproduction

Visit: https://ant.design/components/notification-cn#notification-demo-placement

With CSS variables disabled, notification components should no longer display unexpected colorful backgrounds.

## Closes

Closes #55765

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)