### PR TITLE
docs(Button): hide deprecated groupBorderColor from token table

### DIFF
--- a/components/button/style/token.ts
+++ b/components/button/style/token.ts
@@ -182,11 +182,6 @@ export interface ComponentToken {
    */
   onlyIconSizeSM: number | string;
   /**
-   * @desc 按钮组边框颜色
-   * @descEN Border color of button group
-   */
-  groupBorderColor: string;
-  /**
    * @desc 链接按钮悬浮态背景色
    * @descEN Background color of link button when hover
    */
@@ -246,7 +241,17 @@ type ShadowColorMap = {
   [Key in `${PresetColorKey}ShadowColor`]: string;
 };
 
-export interface ButtonToken extends FullToken<'Button'>, ShadowColorMap {
+type GroupToken = {
+  /**
+   * @desc 按钮组边框颜色
+   * @descEN Border color of button group
+   * @internal Button.Group 已废弃相关token不应该在显示在文档上
+   */
+
+  groupBorderColor: string;
+};
+
+export interface ButtonToken extends FullToken<'Button'>, ShadowColorMap, GroupToken {
   /**
    * @desc 按钮横向内边距
    * @descEN Horizontal padding of button


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案

Button.Group 已从4.0就移除了，文档上还显示着他的token

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 English | Hide deprecated `groupBorderColor` from Button component token table. |
| 🇨🇳 中文 | Button 组件的主题 Token 文档中不再展示已弃用的 `groupBorderColor`。 |
