### PR TITLE
fix(result): pass through data-* and aria-* attributes to root element

### DIFF
--- a/components/result/__tests__/index.test.tsx
+++ b/components/result/__tests__/index.test.tsx
@@ -75,4 +75,33 @@ describe('Result', () => {
     const { container: container2 } = render(<Result title="404" icon={false} />);
     expect(container2.querySelectorAll('.ant-result-icon')).toHaveLength(0);
   });
+
+  it('should pass data-* attributes to root element', () => {
+    const { container } = render(
+      <Result status="success" title="Success" data-testid="my-result" data-track-id="track-123" />,
+    );
+
+    const root = container.querySelector('.ant-result') as HTMLElement;
+
+    expect(root).not.toBeNull();
+    expect(root.getAttribute('data-testid')).toBe('my-result');
+    expect(root.getAttribute('data-track-id')).toBe('track-123');
+  });
+
+  it('should pass aria-* attributes to root element', () => {
+    const { container } = render(
+      <Result
+        status="error"
+        title="Error"
+        aria-label="操作结果"
+        aria-describedby="result-description"
+      />,
+    );
+
+    const root = container.querySelector('.ant-result') as HTMLElement;
+
+    expect(root).not.toBeNull();
+    expect(root.getAttribute('aria-label')).toBe('操作结果');
+    expect(root.getAttribute('aria-describedby')).toBe('result-description');
+  });
 });

--- a/components/result/__tests__/index.test.tsx
+++ b/components/result/__tests__/index.test.tsx
@@ -77,15 +77,12 @@ describe('Result', () => {
   });
 
   it('should pass data-* attributes to root element', () => {
-    const { container } = render(
+    const { getByTestId } = render(
       <Result status="success" title="Success" data-testid="my-result" data-track-id="track-123" />,
     );
 
-    const root = container.querySelector('.ant-result') as HTMLElement;
-
-    expect(root).not.toBeNull();
-    expect(root.getAttribute('data-testid')).toBe('my-result');
-    expect(root.getAttribute('data-track-id')).toBe('track-123');
+    const root = getByTestId('my-result');
+    expect(root).toHaveAttribute('data-track-id', 'track-123');
   });
 
   it('should pass aria-* attributes to root element', () => {

--- a/components/result/__tests__/index.test.tsx
+++ b/components/result/__tests__/index.test.tsx
@@ -89,7 +89,7 @@ describe('Result', () => {
   });
 
   it('should pass aria-* attributes to root element', () => {
-    const { container } = render(
+    const { getByLabelText } = render(
       <Result
         status="error"
         title="Error"
@@ -98,10 +98,7 @@ describe('Result', () => {
       />,
     );
 
-    const root = container.querySelector('.ant-result') as HTMLElement;
-
-    expect(root).not.toBeNull();
-    expect(root.getAttribute('aria-label')).toBe('操作结果');
-    expect(root.getAttribute('aria-describedby')).toBe('result-description');
+    const root = getByLabelText('操作结果');
+    expect(root).toHaveAttribute('aria-describedby', 'result-description');
   });
 });

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -6,6 +6,7 @@ import WarningFilled from '@ant-design/icons/WarningFilled';
 import { clsx } from 'clsx';
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
 
+import type { HTMLAriaDataAttributes } from '../_util/aria-data-attrs';
 import { useMergeSemantic } from '../_util/hooks';
 import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks';
 import { devUseWarning } from '../_util/warning';
@@ -38,7 +39,7 @@ export type ResultClassNamesType = SemanticClassNamesType<ResultProps, SemanticN
 
 export type ResultStylesType = SemanticStylesType<ResultProps, SemanticName>;
 
-export interface ResultProps {
+export interface ResultProps extends HTMLAriaDataAttributes {
   icon?: React.ReactNode;
   status?: ResultStatusType;
   title?: React.ReactNode;

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -4,6 +4,7 @@ import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
 import WarningFilled from '@ant-design/icons/WarningFilled';
 import { clsx } from 'clsx';
+import pickAttrs from '@rc-component/util/lib/pickAttrs';
 
 import { useMergeSemantic } from '../_util/hooks';
 import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks';
@@ -141,6 +142,7 @@ const Result: ResultType = (props) => {
     extra,
     styles,
     classNames,
+    ...rest
   } = props;
 
   const {
@@ -203,8 +205,10 @@ const Result: ResultType = (props) => {
     ...style,
   };
 
+  const restProps = pickAttrs(rest, { aria: true, data: true });
+
   return (
-    <div className={rootClassNames} style={rootStyles}>
+    <div {...restProps} className={rootClassNames} style={rootStyles}>
       <Icon className={iconClassNames} style={mergedStyles.icon} status={status} icon={icon} />
       <div className={titleClassNames} style={mergedStyles.title}>
         {title}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #56091 

### 💡 Background and Solution

`Result` component in v6 does not pass through `data-*` or `aria-*` attributes
to its root DOM element. This prevents users from adding testing identifiers
(such as `data-testid`) or accessibility attributes.

This PR adds support for passing through `data-*` and `aria-*` attributes:

- Extend `ResultProps` to inherit `HTMLAttributes<HTMLDivElement>`
- Extract the remaining props via `...otherProps`
- Use `pickAttrs(otherProps, { aria: true, data: true })` to preserve only
  safe DOM attributes
- Spread the filtered attributes onto the root `<div>` of `Result`
- Add test cases to ensure attributes render correctly

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `Result` component not passing through `data-*` and `aria-*` attributes to the root DOM element. |
| 🇨🇳 Chinese | 修复 `Result` 组件未向根节点透传 `data-*` 与 `aria-*` 属性的问题。 |
