### PR TITLE
fix: fix dropdown can not open immediately

### DIFF
--- a/components/_util/wave/WaveEffect.tsx
+++ b/components/_util/wave/WaveEffect.tsx
@@ -40,6 +40,7 @@ const WaveEffect = (props: WaveEffectProps) => {
     width,
     height,
     borderRadius: borderRadius.map((radius) => `${radius}px`).join(' '),
+    pointerEvents: 'none',
   };
 
   if (color) {

--- a/components/_util/wave/WaveEffect.tsx
+++ b/components/_util/wave/WaveEffect.tsx
@@ -40,7 +40,6 @@ const WaveEffect = (props: WaveEffectProps) => {
     width,
     height,
     borderRadius: borderRadius.map((radius) => `${radius}px`).join(' '),
-    pointerEvents: 'none',
   };
 
   if (color) {

--- a/components/_util/wave/index.ts
+++ b/components/_util/wave/index.ts
@@ -25,7 +25,7 @@ const Wave: React.FC<WaveProps> = (props) => {
 
   // ============================== Style ===============================
   const prefixCls = getPrefixCls('wave');
-  const [, hashId] = useStyle(prefixCls);
+  const hashId = useStyle(prefixCls);
 
   // =============================== Wave ===============================
   const showWave = useWave(containerRef, clsx(prefixCls, hashId), component, colorSource);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #56240

### 💡 Background and Solution

排查流程：

* 剥离最小重现，表现为点击关闭并且再次移入无法显示 Popover
* 注入 `rc-trigger` `triggerOpen` 发现二次移入无法触发方法
* 注入 `rc-trigger` hover 相关事件发现二次移入无法触发事件
* 查看 Chrome bug report 无相关事件丢失反馈
* 使用 Firefox 后依然重现，确定为代码问题
* 使用标准 button 后问题修复
* 查看 Button 代码，没有相关阻止事件或者劫持逻辑怀疑为 HOC 影响
* 逐步注释，发现来源自 Wave 组件
* 添加 Wave `pointerEvents: none` 样式，问题解决
* 查看 Wave style 里，发现已经存在 `pointerEvents`，看起来是 CSSINJS 样式没有生效
* console 对应 `useStyle` className，发现为 `c` `s` 即解构文字类型缘由为 `genComponentStyleHook` 返回类型从 `[wrapperFn, hashId]` 改成了 `string` 类型。导致 CSSINJS 的 className 被破坏
* 那 Button 应该缺少了动画效果，回看发现果然谜底出现在谜面上……

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Wave effect missing. Fix Button can not hover to show Dropdown immediately when click on it.      |
| 🇨🇳 Chinese |   修复 Wave 水波纹消失问题。修复 Button 如果配置了 Dropdown 在点击后再次 hover 无法立刻显示 Dropdown 的问题。    |
