### PR TITLE
feat: export ColorPickerPanel as ColorPicker.Panel and ColorPickerPanelProps

### DIFF
--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -26,6 +26,7 @@ import { genAlphaColor, generateColor, getColorAlpha } from './util';
 
 type CompoundedComponent = React.FC<ColorPickerProps> & {
   _InternalPanelDoNotUseOrYouWillBeFired: typeof PurePanel;
+  Panel: typeof ColorPickerPanel;
 };
 
 const ColorPicker: CompoundedComponent = (props) => {
@@ -335,5 +336,6 @@ const PurePanel = genPurePanel(
 );
 
 ColorPicker._InternalPanelDoNotUseOrYouWillBeFired = PurePanel;
+ColorPicker.Panel = ColorPickerPanel;
 
 export default ColorPicker;

--- a/components/color-picker/index.tsx
+++ b/components/color-picker/index.tsx
@@ -2,6 +2,6 @@ import ColorPicker from './ColorPicker';
 
 export type { AggregationColor as Color } from './color';
 export type { ColorPickerProps } from './interface';
-export type { ColorPickerPanelProps } from "./ColorPickerPanel"
+export type { ColorPickerPanelProps } from "./ColorPickerPanel";
 
 export default ColorPicker;

--- a/components/color-picker/index.tsx
+++ b/components/color-picker/index.tsx
@@ -2,5 +2,6 @@ import ColorPicker from './ColorPicker';
 
 export type { AggregationColor as Color } from './color';
 export type { ColorPickerProps } from './interface';
+export type { ColorPickerPanelProps } from "./ColorPickerPanel"
 
 export default ColorPicker;

--- a/components/color-picker/index.tsx
+++ b/components/color-picker/index.tsx
@@ -1,7 +1,7 @@
 import ColorPicker from './ColorPicker';
 
 export type { AggregationColor as Color } from './color';
+export type { ColorPickerPanelProps } from './ColorPickerPanel';
 export type { ColorPickerProps } from './interface';
-export type { ColorPickerPanelProps } from "./ColorPickerPanel";
 
 export default ColorPicker;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [x] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #56277 

### 💡 Background and Solution

In some scenarios, only the ColorPickerPanel is needed, without the entire ColorPicker component, similar to Cascader.Panel.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |export `ColorPickerPanel` as `ColorPicker.Panel` and `ColorPickerPanelProps`|
| 🇨🇳 Chinese |导出`ColorPickerPanel`为`ColorPicker.Panel`和`ColorPickerPanelProps`|
