### PR TITLE
fix: remove duplicate radio role and optimize aria attributes

### DIFF
--- a/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3810,6 +3810,7 @@ exports[`renders components/color-picker/demo/line-gradient.tsx extend context c
               >
                 <div
                   aria-label="segmented control"
+                  aria-orientation="horizontal"
                   class="ant-segmented ant-segmented-sm css-var-test-id"
                   role="radiogroup"
                   tabindex="0"
@@ -3827,9 +3828,7 @@ exports[`renders components/color-picker/demo/line-gradient.tsx extend context c
                         type="radio"
                       />
                       <div
-                        aria-checked="false"
                         class="ant-segmented-item-label"
-                        role="radio"
                         title="Single"
                       >
                         Single
@@ -3844,9 +3843,7 @@ exports[`renders components/color-picker/demo/line-gradient.tsx extend context c
                         type="radio"
                       />
                       <div
-                        aria-checked="true"
                         class="ant-segmented-item-label"
-                        role="radio"
                         title="Gradient"
                       >
                         Gradient

--- a/components/flex/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/flex/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -9,6 +9,7 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
   </p>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -26,9 +27,7 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="flex-start"
         >
           flex-start
@@ -43,9 +42,7 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="center"
         >
           center
@@ -60,9 +57,7 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="flex-end"
         >
           flex-end
@@ -77,9 +72,7 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="space-between"
         >
           space-between
@@ -94,9 +87,7 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="space-around"
         >
           space-around
@@ -111,9 +102,7 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="space-evenly"
         >
           space-evenly
@@ -126,6 +115,7 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
   </p>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -143,9 +133,7 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="flex-start"
         >
           flex-start
@@ -160,9 +148,7 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="center"
         >
           center
@@ -177,9 +163,7 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="flex-end"
         >
           flex-end

--- a/components/flex/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/flex/__tests__/__snapshots__/demo.test.ts.snap
@@ -9,6 +9,7 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
   </p>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -26,9 +27,7 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="flex-start"
         >
           flex-start
@@ -43,9 +42,7 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="center"
         >
           center
@@ -60,9 +57,7 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="flex-end"
         >
           flex-end
@@ -77,9 +72,7 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="space-between"
         >
           space-between
@@ -94,9 +87,7 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="space-around"
         >
           space-around
@@ -111,9 +102,7 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="space-evenly"
         >
           space-evenly
@@ -126,6 +115,7 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
   </p>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -143,9 +133,7 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="flex-start"
         >
           flex-start
@@ -160,9 +148,7 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="center"
         >
           center
@@ -177,9 +163,7 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="flex-end"
         >
           flex-end

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -32252,6 +32252,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
           >
             <div
               aria-label="segmented control"
+              aria-orientation="horizontal"
               class="ant-segmented css-var-test-id"
               id="variant"
               role="radiogroup"
@@ -32269,9 +32270,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                     type="radio"
                   />
                   <div
-                    aria-checked="false"
                     class="ant-segmented-item-label"
-                    role="radio"
                     title="outlined"
                   >
                     outlined
@@ -32287,9 +32286,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                     type="radio"
                   />
                   <div
-                    aria-checked="true"
                     class="ant-segmented-item-label"
-                    role="radio"
                     title="filled"
                   >
                     filled
@@ -32304,9 +32301,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                     type="radio"
                   />
                   <div
-                    aria-checked="false"
                     class="ant-segmented-item-label"
-                    role="radio"
                     title="borderless"
                   >
                     borderless
@@ -32321,9 +32316,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                     type="radio"
                   />
                   <div
-                    aria-checked="false"
                     class="ant-segmented-item-label"
-                    role="radio"
                     title="underlined"
                   >
                     underlined

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -14502,6 +14502,7 @@ exports[`renders components/form/demo/variant.tsx correctly 1`] = `
           >
             <div
               aria-label="segmented control"
+              aria-orientation="horizontal"
               class="ant-segmented css-var-test-id"
               id="variant"
               role="radiogroup"
@@ -14519,9 +14520,7 @@ exports[`renders components/form/demo/variant.tsx correctly 1`] = `
                     type="radio"
                   />
                   <div
-                    aria-checked="false"
                     class="ant-segmented-item-label"
-                    role="radio"
                     title="outlined"
                   >
                     outlined
@@ -14537,9 +14536,7 @@ exports[`renders components/form/demo/variant.tsx correctly 1`] = `
                     type="radio"
                   />
                   <div
-                    aria-checked="true"
                     class="ant-segmented-item-label"
-                    role="radio"
                     title="filled"
                   >
                     filled
@@ -14554,9 +14551,7 @@ exports[`renders components/form/demo/variant.tsx correctly 1`] = `
                     type="radio"
                   />
                   <div
-                    aria-checked="false"
                     class="ant-segmented-item-label"
-                    role="radio"
                     title="borderless"
                   >
                     borderless
@@ -14571,9 +14566,7 @@ exports[`renders components/form/demo/variant.tsx correctly 1`] = `
                     type="radio"
                   />
                   <div
-                    aria-checked="false"
                     class="ant-segmented-item-label"
-                    role="radio"
                     title="underlined"
                   >
                     underlined

--- a/components/popover/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/popover/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4,6 +4,7 @@ exports[`renders components/popover/demo/arrow.tsx extend context correctly 1`] 
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     style="margin-bottom: 24px;"
@@ -22,9 +23,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Show"
         >
           Show
@@ -39,9 +38,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Hide"
         >
           Hide
@@ -56,9 +53,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Center"
         >
           Center

--- a/components/popover/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/popover/__tests__/__snapshots__/demo.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`renders components/popover/demo/arrow.tsx correctly 1`] = `
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     style="margin-bottom:24px"
@@ -22,9 +23,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Show"
         >
           Show
@@ -39,9 +38,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Hide"
         >
           Hide
@@ -56,9 +53,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Center"
         >
           Center

--- a/components/progress/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/progress/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1457,6 +1457,7 @@ exports[`renders components/progress/demo/dashboard.tsx extend context correctly
     gapDegree:
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented css-var-test-id"
       role="radiogroup"
       tabindex="0"
@@ -1474,9 +1475,7 @@ exports[`renders components/progress/demo/dashboard.tsx extend context correctly
             type="radio"
           />
           <div
-            aria-checked="true"
             class="ant-segmented-item-label"
-            role="radio"
             title="50"
           >
             50
@@ -1491,9 +1490,7 @@ exports[`renders components/progress/demo/dashboard.tsx extend context correctly
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="100"
           >
             100
@@ -1506,6 +1503,7 @@ exports[`renders components/progress/demo/dashboard.tsx extend context correctly
     gapPlacement:
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented css-var-test-id"
       role="radiogroup"
       tabindex="0"
@@ -1522,9 +1520,7 @@ exports[`renders components/progress/demo/dashboard.tsx extend context correctly
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="start"
           >
             start
@@ -1539,9 +1535,7 @@ exports[`renders components/progress/demo/dashboard.tsx extend context correctly
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="end"
           >
             end
@@ -1556,9 +1550,7 @@ exports[`renders components/progress/demo/dashboard.tsx extend context correctly
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="top"
           >
             top
@@ -1574,9 +1566,7 @@ exports[`renders components/progress/demo/dashboard.tsx extend context correctly
             type="radio"
           />
           <div
-            aria-checked="true"
             class="ant-segmented-item-label"
-            role="radio"
             title="bottom"
           >
             bottom

--- a/components/progress/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.ts.snap
@@ -1327,6 +1327,7 @@ exports[`renders components/progress/demo/dashboard.tsx correctly 1`] = `
     gapDegree:
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented css-var-test-id"
       role="radiogroup"
       tabindex="0"
@@ -1344,9 +1345,7 @@ exports[`renders components/progress/demo/dashboard.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="true"
             class="ant-segmented-item-label"
-            role="radio"
             title="50"
           >
             50
@@ -1361,9 +1360,7 @@ exports[`renders components/progress/demo/dashboard.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="100"
           >
             100
@@ -1376,6 +1373,7 @@ exports[`renders components/progress/demo/dashboard.tsx correctly 1`] = `
     gapPlacement:
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented css-var-test-id"
       role="radiogroup"
       tabindex="0"
@@ -1392,9 +1390,7 @@ exports[`renders components/progress/demo/dashboard.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="start"
           >
             start
@@ -1409,9 +1405,7 @@ exports[`renders components/progress/demo/dashboard.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="end"
           >
             end
@@ -1426,9 +1420,7 @@ exports[`renders components/progress/demo/dashboard.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="top"
           >
             top
@@ -1444,9 +1436,7 @@ exports[`renders components/progress/demo/dashboard.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="true"
             class="ant-segmented-item-label"
-            role="radio"
             title="bottom"
           >
             bottom

--- a/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -391,6 +391,7 @@ exports[`renders components/qr-code/demo/download.tsx extend context correctly 1
   >
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented css-var-test-id"
       role="radiogroup"
       tabindex="0"
@@ -408,9 +409,7 @@ exports[`renders components/qr-code/demo/download.tsx extend context correctly 1
             type="radio"
           />
           <div
-            aria-checked="true"
             class="ant-segmented-item-label"
-            role="radio"
             title="canvas"
           >
             canvas
@@ -425,9 +424,7 @@ exports[`renders components/qr-code/demo/download.tsx extend context correctly 1
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="svg"
           >
             svg
@@ -485,6 +482,7 @@ Array [
   </div>,
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -502,9 +500,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="L"
         >
           L
@@ -519,9 +515,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="M"
         >
           M
@@ -536,9 +530,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Q"
         >
           Q
@@ -553,9 +545,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="H"
         >
           H

--- a/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
@@ -347,6 +347,7 @@ exports[`renders components/qr-code/demo/download.tsx correctly 1`] = `
   >
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented css-var-test-id"
       role="radiogroup"
       tabindex="0"
@@ -364,9 +365,7 @@ exports[`renders components/qr-code/demo/download.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="true"
             class="ant-segmented-item-label"
-            role="radio"
             title="canvas"
           >
             canvas
@@ -381,9 +380,7 @@ exports[`renders components/qr-code/demo/download.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="svg"
           >
             svg
@@ -439,6 +436,7 @@ Array [
   </div>,
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -456,9 +454,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="L"
         >
           L
@@ -473,9 +469,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="M"
         >
           M
@@ -490,9 +484,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Q"
         >
           Q
@@ -507,9 +499,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="H"
         >
           H

--- a/components/segmented/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/segmented/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`renders components/segmented/demo/basic.tsx extend context correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-test-id"
   role="radiogroup"
   tabindex="0"
@@ -20,9 +21,7 @@ exports[`renders components/segmented/demo/basic.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Daily"
       >
         Daily
@@ -37,9 +36,7 @@ exports[`renders components/segmented/demo/basic.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Weekly"
       >
         Weekly
@@ -54,9 +51,7 @@ exports[`renders components/segmented/demo/basic.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Monthly"
       >
         Monthly
@@ -71,9 +66,7 @@ exports[`renders components/segmented/demo/basic.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Quarterly"
       >
         Quarterly
@@ -88,9 +81,7 @@ exports[`renders components/segmented/demo/basic.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Yearly"
       >
         Yearly
@@ -105,6 +96,7 @@ exports[`renders components/segmented/demo/basic.tsx extend context correctly 2`
 exports[`renders components/segmented/demo/block.tsx extend context correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-block css-var-test-id"
   role="radiogroup"
   tabindex="0"
@@ -122,9 +114,7 @@ exports[`renders components/segmented/demo/block.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="123"
       >
         123
@@ -139,9 +129,7 @@ exports[`renders components/segmented/demo/block.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="456"
       >
         456
@@ -156,9 +144,7 @@ exports[`renders components/segmented/demo/block.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="longtext-longtext-longtext-longtext"
       >
         longtext-longtext-longtext-longtext
@@ -174,6 +160,7 @@ exports[`renders components/segmented/demo/componentToken.tsx extend context cor
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -191,9 +178,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Daily"
         >
           Daily
@@ -208,9 +193,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Weekly"
         >
           Weekly
@@ -225,9 +208,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Monthly"
         >
           Monthly
@@ -242,9 +223,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Quarterly"
         >
           Quarterly
@@ -259,9 +238,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Yearly"
         >
           Yearly
@@ -272,6 +249,7 @@ Array [
     ,
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -289,9 +267,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Daily"
         >
           Daily
@@ -306,9 +282,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Weekly"
         >
           Weekly
@@ -323,9 +297,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Monthly"
         >
           Monthly
@@ -340,9 +312,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Quarterly"
         >
           Quarterly
@@ -357,9 +327,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Yearly"
         >
           Yearly
@@ -375,6 +343,7 @@ exports[`renders components/segmented/demo/componentToken.tsx extend context cor
 exports[`renders components/segmented/demo/controlled.tsx extend context correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-test-id"
   role="radiogroup"
   tabindex="0"
@@ -392,9 +361,7 @@ exports[`renders components/segmented/demo/controlled.tsx extend context correct
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Map"
       >
         Map
@@ -409,9 +376,7 @@ exports[`renders components/segmented/demo/controlled.tsx extend context correct
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Transit"
       >
         Transit
@@ -426,9 +391,7 @@ exports[`renders components/segmented/demo/controlled.tsx extend context correct
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Satellite"
       >
         Satellite
@@ -444,6 +407,7 @@ exports[`renders components/segmented/demo/controlled-two.tsx extend context cor
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -461,9 +425,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="AND"
         >
           AND
@@ -478,9 +440,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="OR"
         >
           OR
@@ -495,9 +455,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="NOT"
         >
           NOT
@@ -508,6 +466,7 @@ Array [
     ,
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -525,9 +484,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="AND"
         >
           AND
@@ -542,9 +499,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="OR"
         >
           OR
@@ -559,9 +514,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="NOT"
         >
           NOT
@@ -580,6 +533,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -598,9 +552,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <div
             style="padding: 4px;"
@@ -609,6 +561,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
               class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
             >
               <img
+                alt="User 1"
                 src="https://api.dicebear.com/7.x/miniavs/svg?seed=8"
               />
             </span>
@@ -648,9 +601,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <div
             style="padding: 4px;"
@@ -702,9 +653,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <div
             style="padding: 4px;"
@@ -763,6 +712,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -780,9 +730,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <div
             style="padding: 4px;"
@@ -805,9 +753,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <div
             style="padding: 4px;"
@@ -830,9 +776,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <div
             style="padding: 4px;"
@@ -855,9 +799,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <div
             style="padding: 4px;"
@@ -884,6 +826,7 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-disabled css-var-test-id"
     role="radiogroup"
   >
@@ -901,9 +844,7 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Map"
         >
           Map
@@ -919,9 +860,7 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Transit"
         >
           Transit
@@ -937,9 +876,7 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Satellite"
         >
           Satellite
@@ -949,6 +886,7 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -966,9 +904,7 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Daily"
         >
           Daily
@@ -984,9 +920,7 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Weekly"
         >
           Weekly
@@ -1001,9 +935,7 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Monthly"
         >
           Monthly
@@ -1019,9 +951,7 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Quarterly"
         >
           Quarterly
@@ -1036,9 +966,7 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Yearly"
         >
           Yearly
@@ -1057,6 +985,7 @@ exports[`renders components/segmented/demo/dynamic.tsx extend context correctly 
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -1074,9 +1003,7 @@ exports[`renders components/segmented/demo/dynamic.tsx extend context correctly 
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Daily"
         >
           Daily
@@ -1091,9 +1018,7 @@ exports[`renders components/segmented/demo/dynamic.tsx extend context correctly 
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Weekly"
         >
           Weekly
@@ -1108,9 +1033,7 @@ exports[`renders components/segmented/demo/dynamic.tsx extend context correctly 
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Monthly"
         >
           Monthly
@@ -1134,6 +1057,7 @@ exports[`renders components/segmented/demo/dynamic.tsx extend context correctly 
 exports[`renders components/segmented/demo/icon-only.tsx extend context correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-test-id"
   role="radiogroup"
   tabindex="0"
@@ -1151,9 +1075,7 @@ exports[`renders components/segmented/demo/icon-only.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <span
           class="ant-segmented-item-icon"
@@ -1189,9 +1111,7 @@ exports[`renders components/segmented/demo/icon-only.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <span
           class="ant-segmented-item-icon"
@@ -1230,6 +1150,7 @@ exports[`renders components/segmented/demo/shape.tsx extend context correctly 1`
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -1246,9 +1167,7 @@ exports[`renders components/segmented/demo/shape.tsx extend context correctly 1`
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="small"
         >
           small
@@ -1264,9 +1183,7 @@ exports[`renders components/segmented/demo/shape.tsx extend context correctly 1`
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="middle"
         >
           middle
@@ -1281,9 +1198,7 @@ exports[`renders components/segmented/demo/shape.tsx extend context correctly 1`
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="large"
         >
           large
@@ -1293,6 +1208,7 @@ exports[`renders components/segmented/demo/shape.tsx extend context correctly 1`
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-shape-round css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -1310,9 +1226,7 @@ exports[`renders components/segmented/demo/shape.tsx extend context correctly 1`
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -1349,9 +1263,7 @@ exports[`renders components/segmented/demo/shape.tsx extend context correctly 1`
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -1392,6 +1304,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-lg css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -1409,9 +1322,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Daily"
         >
           Daily
@@ -1426,9 +1337,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Weekly"
         >
           Weekly
@@ -1443,9 +1352,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Monthly"
         >
           Monthly
@@ -1460,9 +1367,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Quarterly"
         >
           Quarterly
@@ -1477,9 +1382,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Yearly"
         >
           Yearly
@@ -1489,6 +1392,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -1506,9 +1410,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Daily"
         >
           Daily
@@ -1523,9 +1425,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Weekly"
         >
           Weekly
@@ -1540,9 +1440,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Monthly"
         >
           Monthly
@@ -1557,9 +1455,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Quarterly"
         >
           Quarterly
@@ -1574,9 +1470,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Yearly"
         >
           Yearly
@@ -1586,6 +1480,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-sm css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -1603,9 +1498,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Daily"
         >
           Daily
@@ -1620,9 +1513,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Weekly"
         >
           Weekly
@@ -1637,9 +1528,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Monthly"
         >
           Monthly
@@ -1654,9 +1543,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Quarterly"
         >
           Quarterly
@@ -1671,9 +1558,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Yearly"
         >
           Yearly
@@ -1693,6 +1578,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
   <div>
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented ant-segmented-lg css-var-test-id"
       role="radiogroup"
       style="margin-inline-end: 6px;"
@@ -1711,9 +1597,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-checked="true"
             class="ant-segmented-item-label"
-            role="radio"
             title="Daily"
           >
             Daily
@@ -1728,9 +1612,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="Weekly"
           >
             Weekly
@@ -1745,9 +1627,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="Monthly"
           >
             Monthly
@@ -1767,6 +1647,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
   <div>
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented css-var-test-id"
       role="radiogroup"
       style="margin-inline-end: 6px;"
@@ -1785,9 +1666,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-checked="true"
             class="ant-segmented-item-label"
-            role="radio"
             title="Daily"
           >
             Daily
@@ -1802,9 +1681,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="Weekly"
           >
             Weekly
@@ -1819,9 +1696,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="Monthly"
           >
             Monthly
@@ -1840,6 +1715,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
   <div>
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented ant-segmented-sm css-var-test-id"
       role="radiogroup"
       style="margin-inline-end: 6px;"
@@ -1858,9 +1734,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-checked="true"
             class="ant-segmented-item-label"
-            role="radio"
             title="Daily"
           >
             Daily
@@ -1875,9 +1749,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="Weekly"
           >
             Weekly
@@ -1892,9 +1764,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="Monthly"
           >
             Monthly
@@ -1903,6 +1773,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
       </div>
     </div>
     <div
+      aria-label="select"
       class="ant-select ant-select-sm ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
       style="width: 150px;"
     >
@@ -1920,6 +1791,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
           aria-autocomplete="list"
           aria-expanded="false"
           aria-haspopup="listbox"
+          aria-label="select"
           autocomplete="off"
           class="ant-select-input"
           id="test-id"
@@ -2019,6 +1891,7 @@ exports[`renders components/segmented/demo/style-class.tsx extend context correc
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented acss-1o3848f css-var-test-id"
     role="radiogroup"
     style="padding: 4px; width: 260px;"
@@ -2037,9 +1910,7 @@ exports[`renders components/segmented/demo/style-class.tsx extend context correc
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -2078,9 +1949,7 @@ exports[`renders components/segmented/demo/style-class.tsx extend context correc
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -2119,9 +1988,7 @@ exports[`renders components/segmented/demo/style-class.tsx extend context correc
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -2155,6 +2022,7 @@ exports[`renders components/segmented/demo/style-class.tsx extend context correc
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="vertical"
     class="ant-segmented ant-segmented-vertical acss-1o3848f ant-segmented-vertical css-var-test-id"
     role="radiogroup"
     style="border: 1px solid rgb(119, 190, 240); padding: 4px; width: 100px;"
@@ -2174,9 +2042,7 @@ exports[`renders components/segmented/demo/style-class.tsx extend context correc
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -2217,9 +2083,7 @@ exports[`renders components/segmented/demo/style-class.tsx extend context correc
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -2260,9 +2124,7 @@ exports[`renders components/segmented/demo/style-class.tsx extend context correc
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -2303,6 +2165,7 @@ exports[`renders components/segmented/demo/style-class.tsx extend context correc
 exports[`renders components/segmented/demo/vertical.tsx extend context correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="vertical"
   class="ant-segmented ant-segmented-vertical ant-segmented-vertical css-var-test-id"
   role="radiogroup"
   tabindex="0"
@@ -2320,9 +2183,7 @@ exports[`renders components/segmented/demo/vertical.tsx extend context correctly
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <span
           class="ant-segmented-item-icon"
@@ -2358,9 +2219,7 @@ exports[`renders components/segmented/demo/vertical.tsx extend context correctly
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <span
           class="ant-segmented-item-icon"
@@ -2396,6 +2255,7 @@ exports[`renders components/segmented/demo/vertical.tsx extend context correctly
 exports[`renders components/segmented/demo/with-icon.tsx extend context correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-test-id"
   role="radiogroup"
   tabindex="0"
@@ -2413,9 +2273,7 @@ exports[`renders components/segmented/demo/with-icon.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <span
           class="ant-segmented-item-icon"
@@ -2454,9 +2312,7 @@ exports[`renders components/segmented/demo/with-icon.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <span
           class="ant-segmented-item-icon"
@@ -2495,6 +2351,7 @@ exports[`renders components/segmented/demo/with-icon.tsx extend context correctl
 exports[`renders components/segmented/demo/with-name.tsx extend context correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-test-id"
   role="radiogroup"
   tabindex="0"
@@ -2512,9 +2369,7 @@ exports[`renders components/segmented/demo/with-name.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Daily"
       >
         Daily
@@ -2529,9 +2384,7 @@ exports[`renders components/segmented/demo/with-name.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Weekly"
       >
         Weekly
@@ -2546,9 +2399,7 @@ exports[`renders components/segmented/demo/with-name.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Monthly"
       >
         Monthly
@@ -2563,9 +2414,7 @@ exports[`renders components/segmented/demo/with-name.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Quarterly"
       >
         Quarterly
@@ -2580,9 +2429,7 @@ exports[`renders components/segmented/demo/with-name.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Yearly"
       >
         Yearly

--- a/components/segmented/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/segmented/__tests__/__snapshots__/demo.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`renders components/segmented/demo/basic.tsx correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-test-id"
   role="radiogroup"
   tabindex="0"
@@ -20,9 +21,7 @@ exports[`renders components/segmented/demo/basic.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Daily"
       >
         Daily
@@ -37,9 +36,7 @@ exports[`renders components/segmented/demo/basic.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Weekly"
       >
         Weekly
@@ -54,9 +51,7 @@ exports[`renders components/segmented/demo/basic.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Monthly"
       >
         Monthly
@@ -71,9 +66,7 @@ exports[`renders components/segmented/demo/basic.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Quarterly"
       >
         Quarterly
@@ -88,9 +81,7 @@ exports[`renders components/segmented/demo/basic.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Yearly"
       >
         Yearly
@@ -103,6 +94,7 @@ exports[`renders components/segmented/demo/basic.tsx correctly 1`] = `
 exports[`renders components/segmented/demo/block.tsx correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-block css-var-test-id"
   role="radiogroup"
   tabindex="0"
@@ -120,9 +112,7 @@ exports[`renders components/segmented/demo/block.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="123"
       >
         123
@@ -137,9 +127,7 @@ exports[`renders components/segmented/demo/block.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="456"
       >
         456
@@ -154,9 +142,7 @@ exports[`renders components/segmented/demo/block.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="longtext-longtext-longtext-longtext"
       >
         longtext-longtext-longtext-longtext
@@ -170,6 +156,7 @@ exports[`renders components/segmented/demo/componentToken.tsx correctly 1`] = `
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -187,9 +174,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Daily"
         >
           Daily
@@ -204,9 +189,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Weekly"
         >
           Weekly
@@ -221,9 +204,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Monthly"
         >
           Monthly
@@ -238,9 +219,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Quarterly"
         >
           Quarterly
@@ -255,9 +234,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Yearly"
         >
           Yearly
@@ -268,6 +245,7 @@ Array [
     ,
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -285,9 +263,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Daily"
         >
           Daily
@@ -302,9 +278,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Weekly"
         >
           Weekly
@@ -319,9 +293,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Monthly"
         >
           Monthly
@@ -336,9 +308,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Quarterly"
         >
           Quarterly
@@ -353,9 +323,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Yearly"
         >
           Yearly
@@ -369,6 +337,7 @@ Array [
 exports[`renders components/segmented/demo/controlled.tsx correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-test-id"
   role="radiogroup"
   tabindex="0"
@@ -386,9 +355,7 @@ exports[`renders components/segmented/demo/controlled.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Map"
       >
         Map
@@ -403,9 +370,7 @@ exports[`renders components/segmented/demo/controlled.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Transit"
       >
         Transit
@@ -420,9 +385,7 @@ exports[`renders components/segmented/demo/controlled.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Satellite"
       >
         Satellite
@@ -436,6 +399,7 @@ exports[`renders components/segmented/demo/controlled-two.tsx correctly 1`] = `
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -453,9 +417,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="AND"
         >
           AND
@@ -470,9 +432,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="OR"
         >
           OR
@@ -487,9 +447,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="NOT"
         >
           NOT
@@ -500,6 +458,7 @@ Array [
     ,
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -517,9 +476,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="AND"
         >
           AND
@@ -534,9 +491,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="OR"
         >
           OR
@@ -551,9 +506,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="NOT"
         >
           NOT
@@ -570,6 +523,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -587,9 +541,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <div
             style="padding:4px"
@@ -598,6 +550,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
               class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
             >
               <img
+                alt="User 1"
                 src="https://api.dicebear.com/7.x/miniavs/svg?seed=8"
               />
             </span>
@@ -616,9 +569,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <div
             style="padding:4px"
@@ -649,9 +600,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <div
             style="padding:4px"
@@ -690,6 +639,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -707,9 +657,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <div
             style="padding:4px"
@@ -732,9 +680,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <div
             style="padding:4px"
@@ -757,9 +703,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <div
             style="padding:4px"
@@ -782,9 +726,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <div
             style="padding:4px"
@@ -809,6 +751,7 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-disabled css-var-test-id"
     role="radiogroup"
   >
@@ -826,9 +769,7 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Map"
         >
           Map
@@ -844,9 +785,7 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Transit"
         >
           Transit
@@ -862,9 +801,7 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Satellite"
         >
           Satellite
@@ -874,6 +811,7 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -891,9 +829,7 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Daily"
         >
           Daily
@@ -909,9 +845,7 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Weekly"
         >
           Weekly
@@ -926,9 +860,7 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Monthly"
         >
           Monthly
@@ -944,9 +876,7 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Quarterly"
         >
           Quarterly
@@ -961,9 +891,7 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Yearly"
         >
           Yearly
@@ -980,6 +908,7 @@ exports[`renders components/segmented/demo/dynamic.tsx correctly 1`] = `
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -997,9 +926,7 @@ exports[`renders components/segmented/demo/dynamic.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Daily"
         >
           Daily
@@ -1014,9 +941,7 @@ exports[`renders components/segmented/demo/dynamic.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Weekly"
         >
           Weekly
@@ -1031,9 +956,7 @@ exports[`renders components/segmented/demo/dynamic.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Monthly"
         >
           Monthly
@@ -1055,6 +978,7 @@ exports[`renders components/segmented/demo/dynamic.tsx correctly 1`] = `
 exports[`renders components/segmented/demo/icon-only.tsx correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-test-id"
   role="radiogroup"
   tabindex="0"
@@ -1072,9 +996,7 @@ exports[`renders components/segmented/demo/icon-only.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <span
           class="ant-segmented-item-icon"
@@ -1110,9 +1032,7 @@ exports[`renders components/segmented/demo/icon-only.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <span
           class="ant-segmented-item-icon"
@@ -1149,6 +1069,7 @@ exports[`renders components/segmented/demo/shape.tsx correctly 1`] = `
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -1165,9 +1086,7 @@ exports[`renders components/segmented/demo/shape.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="small"
         >
           small
@@ -1183,9 +1102,7 @@ exports[`renders components/segmented/demo/shape.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="middle"
         >
           middle
@@ -1200,9 +1117,7 @@ exports[`renders components/segmented/demo/shape.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="large"
         >
           large
@@ -1212,6 +1127,7 @@ exports[`renders components/segmented/demo/shape.tsx correctly 1`] = `
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-shape-round css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -1229,9 +1145,7 @@ exports[`renders components/segmented/demo/shape.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -1268,9 +1182,7 @@ exports[`renders components/segmented/demo/shape.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -1309,6 +1221,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-lg css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -1326,9 +1239,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Daily"
         >
           Daily
@@ -1343,9 +1254,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Weekly"
         >
           Weekly
@@ -1360,9 +1269,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Monthly"
         >
           Monthly
@@ -1377,9 +1284,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Quarterly"
         >
           Quarterly
@@ -1394,9 +1299,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Yearly"
         >
           Yearly
@@ -1406,6 +1309,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -1423,9 +1327,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Daily"
         >
           Daily
@@ -1440,9 +1342,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Weekly"
         >
           Weekly
@@ -1457,9 +1357,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Monthly"
         >
           Monthly
@@ -1474,9 +1372,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Quarterly"
         >
           Quarterly
@@ -1491,9 +1387,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Yearly"
         >
           Yearly
@@ -1503,6 +1397,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-sm css-var-test-id"
     role="radiogroup"
     tabindex="0"
@@ -1520,9 +1415,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Daily"
         >
           Daily
@@ -1537,9 +1430,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Weekly"
         >
           Weekly
@@ -1554,9 +1445,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Monthly"
         >
           Monthly
@@ -1571,9 +1460,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Quarterly"
         >
           Quarterly
@@ -1588,9 +1475,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Yearly"
         >
           Yearly
@@ -1608,6 +1493,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
   <div>
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented ant-segmented-lg css-var-test-id"
       role="radiogroup"
       style="margin-inline-end:6px"
@@ -1626,9 +1512,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="true"
             class="ant-segmented-item-label"
-            role="radio"
             title="Daily"
           >
             Daily
@@ -1643,9 +1527,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="Weekly"
           >
             Weekly
@@ -1660,9 +1542,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="Monthly"
           >
             Monthly
@@ -1682,6 +1562,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
   <div>
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented css-var-test-id"
       role="radiogroup"
       style="margin-inline-end:6px"
@@ -1700,9 +1581,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="true"
             class="ant-segmented-item-label"
-            role="radio"
             title="Daily"
           >
             Daily
@@ -1717,9 +1596,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="Weekly"
           >
             Weekly
@@ -1734,9 +1611,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="Monthly"
           >
             Monthly
@@ -1755,6 +1630,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
   <div>
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented ant-segmented-sm css-var-test-id"
       role="radiogroup"
       style="margin-inline-end:6px"
@@ -1773,9 +1649,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="true"
             class="ant-segmented-item-label"
-            role="radio"
             title="Daily"
           >
             Daily
@@ -1790,9 +1664,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="Weekly"
           >
             Weekly
@@ -1807,9 +1679,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-checked="false"
             class="ant-segmented-item-label"
-            role="radio"
             title="Monthly"
           >
             Monthly
@@ -1818,6 +1688,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
       </div>
     </div>
     <div
+      aria-label="select"
       class="ant-select ant-select-sm ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
       style="width:150px"
     >
@@ -1835,6 +1706,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
           aria-autocomplete="list"
           aria-expanded="false"
           aria-haspopup="listbox"
+          aria-label="select"
           autocomplete="off"
           class="ant-select-input"
           id="test-id"
@@ -1878,6 +1750,7 @@ exports[`renders components/segmented/demo/style-class.tsx correctly 1`] = `
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented acss-1o3848f css-var-test-id"
     role="radiogroup"
     style="padding:4px;width:260px"
@@ -1896,9 +1769,7 @@ exports[`renders components/segmented/demo/style-class.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -1937,9 +1808,7 @@ exports[`renders components/segmented/demo/style-class.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -1978,9 +1847,7 @@ exports[`renders components/segmented/demo/style-class.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -2014,6 +1881,7 @@ exports[`renders components/segmented/demo/style-class.tsx correctly 1`] = `
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="vertical"
     class="ant-segmented ant-segmented-vertical acss-1o3848f ant-segmented-vertical css-var-test-id"
     role="radiogroup"
     style="border:1px solid #77BEF0;padding:4px;width:100px"
@@ -2033,9 +1901,7 @@ exports[`renders components/segmented/demo/style-class.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -2076,9 +1942,7 @@ exports[`renders components/segmented/demo/style-class.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -2119,9 +1983,7 @@ exports[`renders components/segmented/demo/style-class.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
         >
           <span
             class="ant-segmented-item-icon"
@@ -2160,6 +2022,7 @@ exports[`renders components/segmented/demo/style-class.tsx correctly 1`] = `
 exports[`renders components/segmented/demo/vertical.tsx correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="vertical"
   class="ant-segmented ant-segmented-vertical ant-segmented-vertical css-var-test-id"
   role="radiogroup"
   tabindex="0"
@@ -2177,9 +2040,7 @@ exports[`renders components/segmented/demo/vertical.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <span
           class="ant-segmented-item-icon"
@@ -2215,9 +2076,7 @@ exports[`renders components/segmented/demo/vertical.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <span
           class="ant-segmented-item-icon"
@@ -2251,6 +2110,7 @@ exports[`renders components/segmented/demo/vertical.tsx correctly 1`] = `
 exports[`renders components/segmented/demo/with-icon.tsx correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-test-id"
   role="radiogroup"
   tabindex="0"
@@ -2268,9 +2128,7 @@ exports[`renders components/segmented/demo/with-icon.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <span
           class="ant-segmented-item-icon"
@@ -2309,9 +2167,7 @@ exports[`renders components/segmented/demo/with-icon.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <span
           class="ant-segmented-item-icon"
@@ -2348,6 +2204,7 @@ exports[`renders components/segmented/demo/with-icon.tsx correctly 1`] = `
 exports[`renders components/segmented/demo/with-name.tsx correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-test-id"
   role="radiogroup"
   tabindex="0"
@@ -2365,9 +2222,7 @@ exports[`renders components/segmented/demo/with-name.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Daily"
       >
         Daily
@@ -2382,9 +2237,7 @@ exports[`renders components/segmented/demo/with-name.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Weekly"
       >
         Weekly
@@ -2399,9 +2252,7 @@ exports[`renders components/segmented/demo/with-name.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Monthly"
       >
         Monthly
@@ -2416,9 +2267,7 @@ exports[`renders components/segmented/demo/with-name.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Quarterly"
       >
         Quarterly
@@ -2433,9 +2282,7 @@ exports[`renders components/segmented/demo/with-name.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Yearly"
       >
         Yearly

--- a/components/segmented/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/segmented/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Segmented render empty segmented 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-root"
   role="radiogroup"
   tabindex="0"
@@ -16,6 +17,7 @@ exports[`Segmented render empty segmented 1`] = `
 exports[`Segmented render label with ReactNode 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-root"
   role="radiogroup"
   tabindex="0"
@@ -33,9 +35,7 @@ exports[`Segmented render label with ReactNode 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Daily"
       >
         Daily
@@ -50,9 +50,7 @@ exports[`Segmented render label with ReactNode 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <div
           id="weekly"
@@ -70,9 +68,7 @@ exports[`Segmented render label with ReactNode 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <div
           class="little"
@@ -88,6 +84,7 @@ exports[`Segmented render label with ReactNode 1`] = `
 exports[`Segmented render segmented ok 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-root"
   role="radiogroup"
   tabindex="0"
@@ -105,9 +102,7 @@ exports[`Segmented render segmented ok 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Daily"
       >
         Daily
@@ -122,9 +117,7 @@ exports[`Segmented render segmented ok 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Weekly"
       >
         Weekly
@@ -139,9 +132,7 @@ exports[`Segmented render segmented ok 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Monthly"
       >
         Monthly
@@ -154,6 +145,7 @@ exports[`Segmented render segmented ok 1`] = `
 exports[`Segmented render segmented with \`block\` 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-block css-var-root"
   role="radiogroup"
   tabindex="0"
@@ -171,9 +163,7 @@ exports[`Segmented render segmented with \`block\` 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Daily"
       >
         Daily
@@ -188,9 +178,7 @@ exports[`Segmented render segmented with \`block\` 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Weekly"
       >
         Weekly
@@ -205,9 +193,7 @@ exports[`Segmented render segmented with \`block\` 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Monthly"
       >
         Monthly
@@ -220,6 +206,7 @@ exports[`Segmented render segmented with \`block\` 1`] = `
 exports[`Segmented render segmented with \`size#large\` 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-lg css-var-root"
   role="radiogroup"
   tabindex="0"
@@ -237,9 +224,7 @@ exports[`Segmented render segmented with \`size#large\` 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Daily"
       >
         Daily
@@ -254,9 +239,7 @@ exports[`Segmented render segmented with \`size#large\` 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Weekly"
       >
         Weekly
@@ -271,9 +254,7 @@ exports[`Segmented render segmented with \`size#large\` 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Monthly"
       >
         Monthly
@@ -286,6 +267,7 @@ exports[`Segmented render segmented with \`size#large\` 1`] = `
 exports[`Segmented render segmented with \`size#small\` 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-sm css-var-root"
   role="radiogroup"
   tabindex="0"
@@ -303,9 +285,7 @@ exports[`Segmented render segmented with \`size#small\` 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Daily"
       >
         Daily
@@ -320,9 +300,7 @@ exports[`Segmented render segmented with \`size#small\` 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Weekly"
       >
         Weekly
@@ -337,9 +315,7 @@ exports[`Segmented render segmented with \`size#small\` 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Monthly"
       >
         Monthly
@@ -352,6 +328,7 @@ exports[`Segmented render segmented with \`size#small\` 1`] = `
 exports[`Segmented render segmented with mixed options 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-root"
   role="radiogroup"
   tabindex="0"
@@ -369,9 +346,7 @@ exports[`Segmented render segmented with mixed options 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Daily"
       >
         Daily
@@ -386,9 +361,7 @@ exports[`Segmented render segmented with mixed options 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Weekly"
       >
         Weekly
@@ -403,9 +376,7 @@ exports[`Segmented render segmented with mixed options 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Monthly"
       >
         Monthly
@@ -418,6 +389,7 @@ exports[`Segmented render segmented with mixed options 1`] = `
 exports[`Segmented render segmented with numeric options 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-root"
   role="radiogroup"
   tabindex="0"
@@ -435,9 +407,7 @@ exports[`Segmented render segmented with numeric options 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="1"
       >
         1
@@ -452,9 +422,7 @@ exports[`Segmented render segmented with numeric options 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="2"
       >
         2
@@ -469,9 +437,7 @@ exports[`Segmented render segmented with numeric options 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="3"
       >
         3
@@ -486,9 +452,7 @@ exports[`Segmented render segmented with numeric options 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="4"
       >
         4
@@ -503,9 +467,7 @@ exports[`Segmented render segmented with numeric options 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="5"
       >
         5
@@ -518,6 +480,7 @@ exports[`Segmented render segmented with numeric options 1`] = `
 exports[`Segmented render segmented with options null/undefined 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-disabled css-var-root"
   role="radiogroup"
 >
@@ -535,9 +498,7 @@ exports[`Segmented render segmented with options null/undefined 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
       />
     </label>
     <label
@@ -550,9 +511,7 @@ exports[`Segmented render segmented with options null/undefined 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
       />
     </label>
     <label
@@ -565,9 +524,7 @@ exports[`Segmented render segmented with options null/undefined 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title=""
       />
     </label>
@@ -578,6 +535,7 @@ exports[`Segmented render segmented with options null/undefined 1`] = `
 exports[`Segmented render segmented with options: disabled 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-root"
   role="radiogroup"
   tabindex="0"
@@ -595,9 +553,7 @@ exports[`Segmented render segmented with options: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Daily"
       >
         Daily
@@ -613,9 +569,7 @@ exports[`Segmented render segmented with options: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Weekly"
       >
         Weekly
@@ -630,9 +584,7 @@ exports[`Segmented render segmented with options: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Monthly"
       >
         Monthly
@@ -645,6 +597,7 @@ exports[`Segmented render segmented with options: disabled 1`] = `
 exports[`Segmented render segmented with string options 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-root"
   role="radiogroup"
   tabindex="0"
@@ -662,9 +615,7 @@ exports[`Segmented render segmented with string options 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Daily"
       >
         Daily
@@ -679,9 +630,7 @@ exports[`Segmented render segmented with string options 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Weekly"
       >
         Weekly
@@ -696,9 +645,7 @@ exports[`Segmented render segmented with string options 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Monthly"
       >
         Monthly
@@ -711,6 +658,7 @@ exports[`Segmented render segmented with string options 1`] = `
 exports[`Segmented render segmented with thumb 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-root"
   role="radiogroup"
   tabindex="0"
@@ -728,9 +676,7 @@ exports[`Segmented render segmented with thumb 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Map"
       >
         Map
@@ -745,9 +691,7 @@ exports[`Segmented render segmented with thumb 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Transit"
       >
         Transit
@@ -762,9 +706,7 @@ exports[`Segmented render segmented with thumb 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Satellite"
       >
         Satellite
@@ -777,6 +719,7 @@ exports[`Segmented render segmented with thumb 1`] = `
 exports[`Segmented render segmented: disabled 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-disabled css-var-root"
   role="radiogroup"
 >
@@ -794,9 +737,7 @@ exports[`Segmented render segmented: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
         title="Daily"
       >
         Daily
@@ -812,9 +753,7 @@ exports[`Segmented render segmented: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Weekly"
       >
         Weekly
@@ -830,9 +769,7 @@ exports[`Segmented render segmented: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
         title="Monthly"
       >
         Monthly
@@ -845,6 +782,7 @@ exports[`Segmented render segmented: disabled 1`] = `
 exports[`Segmented render with icons 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented css-var-root"
   role="radiogroup"
   tabindex="0"
@@ -862,9 +800,7 @@ exports[`Segmented render with icons 1`] = `
         type="radio"
       />
       <div
-        aria-checked="true"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <span
           class="ant-segmented-item-icon"
@@ -900,9 +836,7 @@ exports[`Segmented render with icons 1`] = `
         type="radio"
       />
       <div
-        aria-checked="false"
         class="ant-segmented-item-label"
-        role="radio"
       >
         <span
           class="ant-segmented-item-icon"
@@ -939,6 +873,7 @@ exports[`Segmented render with icons 1`] = `
 exports[`Segmented rtl render component should be rendered correctly in RTL direction 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-rtl css-var-root"
   role="radiogroup"
   tabindex="0"

--- a/components/segmented/__tests__/a11y.test.ts
+++ b/components/segmented/__tests__/a11y.test.ts
@@ -1,6 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('segmented', {
-  // we can add aria attributes to fix it
-  skip: ['custom.tsx', 'size-consistent.tsx'],
-});
+accessibilityDemoTest('segmented');

--- a/components/segmented/demo/custom.tsx
+++ b/components/segmented/demo/custom.tsx
@@ -9,7 +9,7 @@ const App: React.FC = () => (
         {
           label: (
             <div style={{ padding: 4 }}>
-              <Avatar src="https://api.dicebear.com/7.x/miniavs/svg?seed=8" />
+              <Avatar src="https://api.dicebear.com/7.x/miniavs/svg?seed=8" alt="User 1" />
               <div>User 1</div>
             </div>
           ),
@@ -19,7 +19,9 @@ const App: React.FC = () => (
         {
           label: (
             <div style={{ padding: 4 }}>
-              <Avatar style={{ backgroundColor: '#f56a00' }}>K</Avatar>
+              <Avatar style={{ backgroundColor: '#f56a00' }} alt="User 2">
+                K
+              </Avatar>
               <div>User 2</div>
             </div>
           ),
@@ -29,7 +31,7 @@ const App: React.FC = () => (
         {
           label: (
             <div style={{ padding: 4 }}>
-              <Avatar style={{ backgroundColor: '#87d068' }} icon={<UserOutlined />} />
+              <Avatar style={{ backgroundColor: '#87d068' }} icon={<UserOutlined />} alt="User 3" />
               <div>User 3</div>
             </div>
           ),

--- a/components/segmented/demo/size-consistent.tsx
+++ b/components/segmented/demo/size-consistent.tsx
@@ -30,6 +30,7 @@ const App: React.FC = () => (
       <Select
         size="small"
         defaultValue="lucy"
+        aria-label="select"
         style={{ width: 150 }}
         options={[{ label: 'Lucy', value: 'lucy' }]}
       />

--- a/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2833,6 +2833,7 @@ exports[`renders components/tabs/demo/custom-indicator.tsx extend context correc
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     style="margin-bottom: 8px;"
@@ -2850,9 +2851,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="start"
         >
           start
@@ -2868,9 +2867,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="center"
         >
           center
@@ -2885,9 +2882,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="end"
         >
           end

--- a/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
@@ -2385,6 +2385,7 @@ exports[`renders components/tabs/demo/custom-indicator.tsx correctly 1`] = `
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     style="margin-bottom:8px"
@@ -2402,9 +2403,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="start"
         >
           start
@@ -2420,9 +2419,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="center"
         >
           center
@@ -2437,9 +2434,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="end"
         >
           end

--- a/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4,6 +4,7 @@ exports[`renders components/tooltip/demo/arrow.tsx extend context correctly 1`] 
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     style="margin-bottom: 24px;"
@@ -22,9 +23,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Show"
         >
           Show
@@ -39,9 +38,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Hide"
         >
           Hide
@@ -56,9 +53,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Center"
         >
           Center

--- a/components/tooltip/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`renders components/tooltip/demo/arrow.tsx correctly 1`] = `
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented css-var-test-id"
     role="radiogroup"
     style="margin-bottom:24px"
@@ -22,9 +23,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="true"
           class="ant-segmented-item-label"
-          role="radio"
           title="Show"
         >
           Show
@@ -39,9 +38,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Hide"
         >
           Hide
@@ -56,9 +53,7 @@ Array [
           type="radio"
         />
         <div
-          aria-checked="false"
           class="ant-segmented-item-label"
-          role="radio"
           title="Center"
         >
           Center

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "@rc-component/qrcode": "~1.1.1",
     "@rc-component/rate": "~1.0.1",
     "@rc-component/resize-observer": "^1.0.1",
-    "@rc-component/segmented": "~1.2.3",
+    "@rc-component/segmented": "~1.3.0",
     "@rc-component/select": "~1.3.6",
     "@rc-component/slider": "~1.0.1",
     "@rc-component/steps": "~1.2.2",


### PR DESCRIPTION
### 🤔 This is a ...

- [x] ⌨️ Accessibility improvement

### 🔗 Related Issues

- ref https://github.com/react-component/segmented/pull/317

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Segmented duplicate role and unnecessary aria attributes on items.         |
| 🇨🇳 Chinese |    修复 Segmented 中重复的 role 和不必要的 aria 属性。       |
