### PR TITLE
fix(Input): colorText token does not work with filled variant without affix

### DIFF
--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -6,9 +6,10 @@ import Input from '..';
 import { resetWarned } from '../../_util/warning';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import { fireEvent, render } from '../../../tests/utils';
+import { fireEvent, render, waitFor } from '../../../tests/utils';
 import Form from '../../form';
 import { triggerFocus } from '../Input';
+import { ConfigProvider } from 'antd';
 
 describe('Input', () => {
   const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -152,6 +153,23 @@ describe('prefix and suffix', () => {
 
     expect(container.querySelector('.prefix-with-hidden')?.getAttribute('hidden')).toBe('');
     expect(container.querySelector('.suffix-with-hidden')?.getAttribute('hidden')).toBe('');
+  });
+
+  it('should apply colorText token to filled variant without affix', async () => {
+    const colorText = '#445566';
+
+    const { container } = render(
+      <ConfigProvider theme={{ token: { colorText } }}>
+        <Input variant="filled" placeholder="Filled" defaultValue="Default" />
+      </ConfigProvider>,
+    );
+
+    const input = container.querySelector('input') as HTMLInputElement;
+
+    await waitFor(() => {
+      const computed = getComputedStyle(input).color;
+      expect(computed).toBe('var(--ant-color-text)');
+    });
   });
 });
 

--- a/components/input/style/variants.ts
+++ b/components/input/style/variants.ts
@@ -263,6 +263,7 @@ export const genFilledStyle = (token: InputToken, extraStyles?: CSSObject): CSSO
       bg: token.colorFillTertiary,
       hoverBg: token.colorFillSecondary,
       activeBorderColor: token.activeBorderColor,
+      inputColor: token.colorText,
     }),
 
     [`&${token.componentCls}-disabled, &[disabled]`]: {


### PR DESCRIPTION
… affix

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

close https://github.com/ant-design/ant-design/issues/55998

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix colorText token does not work with filled variant without affix      |
| 🇨🇳 Chinese |     fix colorText token does not work with filled variant without affix      |
