### PR TITLE
feat: feature supported #50885

### DIFF
--- a/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -889,6 +889,375 @@ exports[`renders components/input-number/demo/addon.tsx extend context correctly
 ]
 `;
 
+exports[`renders components/input-number/demo/allow-clear.tsx extend context correctly 1`] = `
+<div
+  style="display: flex; flex-direction: column; gap: 16px;"
+>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined ant-input-number-has-clear"
+    style="width: 200px;"
+  >
+    <input
+      aria-valuenow="100"
+      autocomplete="off"
+      class="ant-input-number-input"
+      placeholder="Basic usage"
+      role="spinbutton"
+      step="1"
+      value="100"
+    />
+    <div
+      class="ant-input-number-suffix"
+    >
+      <div
+        aria-label="clear"
+        class="ant-input-number-clear"
+        role="button"
+        tabindex="-1"
+      >
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            />
+          </svg>
+        </span>
+      </div>
+    </div>
+    <div
+      class="ant-input-number-actions"
+    >
+      <span
+        aria-disabled="false"
+        aria-label="Increase Value"
+        class="ant-input-number-action ant-input-number-action-up"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="up"
+          class="anticon anticon-up"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="up"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span
+        aria-disabled="false"
+        aria-label="Decrease Value"
+        class="ant-input-number-action ant-input-number-action-down"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+    style="width: 200px;"
+  >
+    <input
+      autocomplete="off"
+      class="ant-input-number-input"
+      placeholder="Initially empty"
+      role="spinbutton"
+      step="1"
+      value=""
+    />
+    <div
+      class="ant-input-number-actions"
+    >
+      <span
+        aria-disabled="false"
+        aria-label="Increase Value"
+        class="ant-input-number-action ant-input-number-action-up"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="up"
+          class="anticon anticon-up"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="up"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span
+        aria-disabled="false"
+        aria-label="Decrease Value"
+        class="ant-input-number-action ant-input-number-action-down"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined ant-input-number-has-clear"
+    style="width: 200px;"
+  >
+    <input
+      aria-valuenow="42"
+      autocomplete="off"
+      class="ant-input-number-input"
+      placeholder="With custom clear icon"
+      role="spinbutton"
+      step="1"
+      value="42"
+    />
+    <div
+      class="ant-input-number-suffix"
+    >
+      <div
+        aria-label="clear"
+        class="ant-input-number-clear"
+        role="button"
+        tabindex="-1"
+      >
+        🧹
+      </div>
+    </div>
+    <div
+      class="ant-input-number-actions"
+    >
+      <span
+        aria-disabled="false"
+        aria-label="Increase Value"
+        class="ant-input-number-action ant-input-number-action-up"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="up"
+          class="anticon anticon-up"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="up"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span
+        aria-disabled="false"
+        aria-label="Decrease Value"
+        class="ant-input-number-action ant-input-number-action-down"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined ant-input-number-without-controls ant-input-number-disabled"
+    style="width: 200px;"
+  >
+    <input
+      aria-valuenow="50"
+      autocomplete="off"
+      class="ant-input-number-input"
+      disabled=""
+      placeholder="Disabled clear"
+      role="spinbutton"
+      step="1"
+      value="50"
+    />
+  </div>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined ant-input-number-without-controls ant-input-number-readonly"
+    style="width: 200px;"
+  >
+    <input
+      aria-valuenow="75"
+      autocomplete="off"
+      class="ant-input-number-input"
+      placeholder="Readonly with clear"
+      readonly=""
+      role="spinbutton"
+      step="1"
+      value="75"
+    />
+  </div>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+    style="width: 200px;"
+  >
+    <input
+      aria-valuenow="0"
+      autocomplete="off"
+      class="ant-input-number-input"
+      placeholder="Zero value (no clear button)"
+      role="spinbutton"
+      step="1"
+      value="0"
+    />
+    <div
+      class="ant-input-number-actions"
+    >
+      <span
+        aria-disabled="false"
+        aria-label="Increase Value"
+        class="ant-input-number-action ant-input-number-action-up"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="up"
+          class="anticon anticon-up"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="up"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span
+        aria-disabled="false"
+        aria-label="Decrease Value"
+        class="ant-input-number-action ant-input-number-action-down"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/input-number/demo/allow-clear.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/input-number/demo/basic.tsx extend context correctly 1`] = `
 <div
   class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"

--- a/components/input-number/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input-number/__tests__/__snapshots__/demo.test.tsx.snap
@@ -619,6 +619,373 @@ exports[`renders components/input-number/demo/addon.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/input-number/demo/allow-clear.tsx correctly 1`] = `
+<div
+  style="display:flex;flex-direction:column;gap:16px"
+>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined ant-input-number-has-clear"
+    style="width:200px"
+  >
+    <input
+      aria-valuenow="100"
+      autocomplete="off"
+      class="ant-input-number-input"
+      placeholder="Basic usage"
+      role="spinbutton"
+      step="1"
+      value="100"
+    />
+    <div
+      class="ant-input-number-suffix"
+    >
+      <div
+        aria-label="clear"
+        class="ant-input-number-clear"
+        role="button"
+        tabindex="-1"
+      >
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            />
+          </svg>
+        </span>
+      </div>
+    </div>
+    <div
+      class="ant-input-number-actions"
+    >
+      <span
+        aria-disabled="false"
+        aria-label="Increase Value"
+        class="ant-input-number-action ant-input-number-action-up"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="up"
+          class="anticon anticon-up"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="up"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span
+        aria-disabled="false"
+        aria-label="Decrease Value"
+        class="ant-input-number-action ant-input-number-action-down"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+    style="width:200px"
+  >
+    <input
+      autocomplete="off"
+      class="ant-input-number-input"
+      placeholder="Initially empty"
+      role="spinbutton"
+      step="1"
+      value=""
+    />
+    <div
+      class="ant-input-number-actions"
+    >
+      <span
+        aria-disabled="false"
+        aria-label="Increase Value"
+        class="ant-input-number-action ant-input-number-action-up"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="up"
+          class="anticon anticon-up"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="up"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span
+        aria-disabled="false"
+        aria-label="Decrease Value"
+        class="ant-input-number-action ant-input-number-action-down"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined ant-input-number-has-clear"
+    style="width:200px"
+  >
+    <input
+      aria-valuenow="42"
+      autocomplete="off"
+      class="ant-input-number-input"
+      placeholder="With custom clear icon"
+      role="spinbutton"
+      step="1"
+      value="42"
+    />
+    <div
+      class="ant-input-number-suffix"
+    >
+      <div
+        aria-label="clear"
+        class="ant-input-number-clear"
+        role="button"
+        tabindex="-1"
+      >
+        🧹
+      </div>
+    </div>
+    <div
+      class="ant-input-number-actions"
+    >
+      <span
+        aria-disabled="false"
+        aria-label="Increase Value"
+        class="ant-input-number-action ant-input-number-action-up"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="up"
+          class="anticon anticon-up"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="up"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span
+        aria-disabled="false"
+        aria-label="Decrease Value"
+        class="ant-input-number-action ant-input-number-action-down"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined ant-input-number-without-controls ant-input-number-disabled"
+    style="width:200px"
+  >
+    <input
+      aria-valuenow="50"
+      autocomplete="off"
+      class="ant-input-number-input"
+      disabled=""
+      placeholder="Disabled clear"
+      role="spinbutton"
+      step="1"
+      value="50"
+    />
+  </div>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined ant-input-number-without-controls ant-input-number-readonly"
+    style="width:200px"
+  >
+    <input
+      aria-valuenow="75"
+      autocomplete="off"
+      class="ant-input-number-input"
+      placeholder="Readonly with clear"
+      readonly=""
+      role="spinbutton"
+      step="1"
+      value="75"
+    />
+  </div>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+    style="width:200px"
+  >
+    <input
+      aria-valuenow="0"
+      autocomplete="off"
+      class="ant-input-number-input"
+      placeholder="Zero value (no clear button)"
+      role="spinbutton"
+      step="1"
+      value="0"
+    />
+    <div
+      class="ant-input-number-actions"
+    >
+      <span
+        aria-disabled="false"
+        aria-label="Increase Value"
+        class="ant-input-number-action ant-input-number-action-up"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="up"
+          class="anticon anticon-up"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="up"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span
+        aria-disabled="false"
+        aria-label="Decrease Value"
+        class="ant-input-number-action ant-input-number-action-down"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/input-number/demo/basic.tsx correctly 1`] = `
 <div
   class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"

--- a/components/input-number/demo/allow-clear.md
+++ b/components/input-number/demo/allow-clear.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+启用可清空功能，点击清除按钮可清空输入内容。
+
+## en-US
+
+Enable clearable functionality, click the clear button to remove input content.

--- a/components/input-number/demo/allow-clear.tsx
+++ b/components/input-number/demo/allow-clear.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import { InputNumber } from 'antd';
+
+const Demo: React.FC = () => {
+  const [value1, setValue1] = useState<number | null>(100);
+  const [value2, setValue2] = useState<number | null>(null);
+  const [value3, setValue3] = useState<number | null>(42);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <InputNumber
+        placeholder="Basic usage"
+        allowClear
+        value={value1}
+        onChange={setValue1}
+        style={{ width: 200 }}
+      />
+
+      <InputNumber
+        placeholder="Initially empty"
+        allowClear
+        value={value2}
+        onChange={setValue2}
+        style={{ width: 200 }}
+      />
+
+      <InputNumber
+        placeholder="With custom clear icon"
+        allowClear={{ clearIcon: '🧹' }}
+        value={value3}
+        onChange={setValue3}
+        style={{ width: 200 }}
+      />
+
+      <InputNumber
+        placeholder="Disabled clear"
+        allowClear
+        disabled
+        defaultValue={50}
+        style={{ width: 200 }}
+      />
+
+      <InputNumber
+        placeholder="Readonly with clear"
+        allowClear
+        readOnly
+        defaultValue={75}
+        style={{ width: 200 }}
+      />
+
+      <InputNumber
+        placeholder="Zero value (no clear button)"
+        allowClear
+        defaultValue={0}
+        style={{ width: 200 }}
+      />
+    </div>
+  );
+};
+
+export default Demo;

--- a/components/input-number/index.en-US.md
+++ b/components/input-number/index.en-US.md
@@ -35,6 +35,7 @@ When a numeric value needs to be provided.
 <code src="./demo/controls.tsx" debug>Icon</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>
 <code src="./demo/debug-token.tsx" debug>Override Component Style</code>
+<code src="./demo/allow-clear.tsx" version="6.x">Allow Clear</code>
 
 ## API
 
@@ -69,9 +70,11 @@ Common props ref：[Common props](/docs/react/common-props)
 | mode | Show input or spinner | `'input' \| 'spinner'` | `'input'` |  |
 | value | The current value of the component | number | - | - |
 | variant | Variants of Input | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 |
+| allowClear | If allow clear, click to remove the content | `boolean` \| { clearIcon?: React.ReactNode } | false | 6.x |
 | onChange | The callback triggered when the value is changed | function(value: number \| string \| null) | - | - |
 | onPressEnter | The callback function that is triggered when Enter key is pressed | function(e) | - | - |
 | onStep | The callback function that is triggered when click up or down buttons | (value: number, info: { offset: number, type: 'up' \| 'down' }) => void | - |  |
+| onClear | The callback function that is triggered when click clear icon | `function(e: React.MouseEvent<HTMLDivElement>)` | - | 6.x |
 
 ## Ref
 
@@ -112,3 +115,20 @@ InputNumber's value is wrapped by internal logic. The `event.target.value` you g
 > The use of the `type` attribute is deprecated
 
 The InputNumber component allows you to use all the attributes of the input element and ultimately pass them to the input element, This attribute will also be added to the input element when you pass in `type='number'`, which will activate native behavior (allowing the mouse wheel to change the value), As a result `changeOnWheel` cannot control whether the mouse wheel changes the value.
+
+### How to use allowClear feature? {#faq-allow-clear}
+
+The `allowClear` property allows users to quickly clear the input content by clicking the clear button on the right side. When set to `true`, the clear button will be displayed when the input has content and is not disabled. You can also customize the clear icon using `allowClear={{ clearIcon: <CustomIcon /> }}`. Clicking the clear button will trigger the `onClear` callback and set the value to `null`.
+
+```tsx
+// Basic usage
+<InputNumber allowClear />
+
+// Custom clear icon
+<InputNumber
+  allowClear={{ clearIcon: <CustomClearIcon /> }}
+  onClear={(e) => console.log('cleared!')}
+/>
+```
+
+Note: The clear button will not be displayed when the `value` is `0`, as `0` is considered a valid numeric value.

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { MinusOutlined, PlusOutlined } from '@ant-design/icons';
 import DownOutlined from '@ant-design/icons/DownOutlined';
 import UpOutlined from '@ant-design/icons/UpOutlined';
+import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import RcInputNumber from '@rc-component/input-number';
 import type {
   InputNumberProps as RcInputNumberProps,
@@ -92,6 +93,15 @@ export interface InputNumberProps<T extends ValueType = ValueType>
    * @default "outlined"
    */
   variant?: Variant;
+  /**
+   * Allow to clear input number
+   * @default false
+   */
+  allowClear?: boolean | { clearIcon?: React.ReactNode };
+  /**
+   * Callback when click clear icon
+   */
+  onClear?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 type InternalInputNumberProps = InputNumberProps & {
@@ -123,6 +133,10 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
       classNames,
       styles,
       mode,
+      allowClear = false,
+      onClear,
+      value,
+      onChange,
       ...others
     } = props;
 
@@ -163,6 +177,36 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
 
     const [variant, enableVariantCls] = useVariant('inputNumber', customVariant, bordered);
 
+    // ===================== Clear Button =====================
+    const hasValue = value !== null && value !== undefined && value !== '';
+    const showClear = !mergedDisabled && allowClear && hasValue;
+
+    const defaultClearIcon = <CloseCircleFilled />;
+    const mergedAllowClear = typeof allowClear === 'object' ? allowClear : {};
+    const clearIcon = mergedAllowClear.clearIcon ?? defaultClearIcon;
+
+    const handleClear = (e: React.MouseEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      onClear?.(e);
+      onChange?.(null as any);
+    };
+
+    const clearButton = showClear ? (
+      <div
+        className={`${prefixCls}-clear`}
+        onClick={handleClear}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
+        role="button"
+        tabIndex={-1}
+        aria-label="clear"
+      >
+        {clearIcon}
+      </div>
+    ) : null;
+
     const suffixNode = hasFeedback && <>{feedbackIcon}</>;
 
     // =========== Merged Props for Semantic ==========
@@ -201,6 +245,7 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
             [`${prefixCls}-rtl`]: direction === 'rtl',
             [`${prefixCls}-in-form-item`]: isFormItemInput,
             [`${prefixCls}-without-controls`]: !mergedControls,
+            [`${prefixCls}-has-clear`]: showClear,
           },
         )}
         style={{ ...mergedStyles.root, ...contextStyle, ...style }}
@@ -210,9 +255,11 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
         readOnly={readOnly}
         controls={controlsTemp}
         prefix={prefix}
-        suffix={suffixNode || suffix}
+        suffix={clearButton || suffixNode || suffix}
         classNames={mergedClassNames}
         styles={mergedStyles}
+        value={value}
+        onChange={onChange}
         {...others}
       />
     );

--- a/components/input-number/index.zh-CN.md
+++ b/components/input-number/index.zh-CN.md
@@ -36,6 +36,7 @@ demo:
 <code src="./demo/controls.tsx" debug>图标按钮</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>
 <code src="./demo/debug-token.tsx" debug>覆盖组件样式</code>
+<code src="./demo/allow-clear.tsx" version="6.x">可清空</code>
 
 ## API
 
@@ -70,9 +71,11 @@ demo:
 | mode | 展示输入框或拨轮 | `'input' \| 'spinner'` | `'input'` |  |
 | value | 当前值 | number | - | - |
 | variant | 形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 |
+| allowClear | 是否显示清除按钮，点击时清空内容 | `boolean` \| { clearIcon?: React.ReactNode } | false | 6.x |
 | onChange | 变化回调 | function(value: number \| string \| null) | - | - |
 | onPressEnter | 按下回车的回调 | function(e) | - | - |
 | onStep | 点击上下箭头的回调 | (value: number, info: { offset: number, type: 'up' \| 'down' }) => void | - | 4.7.0 |
+| onClear | 点击清除按钮的回调 | `function(e: React.MouseEvent<HTMLDivElement>)` | - | 6.x |
 
 ## Ref
 
@@ -109,3 +112,20 @@ InputNumber 的值由内部逻辑封装而成，通过 `onBlur` 等事件获取�
 > 不建议使用 `type` 属性
 
 InputNumber 组件允许你使用 input 元素的所有属性最终透传至 input 元素，当你传入 `type="number"` 时 input 元素也会添加这个属性，这会使 input 元素触发原生特性（允许鼠标滚轮改变数值），从而导致 `changeOnWheel` 无法控制鼠标滚轮是否改变数值。
+
+### 如何使用 allowClear 功能？ {#faq-allow-clear}
+
+`allowClear` 属性允许用户通过点击右侧的清除按钮快速清空输入内容。当值为 `true` 时，在输入框有内容且未禁用状态下会显示清除按钮。你也可以通过 `allowClear={{ clearIcon: <CustomIcon /> }}` 自定义清除图标。点击清除按钮会触发 `onClear` 回调并将值设为 `null`。
+
+```tsx
+// 基本用法
+<InputNumber allowClear />
+
+// 自定义清除图标
+<InputNumber
+  allowClear={{ clearIcon: <CustomClearIcon /> }}
+  onClear={(e) => console.log('已清空！')}
+/>
+```
+
+注意：当 `value` 为 `0` 时，清除按钮不会显示，因为 `0` 是有效数值。

--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -43,6 +43,8 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token: InputNumbe
     handleBorderColor,
     filledHandleBg,
     lineHeightLG,
+    colorTextQuaternary,
+    colorTextTertiary,
   } = token;
 
   const borderStyle = `${unit(lineWidth)} ${lineType} ${handleBorderColor}`;
@@ -313,6 +315,34 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token: InputNumbe
         [`&:hover:not(${componentCls}-without-controls)`]: {
           [`${componentCls}-suffix`]: {
             marginInlineEnd: token.handleWidth,
+          },
+        },
+
+        // ======================= Clear Button =======================
+        [`${componentCls}-clear`]: {
+          ...resetIcon(),
+          marginInlineStart: inputAffixPadding,
+          color: colorTextQuaternary,
+          fontSize: token.fontSizeIcon,
+          verticalAlign: 'top',
+          cursor: 'pointer',
+          transition: `color ${motionDurationMid}`,
+          alignSelf: 'center',
+          lineHeight: 1,
+          pointerEvents: 'auto',
+
+          '&:hover': {
+            color: colorTextTertiary,
+          },
+        },
+
+        [`&:hover ${componentCls}-clear`]: {
+          opacity: 1,
+        },
+
+        '&-has-clear': {
+          [`${componentCls}-suffix`]: {
+            marginInlineStart: 0,
           },
         },
       },


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature

### 🔗 Related Issues

> - Add `allowClear` functionality to InputNumber component, similar to Input component
> - close #50885

### 💡 Background and Solution

> - **The specific problem to be addressed**: Users need a quick way to clear InputNumber content without manually deleting or using keyboard shortcuts. The Input component already has this feature, but InputNumber lacks it.
> - **Final API implementation**: 
>   - Added `allowClear` prop: `boolean | { clearIcon?: React.ReactNode }`
>   - Added `onClear` prop: `(e: React.MouseEvent<HTMLDivElement>) => void`
>   - When `allowClear` is enabled and the input has a value (excluding 0), a clear button appears on the right side
>   - Clicking the clear button triggers `onClear` callback and sets value to `null`
>   - Supports custom clear icons via `allowClear={{ clearIcon: <CustomIcon /> }}`

<img width="308" height="400" alt="image" src="https://github.com/user-attachments/assets/c0eb648b-2406-40bf-ac2f-ecac1d49a8c0" />


> - **Usage example**:
> ```tsx
> // Basic usage
> <InputNumber allowClear />
> 
> // Custom clear icon
> <InputNumber allowClear={{ clearIcon: <CustomClearIcon /> }} onClear={(e) => console.log('cleared!')} />
> ```

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support `allowClear` prop for InputNumber component to enable clearable functionality. |
| 🇨🇳 Chinese | InputNumber 组件支持 `allowClear` 属性，启用可清空功能。 |