### PR TITLE
fix(Dropdown): Adds dynamic calculation for Dropdown menu's maxHeight

### DIFF
--- a/components/dropdown/style/index.ts
+++ b/components/dropdown/style/index.ts
@@ -98,7 +98,7 @@ const genBaseStyle: GenerateStyle<DropdownToken> = (token) => {
 
         // Makes vertical dropdowns have a scrollbar once they become taller than the viewport.
         '&-menu-vertical': {
-          maxHeight: '100vh',
+          maxHeight: '35vh',
           overflowY: 'auto',
         },
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [X] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [X] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
 https://github.com/ant-design/ant-design/issues/56044

### 💡 Background and Solution

> - The specific problem to be addressed.
The problem was that for dropdown menus with many items, the menu could run off-screen when rendering on top. 
<img width="761" height="674" alt="image" src="https://github.com/user-attachments/assets/6f3cbd23-bf60-43dd-b623-5f6fbdff8f18" />
I fixed this via dynamically calculating and setting `maxHeight` according how much space is available for the dropdown menu.

> - List the final API implementation and usage if needed. [No change]
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

New maxHeight UX: 

https://github.com/user-attachments/assets/a239ef30-c6c1-429f-ac0f-ca5b6d324a0e



### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

[Warning : I translated this via ChatGPT]
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  max-height is dynamically calculated and set for dropdown menu and submenus    |
| 🇨🇳 Chinese |   下拉菜单及其子菜单的 max-height 会进行动态计算并自动设置    |
