### PR TITLE
fix: add space in PrevAndNext

### DIFF
--- a/.dumi/hooks/useMenu.tsx
+++ b/.dumi/hooks/useMenu.tsx
@@ -47,6 +47,7 @@ const useStyle = createStyles(({ css, cssVar }) => ({
     font-weight: normal;
     font-size: ${cssVar.fontSizeSM};
     opacity: 0.8;
+    margin-left: 4px;
   `,
 }));
 
@@ -89,7 +90,7 @@ const MenuItemLabelWithTag: React.FC<MenuItemLabelProps> = (props) => {
     <Link to={`${link}${search}`} className={className}>
       {before}
       {title}
-      {subtitle && <span className={styles.subtitle}>&nbsp;{subtitle}</span>}
+      {subtitle && <span className={styles.subtitle}>{subtitle}</span>}
       {after}
     </Link>
   );

--- a/.dumi/hooks/useMenu.tsx
+++ b/.dumi/hooks/useMenu.tsx
@@ -89,7 +89,7 @@ const MenuItemLabelWithTag: React.FC<MenuItemLabelProps> = (props) => {
     <Link to={`${link}${search}`} className={className}>
       {before}
       {title}
-      {subtitle && <span className={styles.subtitle}>{subtitle}</span>}
+      {subtitle && <span className={styles.subtitle}>&nbsp;{subtitle}</span>}
       {after}
     </Link>
   );


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

> 1. 描述相关需求的来源，如相关的 issue 讨论链接。
> 2. 例如 close #xxxx、 fix #xxxx

fix https://github.com/ant-design/ant-design/issues/55778
### 💡 需求背景和解决方案


> 1. 要解决的具体问题。
> 2. 列出最终的 API 实现和用法。
> 3. 涉及UI/交互变动建议提供截图或 GIF。

PrevAndNext 依赖useMemu，useMemu中构建好了label(ReactElement)给PrevAndNext使用。
这是包裹在一个Link里面的，所以我认为直接在这里加空格也可以。没有影响subtitle的值。

更新：不再使用 &nbsp; 符，而是使用css。


修复后的效果：
<img width="213" height="62" alt="image" src="https://github.com/user-attachments/assets/5689f25c-62ec-4770-a6eb-9c5973653cac" />

### 📝 更新日志

> - 郑重地阅读 [如何维护更新日志](https://keepachangelog.com/zh-CN/1.1.0/)
> - 描述改动对开发者有哪些影响，而非解决方式
> - 可参考：https://ant.design/changelog-cn

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     修复导航组件（PrevAndNext）的显示问题     |
| 🇨🇳 中文 |      Fix the display issue of the navigation component (PrevAndNext)   |