### PR TITLE
fix(splitter): resolve incorrect collapse behavior in RTL vertical mode

### DIFF
--- a/components/splitter/Splitter.tsx
+++ b/components/splitter/Splitter.tsx
@@ -100,7 +100,7 @@ const Splitter: React.FC<React.PropsWithChildren<SplitterProps>> = (props) => {
     useSizes(items, containerSize);
 
   // ====================== Resizable =======================
-  const resizableInfos = useResizable(items, itemPxSizes, isRTL);
+  const resizableInfos = useResizable(items, itemPxSizes, reverse);
 
   const [onOffsetStart, onOffsetUpdate, onOffsetEnd, onCollapse, movingIndex] = useResize(
     items,
@@ -108,7 +108,7 @@ const Splitter: React.FC<React.PropsWithChildren<SplitterProps>> = (props) => {
     itemPtgSizes,
     containerSize,
     updateSizes,
-    isRTL,
+    reverse,
   );
 
   // ======================== Events ========================

--- a/components/splitter/hooks/useResizable.ts
+++ b/components/splitter/hooks/useResizable.ts
@@ -32,7 +32,7 @@ function getShowCollapsibleIcon(prev: Option, next: Option) {
   return false;
 }
 
-export default function useResizable(items: ItemType[], pxSizes: number[], isRTL: boolean) {
+export default function useResizable(items: ItemType[], pxSizes: number[], reverse: boolean) {
   return React.useMemo(() => {
     const resizeInfos: ResizableInfo[] = [];
 
@@ -94,13 +94,13 @@ export default function useResizable(items: ItemType[], pxSizes: number[], isRTL
 
       resizeInfos[i] = {
         resizable: mergedResizable,
-        startCollapsible: !!(isRTL ? endCollapsible : startCollapsible),
-        endCollapsible: !!(isRTL ? startCollapsible : endCollapsible),
-        showStartCollapsibleIcon: isRTL ? showEndCollapsibleIcon : showStartCollapsibleIcon,
-        showEndCollapsibleIcon: isRTL ? showStartCollapsibleIcon : showEndCollapsibleIcon,
+        startCollapsible: !!(reverse ? endCollapsible : startCollapsible),
+        endCollapsible: !!(reverse ? startCollapsible : endCollapsible),
+        showStartCollapsibleIcon: reverse ? showEndCollapsibleIcon : showStartCollapsibleIcon,
+        showEndCollapsibleIcon: reverse ? showStartCollapsibleIcon : showEndCollapsibleIcon,
       };
     }
 
     return resizeInfos;
-  }, [pxSizes, items, isRTL]);
+  }, [pxSizes, items, reverse]);
 }

--- a/components/splitter/hooks/useResize.ts
+++ b/components/splitter/hooks/useResize.ts
@@ -13,7 +13,7 @@ export default function useResize(
   percentSizes: number[],
   containerSize: number | undefined,
   updateSizes: (sizes: number[]) => void,
-  isRTL: boolean,
+  reverse: boolean,
 ) {
   const limitSizes = items.map((item) => [item.min, item.max]);
 
@@ -120,7 +120,7 @@ export default function useResize(
   // ======================= Collapse =======================
   const onCollapse = (index: number, type: 'start' | 'end') => {
     const currentSizes = getPxSizes();
-    const adjustedType = isRTL ? (type === 'start' ? 'end' : 'start') : type;
+    const adjustedType = reverse ? (type === 'start' ? 'end' : 'start') : type;
 
     const currentIndex = adjustedType === 'start' ? index : index + 1;
     const targetIndex = adjustedType === 'start' ? index + 1 : index;

--- a/components/splitter/style/index.ts
+++ b/components/splitter/style/index.ts
@@ -30,39 +30,6 @@ export interface ComponentToken {
 
 interface SplitterToken extends FullToken<'Splitter'> {}
 
-const genRtlStyle = (token: SplitterToken): CSSObject => {
-  const { componentCls } = token;
-  return {
-    [`&-rtl${componentCls}-horizontal`]: {
-      [`> ${componentCls}-bar`]: {
-        [`${componentCls}-bar-collapse-previous`]: {
-          insetInlineEnd: 0,
-          insetInlineStart: 'unset',
-        },
-
-        [`${componentCls}-bar-collapse-next`]: {
-          insetInlineEnd: 'unset',
-          insetInlineStart: 0,
-        },
-      },
-    },
-
-    [`&-rtl${componentCls}-vertical`]: {
-      [`> ${componentCls}-bar`]: {
-        [`${componentCls}-bar-collapse-previous`]: {
-          insetInlineEnd: '50%',
-          insetInlineStart: 'unset',
-        },
-
-        [`${componentCls}-bar-collapse-next`]: {
-          insetInlineEnd: '50%',
-          insetInlineStart: 'unset',
-        },
-      },
-    },
-  };
-};
-
 const centerStyle: CSSObject = {
   position: 'absolute',
   top: '50%',
@@ -406,8 +373,6 @@ const genSplitterStyle: GenerateStyle<SplitterToken> = (token: SplitterToken): C
           overflow: 'hidden',
         },
       },
-
-      ...genRtlStyle(token),
     },
   };
 };


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Fix #56101

### 💡 Background and Solution

在 RTL + Vertical 模式下出现折叠面板方向错误，原因是逻辑层在判断 RTL 时，把「start/end」进行了反转。但实际上：

Vertical 布局不需要也不应该在 RTL 模式下反转方向。

RTL 只影响 inline 方向（左右），不会影响 block 方向（上下）。
Vertical 模式是上下方向，所以在 RTL 下保持不变才是正确的。

因此，这次修复把 RTL 反转逻辑限定为「Horizontal + RTL」才会生效，Vertical 模式下不再反转，从而修复了折叠错误的问题。

另外，代码里原先的 genRtlStyle 中包含一些选择器（例如 collapse-previous / collapse-next），但这些类名在当前 DOM 中已经完全不存在，这段 CSS 不会被渲染、不会生效，也不会影响实际布局。

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix incorrect collapse behavior in RTL vertical Splitter. RTL flipping is now applied only to horizontal layouts. Removed obsolete RTL style definitions. |
| 🇨🇳 Chinese | 修复 Splitter 在 RTL + 垂直模式下折叠方向错误的问题。RTL 逻辑现在仅在横向布局下生效。同时移除了已失效的 RTL 样式代码。 |