### PR TITLE
docs: bump version to 5.29.2 and update changelogs

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -17,7 +17,7 @@ tag: vVERSION
 
 ## 5.29.2
 
-`2025-12-12`
+`2025-12-15`
 
 - 🐞 Fix notification background colors incorrect when `cssVar` is disabled. [#56133](https://github.com/ant-design/ant-design/pull/56133) [@afc163](https://github.com/afc163)
 - 🐞 Raise Breadcrumb link style priority to avoid being overridden by global styles (v5). [#56139](https://github.com/ant-design/ant-design/pull/56139) [@guoyunhe](https://github.com/guoyunhe)

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,14 @@ tag: vVERSION
 
 ---
 
+## 5.29.2
+
+`2025-12-12`
+
+ - 🐞 Fix notification background colors incorrect when `cssVar` is disabled. [#56133](https://github.com/ant-design/ant-design/pull/56133) [@afc163](https://github.com/afc163)
+ - 🐞 Raise Breadcrumb link style priority to avoid being overridden by global styles (v5). [#56139](https://github.com/ant-design/ant-design/pull/56139) [@guoyunhe](https://github.com/guoyunhe)
+ - 🐞 Fix Input.Search should not warn about deprecated `addonAfter`. [#55806](https://github.com/ant-design/ant-design/pull/55806) [@zombieJ](https://github.com/zombieJ)
+
 ## 5.29.1
 
 `2025-11-18`

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -19,9 +19,9 @@ tag: vVERSION
 
 `2025-12-12`
 
- - 🐞 Fix notification background colors incorrect when `cssVar` is disabled. [#56133](https://github.com/ant-design/ant-design/pull/56133) [@afc163](https://github.com/afc163)
- - 🐞 Raise Breadcrumb link style priority to avoid being overridden by global styles (v5). [#56139](https://github.com/ant-design/ant-design/pull/56139) [@guoyunhe](https://github.com/guoyunhe)
- - 🐞 Fix Input.Search should not warn about deprecated `addonAfter`. [#55806](https://github.com/ant-design/ant-design/pull/55806) [@zombieJ](https://github.com/zombieJ)
+- 🐞 Fix notification background colors incorrect when `cssVar` is disabled. [#56133](https://github.com/ant-design/ant-design/pull/56133) [@afc163](https://github.com/afc163)
+- 🐞 Raise Breadcrumb link style priority to avoid being overridden by global styles (v5). [#56139](https://github.com/ant-design/ant-design/pull/56139) [@guoyunhe](https://github.com/guoyunhe)
+- 🐞 Fix Input.Search should not warn about deprecated `addonAfter`. [#55806](https://github.com/ant-design/ant-design/pull/55806) [@zombieJ](https://github.com/zombieJ)
 
 ## 5.29.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -17,7 +17,7 @@ tag: vVERSION
 
 ## 5.29.2
 
-`2025-12-12`
+`2025-12-15`
 
 - 🐞 修复关闭 `cssVar` 时 notification 背景色异常的问题。[#56133](https://github.com/ant-design/ant-design/pull/56133) [@afc163](https://github.com/afc163)
 - 🐞 提升 Breadcrumb 链接样式的优先级以避免被全局样式覆盖。[#56139](https://github.com/ant-design/ant-design/pull/56139) [@guoyunhe](https://github.com/guoyunhe)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,14 @@ tag: vVERSION
 
 ---
 
+## 5.29.2
+
+`2025-12-12`
+
+- 🐞 修复关闭 `cssVar` 时 notification 背景色异常的问题。[#56133](https://github.com/ant-design/ant-design/pull/56133) [@afc163](https://github.com/afc163)
+- 🐞 提升 Breadcrumb 链接样式的优先级以避免被全局样式覆盖。[#56139](https://github.com/ant-design/ant-design/pull/56139) [@guoyunhe](https://github.com/guoyunhe)
+- 🐞 修复 Input.Search 会报 `addonAfter` 已经废弃的警告信息的问题。[#55806](https://github.com/ant-design/ant-design/pull/55806) [@zombieJ](https://github.com/zombieJ)
+
 ## 5.29.1
 
 `2025-11-18`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "5.29.1",
+  "version": "5.29.2",
   "description": "An enterprise-class UI design language and React components implementation",
   "license": "MIT",
   "funding": {


### PR DESCRIPTION

 - 🐞 Fix notification background colors incorrect when `cssVar` is disabled. [#56133](https://github.com/ant-design/ant-design/pull/56133) [@afc163](https://github.com/afc163)
 - 🐞 Raise Breadcrumb link style priority to avoid being overridden by global styles (v5). [#56139](https://github.com/ant-design/ant-design/pull/56139) [@guoyunhe](https://github.com/guoyunhe)
 - 🐞 Fix Input.Search should not warn about deprecated `addonAfter`. [#55806](https://github.com/ant-design/ant-design/pull/55806) [@zombieJ](https://github.com/zombieJ)

---

- 🐞 修复关闭 `cssVar` 时 notification 背景色异常的问题。[#56133](https://github.com/ant-design/ant-design/pull/56133) [@afc163](https://github.com/afc163)
- 🐞 提升 Breadcrumb 链接样式的优先级以避免被全局样式覆盖。[#56139](https://github.com/ant-design/ant-design/pull/56139) [@guoyunhe](https://github.com/guoyunhe)
- 🐞 修复 Input.Search 会报 `addonAfter` 已经废弃的警告信息的问题。[#55806](https://github.com/ant-design/ant-design/pull/55806) [@zombieJ](https://github.com/zombieJ)