### PR TITLE
fix(V5): Splitter ptg not fully cover

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -22,6 +22,7 @@ tag: vVERSION
 - 🐞 Fix notification background colors incorrect when `cssVar` is disabled. [#56133](https://github.com/ant-design/ant-design/pull/56133) [@afc163](https://github.com/afc163)
 - 🐞 Raise Breadcrumb link style priority to avoid being overridden by global styles (v5). [#56139](https://github.com/ant-design/ant-design/pull/56139) [@guoyunhe](https://github.com/guoyunhe)
 - 🐞 Fix Input.Search should not warn about deprecated `addonAfter`. [#55806](https://github.com/ant-design/ant-design/pull/55806) [@zombieJ](https://github.com/zombieJ)
+- 🐞 Fix Splitter failing to fill its container when the sum of panel proportions is not 1. [#56217](https://github.com/ant-design/ant-design/pull/56217) [@zombieJ](https://github.com/zombieJ)
 
 ## 5.29.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -22,6 +22,7 @@ tag: vVERSION
 - 🐞 修复关闭 `cssVar` 时 notification 背景色异常的问题。[#56133](https://github.com/ant-design/ant-design/pull/56133) [@afc163](https://github.com/afc163)
 - 🐞 提升 Breadcrumb 链接样式的优先级以避免被全局样式覆盖。[#56139](https://github.com/ant-design/ant-design/pull/56139) [@guoyunhe](https://github.com/guoyunhe)
 - 🐞 修复 Input.Search 会报 `addonAfter` 已经废弃的警告信息的问题。[#55806](https://github.com/ant-design/ant-design/pull/55806) [@zombieJ](https://github.com/zombieJ)
+- 🐞 修复 Splitter 在 Panel 总占比不为 1 时出现占不满的情况。 [#56217](https://github.com/ant-design/ant-design/pull/56217) [@zombieJ](https://github.com/zombieJ)
 
 ## 5.29.1
 

--- a/components/splitter/__tests__/size.test.tsx
+++ b/components/splitter/__tests__/size.test.tsx
@@ -74,4 +74,37 @@ describe('useSizes', () => {
     // In impossible case, should average fill (1000 / 3 = 333.33... for each)
     expect(postPxSizes).toEqual([1000 / 3, 1000 / 3, 1000 / 3]);
   });
+
+  it('should average if size total is not 100%', () => {
+    const items = [
+      {
+        size: '20%',
+      },
+      {
+        size: '30%',
+      },
+    ];
+
+    const { result } = renderHook(() => useSizes(items, containerSize));
+    const [sizes] = result.current;
+
+    // Check sizes
+    expect(sizes).toEqual([400, 600]);
+  });
+
+  it('should correct when all size is 0', () => {
+    const items = [
+      {
+        size: 0,
+      },
+      {
+        size: 0,
+      },
+    ];
+
+    const { result } = renderHook(() => useSizes(items, containerSize));
+    const [, postPxSizes] = result.current;
+
+    expect(postPxSizes).toEqual([500, 500]);
+  });
 });

--- a/components/splitter/hooks/sizeUtil.ts
+++ b/components/splitter/hooks/sizeUtil.ts
@@ -19,6 +19,18 @@ export function autoPtgSizes(
   const restPtg = 1 - currentTotalPtg;
   const undefinedCount = undefinedIndexes.length;
 
+  // If all sizes are defined but don't sum to 1, scale them.
+  if (ptgSizes.length && !undefinedIndexes.length && currentTotalPtg !== 1) {
+    // Handle the case when all sizes are 0
+    if (currentTotalPtg === 0) {
+      const avg = 1 / ptgSizes.length;
+      return ptgSizes.map(() => avg);
+    }
+    const scale = 1 / currentTotalPtg;
+    // We know `size` is a number here because undefinedIndexes is empty.
+    return ptgSizes.map((size) => (size as number) * scale);
+  }
+
   // Fill if exceed
   if (restPtg < 0) {
     const scale = 1 / currentTotalPtg;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [X] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues


同步 V5 时期提出的bug修复
- ref: https://github.com/ant-design/ant-design/pull/56025

### 💡 Background and Solution



### 📝 Change Log



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Splitter failing to fill its container when the sum of panel proportions is not 1.      |
| 🇨🇳 Chinese |     修复 Splitter 在 Panel 总占比不为 1 时出现占不满的情况。     |
