### PR TITLE
feat: menu sort

### DIFF
--- a/components/menu/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/menu/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -6584,6 +6584,584 @@ Array [
 
 exports[`renders components/menu/demo/sider-current.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/menu/demo/sorted.tsx extend context correctly 1`] = `
+Array [
+  <ul
+    class="ant-menu ant-menu-root ant-menu-inline ant-menu-light css-var-test-id ant-menu-css-var"
+    data-menu-list="true"
+    role="menu"
+    style="width: 256px;"
+    tabindex="0"
+  >
+    <li
+      aria-describedby="test-id"
+      class="ant-menu-item"
+      data-menu-id="rc-menu-uuid-apps"
+      role="menuitem"
+      style="padding-left: 24px;"
+      tabindex="-1"
+    >
+      <span
+        aria-label="appstore"
+        class="anticon anticon-appstore ant-menu-item-icon"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="appstore"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M464 144H160c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V160c0-8.8-7.2-16-16-16zm-52 268H212V212h200v200zm452-268H560c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V160c0-8.8-7.2-16-16-16zm-52 268H612V212h200v200zM464 544H160c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V560c0-8.8-7.2-16-16-16zm-52 268H212V612h200v200zm452-268H560c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V560c0-8.8-7.2-16-16-16zm-52 268H612V612h200v200z"
+          />
+        </svg>
+      </span>
+      <span
+        class="ant-menu-title-content"
+      >
+        Applications
+      </span>
+    </li>
+    <div
+      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+    >
+      <div
+        class="ant-tooltip-arrow"
+        style="position: absolute; top: 0px; left: 0px;"
+      >
+        <span
+          class="ant-tooltip-arrow-content"
+        />
+      </div>
+      <div
+        class="ant-tooltip-container"
+        id="test-id"
+        role="tooltip"
+      />
+    </div>
+    <li
+      class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
+      role="none"
+    >
+      <div
+        aria-controls="rc-menu-uuid-mail-popup"
+        aria-expanded="true"
+        aria-haspopup="true"
+        class="ant-menu-submenu-title"
+        data-menu-id="rc-menu-uuid-mail"
+        role="menuitem"
+        style="padding-left: 24px;"
+        tabindex="-1"
+      >
+        <span
+          aria-label="mail"
+          class="anticon anticon-mail ant-menu-item-icon"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="mail"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M928 160H96c-17.7 0-32 14.3-32 32v640c0 17.7 14.3 32 32 32h832c17.7 0 32-14.3 32-32V192c0-17.7-14.3-32-32-32zm-40 110.8V792H136V270.8l-27.6-21.5 39.3-50.5 42.8 33.3h643.1l42.8-33.3 39.3 50.5-27.7 21.5zM833.6 232L512 482 190.4 232l-42.8-33.3-39.3 50.5 27.6 21.5 341.6 265.6a55.99 55.99 0 0068.7 0L888 270.8l27.6-21.5-39.3-50.5-42.7 33.2z"
+            />
+          </svg>
+        </span>
+        <span
+          class="ant-menu-title-content"
+        >
+          Mail
+        </span>
+        <i
+          class="ant-menu-submenu-arrow"
+        />
+      </div>
+      <div
+        class="ant-menu-submenu ant-menu-submenu-popup ant-menu ant-menu-light css-var-test-id ant-menu-css-var"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+      >
+        <ul
+          class="ant-menu ant-menu-sub ant-menu-inline"
+          data-menu-list="true"
+          id="rc-menu-uuid-mail-popup"
+          role="menu"
+        >
+          <li
+            aria-describedby="test-id"
+            class="ant-menu-item ant-menu-item-only-child"
+            data-menu-id="rc-menu-uuid-drafts"
+            role="menuitem"
+            style="padding-left: 48px;"
+            tabindex="-1"
+          >
+            <span
+              class="ant-menu-title-content"
+            >
+              Drafts
+            </span>
+          </li>
+          <div
+            class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+          >
+            <div
+              class="ant-tooltip-arrow"
+              style="position: absolute; top: 0px; left: 0px;"
+            >
+              <span
+                class="ant-tooltip-arrow-content"
+              />
+            </div>
+            <div
+              class="ant-tooltip-container"
+              id="test-id"
+              role="tooltip"
+            />
+          </div>
+          <li
+            aria-describedby="test-id"
+            class="ant-menu-item ant-menu-item-only-child"
+            data-menu-id="rc-menu-uuid-inbox"
+            role="menuitem"
+            style="padding-left: 48px;"
+            tabindex="-1"
+          >
+            <span
+              class="ant-menu-title-content"
+            >
+              Inbox
+            </span>
+          </li>
+          <div
+            class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+          >
+            <div
+              class="ant-tooltip-arrow"
+              style="position: absolute; top: 0px; left: 0px;"
+            >
+              <span
+                class="ant-tooltip-arrow-content"
+              />
+            </div>
+            <div
+              class="ant-tooltip-container"
+              id="test-id"
+              role="tooltip"
+            />
+          </div>
+          <li
+            aria-describedby="test-id"
+            class="ant-menu-item ant-menu-item-only-child"
+            data-menu-id="rc-menu-uuid-sent"
+            role="menuitem"
+            style="padding-left: 48px;"
+            tabindex="-1"
+          >
+            <span
+              class="ant-menu-title-content"
+            >
+              Sent
+            </span>
+          </li>
+          <div
+            class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+          >
+            <div
+              class="ant-tooltip-arrow"
+              style="position: absolute; top: 0px; left: 0px;"
+            >
+              <span
+                class="ant-tooltip-arrow-content"
+              />
+            </div>
+            <div
+              class="ant-tooltip-container"
+              id="test-id"
+              role="tooltip"
+            />
+          </div>
+        </ul>
+      </div>
+      <ul
+        class="ant-menu ant-menu-sub ant-menu-inline"
+        data-menu-list="true"
+        id="rc-menu-uuid-mail-popup"
+        role="menu"
+      >
+        <li
+          aria-describedby="test-id"
+          class="ant-menu-item ant-menu-item-only-child"
+          data-menu-id="rc-menu-uuid-drafts"
+          role="menuitem"
+          style="padding-left: 48px;"
+          tabindex="-1"
+        >
+          <span
+            class="ant-menu-title-content"
+          >
+            Drafts
+          </span>
+        </li>
+        <div
+          class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+        >
+          <div
+            class="ant-tooltip-arrow"
+            style="position: absolute; top: 0px; left: 0px;"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
+          <div
+            class="ant-tooltip-container"
+            id="test-id"
+            role="tooltip"
+          />
+        </div>
+        <li
+          aria-describedby="test-id"
+          class="ant-menu-item ant-menu-item-only-child"
+          data-menu-id="rc-menu-uuid-inbox"
+          role="menuitem"
+          style="padding-left: 48px;"
+          tabindex="-1"
+        >
+          <span
+            class="ant-menu-title-content"
+          >
+            Inbox
+          </span>
+        </li>
+        <div
+          class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+        >
+          <div
+            class="ant-tooltip-arrow"
+            style="position: absolute; top: 0px; left: 0px;"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
+          <div
+            class="ant-tooltip-container"
+            id="test-id"
+            role="tooltip"
+          />
+        </div>
+        <li
+          aria-describedby="test-id"
+          class="ant-menu-item ant-menu-item-only-child"
+          data-menu-id="rc-menu-uuid-sent"
+          role="menuitem"
+          style="padding-left: 48px;"
+          tabindex="-1"
+        >
+          <span
+            class="ant-menu-title-content"
+          >
+            Sent
+          </span>
+        </li>
+        <div
+          class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+        >
+          <div
+            class="ant-tooltip-arrow"
+            style="position: absolute; top: 0px; left: 0px;"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
+          <div
+            class="ant-tooltip-container"
+            id="test-id"
+            role="tooltip"
+          />
+        </div>
+      </ul>
+    </li>
+    <li
+      class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
+      role="none"
+    >
+      <div
+        aria-controls="rc-menu-uuid-settings-popup"
+        aria-expanded="true"
+        aria-haspopup="true"
+        class="ant-menu-submenu-title"
+        data-menu-id="rc-menu-uuid-settings"
+        role="menuitem"
+        style="padding-left: 24px;"
+        tabindex="-1"
+      >
+        <span
+          aria-label="setting"
+          class="anticon anticon-setting ant-menu-item-icon"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="setting"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"
+            />
+          </svg>
+        </span>
+        <span
+          class="ant-menu-title-content"
+        >
+          Settings
+        </span>
+        <i
+          class="ant-menu-submenu-arrow"
+        />
+      </div>
+      <div
+        class="ant-menu-submenu ant-menu-submenu-popup ant-menu ant-menu-light css-var-test-id ant-menu-css-var"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+      >
+        <ul
+          class="ant-menu ant-menu-sub ant-menu-inline"
+          data-menu-list="true"
+          id="rc-menu-uuid-settings-popup"
+          role="menu"
+        >
+          <li
+            aria-describedby="test-id"
+            class="ant-menu-item ant-menu-item-only-child"
+            data-menu-id="rc-menu-uuid-account"
+            role="menuitem"
+            style="padding-left: 48px;"
+            tabindex="-1"
+          >
+            <span
+              class="ant-menu-title-content"
+            >
+              Account
+            </span>
+          </li>
+          <div
+            class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+          >
+            <div
+              class="ant-tooltip-arrow"
+              style="position: absolute; top: 0px; left: 0px;"
+            >
+              <span
+                class="ant-tooltip-arrow-content"
+              />
+            </div>
+            <div
+              class="ant-tooltip-container"
+              id="test-id"
+              role="tooltip"
+            />
+          </div>
+          <li
+            aria-describedby="test-id"
+            class="ant-menu-item ant-menu-item-only-child"
+            data-menu-id="rc-menu-uuid-privacy"
+            role="menuitem"
+            style="padding-left: 48px;"
+            tabindex="-1"
+          >
+            <span
+              class="ant-menu-title-content"
+            >
+              Privacy
+            </span>
+          </li>
+          <div
+            class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+          >
+            <div
+              class="ant-tooltip-arrow"
+              style="position: absolute; top: 0px; left: 0px;"
+            >
+              <span
+                class="ant-tooltip-arrow-content"
+              />
+            </div>
+            <div
+              class="ant-tooltip-container"
+              id="test-id"
+              role="tooltip"
+            />
+          </div>
+          <li
+            aria-describedby="test-id"
+            class="ant-menu-item ant-menu-item-only-child"
+            data-menu-id="rc-menu-uuid-profile"
+            role="menuitem"
+            style="padding-left: 48px;"
+            tabindex="-1"
+          >
+            <span
+              class="ant-menu-title-content"
+            >
+              Profile
+            </span>
+          </li>
+          <div
+            class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+          >
+            <div
+              class="ant-tooltip-arrow"
+              style="position: absolute; top: 0px; left: 0px;"
+            >
+              <span
+                class="ant-tooltip-arrow-content"
+              />
+            </div>
+            <div
+              class="ant-tooltip-container"
+              id="test-id"
+              role="tooltip"
+            />
+          </div>
+        </ul>
+      </div>
+      <ul
+        class="ant-menu ant-menu-sub ant-menu-inline"
+        data-menu-list="true"
+        id="rc-menu-uuid-settings-popup"
+        role="menu"
+      >
+        <li
+          aria-describedby="test-id"
+          class="ant-menu-item ant-menu-item-only-child"
+          data-menu-id="rc-menu-uuid-account"
+          role="menuitem"
+          style="padding-left: 48px;"
+          tabindex="-1"
+        >
+          <span
+            class="ant-menu-title-content"
+          >
+            Account
+          </span>
+        </li>
+        <div
+          class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+        >
+          <div
+            class="ant-tooltip-arrow"
+            style="position: absolute; top: 0px; left: 0px;"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
+          <div
+            class="ant-tooltip-container"
+            id="test-id"
+            role="tooltip"
+          />
+        </div>
+        <li
+          aria-describedby="test-id"
+          class="ant-menu-item ant-menu-item-only-child"
+          data-menu-id="rc-menu-uuid-privacy"
+          role="menuitem"
+          style="padding-left: 48px;"
+          tabindex="-1"
+        >
+          <span
+            class="ant-menu-title-content"
+          >
+            Privacy
+          </span>
+        </li>
+        <div
+          class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+        >
+          <div
+            class="ant-tooltip-arrow"
+            style="position: absolute; top: 0px; left: 0px;"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
+          <div
+            class="ant-tooltip-container"
+            id="test-id"
+            role="tooltip"
+          />
+        </div>
+        <li
+          aria-describedby="test-id"
+          class="ant-menu-item ant-menu-item-only-child"
+          data-menu-id="rc-menu-uuid-profile"
+          role="menuitem"
+          style="padding-left: 48px;"
+          tabindex="-1"
+        >
+          <span
+            class="ant-menu-title-content"
+          >
+            Profile
+          </span>
+        </li>
+        <div
+          class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-menu-inline-collapsed-tooltip ant-tooltip-placement-right"
+          style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+        >
+          <div
+            class="ant-tooltip-arrow"
+            style="position: absolute; top: 0px; left: 0px;"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
+          <div
+            class="ant-tooltip-container"
+            id="test-id"
+            role="tooltip"
+          />
+        </div>
+      </ul>
+    </li>
+  </ul>,
+  <div
+    aria-hidden="true"
+    style="display: none;"
+  />,
+]
+`;
+
+exports[`renders components/menu/demo/sorted.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/menu/demo/style-class.tsx extend context correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"

--- a/components/menu/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/menu/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2656,6 +2656,240 @@ Array [
 ]
 `;
 
+exports[`renders components/menu/demo/sorted.tsx correctly 1`] = `
+Array [
+  <ul
+    class="ant-menu ant-menu-root ant-menu-inline ant-menu-light css-var-test-id ant-menu-css-var"
+    data-menu-list="true"
+    role="menu"
+    style="width:256px"
+    tabindex="0"
+  >
+    <li
+      aria-describedby="test-id"
+      class="ant-menu-item"
+      data-menu-id="rc-menu-uuid-apps"
+      role="menuitem"
+      style="padding-left:24px"
+      tabindex="-1"
+    >
+      <span
+        aria-label="appstore"
+        class="anticon anticon-appstore ant-menu-item-icon"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="appstore"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M464 144H160c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V160c0-8.8-7.2-16-16-16zm-52 268H212V212h200v200zm452-268H560c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V160c0-8.8-7.2-16-16-16zm-52 268H612V212h200v200zM464 544H160c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V560c0-8.8-7.2-16-16-16zm-52 268H212V612h200v200zm452-268H560c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V560c0-8.8-7.2-16-16-16zm-52 268H612V612h200v200z"
+          />
+        </svg>
+      </span>
+      <span
+        class="ant-menu-title-content"
+      >
+        Applications
+      </span>
+    </li>
+    <li
+      class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
+      role="none"
+    >
+      <div
+        aria-controls="rc-menu-uuid-mail-popup"
+        aria-expanded="true"
+        aria-haspopup="true"
+        class="ant-menu-submenu-title"
+        data-menu-id="rc-menu-uuid-mail"
+        role="menuitem"
+        style="padding-left:24px"
+        tabindex="-1"
+      >
+        <span
+          aria-label="mail"
+          class="anticon anticon-mail ant-menu-item-icon"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="mail"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M928 160H96c-17.7 0-32 14.3-32 32v640c0 17.7 14.3 32 32 32h832c17.7 0 32-14.3 32-32V192c0-17.7-14.3-32-32-32zm-40 110.8V792H136V270.8l-27.6-21.5 39.3-50.5 42.8 33.3h643.1l42.8-33.3 39.3 50.5-27.7 21.5zM833.6 232L512 482 190.4 232l-42.8-33.3-39.3 50.5 27.6 21.5 341.6 265.6a55.99 55.99 0 0068.7 0L888 270.8l27.6-21.5-39.3-50.5-42.7 33.2z"
+            />
+          </svg>
+        </span>
+        <span
+          class="ant-menu-title-content"
+        >
+          Mail
+        </span>
+        <i
+          class="ant-menu-submenu-arrow"
+        />
+      </div>
+      <ul
+        class="ant-menu ant-menu-sub ant-menu-inline"
+        data-menu-list="true"
+        id="rc-menu-uuid-mail-popup"
+        role="menu"
+      >
+        <li
+          aria-describedby="test-id"
+          class="ant-menu-item ant-menu-item-only-child"
+          data-menu-id="rc-menu-uuid-drafts"
+          role="menuitem"
+          style="padding-left:48px"
+          tabindex="-1"
+        >
+          <span
+            class="ant-menu-title-content"
+          >
+            Drafts
+          </span>
+        </li>
+        <li
+          aria-describedby="test-id"
+          class="ant-menu-item ant-menu-item-only-child"
+          data-menu-id="rc-menu-uuid-inbox"
+          role="menuitem"
+          style="padding-left:48px"
+          tabindex="-1"
+        >
+          <span
+            class="ant-menu-title-content"
+          >
+            Inbox
+          </span>
+        </li>
+        <li
+          aria-describedby="test-id"
+          class="ant-menu-item ant-menu-item-only-child"
+          data-menu-id="rc-menu-uuid-sent"
+          role="menuitem"
+          style="padding-left:48px"
+          tabindex="-1"
+        >
+          <span
+            class="ant-menu-title-content"
+          >
+            Sent
+          </span>
+        </li>
+      </ul>
+    </li>
+    <li
+      class="ant-menu-submenu ant-menu-submenu-inline ant-menu-submenu-open"
+      role="none"
+    >
+      <div
+        aria-controls="rc-menu-uuid-settings-popup"
+        aria-expanded="true"
+        aria-haspopup="true"
+        class="ant-menu-submenu-title"
+        data-menu-id="rc-menu-uuid-settings"
+        role="menuitem"
+        style="padding-left:24px"
+        tabindex="-1"
+      >
+        <span
+          aria-label="setting"
+          class="anticon anticon-setting ant-menu-item-icon"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="setting"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"
+            />
+          </svg>
+        </span>
+        <span
+          class="ant-menu-title-content"
+        >
+          Settings
+        </span>
+        <i
+          class="ant-menu-submenu-arrow"
+        />
+      </div>
+      <ul
+        class="ant-menu ant-menu-sub ant-menu-inline"
+        data-menu-list="true"
+        id="rc-menu-uuid-settings-popup"
+        role="menu"
+      >
+        <li
+          aria-describedby="test-id"
+          class="ant-menu-item ant-menu-item-only-child"
+          data-menu-id="rc-menu-uuid-account"
+          role="menuitem"
+          style="padding-left:48px"
+          tabindex="-1"
+        >
+          <span
+            class="ant-menu-title-content"
+          >
+            Account
+          </span>
+        </li>
+        <li
+          aria-describedby="test-id"
+          class="ant-menu-item ant-menu-item-only-child"
+          data-menu-id="rc-menu-uuid-privacy"
+          role="menuitem"
+          style="padding-left:48px"
+          tabindex="-1"
+        >
+          <span
+            class="ant-menu-title-content"
+          >
+            Privacy
+          </span>
+        </li>
+        <li
+          aria-describedby="test-id"
+          class="ant-menu-item ant-menu-item-only-child"
+          data-menu-id="rc-menu-uuid-profile"
+          role="menuitem"
+          style="padding-left:48px"
+          tabindex="-1"
+        >
+          <span
+            class="ant-menu-title-content"
+          >
+            Profile
+          </span>
+        </li>
+      </ul>
+    </li>
+  </ul>,
+  <div
+    aria-hidden="true"
+    style="display:none"
+  />,
+]
+`;
+
 exports[`renders components/menu/demo/style-class.tsx correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"

--- a/components/menu/__tests__/sort.test.tsx
+++ b/components/menu/__tests__/sort.test.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { render } from '../../../tests/utils';
+import Menu from '../index';
+
+describe('Menu.sorted', () => {
+  it('should not sort items by default', () => {
+    const { container } = render(
+      <Menu
+        items={[
+          { key: 'z', label: 'Zebra' },
+          { key: 'a', label: 'Apple' },
+          { key: 'm', label: 'Mango' },
+        ]}
+      />,
+    );
+
+    const items = container.querySelectorAll('.ant-menu-item');
+    expect(items[0].textContent).toBe('Zebra');
+    expect(items[1].textContent).toBe('Apple');
+    expect(items[2].textContent).toBe('Mango');
+  });
+
+  it('should sort items alphabetically when sorted=true', () => {
+    const { container } = render(
+      <Menu
+        sorted
+        items={[
+          { key: 'z', label: 'Zebra' },
+          { key: 'a', label: 'Apple' },
+          { key: 'm', label: 'Mango' },
+        ]}
+      />,
+    );
+
+    const items = container.querySelectorAll('.ant-menu-item');
+    expect(items[0].textContent).toBe('Apple');
+    expect(items[1].textContent).toBe('Mango');
+    expect(items[2].textContent).toBe('Zebra');
+  });
+
+  it('should handle case-insensitive sorting', () => {
+    const { container } = render(
+      <Menu
+        sorted
+        items={[
+          { key: '1', label: 'zebra' },
+          { key: '2', label: 'Apple' },
+          { key: '3', label: 'MANGO' },
+        ]}
+      />,
+    );
+
+    const items = container.querySelectorAll('.ant-menu-item');
+    expect(items[0].textContent).toBe('Apple');
+    expect(items[1].textContent).toBe('MANGO');
+    expect(items[2].textContent).toBe('zebra');
+  });
+
+  it('should sort submenu children recursively', () => {
+    const { container } = render(
+      <Menu
+        mode="inline"
+        sorted
+        defaultOpenKeys={['sub']}
+        items={[
+          {
+            key: 'sub',
+            label: 'Submenu',
+            children: [
+              { key: 'z', label: 'Zebra' },
+              { key: 'a', label: 'Apple' },
+              { key: 'm', label: 'Mango' },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const items = container.querySelectorAll('.ant-menu-item');
+    expect(items[0].textContent).toBe('Apple');
+    expect(items[1].textContent).toBe('Mango');
+    expect(items[2].textContent).toBe('Zebra');
+  });
+
+  it('should sort deeply nested submenus', () => {
+    const { container } = render(
+      <Menu
+        mode="inline"
+        sorted
+        defaultOpenKeys={['sub1', 'sub2']}
+        items={[
+          {
+            key: 'sub1',
+            label: 'Level 1',
+            children: [
+              {
+                key: 'sub2',
+                label: 'Level 2',
+                children: [
+                  { key: 'z', label: 'Zebra' },
+                  { key: 'a', label: 'Apple' },
+                ],
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const nested = container.querySelectorAll('.ant-menu-sub .ant-menu-sub .ant-menu-item');
+    expect(nested[0].textContent).toBe('Apple');
+    expect(nested[1].textContent).toBe('Zebra');
+  });
+
+  it('should preserve item properties', () => {
+    const onClick = jest.fn();
+    const { container } = render(
+      <Menu
+        sorted
+        items={[
+          { key: 'z', label: 'Zebra', disabled: true },
+          { key: 'a', label: 'Apple', onClick, danger: true },
+        ]}
+      />,
+    );
+
+    const items = container.querySelectorAll('.ant-menu-item');
+    expect(items[0].textContent).toBe('Apple');
+    expect(items[0]).toHaveClass('ant-menu-item-danger');
+    expect(items[1].textContent).toBe('Zebra');
+    expect(items[1]).toHaveClass('ant-menu-item-disabled');
+  });
+
+  it('should handle non-string labels', () => {
+    const { container } = render(
+      <Menu
+        sorted
+        items={[
+          { key: '1', label: <span>Custom</span> },
+          { key: '2', label: 'Apple' },
+          { key: '3', label: 123 },
+        ]}
+      />,
+    );
+
+    const items = container.querySelectorAll('.ant-menu-item');
+    expect(items).toHaveLength(3);
+    expect(items[0].textContent).toBe('Custom');
+    expect(items[1].textContent).toBe('123');
+    expect(items[2].textContent).toBe('Apple');
+  });
+
+  it('should handle empty and null items', () => {
+    const { container } = render(
+      <Menu sorted items={[{ key: 'a', label: 'Apple' }, null, { key: 'z', label: 'Zebra' }]} />,
+    );
+
+    const items = container.querySelectorAll('.ant-menu-item');
+    expect(items).toHaveLength(2);
+    expect(items[0].textContent).toBe('Apple');
+    expect(items[1].textContent).toBe('Zebra');
+  });
+});

--- a/components/menu/__tests__/sort.test.tsx
+++ b/components/menu/__tests__/sort.test.tsx
@@ -136,7 +136,7 @@ describe('Menu.sorted', () => {
       <Menu
         sorted
         items={[
-          { key: '1', label: <span>Custom</span> },
+          { key: '1', label: <span>Zebra</span> },
           { key: '2', label: 'Apple' },
           { key: '3', label: 123 },
         ]}
@@ -145,9 +145,34 @@ describe('Menu.sorted', () => {
 
     const items = container.querySelectorAll('.ant-menu-item');
     expect(items).toHaveLength(3);
-    expect(items[0].textContent).toBe('Custom');
-    expect(items[1].textContent).toBe('123');
-    expect(items[2].textContent).toBe('Apple');
+    expect(items[0].textContent).toBe('123');
+    expect(items[1].textContent).toBe('Apple');
+    expect(items[2].textContent).toBe('Zebra');
+  });
+
+  it('should extract text from React nodes for sorting', () => {
+    const { container } = render(
+      <Menu
+        sorted
+        items={[
+          { key: '1', label: <span>Zebra</span> },
+          {
+            key: '2',
+            label: (
+              <div>
+                <span>Apple</span>
+              </div>
+            ),
+          },
+          { key: '3', label: <span>Mango</span> },
+        ]}
+      />,
+    );
+
+    const items = container.querySelectorAll('.ant-menu-item');
+    expect(items[0].textContent).toBe('Apple');
+    expect(items[1].textContent).toBe('Mango');
+    expect(items[2].textContent).toBe('Zebra');
   });
 
   it('should handle empty and null items', () => {

--- a/components/menu/demo/sorted.tsx
+++ b/components/menu/demo/sorted.tsx
@@ -1,0 +1,44 @@
+import { AppstoreOutlined, MailOutlined, SettingOutlined } from '@ant-design/icons';
+import type { MenuProps } from 'antd';
+import { Menu } from 'antd';
+import React from 'react';
+
+const items: MenuProps['items'] = [
+  {
+    key: 'settings',
+    label: 'Settings',
+    icon: <SettingOutlined />,
+    children: [
+      { key: 'profile', label: 'Profile' },
+      { key: 'account', label: 'Account' },
+      { key: 'privacy', label: 'Privacy' },
+    ],
+  },
+  {
+    key: 'mail',
+    label: 'Mail',
+    icon: <MailOutlined />,
+    children: [
+      { key: 'sent', label: 'Sent' },
+      { key: 'inbox', label: 'Inbox' },
+      { key: 'drafts', label: 'Drafts' },
+    ],
+  },
+  {
+    key: 'apps',
+    label: 'Applications',
+    icon: <AppstoreOutlined />,
+  },
+];
+
+const App: React.FC = () => (
+  <Menu
+    mode="inline"
+    sorted
+    defaultOpenKeys={['mail', 'settings']}
+    style={{ width: 256 }}
+    items={items}
+  />
+);
+
+export default App;

--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -36,6 +36,7 @@ More layouts with navigation: [Layout](/components/layout).
 <code src="./demo/component-token.tsx" debug>Component Token</code>
 <code src="./demo/extra-style.tsx" debug>Extra Style debug</code>
 <code src="./demo/custom-popup-render.tsx">Custom Submenu Render</code>
+<code src="./demo/sorted.tsx">Sorted Menu</code>
 
 ## API
 
@@ -59,6 +60,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | overflowedIndicator | Customized the ellipsis icon when menu is collapsed horizontally | ReactNode | `<EllipsisOutlined />` |  |
 | selectable | Allows selecting menu items | boolean | true |  |
 | selectedKeys | Array with the keys of currently selected menu items | string\[] | - |  |
+| sorted | Sort menu items alphabetically by label (case-insensitive, recursive) | boolean | false |  |
 | style | Style of the root node | CSSProperties | - |  |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
 | subMenuCloseDelay | Delay time to hide submenu when mouse leaves (in seconds) | number | 0.1 |  |

--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -37,6 +37,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*Vn4XSqJFAxcAAA
 <code src="./demo/component-token.tsx" debug>组件 Token</code>
 <code src="./demo/extra-style.tsx" debug>Extra Style debug</code>
 <code src="./demo/custom-popup-render.tsx">自定义弹出框</code>
+<code src="./demo/sorted.tsx">排序菜单</code>
 
 ## API
 
@@ -60,6 +61,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*Vn4XSqJFAxcAAA
 | overflowedIndicator | 用于自定义 Menu 水平空间不足时的省略收缩的图标 | ReactNode | `<EllipsisOutlined />` |  |
 | selectable | 是否允许选中 | boolean | true |  |
 | selectedKeys | 当前选中的菜单项 key 数组 | string\[] | - |  |
+| sorted | 按标签对菜单项进行字母排序（不区分大小写，递归） | boolean | false |  |
 | style | 根节点样式 | CSSProperties | - |  |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom) , CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom) , CSSProperties> | - |  |
 | subMenuCloseDelay | 用户鼠标离开子菜单后关闭延时，单位：秒 | number | 0.1 |  |

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -24,6 +24,7 @@ import MenuItem from './MenuItem';
 import OverrideContext from './OverrideContext';
 import useStyle from './style';
 import SubMenu from './SubMenu';
+import { sortMenuItems } from './utils/sortMenuItems';
 
 function isEmptyIcon(icon?: React.ReactNode) {
   return icon === null || icon === false;
@@ -75,6 +76,7 @@ export interface MenuProps
   items?: ItemType[];
   classNames?: MenuClassNamesType;
   styles?: MenuStylesType;
+  sorted?: boolean;
 }
 
 type InternalMenuProps = MenuProps &
@@ -102,6 +104,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
     overflowedIndicatorPopupClassName,
     classNames,
     styles,
+    sorted,
     ...restProps
   } = props;
 
@@ -120,6 +123,10 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
   const rootPrefixCls = getPrefixCls();
 
   const passedProps = omit(restProps, ['collapsedWidth']);
+  const menuItems = React.useMemo(
+    () => (sorted ? sortMenuItems(passedProps.items) : passedProps.items),
+    [sorted, passedProps.items],
+  );
 
   // ======================== Warning ==========================
   if (process.env.NODE_ENV !== 'production') {
@@ -262,6 +269,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
           selectable={mergedSelectable}
           onClick={onItemClick}
           {...passedProps}
+          items={menuItems}
           inlineCollapsed={mergedInlineCollapsed}
           style={{ ...mergedStyles.root, ...contextStyle, ...style }}
           className={menuClassName}

--- a/components/menu/utils/sortMenuItems.ts
+++ b/components/menu/utils/sortMenuItems.ts
@@ -1,0 +1,28 @@
+import type { ItemType } from '../interface';
+
+const getLabel = (item: ItemType): string => {
+  if (!item || typeof item !== 'object') return '';
+  if (!('label' in item)) return '';
+
+  const { label } = item;
+  if (typeof label === 'string') return label;
+  if (typeof label === 'number') return String(label);
+  return '';
+};
+
+export const sortMenuItems = <T extends ItemType>(items?: T[]): T[] | undefined => {
+  if (!items?.length) return items;
+
+  const sorted = [...items].sort((a, b) => {
+    const labelA = getLabel(a).toLowerCase();
+    const labelB = getLabel(b).toLowerCase();
+    return labelA.localeCompare(labelB);
+  });
+
+  return sorted.map((item) => {
+    if (!item || typeof item !== 'object') return item;
+    if (!('children' in item) || !Array.isArray(item.children)) return item;
+
+    return { ...item, children: sortMenuItems(item.children) } as T;
+  });
+};

--- a/components/menu/utils/sortMenuItems.ts
+++ b/components/menu/utils/sortMenuItems.ts
@@ -1,5 +1,24 @@
 import type { ItemType } from '../interface';
 
+const extractTextFromNode = (node: any): string => {
+  if (!node) return '';
+
+  if (typeof node === 'string') return node;
+  if (typeof node === 'number') return String(node);
+
+  if (typeof node === 'object') {
+    if (Array.isArray(node)) {
+      return node.map(extractTextFromNode).join('');
+    }
+
+    if (node.props && node.props.children) {
+      return extractTextFromNode(node.props.children);
+    }
+  }
+
+  return '';
+};
+
 const getLabel = (item: ItemType): string => {
   if (!item || typeof item !== 'object') return '';
   if (!('label' in item)) return '';
@@ -7,16 +26,17 @@ const getLabel = (item: ItemType): string => {
   const { label } = item;
   if (typeof label === 'string') return label;
   if (typeof label === 'number') return String(label);
-  return '';
+
+  return extractTextFromNode(label);
 };
 
 export const sortMenuItems = <T extends ItemType>(items?: T[]): T[] | undefined => {
   if (!items?.length) return items;
 
   const sorted = [...items].sort((a, b) => {
-    const labelA = getLabel(a).toLowerCase();
-    const labelB = getLabel(b).toLowerCase();
-    return labelA.localeCompare(labelB);
+    const labelA = getLabel(a);
+    const labelB = getLabel(b);
+    return labelA.localeCompare(labelB, undefined, { sensitivity: 'base' });
   });
 
   return sorted.map((item) => {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature

🔗 Related Issues
This is a new feature enhancement for the Menu component. No related issues.

This feature provides developers with a convenient way to automatically sort menu items alphabetically, improving navigation consistency and user experience.

💡 Background and Solution
Background

Currently, the Menu component renders items in the exact order they are defined in the items array. For applications with dynamic menu items or large navigation structures, maintaining alphabetical order manually can be cumbersome and error-prone. An opt-in alphabetical sorting feature would:

Improve navigation consistency across applications
Reduce manual sorting overhead for developers
Enhance user experience with predictable menu ordering
Support localized alphabetical sorting

Solution

Added an optional sorted prop to the Menu component that enables automatic alphabetical sorting of menu items by their labels.

📝 Change Log
| Language | Changelog |

| 🇺🇸 English | - Menu: Add sorted prop to enable alphabetical sorting of menu items by label (case-insensitive, recursive) |
| 🇨🇳 Chinese | - Menu: 新增 sorted 属性，支持按标签对菜单项进行字母排序（不区分大小写，递归） |
