### PR TITLE
fix: cssinjs should be hashed defaultly

### DIFF
--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -264,7 +264,6 @@ const GlobalLayout: React.FC = () => {
           ...dynamicToken,
           // colorBgContainer: 'rgba(255,0,0,0.1)',
         },
-        hashed: false,
         zeroRuntime: process.env.NODE_ENV === 'production',
       },
       nextComponentsClassNames,

--- a/components/mentions/style/index.ts
+++ b/components/mentions/style/index.ts
@@ -240,7 +240,7 @@ const genMentionsStyle: GenerateStyle<MentionsToken> = (token) => {
         },
 
         // ========================== Suffix ==========================
-        '&-suffix': {
+        [`${componentCls}-suffix`]: {
           display: 'inline-flex',
           alignItems: 'center',
           flex: 'none',

--- a/components/theme/context.ts
+++ b/components/theme/context.ts
@@ -11,7 +11,7 @@ export { default as defaultTheme } from './themes/default/theme';
 export const defaultConfig = {
   token: defaultSeedToken,
   override: { override: defaultSeedToken },
-  hashed: false,
+  hashed: true,
 };
 
 export type ComponentsToken = {

--- a/package.json
+++ b/package.json
@@ -110,8 +110,8 @@
   },
   "dependencies": {
     "@ant-design/colors": "^8.0.0",
-    "@ant-design/cssinjs": "^2.0.0",
-    "@ant-design/cssinjs-utils": "^2.0.1",
+    "@ant-design/cssinjs": "^2.0.1",
+    "@ant-design/cssinjs-utils": "^2.0.2",
     "@ant-design/fast-color": "^3.0.0",
     "@ant-design/icons": "^6.1.0",
     "@ant-design/react-slick": "~1.1.2",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix ConfigProvider default not config `theme.hashed` is `true` which will cause style conflict with multiple versions. |
| 🇨🇳 Chinese |       修复 ConfigProvider 默认没有配置 `theme.hashed` 为 `true`，从而会导致多版本混用样式冲突的问题。    |
