### PR TITLE
chore: fix some broken change on the website

### DIFF
--- a/.dumi/theme/builtins/ColorChunk/index.tsx
+++ b/.dumi/theme/builtins/ColorChunk/index.tsx
@@ -4,11 +4,11 @@ import type { ColorInput } from '@ant-design/fast-color';
 import { Popover } from 'antd';
 import { createStyles } from 'antd-style';
 
-const useStyle = createStyles(({ css, cssVar }) => ({
+const useStyle = createStyles(({ css, cssVar, token }) => ({
   codeSpan: css`
     padding: 0.2em 0.4em;
     font-size: 0.9em;
-    background: ${cssVar.siteMarkdownCodeBg};
+    background: ${token.siteMarkdownCodeBg};
     border-radius: ${cssVar.borderRadius};
     font-family: monospace;
   `,
@@ -46,7 +46,7 @@ const ColorChunk: React.FC<React.PropsWithChildren<ColorChunkProps>> = (props) =
         placement="left"
         content={<div hidden />}
         styles={{
-          body: {
+          container: {
             backgroundColor: dotColor,
             width: 120,
             height: 120,


### PR DESCRIPTION

两个问题：

1. antd-style 目前还不支持通过 cssvar 消费自定义的 token
2. Popover 的 semantic styles `body` break 为 `container` 了，并且当前 TS 支持还不够智能

<img width="781" height="573" alt="image" src="https://github.com/user-attachments/assets/f32f070b-932d-4852-955e-e7281ef58148" />

先单独开PR 修复问题并记录。后面看看如何跟进
