### PR TITLE
fix: Cascader page scroll to top on first open with defaultValue

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@ant-design/fast-color": "^3.0.0",
     "@ant-design/icons": "^6.1.0",
     "@ant-design/react-slick": "~1.1.2",
-    "@rc-component/cascader": "~1.7.0",
+    "@rc-component/cascader": "~1.8.0",
     "@rc-component/checkbox": "~1.0.0",
     "@rc-component/collapse": "~1.1.1",
     "@rc-component/color-picker": "~3.0.2",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
 
Fixes #55820

### 💡 Background and Solution

#55820

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fix Cascader page scroll to top on first open with defaultValue     |
| 🇨🇳 Chinese |     修复 Cascader 设置 defaultValue 时首次打开导致页面滚动到顶部的问题。      |
