### PR TITLE
fix: add Layout subComponent style

### DIFF
--- a/scripts/build-style.tsx
+++ b/scripts/build-style.tsx
@@ -83,6 +83,14 @@ const ComponentCustomizeRender: Record<
     const { _InternalPanelDoNotUseOrYouWillBeFired: PurePanel } = notification;
     return <PurePanel />;
   },
+  Layout: () => (
+    <antd.Layout>
+      <antd.Layout.Header>Header</antd.Layout.Header>
+      <antd.Layout.Sider>Sider</antd.Layout.Sider>
+      <antd.Layout.Content>Content</antd.Layout.Content>
+      <antd.Layout.Footer>Footer</antd.Layout.Footer>
+    </antd.Layout>
+  ),
 };
 
 const defaultNode = () => (


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- fix https://github.com/ant-design/ant-design/issues/55850

### 💡 Background and Solution

Layout 子组件没有加入预构建样式

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fixed the issue of missing styles for layout child components.     |
| 🇨🇳 Chinese |     修复 Layout 子组件样式缺失问题       |
