### PR TITLE
fix(watermark): fix wrong font-weight enum

### DIFF
--- a/components/watermark/index.en-US.md
+++ b/components/watermark/index.en-US.md
@@ -53,7 +53,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | --- | --- | --- | --- | --- |
 | color | font color | [CanvasFillStrokeStyles.fillStyle](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/fillStyle) | rgba(0,0,0,.15) |  |
 | fontSize | font size | number | 16 |  |
-| fontWeight | font weight | `normal` \| `light` \| `weight` \| number | normal |  |
+| fontWeight | font weight | `normal` \| `lighter` \| `bold` \| `bolder` \| number | normal |  |
 | fontFamily | font family | string | sans-serif |  |
 | fontStyle | font style  | `none` \| `normal` \| `italic` \| `oblique` | normal |  |
 | textAlign | specify the text alignment direction  | [CanvasTextAlign](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/textAlign) | `center` | 5.10.0 |

--- a/components/watermark/index.tsx
+++ b/components/watermark/index.tsx
@@ -24,7 +24,7 @@ export interface WatermarkProps {
   font?: {
     color?: CanvasFillStrokeStyles['fillStyle'];
     fontSize?: number | string;
-    fontWeight?: 'normal' | 'light' | 'weight' | number;
+    fontWeight?: 'normal' | 'lighter' | 'bold' | 'bolder' | number;
     fontStyle?: 'none' | 'normal' | 'italic' | 'oblique';
     fontFamily?: string;
     textAlign?: CanvasTextAlign;

--- a/components/watermark/index.zh-CN.md
+++ b/components/watermark/index.zh-CN.md
@@ -54,7 +54,7 @@ tag: 5.1.0
 | --- | --- | --- | --- | --- |
 | color | 字体颜色 | [CanvasFillStrokeStyles.fillStyle](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/fillStyle) | rgba(0,0,0,.15) |  |
 | fontSize | 字体大小 | number | 16 |  |
-| fontWeight | 字体粗细 | `normal` \| `light` \| `weight` \| number | normal |  |
+| fontWeight | 字体粗细 | `normal` \| `lighter` \| `bold` \| `bolder` \| number | normal |  |
 | fontFamily | 字体类型 | string | sans-serif |  |
 | fontStyle | 字体样式 | `none` \| `normal` \| `italic` \| `oblique` | normal |  |
 | textAlign | 指定文本对齐方向  | [CanvasTextAlign](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/textAlign) | `center` | 5.10.0 |


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

No issues related.

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

#### Background
Watermark component use canvas to draw the watermark, and provides font -> fontWeight prop for developers to control the font weight. But the type of it is `'normal' | 'weight' | 'light' | number` which is wrong. While setting value not normal, such as weight(correct enum is bold or bolder), canvas will **parse failed** and set it as default value —— 10px sans-serif.
<img width="1414" height="876" alt="image" src="https://github.com/user-attachments/assets/249dbad3-14ec-445e-a509-a0aff0027e14" />

#### Implementation
Change TS Type: `'normal' | 'weight' | 'light' | number` -> `'normal' | 'lighter' | 'bold' | 'bolder' | number`

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix the type of fontWeight in Watermark component      |
| 🇨🇳 Chinese |     修复 Watermark 的 fontWeight 的类型错误的问题。      |
