### PR TITLE
fix(radio): ensure Radio.Group disabled state overrides child Radio d…

### DIFF
--- a/components/radio/__tests__/radio.test.tsx
+++ b/components/radio/__tests__/radio.test.tsx
@@ -44,7 +44,7 @@ describe('Radio', () => {
     expect(getByRole('radio')).not.toBeDisabled();
   });
 
-  it('should obtained correctly disabled status', () => {
+  it('should correctly disabled status', () => {
     const { getByRole } = render(
       <Form disabled>
         <Radio.Group disabled={false}>
@@ -52,6 +52,6 @@ describe('Radio', () => {
         </Radio.Group>
       </Form>,
     );
-    expect(getByRole('radio')).not.toBeDisabled();
+    expect(getByRole('radio')).toBeDisabled();
   });
 });

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -42,7 +42,7 @@ const InternalRadio: React.ForwardRefRenderFunction<HTMLElement, RadioProps> = (
     radioProps.name = groupContext.name;
     radioProps.onChange = onChange;
     radioProps.checked = props.value === groupContext.value;
-    radioProps.disabled = radioProps.disabled ?? groupContext.disabled;
+    radioProps.disabled = groupContext.disabled ? groupContext.disabled : radioProps.disabled;
   }
 
   radioProps.disabled = radioProps.disabled ?? disabled;


### PR DESCRIPTION
## Radio.Group disabled Prop Behavior Update

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ✔️] 🐞 Bug fix
- [✔️ ] ✅ Test Case

### 🔗 Related Issues

> - [Radio disabled 失效 #55901](https://github.com/ant-design/ant-design/issues/55901)
> - Close #55901

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix(radio): ensure Radio.Group disabled state overrides child Radio disabled prop       |
| 🇨🇳 Chinese |   fix(radio): 确保 Radio.Group 的 disabled 状态覆盖子 Radio 的 disabled 属性        |
