### PR TITLE
feat(input-number): 新增 allowClear 支持清除功能

### DIFF
--- a/components/input-number/__tests__/allow-clear.test.tsx
+++ b/components/input-number/__tests__/allow-clear.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { CloseCircleFilled } from '@ant-design/icons';
+
+import InputNumber from '..';
+import { fireEvent, render } from '../../../tests/utils';
+
+describe('InputNumber.AllowClear', () => {
+  it('should support allowClear', () => {
+    const onChange = jest.fn();
+    const { container } = render(<InputNumber allowClear defaultValue={1} onChange={onChange} />);
+
+    // Should have clear icon
+    expect(container.querySelector('.ant-input-number-clear-icon')).toBeTruthy();
+
+    // Click clear icon
+    fireEvent.click(container.querySelector('.ant-input-number-clear-icon')!);
+
+    // Should call onChange with null
+    expect(onChange).toHaveBeenCalledWith(null);
+
+    // Should focus input after clear
+    expect(document.activeElement).toBe(container.querySelector('input'));
+  });
+
+  it('should not show clear icon when value is null', () => {
+    const { container } = render(<InputNumber allowClear value={null} />);
+
+    // Should not have clear icon
+    expect(container.querySelector('.ant-input-number-clear-icon')).toBeFalsy();
+  });
+
+  it('should not show clear icon when value is undefined', () => {
+    const { container } = render(<InputNumber allowClear value={undefined} />);
+
+    // Should not have clear icon
+    expect(container.querySelector('.ant-input-number-clear-icon')).toBeFalsy();
+  });
+
+  it('should support custom clearIcon', () => {
+    const { container } = render(
+      <InputNumber allowClear={{ clearIcon: <CloseCircleFilled /> }} defaultValue={1} />,
+    );
+
+    // Should have custom clear icon
+    expect(container.querySelector('.anticon-close-circle')).toBeTruthy();
+  });
+
+  it('should not show clear icon when disabled', () => {
+    const { container } = render(<InputNumber allowClear defaultValue={1} disabled />);
+
+    // Should not have clear icon
+    expect(container.querySelector('.ant-input-number-clear-icon')).toBeFalsy();
+  });
+
+  it('should not show clear icon when readOnly', () => {
+    const { container } = render(<InputNumber allowClear defaultValue={1} readOnly />);
+
+    // Should not have clear icon
+    expect(container.querySelector('.ant-input-number-clear-icon')).toBeFalsy();
+  });
+});

--- a/components/input-number/demo/allow-clear.md
+++ b/components/input-number/demo/allow-clear.md
@@ -1,0 +1,13 @@
+---
+title:
+  zh-CN: 可清除
+  en-US: Allow Clear
+---
+
+## zh-CN
+
+通过 `allowClear` 属性可以设置输入框可清除。
+
+## en-US
+
+Set `allowClear` to allow clearing the input.

--- a/components/input-number/demo/allow-clear.tsx
+++ b/components/input-number/demo/allow-clear.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import type { InputNumberProps } from 'antd';
+import { InputNumber, Space } from 'antd';
+
+const onChange: InputNumberProps['onChange'] = (value) => {
+  console.log('changed', value);
+};
+
+const App: React.FC = () => {
+  return (
+    <Space size="large" orientation="vertical">
+      <InputNumber
+        placeholder="Basic"
+        allowClear
+        onChange={onChange}
+        style={{
+          width: '100%',
+        }}
+      />
+      <InputNumber
+        style={{
+          width: '100%',
+        }}
+        placeholder="Custom clear icon"
+        allowClear={{ clearIcon: '✖' }}
+        onChange={onChange}
+      />
+    </Space>
+  );
+};
+
+export default App;

--- a/components/input-number/index.en-US.md
+++ b/components/input-number/index.en-US.md
@@ -32,6 +32,7 @@ When a numeric value needs to be provided.
 <code src="./demo/status.tsx">Status</code>
 <code src="./demo/focus.tsx" version="5.22.0">Focus</code>
 <code src="./demo/style-class.tsx" version="6.0.0">Custom semantic dom styling</code>
+<code src="./demo/allow-clear.tsx">Allow Clear</code>
 <code src="./demo/controls.tsx" debug>Icon</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>
 <code src="./demo/debug-token.tsx" debug>Override Component Style</code>
@@ -44,6 +45,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | --- | --- | --- | --- | --- |
 | ~~addonAfter~~ | The label text displayed after (on the right side of) the input field, please use Space.Compact instead | ReactNode | - |  |
 | ~~addonBefore~~ | The label text displayed before (on the left side of) the input field, please use Space.Compact instead | ReactNode | - |  |
+| allowClear | Whether to show clear button | boolean \| { clearIcon?: ReactNode } | - |  |
 | changeOnBlur | Trigger `onChange` when blur. e.g. reset value in range by blur | boolean | true | 5.11.0 |
 | changeOnWheel | Allows control with mouse wheel | boolean | - | 5.14.0 |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | - |

--- a/components/input-number/index.zh-CN.md
+++ b/components/input-number/index.zh-CN.md
@@ -33,6 +33,7 @@ demo:
 <code src="./demo/status.tsx">自定义状态</code>
 <code src="./demo/focus.tsx" version="5.22.0">聚焦</code>
 <code src="./demo/style-class.tsx" version="6.0.0">自定义语义结构的样式和类</code>
+<code src="./demo/allow-clear.tsx">可清除</code>
 <code src="./demo/controls.tsx" debug>图标按钮</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>
 <code src="./demo/debug-token.tsx" debug>覆盖组件样式</code>
@@ -45,6 +46,7 @@ demo:
 | --- | --- | --- | --- | --- |
 | ~~addonAfter~~ | 带标签的 input，设置后置标签，请使用 Space.Compact 替换 | ReactNode | - | 4.17.0 |
 | ~~addonBefore~~ | 带标签的 input，设置前置标签，请使用 Space.Compact 替换 | ReactNode | - | 4.17.0 |
+| allowClear | 可以点击清除图标删除内容 | boolean \| { clearIcon?: ReactNode } | - |  |
 | changeOnBlur | 是否在失去焦点时，触发 `onChange` 事件（例如值超出范围时，重新限制回范围并触发事件） | boolean | true | 5.11.0 |
 | changeOnWheel | 允许鼠标滚轮改变数值 | boolean | - | 5.14.0 |
 | classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | - |

--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -16,6 +16,43 @@ import { prepareComponentToken } from './token';
 
 export type { ComponentToken };
 
+const genAllowClearStyle = (token: InputNumberToken): any => {
+  const { componentCls } = token;
+  return {
+    // ========================= Input =========================
+    [`${componentCls}-clear-icon`]: {
+      margin: 0,
+      padding: 0,
+      lineHeight: 0,
+      color: token.colorTextQuaternary,
+      fontSize: token.fontSizeIcon,
+      verticalAlign: -1,
+      // https://github.com/ant-design/ant-design/pull/18151
+      // https://codesandbox.io/s/wizardly-sun-u10br
+      cursor: 'pointer',
+      transition: `color ${token.motionDurationSlow}`,
+      border: 'none',
+      outline: 'none',
+      backgroundColor: 'transparent',
+      '&:hover': {
+        color: token.colorIcon,
+      },
+
+      '&:active': {
+        color: token.colorText,
+      },
+
+      '&-hidden': {
+        visibility: 'hidden',
+      },
+
+      '&-has-suffix': {
+        margin: `0 ${unit(token.inputAffixPadding)}`,
+      },
+    },
+  };
+};
+
 const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token: InputNumberToken) => {
   const {
     componentCls,
@@ -317,6 +354,11 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token: InputNumbe
         },
       },
     },
+
+    // ==========================================================
+    // ==                     Allow Clear                      ==
+    // ==========================================================
+    genAllowClearStyle(token),
   ];
 };
 


### PR DESCRIPTION
- 添加 allowClear 属性控制是否显示清除按钮
- 实现清除逻辑和样式
- 更新中英文文档

<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [x] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

> 1. 描述相关需求的来源，如相关的 issue 讨论链接。
[https://github.com/ant-design/ant-design/issues/50885](https://github.com/ant-design/ant-design/issues/50885)
> 2. 例如 close #xxxx、 fix #xxxx

### 💡 需求背景和解决方案

> 1. 要解决的具体问题。
InputNumber支持清除功能
> 2. 列出最终的 API 实现和用法。
`      <InputNumber
        placeholder="Basic"
        allowClear
        onChange={onChange}
      />`
`      <InputNumber
        style={{
          width: '100%',
        }}
        placeholder="Custom clear icon"
        allowClear={{ clearIcon: '✖' }}
        onChange={onChange}
      />`
> 3. 涉及UI/交互变动建议提供截图或 GIF。

<img width="249" height="63" alt="image" src="https://github.com/user-attachments/assets/e9cf021b-db37-4072-abd9-610e565f1ffe" />
<img width="276" height="70" alt="image" src="https://github.com/user-attachments/assets/e6326d07-db56-4f2f-9496-fa0ec1a48cfc" />



### 📝 更新日志

> - 郑重地阅读 [如何维护更新日志](https://keepachangelog.com/zh-CN/1.1.0/)
> - 描述改动对开发者有哪些影响，而非解决方式
> - 可参考：https://ant.design/changelog-cn


| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |  The InputNumber component supports the allowClear property, which accepts either a boolean value or a custom icon.        |
| 🇨🇳 中文 | InputNumber支持allowClear属性，支持boolean或者自定义icon         |