### PR TITLE
fix: respect empty string cssVar prefix and key

### DIFF
--- a/components/theme/__tests__/token.test.tsx
+++ b/components/theme/__tests__/token.test.tsx
@@ -340,4 +340,27 @@ describe('Theme', () => {
     expect(cssVar.colorLinkHover).toBe('var(--ant-color-link-hover)');
     expect(cssVar.colorLinkActive).toBe('var(--ant-color-link-active)');
   });
+
+  it('should respect empty string cssVar prefix', () => {
+    const { cssVar: defaultCssVar } = getHookToken();
+    const { cssVar: emptyPrefixCssVar } = getHookToken({
+      cssVar: {
+        prefix: '',
+        key: '',
+      },
+    });
+
+    // Default behavior should still use "ant" prefix
+    expect(defaultCssVar.colorLink).toBe('var(--ant-color-link)');
+
+    // When cssVar.prefix is an empty string, it should not equal default value
+    expect(emptyPrefixCssVar.colorLink).not.toBe(defaultCssVar.colorLink);
+
+    // It should not start with "ant" prefix
+    expect(emptyPrefixCssVar.colorLink.startsWith('var(--ant-')).toBeFalsy();
+
+    // It should still be a valid CSS variable reference and contain "color-link"
+    expect(emptyPrefixCssVar.colorLink.startsWith('var(--')).toBeTruthy();
+    expect(emptyPrefixCssVar.colorLink).toContain('color-link');
+  });
 });

--- a/components/theme/useToken.ts
+++ b/components/theme/useToken.ts
@@ -118,8 +118,8 @@ export default function useToken(): [
   } = React.useContext(DesignTokenContext);
 
   const cssVar = {
-    prefix: ctxCssVar?.prefix || 'ant',
-    key: ctxCssVar?.key || 'css-var-root',
+    prefix: ctxCssVar?.prefix ?? 'ant',
+    key: ctxCssVar?.key ?? 'css-var-root',
   };
 
   const salt = `${version}-${hashed || ''}`;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Close #56022

### 💡 Background and Solution

In v6, `cssVar.prefix` and `cssVar.key` were using logical OR (`||`) as fallback:

    prefix: ctxCssVar?.prefix || 'ant';
    key: ctxCssVar?.key || 'css-var-root';

This caused an issue: **empty string (`''`) was treated as a falsy value**, so it always fell back to `'ant'` / `'css-var-root'`.  
However, v5 allowed `prefix: ''` to generate CSS variables *without* the `"ant"` prefix.

To restore the expected behavior, this PR replaces `||` with nullish coalescing (`??`):

    prefix: ctxCssVar?.prefix ?? 'ant';
    key: ctxCssVar?.key ?? 'css-var-root';

This ensures:

- `''` (empty string) is preserved  
- `undefined` / `null` still fall back to default values  
- `prefix` and `key` behave consistently 

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix: `theme.cssVar.prefix` and `theme.cssVar.key` now correctly respect empty string values instead of falling back to `"ant"` / `"css-var-root"`. |
| 🇨🇳 Chinese | 修复：`theme.cssVar.prefix` 与 `theme.cssVar.key` 在传入空字符串时不再回退为 `"ant"` / `"css-var-root"`，恢复预期行为。 |

### 🧪 Additional Tests

Added test cases to ensure:

- default behavior still uses `"ant"` prefix  
- empty string prefix produces CSS variables without `"ant"` prefix  
- output remains a valid CSS variable reference 
