### PR TITLE
fix(Notification): rm bg-token default value

### DIFF
--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -106,6 +106,16 @@ const GlobalHolderWrapper = React.forwardRef<GlobalHolderRef, unknown>((_, ref) 
   const rootIconPrefixCls = global.getIconPrefixCls();
   const theme = global.getTheme();
 
+  // https://github.com/ant-design/ant-design/issues/55649
+  // Static Methods do not use ThemeProvider, we need to reset these color variables to avoid
+  theme.token = {
+    ...(theme.token || {}),
+    colorSuccessBg: '',
+    colorErrorBg: '',
+    colorInfoBg: '',
+    colorWarningBg: '',
+  };
+
   const dom = <GlobalHolder ref={ref} sync={sync} notificationConfig={notificationConfig} />;
   return (
     <ConfigProvider prefixCls={rootPrefixCls} iconPrefixCls={rootIconPrefixCls} theme={theme}>

--- a/components/notification/index.tsx
+++ b/components/notification/index.tsx
@@ -106,16 +106,6 @@ const GlobalHolderWrapper = React.forwardRef<GlobalHolderRef, unknown>((_, ref) 
   const rootIconPrefixCls = global.getIconPrefixCls();
   const theme = global.getTheme();
 
-  // https://github.com/ant-design/ant-design/issues/55649
-  // Static Methods do not use ThemeProvider, we need to reset these color variables to avoid
-  theme.token = {
-    ...(theme.token || {}),
-    colorSuccessBg: '',
-    colorErrorBg: '',
-    colorInfoBg: '',
-    colorWarningBg: '',
-  };
-
   const dom = <GlobalHolder ref={ref} sync={sync} notificationConfig={notificationConfig} />;
   return (
     <ConfigProvider prefixCls={rootPrefixCls} iconPrefixCls={rootIconPrefixCls} theme={theme}>

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -377,10 +377,6 @@ const genNotificationStyle: GenerateStyle<NotificationToken> = (token) => {
 export const prepareComponentToken = (token: AliasToken) => ({
   zIndexPopup: token.zIndexPopupBase + CONTAINER_MAX_OFFSET + 50,
   width: 384,
-  colorSuccessBg: token.colorSuccessBg,
-  colorErrorBg: token.colorErrorBg,
-  colorInfoBg: token.colorInfoBg,
-  colorWarningBg: token.colorWarningBg,
 });
 
 export const prepareNotificationToken: (

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -377,6 +377,7 @@ const genNotificationStyle: GenerateStyle<NotificationToken> = (token) => {
 export const prepareComponentToken = (token: AliasToken) => ({
   zIndexPopup: token.zIndexPopupBase + CONTAINER_MAX_OFFSET + 50,
   width: 384,
+  // test
 });
 
 export const prepareNotificationToken: (


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- fix https://github.com/ant-design/ant-design/issues/55649

### 💡 Background and Solution

Notification 静态方法重置 bg-token 恢复为默认白色背景色 

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix notification unexpected default background color.  |
| 🇨🇳 Chinese |      修复 notification 组件默认带背景色的问题。       |
