### PR TITLE
fix: prevent OTP from allowing input to skip over empty slots

### DIFF
--- a/components/input/OTP/OTPInput.tsx
+++ b/components/input/OTP/OTPInput.tsx
@@ -40,6 +40,11 @@ const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
     });
   };
 
+  const onInternalFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    restProps.onFocus?.(e);
+    syncSelection();
+  };
+
   // ======================== Keyboard ========================
   const onInternalKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (event) => {
     const { key, ctrlKey, metaKey } = event;
@@ -74,7 +79,7 @@ const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
         ref={inputRef}
         value={value}
         onInput={onInternalChange}
-        onFocus={syncSelection}
+        onFocus={onInternalFocus}
         onKeyDown={onInternalKeyDown}
         onMouseDown={syncSelection}
         onMouseUp={syncSelection}

--- a/components/input/OTP/OTPInput.tsx
+++ b/components/input/OTP/OTPInput.tsx
@@ -16,7 +16,7 @@ export interface OTPInputProps extends Omit<InputProps, 'onChange'> {
 }
 
 const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
-  const { className, value, onChange, onActiveChange, index, mask, ...restProps } = props;
+  const { className, value, onChange, onActiveChange, index, mask, onFocus, ...restProps } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('otp');
   const maskValue = typeof mask === 'string' ? mask : value;
@@ -41,7 +41,7 @@ const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
   };
 
   const onInternalFocus = (e: React.FocusEvent<HTMLInputElement>) => {
-    restProps.onFocus?.(e);
+    onFocus?.(e);
     syncSelection();
   };
 

--- a/components/input/OTP/index.tsx
+++ b/components/input/OTP/index.tsx
@@ -104,6 +104,7 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
     mask,
     type,
     onInput,
+    onFocus,
     inputMode,
     classNames,
     styles,
@@ -274,14 +275,16 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
   };
 
   // ======================== Focus ========================
-  const onInputFocus = (index: number) => {
+  const onInputFocus = (event: React.FocusEvent<HTMLInputElement>, index: number) => {
     // keep focus on the first empty cell
     for (let i = 0; i < index; i += 1) {
       if (!refs.current[i]?.input?.value) {
         refs.current[i]?.focus();
-        return;
+        break;
       }
     }
+
+    onFocus?.(event);
   };
 
   // ======================== Render ========================
@@ -333,7 +336,7 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
                 value={singleValue}
                 onActiveChange={onInputActiveChange}
                 autoFocus={index === 0 && autoFocus}
-                onFocus={() => onInputFocus(index)}
+                onFocus={(event) => onInputFocus(event, index)}
                 {...inputSharedProps}
               />
               {index < length - 1 && (

--- a/components/input/OTP/index.tsx
+++ b/components/input/OTP/index.tsx
@@ -176,8 +176,6 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
 
   const refs = React.useRef<Record<number, InputRef | null>>({});
 
-  const internalFocusRef = React.useRef(false);
-
   React.useImperativeHandle(ref, () => ({
     focus: () => {
       refs.current[0]?.focus();
@@ -265,9 +263,7 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
 
     const nextIndex = Math.min(index + txt.length, length - 1);
     if (nextIndex !== index && nextCells[index] !== undefined) {
-      internalFocusRef.current = true;
       refs.current[nextIndex]?.focus();
-      internalFocusRef.current = false;
     }
 
     triggerValueCellsChange(nextCells);
@@ -279,14 +275,12 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
 
   // ======================== Focus ========================
   const onInputFocus = (index: number) => {
-    if (internalFocusRef.current) {
-      return;
-    }
-
-    const nextActiveIndex = Math.min(valueCells.length, length - 1);
-
-    if (index > nextActiveIndex) {
-      refs.current[nextActiveIndex]?.focus();
+    // keep focus on the first empty cell
+    for (let i = 0; i < index; i += 1) {
+      if (!refs.current[i]?.input?.value) {
+        refs.current[i]?.focus();
+        return;
+      }
     }
   };
 

--- a/components/input/OTP/index.tsx
+++ b/components/input/OTP/index.tsx
@@ -176,6 +176,8 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
 
   const refs = React.useRef<Record<number, InputRef | null>>({});
 
+  const internalFocusRef = React.useRef(false);
+
   React.useImperativeHandle(ref, () => ({
     focus: () => {
       refs.current[0]?.focus();
@@ -263,7 +265,9 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
 
     const nextIndex = Math.min(index + txt.length, length - 1);
     if (nextIndex !== index && nextCells[index] !== undefined) {
+      internalFocusRef.current = true;
       refs.current[nextIndex]?.focus();
+      internalFocusRef.current = false;
     }
 
     triggerValueCellsChange(nextCells);
@@ -271,6 +275,19 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
 
   const onInputActiveChange: OTPInputProps['onActiveChange'] = (nextIndex) => {
     refs.current[nextIndex]?.focus();
+  };
+
+  // ======================== Focus ========================
+  const onInputFocus = (index: number) => {
+    if (internalFocusRef.current) {
+      return;
+    }
+
+    const nextActiveIndex = Math.min(valueCells.length, length - 1);
+
+    if (index > nextActiveIndex) {
+      refs.current[nextActiveIndex]?.focus();
+    }
   };
 
   // ======================== Render ========================
@@ -322,6 +339,7 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
                 value={singleValue}
                 onActiveChange={onInputActiveChange}
                 autoFocus={index === 0 && autoFocus}
+                onFocus={() => onInputFocus(index)}
                 {...inputSharedProps}
               />
               {index < length - 1 && (

--- a/components/input/__tests__/otp.test.tsx
+++ b/components/input/__tests__/otp.test.tsx
@@ -122,13 +122,19 @@ describe('Input.OTP', () => {
   });
 
   it('should not switch to next input when value is empty', () => {
-    const { container } = render(<OTP autoFocus />);
+    const onFocus = jest.fn();
+    const { container } = render(<OTP autoFocus onFocus={onFocus} />);
 
     const inputList = Array.from(container.querySelectorAll('input'));
     expect(document.activeElement).toEqual(inputList[0]);
 
+    // Key operation
     fireEvent.keyDown(document.activeElement!, { key: 'ArrowRight' });
-    expect(document.activeElement).toEqual(inputList[0]);
+    expect(document.activeElement).toBe(inputList[0]);
+
+    // Focus directly
+    fireEvent.focus(inputList[3]);
+    expect(document.activeElement).toBe(inputList[0]);
   });
 
   it('fill last cell', () => {

--- a/components/input/__tests__/otp.test.tsx
+++ b/components/input/__tests__/otp.test.tsx
@@ -109,7 +109,7 @@ describe('Input.OTP', () => {
   });
 
   it('arrow key to switch', () => {
-    const { container } = render(<OTP autoFocus />);
+    const { container } = render(<OTP autoFocus defaultValue="12" />);
 
     const inputList = Array.from(container.querySelectorAll('input'));
     expect(document.activeElement).toEqual(inputList[0]);
@@ -118,6 +118,16 @@ describe('Input.OTP', () => {
     expect(document.activeElement).toEqual(inputList[1]);
 
     fireEvent.keyDown(document.activeElement!, { key: 'ArrowLeft' });
+    expect(document.activeElement).toEqual(inputList[0]);
+  });
+
+  it('should not switch to next input when value is empty', () => {
+    const { container } = render(<OTP autoFocus />);
+
+    const inputList = Array.from(container.querySelectorAll('input'));
+    expect(document.activeElement).toEqual(inputList[0]);
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowRight' });
     expect(document.activeElement).toEqual(inputList[0]);
   });
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] ⌨️ Accessibility improvement

### 🔗 Related Issues

- fix #55662 

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix: Optimized the OTP component’s input behavior. Users can no longer skip empty slots when typing.       |
| 🇨🇳 Chinese |    修复： 优化 OTP 组件的输入行为，不再允许用户在输入时跳过空位。       |
