### PR TITLE
fix: Input.Search should not warning for `addonAfter`

### DIFF
--- a/components/form/demo/register.tsx
+++ b/components/form/demo/register.tsx
@@ -80,6 +80,10 @@ const tailFormItemLayout: FormItemProps = {
   },
 };
 
+function Injector({ children, ...rest }: { children: (props: any) => React.ReactElement }) {
+  return children(rest);
+}
+
 const App: React.FC = () => {
   const [form] = Form.useForm();
 
@@ -214,11 +218,14 @@ const App: React.FC = () => {
         label="Phone Number"
         rules={[{ required: true, message: 'Please input your phone number!' }]}
       >
-        {/* Demo only, real usage should wrap as custom component */}
-        <Space.Compact block>
-          {prefixSelector}
-          <Input style={{ width: '100%' }} />
-        </Space.Compact>
+        <Injector>
+          {(props) => (
+            <Space.Compact block>
+              {prefixSelector}
+              <Input style={{ width: '100%' }} {...props} />
+            </Space.Compact>
+          )}
+        </Injector>
       </Form.Item>
 
       <Form.Item
@@ -226,11 +233,14 @@ const App: React.FC = () => {
         label="Donation"
         rules={[{ required: true, message: 'Please input donation amount!' }]}
       >
-        {/* Demo only, real usage should wrap as custom component */}
-        <Space.Compact block>
-          <InputNumber style={{ width: '100%' }} />
-          {suffixSelector}
-        </Space.Compact>
+        <Injector>
+          {(props) => (
+            <Space.Compact block>
+              <InputNumber style={{ width: '100%' }} {...props} />
+              {suffixSelector}
+            </Space.Compact>
+          )}
+        </Injector>
       </Form.Item>
 
       <Form.Item

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -77,6 +77,9 @@ export interface InputProps
   classNames?: Partial<Record<SemanticName, string>>;
   styles?: Partial<Record<SemanticName, React.CSSProperties>>;
   [key: `data-${string}`]: string | undefined;
+
+  /** @private Skip warning of addon. Only work in dev mode */
+  _skipAddonWarning?: boolean;
 }
 
 const Input = forwardRef<InputRef, InputProps>((props, ref) => {
@@ -99,18 +102,22 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     onChange,
     classNames,
     variant: customVariant,
+    _skipAddonWarning,
     ...rest
   } = props;
 
   if (process.env.NODE_ENV !== 'production') {
     const { deprecated } = devUseWarning('Input');
-    [
-      ['bordered', 'variant'],
-      ['addonAfter', 'Space.Compact'],
-      ['addonBefore', 'Space.Compact'],
-    ].forEach(([prop, newProp]) => {
-      deprecated(!(prop in props), prop, newProp);
-    });
+    deprecated(!('bordered' in props), 'bordered', 'variant');
+
+    if (!_skipAddonWarning) {
+      [
+        ['addonAfter', 'Space.Compact'],
+        ['addonBefore', 'Space.Compact'],
+      ].forEach(([prop, newProp]) => {
+        deprecated(!(prop in props), prop, newProp);
+      });
+    }
   }
 
   const {

--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -185,6 +185,7 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
     suffix,
     onChange,
     disabled,
+    _skipAddonWarning: true,
   };
 
   return <Input ref={composeRef<InputRef>(inputRef, ref)} {...inputProps} />;

--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
+import { resetWarned } from '../../_util/warning';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
@@ -12,6 +13,20 @@ describe('Input.Search', () => {
   focusTest(Search, { refFocus: true });
   mountTest(Search);
   rtlTest(Search);
+
+  beforeEach(() => {
+    resetWarned();
+  });
+
+  // V5 Only
+  it('no warning of addon', () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<Search />);
+    expect(errSpy).not.toHaveBeenCalled();
+
+    errSpy.mockRestore();
+  });
 
   it('should support custom button', () => {
     const { asFragment } = render(<Search enterButton={<button type="button">ok</button>} />);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Input.Search warning for `addonAfter` deprecated.     |
| 🇨🇳 Chinese |     修复 Input.Search 会报`addonAfter` 已经废弃的警告信息。    |
