### PR TITLE
docs: Replace old theme logic and fix iframe code previewer inconsistency

### DIFF
--- a/.dumi/theme/builtins/ComponentOverview/index.tsx
+++ b/.dumi/theme/builtins/ComponentOverview/index.tsx
@@ -79,7 +79,7 @@ const { Title } = Typography;
 
 const Overview: React.FC = () => {
   const { styles } = useStyle();
-  const { theme } = React.use(SiteContext);
+  const { isDark } = React.use(SiteContext);
 
   const data = useSidebarData();
   const [searchBarAffixed, setSearchBarAffixed] = useState<boolean>(false);
@@ -225,9 +225,7 @@ const Overview: React.FC = () => {
                           <img
                             draggable={false}
                             src={
-                              theme.includes('dark') && component.coverDark
-                                ? component.coverDark
-                                : component.cover
+                              isDark && component.coverDark ? component.coverDark : component.cover
                             }
                             alt={component.title}
                           />

--- a/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
@@ -79,7 +79,7 @@ const CodePreviewer: React.FC<AntdPreviewerProps> = (props) => {
   });
   const anchorRef = useRef<HTMLAnchorElement>(null);
   const [codeExpand, setCodeExpand] = useState<boolean>(false);
-  const { theme } = React.use(SiteContext);
+  const { isDark } = React.use(SiteContext);
 
   const { hash, pathname, search } = location;
   const docsOnlineUrl = `https://ant.design${pathname ?? ''}${search ?? ''}#${asset.id}`;
@@ -104,7 +104,7 @@ const CodePreviewer: React.FC<AntdPreviewerProps> = (props) => {
   }, [expand]);
 
   const mergedChildren = !iframe && clientOnly ? <ClientOnly>{children}</ClientOnly> : children;
-  const demoUrlWithTheme = `${demoUrl}${theme.includes('dark') ? '?theme=dark' : ''}`;
+  const demoUrlWithTheme = `${demoUrl}${isDark ? '?theme=dark' : ''}`;
 
   if (!previewDemo.current) {
     previewDemo.current = iframe ? (
@@ -131,7 +131,7 @@ const CodePreviewer: React.FC<AntdPreviewerProps> = (props) => {
     'highlight-wrapper-expand': codeExpand,
   });
 
-  const backgroundGrey = theme.includes('dark') ? '#303030' : '#f0f2f5';
+  const backgroundGrey = isDark ? '#303030' : '#f0f2f5';
 
   const codeBoxDemoStyle: React.CSSProperties = {
     padding: iframe || compact ? 0 : undefined,

--- a/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
+++ b/.dumi/theme/builtins/Previewer/CodePreviewer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { UpOutlined } from '@ant-design/icons';
 import { Badge, Tooltip } from 'antd';
 import { createStyles, css } from 'antd-style';
@@ -67,7 +67,6 @@ const CodePreviewer: React.FC<AntdPreviewerProps> = (props) => {
   const entryName = 'index.tsx';
   const entryCode = asset.dependencies[entryName].value;
 
-  const previewDemo = useRef<React.ReactNode>(null);
   const demoContainer = useRef<HTMLElement>(null);
   const {
     node: liveDemoNode,
@@ -104,10 +103,13 @@ const CodePreviewer: React.FC<AntdPreviewerProps> = (props) => {
   }, [expand]);
 
   const mergedChildren = !iframe && clientOnly ? <ClientOnly>{children}</ClientOnly> : children;
-  const demoUrlWithTheme = `${demoUrl}${isDark ? '?theme=dark' : ''}`;
+  const demoUrlWithTheme = useMemo(() => {
+    return `${demoUrl}${isDark ? '?theme=dark' : ''}`;
+  }, [demoUrl, isDark]);
 
-  if (!previewDemo.current) {
-    previewDemo.current = iframe ? (
+  const iframePreview = useMemo(() => {
+    if (!iframe) return null;
+    return (
       <BrowserFrame>
         <iframe
           src={demoUrlWithTheme}
@@ -116,10 +118,9 @@ const CodePreviewer: React.FC<AntdPreviewerProps> = (props) => {
           className="iframe-demo"
         />
       </BrowserFrame>
-    ) : (
-      mergedChildren
     );
-  }
+  }, [demoUrlWithTheme, iframe]);
+  const previewContent = iframePreview ?? mergedChildren;
 
   const codeBoxClass = clsx('code-box', {
     expand: codeExpand,
@@ -147,7 +148,7 @@ const CodePreviewer: React.FC<AntdPreviewerProps> = (props) => {
         style={codeBoxDemoStyle}
         ref={demoContainer}
       >
-        {liveDemoNode || <React.StrictMode>{previewDemo.current}</React.StrictMode>}
+        {liveDemoNode || <React.StrictMode>{previewContent}</React.StrictMode>}
       </section>
       {!simplify && (
         <section className="code-box-meta markdown">

--- a/.dumi/theme/slots/Sidebar/index.tsx
+++ b/.dumi/theme/slots/Sidebar/index.tsx
@@ -108,11 +108,10 @@ const useStyle = createStyles(({ cssVar, token, css }) => {
 
 const Sidebar: React.FC = () => {
   const sidebarData = useSidebarData();
-  const { isMobile, theme } = React.use(SiteContext);
+  const { isMobile, isDark } = React.use(SiteContext);
   const { styles } = useStyle();
 
   const [menuItems, selectedKey] = useMenu();
-  const isDark = theme.includes('dark');
   const { colorBgContainer } = useTheme();
 
   const menuChild = (

--- a/.dumi/theme/slots/SiteContext.ts
+++ b/.dumi/theme/slots/SiteContext.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 import type { DirectionType } from 'antd/es/config-provider';
 
 import type { ConfigComponentProps } from '../../../components/config-provider/context';
-import type { ThemeName } from '../common/ThemeSwitch';
 import { getBannerData } from '../../pages/index/components/util';
+import type { ThemeName } from '../common/ThemeSwitch';
 
 export type SimpleComponentClassNames = Partial<
   Record<keyof ConfigComponentProps, Record<string, string>>
@@ -14,6 +14,9 @@ export interface SiteContextProps {
   bannerVisible: boolean;
   direction: DirectionType;
   theme: ThemeName[];
+  // 主题存在跟随系统模式，解耦实际生效主题
+  // 应使用isDark而非theme.includes('dark')等来判断当前主题
+  isDark: boolean;
   updateSiteConfig: (props: Partial<SiteContextProps>) => void;
 
   dynamicTheme?: {
@@ -27,6 +30,7 @@ const SiteContext = React.createContext<SiteContextProps>({
   bannerVisible: !!getBannerData(),
   direction: 'ltr',
   theme: ['light'],
+  isDark: false,
   updateSiteConfig: () => {},
 });
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

https://github.com/ant-design/ant-design/issues/55763
https://github.com/ant-design/ant-design/issues/55670

### 💡 需求背景和解决方案

本次需求解决两个问题，一是主题取值逻辑落后导致的显示异常问题，二是iframe形式的demo块在主题更改后未实时变更的问题。

> 1. 引入auto theme之后，原先文档仍存在大量
```ts
const isDark = theme.includes('dark');
theme={isDark ? 'dark' : 'light'}
```
的逻辑，导致真正的颜色模式没有被应用。

本次修改在SiteContext中添加isDark，以此作为其它组件判断页面模式的唯一依据，在GlobalLayout中实现isDark和theme同步，同时将所有取主题的旧逻辑更换为新逻辑。

引用部分修改了三处，分别为Menu、组件首页预览和code demo。

> 2. 站点code demo重写了dumi的code previewer逻辑，使用iframe的code demo和文档完全独立，且没有随主题变更的逻辑，导致修改主题后demo主题仍保持原样

本次修改将展示demo的demoUrlWithTheme依赖于isDark，使isDark变更时，iframe可以同步刷新，从而实现主题统一。


### 📝 更新日志

站点级更新，对用户无影响

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |    Replace old theme logic and fix iframe code previewer inconsistency      |
| 🇨🇳 中文 |    修改主题获取逻辑及修复iframe不一致问题      |

### 测试
切换颜色测试，关注Menu及首页组件颜色
![dark switch20251122_215004](https://github.com/user-attachments/assets/23973080-9ac2-47ca-8db8-5c794e10ac2e)

code demo测试，关注切换颜色后iframe demo展示
![previewer20251122_215105](https://github.com/user-attachments/assets/8cedf72c-e43c-4cf3-8ddc-eb1d55b4c6dd)

---
另外，对https://github.com/ant-design/ant-design/issues/55670 提到的dumi的问题也提了pr，不过，当前pr解决的问题并非dumi引起，dumi组件本身存在问题，antd对Previewer的重写也存在问题，分别修改。
https://github.com/umijs/dumi/pull/2301
