### PR TITLE
chore: remove broken check-commit script

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "authors": "tsx scripts/generate-authors.ts",
     "build": "npm run compile && cross-env NODE_OPTIONS='--max-old-space-size=4096' npm run dist",
     "changelog": "npm run lint:changelog && tsx scripts/print-changelog.ts",
-    "check-commit": "tsx scripts/check-commit.ts",
     "clean": "antd-tools run clean && rimraf es lib coverage locale dist report.html artifacts.zip oss-artifacts.zip",
     "clean:lockfiles": "rimraf package-lock.json yarn.lock",
     "precompile": "npm run prestart",

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Full skip argms
-# npm run test-all -- --skip-changelog --skip-commit --skip-lint --skip-build --skip-dekko --skip-dist --skip-es --skip-lib --skip-test --skip-node
+# npm run test-all -- --skip-changelog --skip-lint --skip-build --skip-dekko --skip-dist --skip-es --skip-lib --skip-test --skip-node
 
 # Check exist argument
 has_arg() {
@@ -25,14 +25,6 @@ if ! has_arg '--skip-changelog' "$@"; then
   tsx ./scripts/check-version-md.ts
 else
   echo "[TEST ALL] test changelog...skip"
-fi
-
-if ! has_arg '--skip-commit' "$@"; then
-  echo "[TEST ALL] check-commit"
-  echo "[TEST ALL] check-commit" > ~test-all.txt
-  npm run check-commit
-else
-  echo "[TEST ALL] check-commit...skip"
 fi
 
 if ! has_arg '--skip-lint' "$@"; then


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close #56212 , fix #56212 

### 💡 Background and Solution

https://github.com/ant-design/ant-design/blob/master/package.json。运行pnpm check-commit项目目录未能找到scripts/check-commit.ts脚本而报错。

#### Solution:
在package.json中删除找不到check-commit脚本，以及删除scripts/test-all.sh中引用的无效脚本check-commit。

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        Fix the missing check-commit command in check-commit.ts in package.json and scripts/test-all.sh.   |
| 🇨🇳 Chinese |     修复package.json及scripts/test-all.sh中未找到的check-commit.ts的check-commit命令      |
