### PR TITLE
fix: Splitter ptg not fully cover

### DIFF
--- a/components/splitter/__tests__/size.test.tsx
+++ b/components/splitter/__tests__/size.test.tsx
@@ -74,4 +74,21 @@ describe('useSizes', () => {
     // In impossible case, should average fill (1000 / 3 = 333.33... for each)
     expect(postPxSizes).toEqual([1000 / 3, 1000 / 3, 1000 / 3]);
   });
+
+  it('should average if size total is not 100%', () => {
+    const items = [
+      {
+        size: '20%',
+      },
+      {
+        size: '30%',
+      },
+    ];
+
+    const { result } = renderHook(() => useSizes(items, containerSize));
+    const [sizes] = result.current;
+
+    // Check sizes
+    expect(sizes).toEqual([400, 600]);
+  });
 });

--- a/components/splitter/__tests__/size.test.tsx
+++ b/components/splitter/__tests__/size.test.tsx
@@ -91,4 +91,20 @@ describe('useSizes', () => {
     // Check sizes
     expect(sizes).toEqual([400, 600]);
   });
+
+  it('should correct when all size is 0', () => {
+    const items = [
+      {
+        size: 0,
+      },
+      {
+        size: 0,
+      },
+    ];
+
+    const { result } = renderHook(() => useSizes(items, containerSize));
+    const [, postPxSizes] = result.current;
+
+    expect(postPxSizes).toEqual([500, 500]);
+  });
 });

--- a/components/splitter/demo/size.tsx
+++ b/components/splitter/demo/size.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Flex, Splitter, Typography } from 'antd';
 
-export const Desc: React.FC<Readonly<{ text?: string | number }>> = (props) => (
+const Desc: React.FC<Readonly<{ text?: string | number }>> = (props) => (
   <Flex justify="center" align="center" style={{ height: '100%' }}>
     <Typography.Title type="secondary" level={5} style={{ whiteSpace: 'nowrap' }}>
       {props.text}
@@ -10,18 +10,10 @@ export const Desc: React.FC<Readonly<{ text?: string | number }>> = (props) => (
 );
 
 const App: React.FC = () => (
-  <Splitter
-    style={{ height: 200, boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)' }}
-    styles={{
-      panel: {
-        backgroundColor: '#fafafa',
-      },
-    }}
-  >
+  <Splitter style={{ height: 200, boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)' }}>
     <Splitter.Panel defaultSize="40%" min="20%" max="70%">
       <Desc text="First" />
     </Splitter.Panel>
-    {/* <Splitter.Panel defaultSize="30%"> */}
     <Splitter.Panel>
       <Desc text="Second" />
     </Splitter.Panel>

--- a/components/splitter/demo/size.tsx
+++ b/components/splitter/demo/size.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Flex, Splitter, Typography } from 'antd';
 
-const Desc: React.FC<Readonly<{ text?: string | number }>> = (props) => (
+export const Desc: React.FC<Readonly<{ text?: string | number }>> = (props) => (
   <Flex justify="center" align="center" style={{ height: '100%' }}>
     <Typography.Title type="secondary" level={5} style={{ whiteSpace: 'nowrap' }}>
       {props.text}

--- a/components/splitter/demo/size.tsx
+++ b/components/splitter/demo/size.tsx
@@ -10,10 +10,18 @@ export const Desc: React.FC<Readonly<{ text?: string | number }>> = (props) => (
 );
 
 const App: React.FC = () => (
-  <Splitter style={{ height: 200, boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)' }}>
+  <Splitter
+    style={{ height: 200, boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)' }}
+    styles={{
+      panel: {
+        backgroundColor: '#fafafa',
+      },
+    }}
+  >
     <Splitter.Panel defaultSize="40%" min="20%" max="70%">
       <Desc text="First" />
     </Splitter.Panel>
+    {/* <Splitter.Panel defaultSize="30%"> */}
     <Splitter.Panel>
       <Desc text="Second" />
     </Splitter.Panel>

--- a/components/splitter/hooks/sizeUtil.ts
+++ b/components/splitter/hooks/sizeUtil.ts
@@ -20,7 +20,7 @@ export function autoPtgSizes(
   const undefinedCount = undefinedIndexes.length;
 
   // If all sizes are defined but don't sum to 1, scale them.
-  if (undefinedIndexes.length === 0 && currentTotalPtg !== 1) {
+  if (ptgSizes.length && !undefinedIndexes.length && currentTotalPtg !== 1) {
     const scale = 1 / currentTotalPtg;
     // We know `size` is a number here because undefinedIndexes is empty.
     return ptgSizes.map((size) => (size as number) * scale);

--- a/components/splitter/hooks/sizeUtil.ts
+++ b/components/splitter/hooks/sizeUtil.ts
@@ -19,6 +19,13 @@ export function autoPtgSizes(
   const restPtg = 1 - currentTotalPtg;
   const undefinedCount = undefinedIndexes.length;
 
+  // If all sizes are defined but don't sum to 1, scale them.
+  if (undefinedIndexes.length === 0 && currentTotalPtg !== 1) {
+    const scale = 1 / currentTotalPtg;
+    // We know `size` is a number here because undefinedIndexes is empty.
+    return ptgSizes.map((size) => (size as number) * scale);
+  }
+
   // Fill if exceed
   if (restPtg < 0) {
     const scale = 1 / currentTotalPtg;

--- a/components/splitter/hooks/sizeUtil.ts
+++ b/components/splitter/hooks/sizeUtil.ts
@@ -21,6 +21,11 @@ export function autoPtgSizes(
 
   // If all sizes are defined but don't sum to 1, scale them.
   if (ptgSizes.length && !undefinedIndexes.length && currentTotalPtg !== 1) {
+    // Handle the case when all sizes are 0
+    if (currentTotalPtg === 0) {
+      const avg = 1 / ptgSizes.length;
+      return ptgSizes.map(() => avg);
+    }
     const scale = 1 / currentTotalPtg;
     // We know `size` is a number here because undefinedIndexes is empty.
     return ptgSizes.map((size) => (size as number) * scale);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

resolve #55587
close #55590

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Splitter failing to fill its container when the sum of panel proportions is not 1.      |
| 🇨🇳 Chinese |     修复 Splitter 在 Panel 总占比不为 1 时出现占不满的情况。      |
