### PR TITLE
fix(ColorPicker): fix text clipping in ColorPicker InputNumber

### DIFF
--- a/components/color-picker/style/input.ts
+++ b/components/color-picker/style/input.ts
@@ -28,6 +28,7 @@ const genInputStyle: GenerateStyle<ColorPickerToken, CSSObject> = (token) => {
       [`${componentCls}-steppers${antCls}-input-number`]: {
         fontSize: fontSizeSM,
         lineHeight: lineHeightSM,
+        padding: 0,
         [`${antCls}-input-number-input`]: {
           paddingInlineStart: paddingXXS,
           paddingInlineEnd: 0,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...
- [x] 🐞 Bug fix

### 💡 Background and Solution

InputNumber components in ColorPicker inherit padding from Input base styles. When size="`small`" is used, the `ant-input-number-sm` class applies padding via CSS variables (`var(--ant-input-number-padding-block-sm)` and `var(--ant-input-number-padding-inline-sm)`), which is `7px` horizontally. This causes text clipping in narrow input fields, especially the alpha channel input.

#### Preview
|Before|After|
|---|---|
| <img width="278" height="268" alt="image" src="https://github.com/user-attachments/assets/eb9074e4-c0d6-407c-be02-67ed1022dce4" /> | <img width="270" height="268" alt="image" src="https://github.com/user-attachments/assets/f9054e72-736d-48d4-a96b-510cb01722de" /> |

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   Fix text clipping in ColorPicker InputNumber components caused by inherited padding.        |
| 🇨🇳 Chinese |    修复 ColorPicker 中 InputNumber 组件因继承 padding 导致的文字裁切问题       |
