### PR TITLE
docs(Modal): Page jittering

### DIFF
--- a/.dumi/theme/common/styles/Reset.tsx
+++ b/.dumi/theme/common/styles/Reset.tsx
@@ -58,6 +58,7 @@ export default () => {
 
         body {
           overflow-x: hidden;
+          scrollbar-width: thin;
           color: ${token.colorText};
           font-size: ${token.fontSize}px;
           font-family: ${token.fontFamily};


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 📝 Site / documentation improvement

### 🔗 Related Issues

close https://github.com/ant-design/ant-design/issues/56246

### 💡 Background and Solution

Modal打开的时候，需要锁定滚动条（即滚动条失效），因此需要拿到挂载元素滚动条宽度
官网的demo没有指定挂载对象，默认挂载在body上，body的scrollbar-width没设置，默认值是auto，官网的滚动是基于html滚动的且html设置了scrollbar-width: thin;

Modal打开的时候，拿到的滚动条宽度是auto对应的具体px值，thin的具体px值小于auto的px值，所以会出现抖动

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Page jittering      |
| 🇨🇳 Chinese |     页面抖动      |
