### PR TITLE
feat(App): support breadcrumb prepend items

### DIFF
--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -31,6 +31,7 @@ const App: React.FC<AppProps> = (props) => {
     rootClassName,
     message,
     notification,
+    breadcrumb,
     style,
     component = 'div',
   } = props;
@@ -49,10 +50,17 @@ const App: React.FC<AppProps> = (props) => {
       message: { ...appConfig.message, ...message },
       notification: { ...appConfig.notification, ...notification },
       breadcrumb: {
-        items: [...(appConfig.breadcrumb?.items || []), ...(props.breadcrumb?.items || [])],
+        items: [...(appConfig.breadcrumb?.items || []), ...(breadcrumb?.items || [])],
       },
     }),
-    [message, notification, appConfig.message, appConfig.notification],
+    [
+      message,
+      notification,
+      breadcrumb?.items,
+      appConfig.message,
+      appConfig.notification,
+      appConfig.breadcrumb?.items,
+    ],
   );
 
   const [messageApi, messageContextHolder] = useMessage(mergedAppConfig.message);

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -50,13 +50,16 @@ const App: React.FC<AppProps> = (props) => {
       message: { ...appConfig.message, ...message },
       notification: { ...appConfig.notification, ...notification },
       breadcrumb: {
-        items: [...(appConfig.breadcrumb?.items || []), ...(breadcrumb?.items || [])],
+        items: breadcrumb?.root
+          ? breadcrumb?.items || []
+          : [...(appConfig.breadcrumb?.items || []), ...(breadcrumb?.items || [])],
       },
     }),
     [
       message,
       notification,
       breadcrumb?.items,
+      breadcrumb?.root,
       appConfig.message,
       appConfig.notification,
       appConfig.breadcrumb?.items,

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -12,6 +12,7 @@ import useNotification from '../notification/useNotification';
 import type { AppConfig, useAppProps } from './context';
 import AppContext, { AppConfigContext } from './context';
 import useStyle from './style';
+import useApp from './useApp';
 
 export interface AppProps<P = AnyObject> extends AppConfig {
   style?: React.CSSProperties;
@@ -41,12 +42,15 @@ const App: React.FC<AppProps> = (props) => {
     [`${prefixCls}-rtl`]: direction === 'rtl',
   });
 
-  const appConfig = useContext<AppConfig>(AppConfigContext);
+  const appConfig = useApp();
 
   const mergedAppConfig = React.useMemo<AppConfig>(
     () => ({
       message: { ...appConfig.message, ...message },
       notification: { ...appConfig.notification, ...notification },
+      breadcrumb: {
+        items: [...(appConfig.breadcrumb?.items || []), ...(props.breadcrumb?.items || [])],
+      },
     }),
     [message, notification, appConfig.message, appConfig.notification],
   );
@@ -62,8 +66,9 @@ const App: React.FC<AppProps> = (props) => {
       message: messageApi,
       notification: notificationApi,
       modal: ModalApi,
+      breadcrumb: { items: mergedAppConfig.breadcrumb?.items || [] },
     }),
-    [messageApi, notificationApi, ModalApi],
+    [messageApi, notificationApi, ModalApi, mergedAppConfig.breadcrumb],
   );
 
   // https://github.com/ant-design/ant-design/issues/48802#issuecomment-2097813526

--- a/components/app/App.tsx
+++ b/components/app/App.tsx
@@ -12,7 +12,6 @@ import useNotification from '../notification/useNotification';
 import type { AppConfig, useAppProps } from './context';
 import AppContext, { AppConfigContext } from './context';
 import useStyle from './style';
-import useApp from './useApp';
 
 export interface AppProps<P = AnyObject> extends AppConfig {
   style?: React.CSSProperties;
@@ -43,7 +42,7 @@ const App: React.FC<AppProps> = (props) => {
     [`${prefixCls}-rtl`]: direction === 'rtl',
   });
 
-  const appConfig = useApp();
+  const appConfig = useContext<AppConfig>(AppConfigContext);
 
   const mergedAppConfig = React.useMemo<AppConfig>(
     () => ({

--- a/components/app/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/app/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -50,6 +50,115 @@ exports[`renders components/app/demo/basic.tsx extend context correctly 1`] = `
 
 exports[`renders components/app/demo/basic.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/app/demo/breadcrumb.tsx extend context correctly 1`] = `
+<div
+  class="ant-app css-var-test-id"
+>
+  <div
+    class="ant-app css-var-test-id"
+  >
+    <div
+      class="ant-app css-var-test-id"
+    >
+      <div>
+        <nav
+          class="ant-breadcrumb css-var-test-id"
+        >
+          <ol>
+            <li>
+              <span
+                class="ant-breadcrumb-link"
+              >
+                Home
+              </span>
+            </li>
+            <li
+              aria-hidden="true"
+              class="ant-breadcrumb-separator"
+            >
+              /
+            </li>
+            <li>
+              <span
+                class="ant-breadcrumb-link"
+              >
+                Settings
+              </span>
+            </li>
+            <li
+              aria-hidden="true"
+              class="ant-breadcrumb-separator"
+            >
+              /
+            </li>
+            <li>
+              <span
+                class="ant-breadcrumb-link"
+              >
+                Email
+              </span>
+            </li>
+          </ol>
+        </nav>
+        <h2
+          class="ant-typography css-var-test-id"
+        >
+          Email Settings
+        </h2>
+      </div>
+      <div>
+        <nav
+          class="ant-breadcrumb css-var-test-id"
+        >
+          <ol>
+            <li>
+              <span
+                class="ant-breadcrumb-link"
+              >
+                Home
+              </span>
+            </li>
+            <li
+              aria-hidden="true"
+              class="ant-breadcrumb-separator"
+            >
+              /
+            </li>
+            <li>
+              <span
+                class="ant-breadcrumb-link"
+              >
+                Settings
+              </span>
+            </li>
+            <li
+              aria-hidden="true"
+              class="ant-breadcrumb-separator"
+            >
+              /
+            </li>
+            <li>
+              <span
+                class="ant-breadcrumb-link"
+              >
+                Password
+              </span>
+            </li>
+          </ol>
+        </nav>
+        <h2
+          class="ant-typography css-var-test-id"
+        >
+          Password Settings
+        </h2>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/app/demo/breadcrumb.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/app/demo/config.tsx extend context correctly 1`] = `
 <div
   class="ant-app css-var-test-id"

--- a/components/app/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/app/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -62,6 +62,7 @@ exports[`renders components/app/demo/breadcrumb.tsx extend context correctly 1`]
     >
       <div>
         <nav
+          aria-label="Email Breadcrumb"
           class="ant-breadcrumb css-var-test-id"
         >
           <ol>
@@ -108,6 +109,7 @@ exports[`renders components/app/demo/breadcrumb.tsx extend context correctly 1`]
       </div>
       <div>
         <nav
+          aria-label="Password Breadcrumb"
           class="ant-breadcrumb css-var-test-id"
         >
           <ol>

--- a/components/app/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/app/__tests__/__snapshots__/demo.test.ts.snap
@@ -48,6 +48,113 @@ exports[`renders components/app/demo/basic.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/app/demo/breadcrumb.tsx correctly 1`] = `
+<div
+  class="ant-app css-var-test-id"
+>
+  <div
+    class="ant-app css-var-test-id"
+  >
+    <div
+      class="ant-app css-var-test-id"
+    >
+      <div>
+        <nav
+          class="ant-breadcrumb css-var-test-id"
+        >
+          <ol>
+            <li>
+              <span
+                class="ant-breadcrumb-link"
+              >
+                Home
+              </span>
+            </li>
+            <li
+              aria-hidden="true"
+              class="ant-breadcrumb-separator"
+            >
+              /
+            </li>
+            <li>
+              <span
+                class="ant-breadcrumb-link"
+              >
+                Settings
+              </span>
+            </li>
+            <li
+              aria-hidden="true"
+              class="ant-breadcrumb-separator"
+            >
+              /
+            </li>
+            <li>
+              <span
+                class="ant-breadcrumb-link"
+              >
+                Email
+              </span>
+            </li>
+          </ol>
+        </nav>
+        <h2
+          class="ant-typography css-var-test-id"
+        >
+          Email Settings
+        </h2>
+      </div>
+      <div>
+        <nav
+          class="ant-breadcrumb css-var-test-id"
+        >
+          <ol>
+            <li>
+              <span
+                class="ant-breadcrumb-link"
+              >
+                Home
+              </span>
+            </li>
+            <li
+              aria-hidden="true"
+              class="ant-breadcrumb-separator"
+            >
+              /
+            </li>
+            <li>
+              <span
+                class="ant-breadcrumb-link"
+              >
+                Settings
+              </span>
+            </li>
+            <li
+              aria-hidden="true"
+              class="ant-breadcrumb-separator"
+            >
+              /
+            </li>
+            <li>
+              <span
+                class="ant-breadcrumb-link"
+              >
+                Password
+              </span>
+            </li>
+          </ol>
+        </nav>
+        <h2
+          class="ant-typography css-var-test-id"
+        >
+          Password Settings
+        </h2>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/app/demo/config.tsx correctly 1`] = `
 <div
   class="ant-app css-var-test-id"

--- a/components/app/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/app/__tests__/__snapshots__/demo.test.ts.snap
@@ -60,6 +60,7 @@ exports[`renders components/app/demo/breadcrumb.tsx correctly 1`] = `
     >
       <div>
         <nav
+          aria-label="Email Breadcrumb"
           class="ant-breadcrumb css-var-test-id"
         >
           <ol>
@@ -106,6 +107,7 @@ exports[`renders components/app/demo/breadcrumb.tsx correctly 1`] = `
       </div>
       <div>
         <nav
+          aria-label="Password Breadcrumb"
           class="ant-breadcrumb css-var-test-id"
         >
           <ol>

--- a/components/app/context.ts
+++ b/components/app/context.ts
@@ -8,7 +8,7 @@ import type { NotificationConfig, NotificationInstance } from '../notification/i
 export interface AppConfig {
   message?: MessageConfig;
   notification?: NotificationConfig;
-  breadcrumb?: { items?: BreadcrumbItemType[] };
+  breadcrumb?: { items?: BreadcrumbItemType[]; root?: boolean };
 }
 
 export const AppConfigContext = React.createContext<AppConfig>({});

--- a/components/app/context.ts
+++ b/components/app/context.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import type { BreadcrumbItemType } from '../breadcrumb/Breadcrumb';
 import type { ConfigOptions as MessageConfig, MessageInstance } from '../message/interface';
 import type { HookAPI as ModalHookAPI } from '../modal/useModal';
 import type { NotificationConfig, NotificationInstance } from '../notification/interface';
@@ -7,6 +8,7 @@ import type { NotificationConfig, NotificationInstance } from '../notification/i
 export interface AppConfig {
   message?: MessageConfig;
   notification?: NotificationConfig;
+  breadcrumb?: { items?: BreadcrumbItemType[] };
 }
 
 export const AppConfigContext = React.createContext<AppConfig>({});
@@ -15,12 +17,14 @@ export interface useAppProps {
   message: MessageInstance;
   notification: NotificationInstance;
   modal: ModalHookAPI;
+  breadcrumb: { items: BreadcrumbItemType[] };
 }
 
 const AppContext = React.createContext<useAppProps>({
   message: {},
   notification: {},
   modal: {},
+  breadcrumb: { items: [] as BreadcrumbItemType[] },
 } as useAppProps);
 
 export default AppContext;

--- a/components/app/demo/breadcrumb.md
+++ b/components/app/demo/breadcrumb.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+在布局文件中为 `Breadcrumb` 统一设定前置项，并在多个页面生效。
+
+## en-US
+
+Prepend `Breadcrumb` items in layouts that take effects on multiple pages.

--- a/components/app/demo/breadcrumb.md
+++ b/components/app/demo/breadcrumb.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-在布局文件中为 `Breadcrumb` 统一设定前置项，并在多个页面生效。
+在布局文件中为 `Breadcrumb` 统一设定前置项，并在多个页面生效。可以通过 `root: true` 来重置继承链，不继承父级 App 的面包屑配置。
 
 ## en-US
 
-Prepend `Breadcrumb` items in layouts that take effects on multiple pages.
+Prepend `Breadcrumb` items in layouts that take effects on multiple pages. Use `root: true` to reset the inheritance chain and ignore parent App breadcrumb configuration.

--- a/components/app/demo/breadcrumb.tsx
+++ b/components/app/demo/breadcrumb.tsx
@@ -22,8 +22,10 @@ const PasswordPage = () => {
 
 // Entry component
 export default () => (
-  <App breadcrumb={{ items: [{ title: 'Home' }, { title: 'Settings' }] }}>
-    <EmailPage />
-    <PasswordPage />
+  <App breadcrumb={{ items: [{ title: 'Home' }] }}>
+    <App breadcrumb={{ items: [{ title: 'Settings' }] }}>
+      <EmailPage />
+      <PasswordPage />
+    </App>
   </App>
 );

--- a/components/app/demo/breadcrumb.tsx
+++ b/components/app/demo/breadcrumb.tsx
@@ -22,10 +22,17 @@ const PasswordPage = () => {
 
 // Entry component
 export default () => (
-  <App breadcrumb={{ items: [{ title: 'Home' }] }}>
-    <App breadcrumb={{ items: [{ title: 'Settings' }] }}>
-      <EmailPage />
-      <PasswordPage />
+  <App breadcrumb={{ items: [{ title: 'Whatever' }] }}>
+    <App
+      breadcrumb={{
+        items: [{ title: 'Home' }],
+        root: true, // don't inherit the parent's breadcrumb
+      }}
+    >
+      <App breadcrumb={{ items: [{ title: 'Settings' }] }}>
+        <EmailPage />
+        <PasswordPage />
+      </App>
     </App>
   </App>
 );

--- a/components/app/demo/breadcrumb.tsx
+++ b/components/app/demo/breadcrumb.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { App, Breadcrumb, Typography } from 'antd';
+
+// Sub pages
+const EmailPage = () => {
+  return (
+    <div>
+      <Breadcrumb items={[{ title: 'Email' }]} />
+      <Typography.Title level={2}>Email Settings</Typography.Title>
+    </div>
+  );
+};
+
+const PasswordPage = () => {
+  return (
+    <div>
+      <Breadcrumb items={[{ title: 'Password' }]} />
+      <Typography.Title level={2}>Password Settings</Typography.Title>
+    </div>
+  );
+};
+
+// Entry component
+export default () => (
+  <App breadcrumb={{ items: [{ title: 'Home' }, { title: 'Settings' }] }}>
+    <EmailPage />
+    <PasswordPage />
+  </App>
+);

--- a/components/app/demo/breadcrumb.tsx
+++ b/components/app/demo/breadcrumb.tsx
@@ -5,7 +5,7 @@ import { App, Breadcrumb, Typography } from 'antd';
 const EmailPage = () => {
   return (
     <div>
-      <Breadcrumb items={[{ title: 'Email' }]} />
+      <Breadcrumb items={[{ title: 'Email' }]} aria-label="Email Breadcrumb" />
       <Typography.Title level={2}>Email Settings</Typography.Title>
     </div>
   );
@@ -14,7 +14,7 @@ const EmailPage = () => {
 const PasswordPage = () => {
   return (
     <div>
-      <Breadcrumb items={[{ title: 'Password' }]} />
+      <Breadcrumb items={[{ title: 'Password' }]} aria-label="Password Breadcrumb" />
       <Typography.Title level={2}>Password Settings</Typography.Title>
     </div>
   );

--- a/components/app/index.en-US.md
+++ b/components/app/index.en-US.md
@@ -136,7 +136,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | component | Config render element, if `false` will not create DOM node | ComponentType \| false | div | 5.11.0 |
 | message | Global config for Message | [MessageConfig](/components/message/#messageconfig) | - | 5.3.0 |
 | notification | Global config for Notification | [NotificationConfig](/components/notification/#notificationconfig) | - | 5.3.0 |
-| breadcrumb | Prepend items for Breadcrumb | { items?: BreadcrumbItemType[], root?: boolean } | - | 6.2.0 |
+| breadcrumb | Configure prepend items for all Breadcrumb components. Items specified here will be added before items in child Breadcrumb components. Use `root: true` to reset the inheritance chain and ignore parent App breadcrumb configuration | { items?: BreadcrumbItemType[], root?: boolean } | - | 6.2.0 |
 
 ## Design Token
 

--- a/components/app/index.en-US.md
+++ b/components/app/index.en-US.md
@@ -14,12 +14,14 @@ tag: 5.1.0
 
 - Provide reset styles based on `.ant-app` element.
 - You could use static methods of `message/notification/Modal` from `useApp` without writing `contextHolder` manually.
+- Easy way to prepend `Breadcrumb` items in layouts that take effects on multiple pages.
 
 ## Examples
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">Basic</code>
 <code src="./demo/config.tsx">Hooks config</code>
+<code src="./demo/breadcrumb.tsx">Breadcrumb</code>
 
 ## How to use
 
@@ -134,6 +136,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | component | Config render element, if `false` will not create DOM node | ComponentType \| false | div | 5.11.0 |
 | message | Global config for Message | [MessageConfig](/components/message/#messageconfig) | - | 5.3.0 |
 | notification | Global config for Notification | [NotificationConfig](/components/notification/#notificationconfig) | - | 5.3.0 |
+| breadcrumb | Prepend items for Breadcrumb | { items?: BreadcrumbItemType[] } | - | 6.2.0 |
 
 ## Design Token
 

--- a/components/app/index.en-US.md
+++ b/components/app/index.en-US.md
@@ -136,7 +136,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | component | Config render element, if `false` will not create DOM node | ComponentType \| false | div | 5.11.0 |
 | message | Global config for Message | [MessageConfig](/components/message/#messageconfig) | - | 5.3.0 |
 | notification | Global config for Notification | [NotificationConfig](/components/notification/#notificationconfig) | - | 5.3.0 |
-| breadcrumb | Prepend items for Breadcrumb | { items?: BreadcrumbItemType[] } | - | 6.2.0 |
+| breadcrumb | Prepend items for Breadcrumb | { items?: BreadcrumbItemType[], root?: boolean } | - | 6.2.0 |
 
 ## Design Token
 

--- a/components/app/index.zh-CN.md
+++ b/components/app/index.zh-CN.md
@@ -137,7 +137,7 @@ export default () => {
 | component | 设置渲染元素，为 `false` 则不创建 DOM 节点 | ComponentType \| false | div | 5.11.0 |
 | message | App 内 Message 的全局配置 | [MessageConfig](/components/message-cn/#messageconfig) | - | 5.3.0 |
 | notification | App 内 Notification 的全局配置 | [NotificationConfig](/components/notification-cn/#notificationconfig) | - | 5.3.0 |
-| breadcrumb | Breadcrumb 前置项 | { items?: BreadcrumbItemType[], root?: boolean } | - | 6.2.0 |
+| breadcrumb | 为所有 Breadcrumb 组件统一设定前置项。通过 `items` 设置前置面包屑项，这些项会被添加到所有子级 Breadcrumb 组件的前面。通过 `root: true` 可以重置继承链，不继承父级 App 的面包屑配置 | { items?: BreadcrumbItemType[], root?: boolean } | - | 6.2.0 |
 
 ## 主题变量（Design Token）{#design-token}
 

--- a/components/app/index.zh-CN.md
+++ b/components/app/index.zh-CN.md
@@ -137,7 +137,7 @@ export default () => {
 | component | 设置渲染元素，为 `false` 则不创建 DOM 节点 | ComponentType \| false | div | 5.11.0 |
 | message | App 内 Message 的全局配置 | [MessageConfig](/components/message-cn/#messageconfig) | - | 5.3.0 |
 | notification | App 内 Notification 的全局配置 | [NotificationConfig](/components/notification-cn/#notificationconfig) | - | 5.3.0 |
-| breadcrumb | Breadcrumb 前置项 | { items?: BreadcrumbItemType[] } | - | 6.2.0 |
+| breadcrumb | Breadcrumb 前置项 | { items?: BreadcrumbItemType[], root?: boolean } | - | 6.2.0 |
 
 ## 主题变量（Design Token）{#design-token}
 

--- a/components/app/index.zh-CN.md
+++ b/components/app/index.zh-CN.md
@@ -15,12 +15,14 @@ tag: 5.1.0
 
 - 提供可消费 React context 的 `message.xxx`、`Modal.xxx`、`notification.xxx` 的静态方法，可以简化 useMessage 等方法需要手动植入 `contextHolder` 的问题。
 - 提供基于 `.ant-app` 的默认重置样式，解决原生元素没有 antd 规范样式的问题。
+- 在布局文件中便捷地为 `Breadcrumb` 统一设定前置项，并在多个页面生效。
 
 ## 代码演示 {#examples}
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">基本用法</code>
 <code src="./demo/config.tsx">Hooks 配置</code>
+<code src="./demo/breadcrumb.tsx">Breadcrumb</code>
 
 ## 如何使用 {#how-to-use}
 
@@ -135,6 +137,7 @@ export default () => {
 | component | 设置渲染元素，为 `false` 则不创建 DOM 节点 | ComponentType \| false | div | 5.11.0 |
 | message | App 内 Message 的全局配置 | [MessageConfig](/components/message-cn/#messageconfig) | - | 5.3.0 |
 | notification | App 内 Notification 的全局配置 | [NotificationConfig](/components/notification-cn/#notificationconfig) | - | 5.3.0 |
+| breadcrumb | Breadcrumb 前置项 | { items?: BreadcrumbItemType[] } | - | 6.2.0 |
 
 ## 主题变量（Design Token）{#design-token}
 

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -276,7 +276,12 @@ const Breadcrumb = <T extends AnyObject = AnyObject>(props: BreadcrumbProps<T>) 
 
   return (
     <BreadcrumbContext.Provider value={memoizedValue}>
-      <nav className={breadcrumbClassName} style={mergedStyle} {...restProps}>
+      <nav
+        className={breadcrumbClassName}
+        style={mergedStyle}
+        aria-label="Breadcrumb"
+        {...restProps}
+      >
         <ol>{crumbs}</ol>
       </nav>
     </BreadcrumbContext.Provider>

--- a/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Breadcrumb filter React.Fragment 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-root"
 >
   <ol>
@@ -38,6 +39,7 @@ exports[`Breadcrumb filter React.Fragment 1`] = `
 
 exports[`Breadcrumb rtl render component should be rendered correctly in RTL direction 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb ant-breadcrumb-rtl css-var-root"
 >
   <ol />
@@ -46,6 +48,7 @@ exports[`Breadcrumb rtl render component should be rendered correctly in RTL dir
 
 exports[`Breadcrumb should accept undefined items 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-root"
 >
   <ol />
@@ -54,6 +57,7 @@ exports[`Breadcrumb should accept undefined items 1`] = `
 
 exports[`Breadcrumb should allow Breadcrumb.Item is null or undefined 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-root"
 >
   <ol>
@@ -70,6 +74,7 @@ exports[`Breadcrumb should allow Breadcrumb.Item is null or undefined 1`] = `
 
 exports[`Breadcrumb should not display Breadcrumb Item when its children is falsy 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-root"
 >
   <ol>
@@ -99,6 +104,7 @@ exports[`Breadcrumb should not display Breadcrumb Item when its children is fals
 
 exports[`Breadcrumb should render a menu 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-root"
 >
   <ol>
@@ -179,6 +185,7 @@ exports[`Breadcrumb should render a menu 1`] = `
 
 exports[`Breadcrumb should render correct 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-root"
 >
   <ol>
@@ -211,6 +218,7 @@ exports[`Breadcrumb should render correct 1`] = `
 
 exports[`Breadcrumb should support Breadcrumb.Item default separator 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-root"
 >
   <ol>
@@ -255,6 +263,7 @@ exports[`Breadcrumb should support Breadcrumb.Item default separator 1`] = `
 
 exports[`Breadcrumb should support React.Fragment and falsy children 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-root"
 >
   <ol>
@@ -304,6 +313,7 @@ exports[`Breadcrumb should support React.Fragment and falsy children 1`] = `
 
 exports[`Breadcrumb should support custom attribute 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-root"
   data-custom="custom"
 >
@@ -335,6 +345,7 @@ exports[`Breadcrumb should support custom attribute 1`] = `
 
 exports[`Breadcrumb should support string \`0\` and number \`0\` 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-root"
 >
   <ol>

--- a/components/breadcrumb/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`renders components/breadcrumb/demo/basic.tsx extend context correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>
@@ -67,6 +68,7 @@ exports[`renders components/breadcrumb/demo/basic.tsx extend context correctly 2
 
 exports[`renders components/breadcrumb/demo/component-token.tsx extend context correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>
@@ -350,6 +352,7 @@ exports[`renders components/breadcrumb/demo/component-token.tsx extend context c
 
 exports[`renders components/breadcrumb/demo/debug-routes.tsx extend context correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>
@@ -496,6 +499,7 @@ exports[`renders components/breadcrumb/demo/debug-routes.tsx extend context corr
 
 exports[`renders components/breadcrumb/demo/overlay.tsx extend context correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>
@@ -711,6 +715,7 @@ exports[`renders components/breadcrumb/demo/overlay.tsx extend context correctly
 
 exports[`renders components/breadcrumb/demo/separator.tsx extend context correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>
@@ -770,6 +775,7 @@ exports[`renders components/breadcrumb/demo/separator.tsx extend context correct
 
 exports[`renders components/breadcrumb/demo/separator-component.tsx extend context correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>
@@ -931,6 +937,7 @@ exports[`renders components/breadcrumb/demo/style-class.tsx extend context corre
 
 exports[`renders components/breadcrumb/demo/withIcon.tsx extend context correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>
@@ -1016,6 +1023,7 @@ exports[`renders components/breadcrumb/demo/withIcon.tsx extend context correctl
 
 exports[`renders components/breadcrumb/demo/withParams.tsx extend context correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>

--- a/components/breadcrumb/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/demo.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`renders components/breadcrumb/demo/basic.tsx correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>
@@ -65,6 +66,7 @@ exports[`renders components/breadcrumb/demo/basic.tsx correctly 1`] = `
 
 exports[`renders components/breadcrumb/demo/component-token.tsx correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>
@@ -219,6 +221,7 @@ exports[`renders components/breadcrumb/demo/component-token.tsx correctly 1`] = 
 
 exports[`renders components/breadcrumb/demo/debug-routes.tsx correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>
@@ -273,6 +276,7 @@ exports[`renders components/breadcrumb/demo/debug-routes.tsx correctly 1`] = `
 
 exports[`renders components/breadcrumb/demo/overlay.tsx correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>
@@ -359,6 +363,7 @@ exports[`renders components/breadcrumb/demo/overlay.tsx correctly 1`] = `
 
 exports[`renders components/breadcrumb/demo/separator.tsx correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>
@@ -416,6 +421,7 @@ exports[`renders components/breadcrumb/demo/separator.tsx correctly 1`] = `
 
 exports[`renders components/breadcrumb/demo/separator-component.tsx correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>
@@ -573,6 +579,7 @@ exports[`renders components/breadcrumb/demo/style-class.tsx correctly 1`] = `
 
 exports[`renders components/breadcrumb/demo/withIcon.tsx correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>
@@ -656,6 +663,7 @@ exports[`renders components/breadcrumb/demo/withIcon.tsx correctly 1`] = `
 
 exports[`renders components/breadcrumb/demo/withParams.tsx correctly 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-test-id"
 >
   <ol>

--- a/components/breadcrumb/__tests__/__snapshots__/itemRender.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/itemRender.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Breadcrumb.ItemRender render as expect 1`] = `
 <div>
   <nav
+    aria-label="Breadcrumb"
     class="ant-breadcrumb css-var-root"
   >
     <ol>

--- a/components/breadcrumb/__tests__/__snapshots__/router.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/router.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`react router react router legacy 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-root"
 >
   <ol>

--- a/components/breadcrumb/useItems.ts
+++ b/components/breadcrumb/useItems.ts
@@ -42,6 +42,6 @@ export default function useItems(
       return [...breadcrumb.items, ...routes.map(route2item)];
     }
 
-    return null;
+    return breadcrumb.items || null;
   }, [items, routes, breadcrumb.items]);
 }

--- a/components/breadcrumb/useItems.ts
+++ b/components/breadcrumb/useItems.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import useApp from '../app/useApp';
 import type { BreadcrumbItemType, BreadcrumbSeparatorType, ItemType } from './Breadcrumb';
 
 type MergedType = BreadcrumbItemType & {
@@ -30,15 +31,17 @@ export default function useItems(
   items?: ItemType[],
   routes?: ItemType[],
 ): Partial<MergedType & BreadcrumbSeparatorType>[] | null {
+  const { breadcrumb } = useApp();
+
   return useMemo<ItemType[] | null>(() => {
     if (items) {
-      return items;
+      return [...breadcrumb.items, ...items];
     }
 
     if (routes) {
-      return routes.map(route2item);
+      return [...breadcrumb.items, ...routes.map(route2item)];
     }
 
     return null;
-  }, [items, routes]);
+  }, [items, routes, breadcrumb.items]);
 }

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -1137,6 +1137,7 @@ exports[`ConfigProvider components Badge prefixCls 1`] = `
 
 exports[`ConfigProvider components Breadcrumb configProvider 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="config-breadcrumb css-var-root"
 >
   <ol>
@@ -1166,6 +1167,7 @@ exports[`ConfigProvider components Breadcrumb configProvider 1`] = `
 
 exports[`ConfigProvider components Breadcrumb configProvider componentDisabled 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="config-breadcrumb css-var-root"
 >
   <ol>
@@ -1195,6 +1197,7 @@ exports[`ConfigProvider components Breadcrumb configProvider componentDisabled 1
 
 exports[`ConfigProvider components Breadcrumb configProvider componentSize large 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="config-breadcrumb css-var-root"
 >
   <ol>
@@ -1224,6 +1227,7 @@ exports[`ConfigProvider components Breadcrumb configProvider componentSize large
 
 exports[`ConfigProvider components Breadcrumb configProvider componentSize middle 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="config-breadcrumb css-var-root"
 >
   <ol>
@@ -1253,6 +1257,7 @@ exports[`ConfigProvider components Breadcrumb configProvider componentSize middl
 
 exports[`ConfigProvider components Breadcrumb configProvider componentSize small 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="config-breadcrumb css-var-root"
 >
   <ol>
@@ -1282,6 +1287,7 @@ exports[`ConfigProvider components Breadcrumb configProvider componentSize small
 
 exports[`ConfigProvider components Breadcrumb normal 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="ant-breadcrumb css-var-root"
 >
   <ol>
@@ -1311,6 +1317,7 @@ exports[`ConfigProvider components Breadcrumb normal 1`] = `
 
 exports[`ConfigProvider components Breadcrumb prefixCls 1`] = `
 <nav
+  aria-label="Breadcrumb"
   class="prefix-Breadcrumb css-var-root"
 >
   <ol>

--- a/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -881,6 +881,7 @@ exports[`renders components/layout/demo/component-token.tsx extend context corre
       style="padding: 0px 24px 24px;"
     >
       <nav
+        aria-label="Breadcrumb"
         class="ant-breadcrumb css-var-test-id"
         style="margin: 16px 0px;"
       >
@@ -1339,6 +1340,7 @@ exports[`renders components/layout/demo/fixed.tsx extend context correctly 1`] =
     style="padding: 0px 48px;"
   >
     <nav
+      aria-label="Breadcrumb"
       class="ant-breadcrumb css-var-test-id"
       style="margin: 16px 0px;"
     >
@@ -2839,6 +2841,7 @@ exports[`renders components/layout/demo/side.tsx extend context correctly 1`] = 
       style="margin: 0px 16px;"
     >
       <nav
+        aria-label="Breadcrumb"
         class="ant-breadcrumb css-var-test-id"
         style="margin: 16px 0px;"
       >
@@ -3428,6 +3431,7 @@ exports[`renders components/layout/demo/top.tsx extend context correctly 1`] = `
     style="padding: 0px 48px;"
   >
     <nav
+      aria-label="Breadcrumb"
       class="ant-breadcrumb css-var-test-id"
       style="margin: 16px 0px;"
     >
@@ -3656,6 +3660,7 @@ exports[`renders components/layout/demo/top-side.tsx extend context correctly 1`
     style="padding: 0px 48px;"
   >
     <nav
+      aria-label="Breadcrumb"
       class="ant-breadcrumb css-var-test-id"
       style="margin: 16px 0px;"
     >
@@ -5304,6 +5309,7 @@ exports[`renders components/layout/demo/top-side-2.tsx extend context correctly 
       style="padding: 0px 24px 24px;"
     >
       <nav
+        aria-label="Breadcrumb"
         class="ant-breadcrumb css-var-test-id"
         style="margin: 16px 0px;"
       >

--- a/components/layout/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.ts.snap
@@ -383,6 +383,7 @@ exports[`renders components/layout/demo/component-token.tsx correctly 1`] = `
       style="padding:0 24px 24px"
     >
       <nav
+        aria-label="Breadcrumb"
         class="ant-breadcrumb css-var-test-id"
         style="margin:16px 0"
       >
@@ -708,6 +709,7 @@ exports[`renders components/layout/demo/fixed.tsx correctly 1`] = `
     style="padding:0 48px"
   >
     <nav
+      aria-label="Breadcrumb"
       class="ant-breadcrumb css-var-test-id"
       style="margin:16px 0"
     >
@@ -1714,6 +1716,7 @@ exports[`renders components/layout/demo/side.tsx correctly 1`] = `
       style="margin:0 16px"
     >
       <nav
+        aria-label="Breadcrumb"
         class="ant-breadcrumb css-var-test-id"
         style="margin:16px 0"
       >
@@ -2009,6 +2012,7 @@ exports[`renders components/layout/demo/top.tsx correctly 1`] = `
     style="padding:0 48px"
   >
     <nav
+      aria-label="Breadcrumb"
       class="ant-breadcrumb css-var-test-id"
       style="margin:16px 0"
     >
@@ -2171,6 +2175,7 @@ exports[`renders components/layout/demo/top-side.tsx correctly 1`] = `
     style="padding:0 48px"
   >
     <nav
+      aria-label="Breadcrumb"
       class="ant-breadcrumb css-var-test-id"
       style="margin:16px 0"
     >
@@ -2761,6 +2766,7 @@ exports[`renders components/layout/demo/top-side-2.tsx correctly 1`] = `
       style="padding:0 24px 24px"
     >
       <nav
+        aria-label="Breadcrumb"
         class="ant-breadcrumb css-var-test-id"
         style="margin:16px 0"
       >


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- #56112

### 💡 Background and Solution

实现 #56112 的一种方式。

通过在布局文件中添加 `<App breadcrumb={{ items: [...] }}>` 为多个页面设置统一的前置 items，实现更便捷、优雅的面包屑层级管理，与 React Router 的 layout-page 实践更加契合。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat(App): support breadcrumb prepend items |
| 🇨🇳 Chinese | feat(App): 支持前置面包屑项 |
