### PR TITLE
site: remove unused bottom from sticky layout

### DIFF
--- a/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1401,7 +1401,7 @@ exports[`renders components/layout/demo/fixed-sider.tsx extend context correctly
 >
   <aside
     class="ant-layout-sider ant-layout-sider-dark css-var-test-id"
-    style="overflow: auto; height: 100vh; position: sticky; inset-inline-start: 0; top: 0px; bottom: 0px; scrollbar-width: thin; scrollbar-gutter: stable; flex: 0 0 200px; max-width: 200px; min-width: 200px; width: 200px;"
+    style="overflow: auto; height: 100vh; position: sticky; inset-inline-start: 0; top: 0px; scrollbar-width: thin; scrollbar-gutter: stable; flex: 0 0 200px; max-width: 200px; min-width: 200px; width: 200px;"
   >
     <div
       class="ant-layout-sider-children"

--- a/components/layout/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.ts.snap
@@ -772,7 +772,7 @@ exports[`renders components/layout/demo/fixed-sider.tsx correctly 1`] = `
 >
   <aside
     class="ant-layout-sider ant-layout-sider-dark css-var-test-id"
-    style="overflow:auto;height:100vh;position:sticky;inset-inline-start:0;top:0;bottom:0;scrollbar-width:thin;scrollbar-gutter:stable;flex:0 0 200px;max-width:200px;min-width:200px;width:200px"
+    style="overflow:auto;height:100vh;position:sticky;inset-inline-start:0;top:0;scrollbar-width:thin;scrollbar-gutter:stable;flex:0 0 200px;max-width:200px;min-width:200px;width:200px"
   >
     <div
       class="ant-layout-sider-children"

--- a/components/layout/demo/fixed-sider.tsx
+++ b/components/layout/demo/fixed-sider.tsx
@@ -20,7 +20,6 @@ const siderStyle: React.CSSProperties = {
   position: 'sticky',
   insetInlineStart: 0,
   top: 0,
-  bottom: 0,
   scrollbarWidth: 'thin',
   scrollbarGutter: 'stable',
 };


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 📝 Site / documentation improvement


### 💡 Background and Solution

If position is set to relative or height is constrained, the top property takes precedence and the bottom property is ignored.
https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/top#:~:text=If%20position%20is%20set%20to%20relative%20or%20height%20is%20constrained%2C%20the%20top%20property%20takes%20precedence%20and%20the%20bottom%20property%20is%20ignored.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      remove bottom property in layout demo     |
| 🇨🇳 Chinese |         |
