### PR TITLE
fix: resolve ModuleNotFoundError for @rc-component/picker/locale/en_US

### DIFF
--- a/components/date-picker/locale/en_US.ts
+++ b/components/date-picker/locale/en_US.ts
@@ -1,4 +1,4 @@
-import CalendarLocale from '@rc-component/picker/locale/en_US';
+import CalendarLocale from '@rc-component/picker/es/locale/en_US';
 
 import TimePickerLocale from '../../time-picker/locale/en_US';
 import type { PickerLocale } from '../generatePicker';


### PR DESCRIPTION
Fixes #56145

## Description
Explicitly import `en_US` locale from `es` directory to resolve module resolution issues in certain build environments where `exports` field in `package.json` might not be processed correctly.

## Changes
- Changed import path from `@rc-component/picker/locale/en_US` to `@rc-component/picker/es/locale/en_US`.