### PR TITLE
fix(token): The colorBgMask does not take effect.

### DIFF
--- a/components/drawer/style/index.ts
+++ b/components/drawer/style/index.ts
@@ -1,6 +1,6 @@
 import { unit } from '@ant-design/cssinjs';
 
-import { blurMaskStyle, genFocusStyle } from '../../style';
+import { genFocusStyle } from '../../style';
 import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genStyleHooks, mergeToken } from '../../theme/internal';
 import genMotionStyle from './motion';
@@ -105,7 +105,7 @@ const genDrawerStyle: GenerateStyle<DrawerToken> = (token) => {
         pointerEvents: 'auto',
 
         [`&${componentCls}-mask-blur`]: {
-          ...blurMaskStyle,
+          backdropFilter: 'blur(4px)',
         },
       },
 

--- a/components/image/style/index.ts
+++ b/components/image/style/index.ts
@@ -2,7 +2,6 @@ import type { CSSObject } from '@ant-design/cssinjs';
 import { unit } from '@ant-design/cssinjs';
 import { FastColor } from '@ant-design/fast-color';
 
-import { blurMaskStyle } from '../../style';
 import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genStyleHooks, mergeToken } from '../../theme/internal';
 
@@ -44,11 +43,6 @@ export interface ImageToken extends FullToken<'Image'> {
    * @descEN Preview class name
    */
   previewCls: string;
-  /**
-   * @desc 模态框遮罩背景色
-   * @descEN Background color of modal mask
-   */
-  modalMaskBg: string;
   /**
    * @desc 预览切换按钮尺寸
    * @descEN Size of preview switch button
@@ -102,7 +96,7 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken> = (token: ImageToke
     previewCls,
     motionDurationSlow,
     componentCls,
-    modalMaskBg,
+    colorBgMask,
     marginXL,
     marginSM,
     margin,
@@ -115,7 +109,7 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken> = (token: ImageToke
     zIndexPopup,
   } = token;
 
-  const operationBg = new FastColor(modalMaskBg).setA(0.1);
+  const operationBg = new FastColor(colorBgMask).setA(0.1);
   const operationBgHover = operationBg.clone().setA(0.2);
 
   const singleBtn: CSSObject = {
@@ -151,9 +145,9 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken> = (token: ImageToke
       [`${previewCls}-mask`]: {
         inset: 0,
         position: 'absolute',
-        background: modalMaskBg,
+        background: colorBgMask,
         [`&${componentCls}-preview-mask-blur`]: {
-          ...blurMaskStyle,
+          backdropFilter: 'blur(4px)',
         },
         [`&${componentCls}-preview-mask-hidden`]: {
           display: 'none',
@@ -346,7 +340,6 @@ export default genStyleHooks(
 
     const imageToken = mergeToken<ImageToken>(token, {
       previewCls,
-      modalMaskBg: new FastColor('#000').setA(0.45).toRgbString(), // FIXME: Shared Token
       imagePreviewSwitchSize: token.controlHeightLG,
     });
 

--- a/components/modal/style/index.ts
+++ b/components/modal/style/index.ts
@@ -2,7 +2,7 @@ import type React from 'react';
 import { unit } from '@ant-design/cssinjs';
 
 import { getMediaSize } from '../../grid/style';
-import { blurMaskStyle, genFocusStyle, resetComponent } from '../../style';
+import { genFocusStyle, resetComponent } from '../../style';
 import { initFadeMotion, initZoomMotion } from '../../style/motion';
 import type {
   AliasToken,
@@ -162,7 +162,7 @@ export const genModalMaskStyle: GenerateStyle<TokenWithCommonCls<AliasToken>> = 
           pointerEvents: 'none',
 
           [`&${componentCls}-mask-blur`]: {
-            ...blurMaskStyle,
+            backdropFilter: 'blur(4px)',
           },
 
           [`${componentCls}-hidden`]: {

--- a/components/style/index.tsx
+++ b/components/style/index.tsx
@@ -181,8 +181,3 @@ export const operationUnit = (token: AliasToken): CSSObject => ({
     textDecoration: token.linkHoverDecoration,
   },
 });
-
-export const blurMaskStyle = {
-  backdropFilter: 'blur(4px)',
-  backgroundColor: 'rgba(0, 0, 0, 0.3)',
-};

--- a/components/theme/interface/maps/colors.ts
+++ b/components/theme/interface/maps/colors.ts
@@ -626,8 +626,8 @@ export interface ColorMapToken
   /**
    * @nameZH 浮层的背景蒙层颜色
    * @nameEN Background color of the mask
-   * @desc 浮层的背景蒙层颜色，用于遮罩浮层下面的内容，Modal、Drawer 等组件的蒙层使用的是该 token
-   * @descEN The background color of the mask, used to cover the content below the mask, Modal, Drawer and other components use this token
+   * @desc 浮层的背景蒙层颜色，用于遮罩浮层下面的内容，Modal、Drawer、Image 等组件的蒙层使用的是该 token
+   * @descEN The background color of the mask, used to cover the content below the mask, Modal, Drawer, Image and other components use this token
    */
   colorBgMask: string;
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

close https://github.com/ant-design/ant-design/issues/56007
close https://github.com/ant-design/ant-design/issues/56008

### 💡 Background and Solution

做blurMaskStyle的时候，把mask的背景色覆盖掉了
另外：Image组件原先不支持colorBgMask这个token，做了一下兼容

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Modal/Image/Drawer that the `colorBgMask` token does not take effect.     |
| 🇨🇳 Chinese |     修复 Modal/Image/Drawer 组件 `colorBgMask` token 不生效的问题。     |
