### PR TITLE
table column property `defaultFilterValue` should support all type of React.Key

### DIFF
--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -3169,9 +3169,7 @@ describe('Table.filter', () => {
       title: 'Name',
       dataIndex: 'text',
       filters,
-      onFilter: (value, record) => {
-        return record.name === value;
-      },
+      onFilter: (value, record) => record.name === value,
     };
     const testCase = filters.flatMap((filter) =>
       ['filteredValue', 'defaultFilteredValue'].map((propName) => ({

--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -3158,4 +3158,44 @@ describe('Table.filter', () => {
       expect(container.querySelector('.ant-dropdown-placement-topLeft')).toBeTruthy();
     });
   });
+
+  describe('filteredValue and defaultFilteredValue should support all type of React.Key', () => {
+    const filters = [
+      { text: 'Number', value: 1 },
+      { text: 'Boolean', value: true },
+      { text: 'String', value: 'text' },
+    ];
+    const column: ColumnGroupType<any> | ColumnType<any> = {
+      title: 'Name',
+      dataIndex: 'text',
+      filters,
+      onFilter: (value, record) => {
+        return record.name === value;
+      },
+    };
+    for (const filter of filters) {
+      for (const propName of ['filteredValue', 'defaultFilteredValue']) {
+        const { container } = render(
+          createTable({
+            columns: [{ ...column, [propName]: [filter.value] }],
+            dataSource: [
+              { key: 1, name: 1, text: '1' },
+              { key: 2, name: true, text: 'true' },
+              { key: 3, name: 'text', text: 'text' },
+            ],
+          }),
+        );
+        fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
+        act(() => {
+          jest.runAllTimers();
+        });
+        expect(container.querySelectorAll('.ant-dropdown-menu-item-selected').length).toBe(1);
+        expect(container.querySelector('.ant-dropdown-menu-item-selected')?.textContent).toBe(
+          filter.text,
+        );
+        expect(container.querySelectorAll('tbody tr').length).toBe(1);
+        expect(container.querySelector('tbody tr')?.textContent).toBe(String(filter.value));
+      }
+    }
+  });
 });

--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -3173,29 +3173,34 @@ describe('Table.filter', () => {
         return record.name === value;
       },
     };
-    for (const filter of filters) {
-      for (const propName of ['filteredValue', 'defaultFilteredValue']) {
-        const { container } = render(
-          createTable({
-            columns: [{ ...column, [propName]: [filter.value] }],
-            dataSource: [
-              { key: 1, name: 1, text: '1' },
-              { key: 2, name: true, text: 'true' },
-              { key: 3, name: 'text', text: 'text' },
-            ],
-          }),
-        );
-        fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
-        act(() => {
-          jest.runAllTimers();
-        });
-        expect(container.querySelectorAll('.ant-dropdown-menu-item-selected').length).toBe(1);
-        expect(container.querySelector('.ant-dropdown-menu-item-selected')?.textContent).toBe(
-          filter.text,
-        );
-        expect(container.querySelectorAll('tbody tr').length).toBe(1);
-        expect(container.querySelector('tbody tr')?.textContent).toBe(String(filter.value));
-      }
-    }
+    const testCase = filters.flatMap((filter) =>
+      ['filteredValue', 'defaultFilteredValue'].map((propName) => ({
+        propName,
+        filter,
+        description: `prop: ${propName}, value: ${filter.value} (${filter.text})`,
+      })),
+    );
+    it.each(testCase)('should handle $description', ({ propName, filter }) => {
+      const { container } = render(
+        createTable({
+          columns: [{ ...column, [propName]: [filter.value] }],
+          dataSource: [
+            { key: 1, name: 1, text: '1' },
+            { key: 2, name: true, text: 'true' },
+            { key: 3, name: 'text', text: 'text' },
+          ],
+        }),
+      );
+      fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect(container.querySelectorAll('.ant-dropdown-menu-item-selected').length).toBe(1);
+      expect(container.querySelector('.ant-dropdown-menu-item-selected')?.textContent).toBe(
+        filter.text,
+      );
+      expect(container.querySelectorAll('tbody tr').length).toBe(1);
+      expect(container.querySelector('tbody tr')?.textContent).toBe(String(filter.value));
+    });
   });
 });

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -50,12 +50,17 @@ const collectFilterStates = <RecordType extends AnyObject = AnyObject>(
         });
       } else {
         // Uncontrolled
+        // default filterDropdown render trans filters value type to string,
+        // so need to trans defaultFilteredValue to string too, same as filteredValue does
+        let filteredValues =
+          init && column.defaultFilteredValue ? column.defaultFilteredValue! : undefined;
+        if (!filterDropdownIsDefined) {
+          filteredValues = filteredValues?.map(String) ?? filteredValues;
+        }
         filterStates.push({
           column,
           key: getColumnKey(column, columnPos),
-          filteredKeys: (init && column.defaultFilteredValue
-            ? column.defaultFilteredValue!
-            : undefined) as FilterKey,
+          filteredKeys: filteredValues as FilterKey,
           forceFiltered: column.filtered,
         });
       }

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -51,7 +51,7 @@ const collectFilterStates = <RecordType extends AnyObject = AnyObject>(
       } else {
         // Uncontrolled
         // default filterDropdown render trans filters value type to string,
-        // so need to trans defaultFilteredValue to string too, same as filteredValue does
+        // so need to transform defaultFilteredValue to string too, same as filteredValue does
         let filteredValues =
           init && column.defaultFilteredValue ? column.defaultFilteredValue! : undefined;
         if (!filterDropdownIsDefined) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
close #40435

### 💡 Background and Solution

When use default `filterDropdown` render, component `FilterDropdown` transform `filters` `value` to string as tree keys or menu keys, so when `defaultFilteredValue` type is not string, it will not match keys and then check state is not worked, but `filteredValue` is worked because when use default filterDropdown render, it tranform to type string, so should do same as `filteredValue` does.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue when table column defaultFilteredValue type is not string, filterDropdown item not checked  [#40435](https://github.com/ant-design/ant-design/issues/40435)  |
| 🇨🇳 Chinese |   修复表格列属性defaultFilteredValue类型不是string的时候，过滤下拉框不会选中的问题 [#40435](https://github.com/ant-design/ant-design/issues/40435)      |
