### PR TITLE
docs(theme-editor): revert `useLocalStorage` to fix state update issue in Theme Editor

### DIFF
--- a/.dumi/pages/theme-editor/index.tsx
+++ b/.dumi/pages/theme-editor/index.tsx
@@ -1,5 +1,5 @@
-import React, { Suspense, useEffect } from 'react';
-import { App, Button, ConfigProvider, Skeleton } from 'antd';
+import React, { Suspense } from 'react';
+import { App, Button, ConfigProvider, Skeleton, version } from 'antd';
 import { enUS, zhCN } from 'antd-token-previewer';
 import type { ThemeConfig } from 'antd/es/config-provider/context';
 import { Helmet } from 'dumi';
@@ -33,21 +33,21 @@ const locales = {
   },
 };
 
-const ANT_DESIGN_V5_THEME_EDITOR_THEME = 'ant-design-v5-theme-editor-theme';
+const [antdMajor] = version.split('.');
+const ANT_DESIGN_V5_THEME_EDITOR_THEME = `ant-design-v${antdMajor}-theme-editor-theme`;
 
 const CustomTheme: React.FC = () => {
   const { message } = App.useApp();
   const [locale, lang] = useLocale(locales);
 
-  const [theme, setTheme] = React.useState<ThemeConfig>({});
-
-  useEffect(() => {
-    const storedConfig = localStorage.getItem(ANT_DESIGN_V5_THEME_EDITOR_THEME);
-    if (storedConfig) {
-      const themeConfig = JSON.parse(storedConfig);
-      setTheme(themeConfig);
+  const [theme, setTheme] = React.useState<ThemeConfig>(() => {
+    try {
+      const storedConfig = localStorage.getItem(ANT_DESIGN_V5_THEME_EDITOR_THEME);
+      return storedConfig ? JSON.parse(storedConfig) : {};
+    } catch {
+      return {};
     }
-  }, []);
+  });
 
   const handleSave = () => {
     localStorage.setItem(ANT_DESIGN_V5_THEME_EDITOR_THEME, JSON.stringify(theme));

--- a/.dumi/pages/theme-editor/index.tsx
+++ b/.dumi/pages/theme-editor/index.tsx
@@ -1,11 +1,10 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { App, Button, ConfigProvider, Skeleton } from 'antd';
 import { enUS, zhCN } from 'antd-token-previewer';
 import type { ThemeConfig } from 'antd/es/config-provider/context';
 import { Helmet } from 'dumi';
 
 import useLocale from '../../hooks/useLocale';
-import useLocalStorage from '../../hooks/useLocalStorage';
 
 const ThemeEditor = React.lazy(() => import('antd-token-previewer/lib/ThemeEditor'));
 
@@ -34,18 +33,24 @@ const locales = {
   },
 };
 
-const ANT_THEME_EDITOR_THEME = 'ant-theme-editor-theme';
+const ANT_DESIGN_V5_THEME_EDITOR_THEME = 'ant-design-v5-theme-editor-theme';
 
 const CustomTheme: React.FC = () => {
   const { message } = App.useApp();
   const [locale, lang] = useLocale(locales);
 
-  const [themeConfig, setThemeConfig] = useLocalStorage<ThemeConfig>(ANT_THEME_EDITOR_THEME, {
-    defaultValue: {},
-  });
+  const [theme, setTheme] = React.useState<ThemeConfig>({});
+
+  useEffect(() => {
+    const storedConfig = localStorage.getItem(ANT_DESIGN_V5_THEME_EDITOR_THEME);
+    if (storedConfig) {
+      const themeConfig = JSON.parse(storedConfig);
+      setTheme(themeConfig);
+    }
+  }, []);
 
   const handleSave = () => {
-    setThemeConfig(themeConfig);
+    localStorage.setItem(ANT_DESIGN_V5_THEME_EDITOR_THEME, JSON.stringify(theme));
     message.success(locale.saveSuccessfully);
   };
 
@@ -60,9 +65,11 @@ const CustomTheme: React.FC = () => {
           <ThemeEditor
             advanced
             hideAdvancedSwitcher
-            theme={{ name: 'Custom Theme', key: 'test', config: themeConfig }}
+            theme={{ name: 'Custom Theme', key: 'test', config: theme }}
             style={{ height: 'calc(100vh - 64px)' }}
-            onThemeChange={(newTheme) => setThemeConfig(newTheme.config)}
+            onThemeChange={(newTheme) => {
+              setTheme(newTheme.config);
+            }}
             locale={lang === 'cn' ? zhCN : enUS}
             actions={
               <Button type="primary" onClick={handleSave}>


### PR DESCRIPTION
Revert the usage of `useLocalStorage` hook and switch back to `useState` + `useEffect`. This fixes the issue where the theme state was not updating correctly during interaction.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix: #55840, #55841



> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

问题原因： `<ThemeEditor />` 的 onThemeChange 回调的 config 中存在无法序列化的内容，例如 issue 反馈的问题就是因为主题算法是一个函数。 用 useLocalStorage 则会存在问题。


个人认为这部分没必要为了上 useLocalStorage 而上，看了一下之前实现逻辑。

存储在 localStorage 的时机是点击 save 按钮时才存储。并且默认序列化会跳过不可序列部分，只存储了 token 等有关信息。

file history: https://github.com/ant-design/ant-design/commits/5.x-stable/.dumi/pages/theme-editor/index.tsx

回滚部分：https://github.com/ant-design/ant-design/pull/55401/files#diff-ef29a310ce5cad95573716c19d940bb06da30b1a8e571b8d7f6154dd8c42d92e

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       --    |
| 🇨🇳 Chinese |    移除 useLocalStorage 以修复主题编辑器状态更新问题       |
