### PR TITLE
fix: remove duplicate radio role and optimize aria attributes

### DIFF
--- a/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4018,6 +4018,7 @@ exports[`renders components/color-picker/demo/line-gradient.tsx extend context c
                 >
                   <div
                     aria-label="segmented control"
+                    aria-orientation="horizontal"
                     class="ant-segmented ant-segmented-sm"
                     role="radiogroup"
                     tabindex="0"
@@ -4035,7 +4036,6 @@ exports[`renders components/color-picker/demo/line-gradient.tsx extend context c
                           type="radio"
                         />
                         <div
-                          aria-selected="false"
                           class="ant-segmented-item-label"
                           title="Single"
                         >
@@ -4051,7 +4051,6 @@ exports[`renders components/color-picker/demo/line-gradient.tsx extend context c
                           type="radio"
                         />
                         <div
-                          aria-selected="true"
                           class="ant-segmented-item-label"
                           title="Gradient"
                         >

--- a/components/flex/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/flex/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -9,6 +9,7 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
   </p>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -26,7 +27,6 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="flex-start"
         >
@@ -42,7 +42,6 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="center"
         >
@@ -58,7 +57,6 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="flex-end"
         >
@@ -74,7 +72,6 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="space-between"
         >
@@ -90,7 +87,6 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="space-around"
         >
@@ -106,7 +102,6 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="space-evenly"
         >
@@ -120,6 +115,7 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
   </p>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -137,7 +133,6 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="flex-start"
         >
@@ -153,7 +148,6 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="center"
         >
@@ -169,7 +163,6 @@ exports[`renders components/flex/demo/align.tsx extend context correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="flex-end"
         >

--- a/components/flex/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/flex/__tests__/__snapshots__/demo.test.ts.snap
@@ -9,6 +9,7 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
   </p>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -26,7 +27,6 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="flex-start"
         >
@@ -42,7 +42,6 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="center"
         >
@@ -58,7 +57,6 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="flex-end"
         >
@@ -74,7 +72,6 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="space-between"
         >
@@ -90,7 +87,6 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="space-around"
         >
@@ -106,7 +102,6 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="space-evenly"
         >
@@ -120,6 +115,7 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
   </p>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -137,7 +133,6 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="flex-start"
         >
@@ -153,7 +148,6 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="center"
         >
@@ -169,7 +163,6 @@ exports[`renders components/flex/demo/align.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="flex-end"
         >

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -32521,6 +32521,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
           >
             <div
               aria-label="segmented control"
+              aria-orientation="horizontal"
               class="ant-segmented"
               id="variant"
               role="radiogroup"
@@ -32538,7 +32539,6 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                     type="radio"
                   />
                   <div
-                    aria-selected="false"
                     class="ant-segmented-item-label"
                     title="outlined"
                   >
@@ -32555,7 +32555,6 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                     type="radio"
                   />
                   <div
-                    aria-selected="true"
                     class="ant-segmented-item-label"
                     title="filled"
                   >
@@ -32571,7 +32570,6 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                     type="radio"
                   />
                   <div
-                    aria-selected="false"
                     class="ant-segmented-item-label"
                     title="borderless"
                   >
@@ -32587,7 +32585,6 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                     type="radio"
                   />
                   <div
-                    aria-selected="false"
                     class="ant-segmented-item-label"
                     title="underlined"
                   >

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -14611,6 +14611,7 @@ exports[`renders components/form/demo/variant.tsx correctly 1`] = `
           >
             <div
               aria-label="segmented control"
+              aria-orientation="horizontal"
               class="ant-segmented"
               id="variant"
               role="radiogroup"
@@ -14628,7 +14629,6 @@ exports[`renders components/form/demo/variant.tsx correctly 1`] = `
                     type="radio"
                   />
                   <div
-                    aria-selected="false"
                     class="ant-segmented-item-label"
                     title="outlined"
                   >
@@ -14645,7 +14645,6 @@ exports[`renders components/form/demo/variant.tsx correctly 1`] = `
                     type="radio"
                   />
                   <div
-                    aria-selected="true"
                     class="ant-segmented-item-label"
                     title="filled"
                   >
@@ -14661,7 +14660,6 @@ exports[`renders components/form/demo/variant.tsx correctly 1`] = `
                     type="radio"
                   />
                   <div
-                    aria-selected="false"
                     class="ant-segmented-item-label"
                     title="borderless"
                   >
@@ -14677,7 +14675,6 @@ exports[`renders components/form/demo/variant.tsx correctly 1`] = `
                     type="radio"
                   />
                   <div
-                    aria-selected="false"
                     class="ant-segmented-item-label"
                     title="underlined"
                   >

--- a/components/popover/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/popover/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4,6 +4,7 @@ exports[`renders components/popover/demo/arrow.tsx extend context correctly 1`] 
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     style="margin-bottom: 24px;"
@@ -22,7 +23,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Show"
         >
@@ -38,7 +38,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Hide"
         >
@@ -54,7 +53,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Center"
         >

--- a/components/popover/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/popover/__tests__/__snapshots__/demo.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`renders components/popover/demo/arrow.tsx correctly 1`] = `
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     style="margin-bottom:24px"
@@ -22,7 +23,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Show"
         >
@@ -38,7 +38,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Hide"
         >
@@ -54,7 +53,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Center"
         >

--- a/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -391,6 +391,7 @@ exports[`renders components/qr-code/demo/download.tsx extend context correctly 1
   >
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented"
       role="radiogroup"
       tabindex="0"
@@ -408,7 +409,6 @@ exports[`renders components/qr-code/demo/download.tsx extend context correctly 1
             type="radio"
           />
           <div
-            aria-selected="true"
             class="ant-segmented-item-label"
             title="canvas"
           >
@@ -424,7 +424,6 @@ exports[`renders components/qr-code/demo/download.tsx extend context correctly 1
             type="radio"
           />
           <div
-            aria-selected="false"
             class="ant-segmented-item-label"
             title="svg"
           >
@@ -483,6 +482,7 @@ Array [
   </div>,
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -500,7 +500,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="L"
         >
@@ -516,7 +515,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="M"
         >
@@ -532,7 +530,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Q"
         >
@@ -548,7 +545,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="H"
         >

--- a/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
@@ -348,6 +348,7 @@ exports[`renders components/qr-code/demo/download.tsx correctly 1`] = `
   >
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented"
       role="radiogroup"
       tabindex="0"
@@ -365,7 +366,6 @@ exports[`renders components/qr-code/demo/download.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-selected="true"
             class="ant-segmented-item-label"
             title="canvas"
           >
@@ -381,7 +381,6 @@ exports[`renders components/qr-code/demo/download.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-selected="false"
             class="ant-segmented-item-label"
             title="svg"
           >
@@ -438,6 +437,7 @@ Array [
   </div>,
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -455,7 +455,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="L"
         >
@@ -471,7 +470,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="M"
         >
@@ -487,7 +485,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Q"
         >
@@ -503,7 +500,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="H"
         >

--- a/components/segmented/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/segmented/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`renders components/segmented/demo/basic.tsx extend context correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -20,7 +21,6 @@ exports[`renders components/segmented/demo/basic.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Daily"
       >
@@ -36,7 +36,6 @@ exports[`renders components/segmented/demo/basic.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Weekly"
       >
@@ -52,7 +51,6 @@ exports[`renders components/segmented/demo/basic.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Monthly"
       >
@@ -68,7 +66,6 @@ exports[`renders components/segmented/demo/basic.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Quarterly"
       >
@@ -84,7 +81,6 @@ exports[`renders components/segmented/demo/basic.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Yearly"
       >
@@ -100,6 +96,7 @@ exports[`renders components/segmented/demo/basic.tsx extend context correctly 2`
 exports[`renders components/segmented/demo/block.tsx extend context correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-block"
   role="radiogroup"
   tabindex="0"
@@ -117,7 +114,6 @@ exports[`renders components/segmented/demo/block.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="123"
       >
@@ -133,7 +129,6 @@ exports[`renders components/segmented/demo/block.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="456"
       >
@@ -149,7 +144,6 @@ exports[`renders components/segmented/demo/block.tsx extend context correctly 1`
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="longtext-longtext-longtext-longtext"
       >
@@ -166,6 +160,7 @@ exports[`renders components/segmented/demo/componentToken.tsx extend context cor
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -183,7 +178,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Daily"
         >
@@ -199,7 +193,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Weekly"
         >
@@ -215,7 +208,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Monthly"
         >
@@ -231,7 +223,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Quarterly"
         >
@@ -247,7 +238,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Yearly"
         >
@@ -259,6 +249,7 @@ Array [
     ,
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -276,7 +267,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Daily"
         >
@@ -292,7 +282,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Weekly"
         >
@@ -308,7 +297,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Monthly"
         >
@@ -324,7 +312,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Quarterly"
         >
@@ -340,7 +327,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Yearly"
         >
@@ -357,6 +343,7 @@ exports[`renders components/segmented/demo/componentToken.tsx extend context cor
 exports[`renders components/segmented/demo/controlled.tsx extend context correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -374,7 +361,6 @@ exports[`renders components/segmented/demo/controlled.tsx extend context correct
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Map"
       >
@@ -390,7 +376,6 @@ exports[`renders components/segmented/demo/controlled.tsx extend context correct
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Transit"
       >
@@ -406,7 +391,6 @@ exports[`renders components/segmented/demo/controlled.tsx extend context correct
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Satellite"
       >
@@ -423,6 +407,7 @@ exports[`renders components/segmented/demo/controlled-two.tsx extend context cor
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -440,7 +425,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="AND"
         >
@@ -456,7 +440,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="OR"
         >
@@ -472,7 +455,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="NOT"
         >
@@ -484,6 +466,7 @@ Array [
     ,
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -501,7 +484,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="AND"
         >
@@ -517,7 +499,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="OR"
         >
@@ -533,7 +514,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="NOT"
         >
@@ -553,6 +533,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -570,7 +551,6 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
         >
           <div
@@ -598,7 +578,6 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
         >
           <div
@@ -630,7 +609,6 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
         >
           <div
@@ -670,6 +648,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -687,7 +666,6 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
         >
           <div
@@ -711,7 +689,6 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
         >
           <div
@@ -735,7 +712,6 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
         >
           <div
@@ -759,7 +735,6 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
         >
           <div
@@ -787,6 +762,7 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-disabled"
     role="radiogroup"
   >
@@ -804,7 +780,6 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Map"
         >
@@ -821,7 +796,6 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Transit"
         >
@@ -838,7 +812,6 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Satellite"
         >
@@ -849,6 +822,7 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -866,7 +840,6 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Daily"
         >
@@ -883,7 +856,6 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Weekly"
         >
@@ -899,7 +871,6 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Monthly"
         >
@@ -916,7 +887,6 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Quarterly"
         >
@@ -932,7 +902,6 @@ exports[`renders components/segmented/demo/disabled.tsx extend context correctly
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Yearly"
         >
@@ -952,6 +921,7 @@ exports[`renders components/segmented/demo/dynamic.tsx extend context correctly 
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -969,7 +939,6 @@ exports[`renders components/segmented/demo/dynamic.tsx extend context correctly 
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Daily"
         >
@@ -985,7 +954,6 @@ exports[`renders components/segmented/demo/dynamic.tsx extend context correctly 
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Weekly"
         >
@@ -1001,7 +969,6 @@ exports[`renders components/segmented/demo/dynamic.tsx extend context correctly 
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Monthly"
         >
@@ -1026,6 +993,7 @@ exports[`renders components/segmented/demo/dynamic.tsx extend context correctly 
 exports[`renders components/segmented/demo/icon-only.tsx extend context correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -1043,7 +1011,6 @@ exports[`renders components/segmented/demo/icon-only.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
       >
         <span
@@ -1080,7 +1047,6 @@ exports[`renders components/segmented/demo/icon-only.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
       >
         <span
@@ -1120,6 +1086,7 @@ exports[`renders components/segmented/demo/shape.tsx extend context correctly 1`
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -1136,7 +1103,6 @@ exports[`renders components/segmented/demo/shape.tsx extend context correctly 1`
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="small"
         >
@@ -1153,7 +1119,6 @@ exports[`renders components/segmented/demo/shape.tsx extend context correctly 1`
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="middle"
         >
@@ -1169,7 +1134,6 @@ exports[`renders components/segmented/demo/shape.tsx extend context correctly 1`
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="large"
         >
@@ -1180,6 +1144,7 @@ exports[`renders components/segmented/demo/shape.tsx extend context correctly 1`
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-shape-round"
     role="radiogroup"
     tabindex="0"
@@ -1197,7 +1162,6 @@ exports[`renders components/segmented/demo/shape.tsx extend context correctly 1`
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
         >
           <span
@@ -1235,7 +1199,6 @@ exports[`renders components/segmented/demo/shape.tsx extend context correctly 1`
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
         >
           <span
@@ -1277,6 +1240,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-lg"
     role="radiogroup"
     tabindex="0"
@@ -1294,7 +1258,6 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Daily"
         >
@@ -1310,7 +1273,6 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Weekly"
         >
@@ -1326,7 +1288,6 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Monthly"
         >
@@ -1342,7 +1303,6 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Quarterly"
         >
@@ -1358,7 +1318,6 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Yearly"
         >
@@ -1369,6 +1328,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -1386,7 +1346,6 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Daily"
         >
@@ -1402,7 +1361,6 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Weekly"
         >
@@ -1418,7 +1376,6 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Monthly"
         >
@@ -1434,7 +1391,6 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Quarterly"
         >
@@ -1450,7 +1406,6 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Yearly"
         >
@@ -1461,6 +1416,7 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-sm"
     role="radiogroup"
     tabindex="0"
@@ -1478,7 +1434,6 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Daily"
         >
@@ -1494,7 +1449,6 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Weekly"
         >
@@ -1510,7 +1464,6 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Monthly"
         >
@@ -1526,7 +1479,6 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Quarterly"
         >
@@ -1542,7 +1494,6 @@ exports[`renders components/segmented/demo/size.tsx extend context correctly 1`]
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Yearly"
         >
@@ -1563,6 +1514,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
   <div>
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented ant-segmented-lg"
       role="radiogroup"
       style="margin-inline-end: 6px;"
@@ -1581,7 +1533,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-selected="true"
             class="ant-segmented-item-label"
             title="Daily"
           >
@@ -1597,7 +1548,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-selected="false"
             class="ant-segmented-item-label"
             title="Weekly"
           >
@@ -1613,7 +1563,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-selected="false"
             class="ant-segmented-item-label"
             title="Monthly"
           >
@@ -1634,6 +1583,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
   <div>
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented"
       role="radiogroup"
       style="margin-inline-end: 6px;"
@@ -1652,7 +1602,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-selected="true"
             class="ant-segmented-item-label"
             title="Daily"
           >
@@ -1668,7 +1617,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-selected="false"
             class="ant-segmented-item-label"
             title="Weekly"
           >
@@ -1684,7 +1632,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-selected="false"
             class="ant-segmented-item-label"
             title="Monthly"
           >
@@ -1704,6 +1651,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
   <div>
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented ant-segmented-sm"
       role="radiogroup"
       style="margin-inline-end: 6px;"
@@ -1722,7 +1670,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-selected="true"
             class="ant-segmented-item-label"
             title="Daily"
           >
@@ -1738,7 +1685,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-selected="false"
             class="ant-segmented-item-label"
             title="Weekly"
           >
@@ -1754,7 +1700,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
             type="radio"
           />
           <div
-            aria-selected="false"
             class="ant-segmented-item-label"
             title="Monthly"
           >
@@ -1892,6 +1837,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx extend context co
 exports[`renders components/segmented/demo/vertical.tsx extend context correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="vertical"
   class="ant-segmented ant-segmented-vertical ant-segmented-vertical"
   role="radiogroup"
   tabindex="0"
@@ -1909,7 +1855,6 @@ exports[`renders components/segmented/demo/vertical.tsx extend context correctly
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
       >
         <span
@@ -1946,7 +1891,6 @@ exports[`renders components/segmented/demo/vertical.tsx extend context correctly
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
       >
         <span
@@ -1983,6 +1927,7 @@ exports[`renders components/segmented/demo/vertical.tsx extend context correctly
 exports[`renders components/segmented/demo/with-icon.tsx extend context correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -2000,7 +1945,6 @@ exports[`renders components/segmented/demo/with-icon.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
       >
         <span
@@ -2040,7 +1984,6 @@ exports[`renders components/segmented/demo/with-icon.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
       >
         <span
@@ -2080,6 +2023,7 @@ exports[`renders components/segmented/demo/with-icon.tsx extend context correctl
 exports[`renders components/segmented/demo/with-name.tsx extend context correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -2097,7 +2041,6 @@ exports[`renders components/segmented/demo/with-name.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Daily"
       >
@@ -2113,7 +2056,6 @@ exports[`renders components/segmented/demo/with-name.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Weekly"
       >
@@ -2129,7 +2071,6 @@ exports[`renders components/segmented/demo/with-name.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Monthly"
       >
@@ -2145,7 +2086,6 @@ exports[`renders components/segmented/demo/with-name.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Quarterly"
       >
@@ -2161,7 +2101,6 @@ exports[`renders components/segmented/demo/with-name.tsx extend context correctl
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Yearly"
       >

--- a/components/segmented/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/segmented/__tests__/__snapshots__/demo.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`renders components/segmented/demo/basic.tsx correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -20,7 +21,6 @@ exports[`renders components/segmented/demo/basic.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Daily"
       >
@@ -36,7 +36,6 @@ exports[`renders components/segmented/demo/basic.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Weekly"
       >
@@ -52,7 +51,6 @@ exports[`renders components/segmented/demo/basic.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Monthly"
       >
@@ -68,7 +66,6 @@ exports[`renders components/segmented/demo/basic.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Quarterly"
       >
@@ -84,7 +81,6 @@ exports[`renders components/segmented/demo/basic.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Yearly"
       >
@@ -98,6 +94,7 @@ exports[`renders components/segmented/demo/basic.tsx correctly 1`] = `
 exports[`renders components/segmented/demo/block.tsx correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-block"
   role="radiogroup"
   tabindex="0"
@@ -115,7 +112,6 @@ exports[`renders components/segmented/demo/block.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="123"
       >
@@ -131,7 +127,6 @@ exports[`renders components/segmented/demo/block.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="456"
       >
@@ -147,7 +142,6 @@ exports[`renders components/segmented/demo/block.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="longtext-longtext-longtext-longtext"
       >
@@ -162,6 +156,7 @@ exports[`renders components/segmented/demo/componentToken.tsx correctly 1`] = `
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -179,7 +174,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Daily"
         >
@@ -195,7 +189,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Weekly"
         >
@@ -211,7 +204,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Monthly"
         >
@@ -227,7 +219,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Quarterly"
         >
@@ -243,7 +234,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Yearly"
         >
@@ -255,6 +245,7 @@ Array [
     ,
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -272,7 +263,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Daily"
         >
@@ -288,7 +278,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Weekly"
         >
@@ -304,7 +293,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Monthly"
         >
@@ -320,7 +308,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Quarterly"
         >
@@ -336,7 +323,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Yearly"
         >
@@ -351,6 +337,7 @@ Array [
 exports[`renders components/segmented/demo/controlled.tsx correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -368,7 +355,6 @@ exports[`renders components/segmented/demo/controlled.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Map"
       >
@@ -384,7 +370,6 @@ exports[`renders components/segmented/demo/controlled.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Transit"
       >
@@ -400,7 +385,6 @@ exports[`renders components/segmented/demo/controlled.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Satellite"
       >
@@ -415,6 +399,7 @@ exports[`renders components/segmented/demo/controlled-two.tsx correctly 1`] = `
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -432,7 +417,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="AND"
         >
@@ -448,7 +432,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="OR"
         >
@@ -464,7 +447,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="NOT"
         >
@@ -476,6 +458,7 @@ Array [
     ,
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -493,7 +476,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="AND"
         >
@@ -509,7 +491,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="OR"
         >
@@ -525,7 +506,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="NOT"
         >
@@ -543,6 +523,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -560,7 +541,6 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
         >
           <div
@@ -588,7 +568,6 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
         >
           <div
@@ -620,7 +599,6 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
         >
           <div
@@ -660,6 +638,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -677,7 +656,6 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
         >
           <div
@@ -701,7 +679,6 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
         >
           <div
@@ -725,7 +702,6 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
         >
           <div
@@ -749,7 +725,6 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
         >
           <div
@@ -775,6 +750,7 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-disabled"
     role="radiogroup"
   >
@@ -792,7 +768,6 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Map"
         >
@@ -809,7 +784,6 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Transit"
         >
@@ -826,7 +800,6 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Satellite"
         >
@@ -837,6 +810,7 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -854,7 +828,6 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Daily"
         >
@@ -871,7 +844,6 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Weekly"
         >
@@ -887,7 +859,6 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Monthly"
         >
@@ -904,7 +875,6 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Quarterly"
         >
@@ -920,7 +890,6 @@ exports[`renders components/segmented/demo/disabled.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Yearly"
         >
@@ -938,6 +907,7 @@ exports[`renders components/segmented/demo/dynamic.tsx correctly 1`] = `
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -955,7 +925,6 @@ exports[`renders components/segmented/demo/dynamic.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Daily"
         >
@@ -971,7 +940,6 @@ exports[`renders components/segmented/demo/dynamic.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Weekly"
         >
@@ -987,7 +955,6 @@ exports[`renders components/segmented/demo/dynamic.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Monthly"
         >
@@ -1010,6 +977,7 @@ exports[`renders components/segmented/demo/dynamic.tsx correctly 1`] = `
 exports[`renders components/segmented/demo/icon-only.tsx correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -1027,7 +995,6 @@ exports[`renders components/segmented/demo/icon-only.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
       >
         <span
@@ -1064,7 +1031,6 @@ exports[`renders components/segmented/demo/icon-only.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
       >
         <span
@@ -1102,6 +1068,7 @@ exports[`renders components/segmented/demo/shape.tsx correctly 1`] = `
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -1118,7 +1085,6 @@ exports[`renders components/segmented/demo/shape.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="small"
         >
@@ -1135,7 +1101,6 @@ exports[`renders components/segmented/demo/shape.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="middle"
         >
@@ -1151,7 +1116,6 @@ exports[`renders components/segmented/demo/shape.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="large"
         >
@@ -1162,6 +1126,7 @@ exports[`renders components/segmented/demo/shape.tsx correctly 1`] = `
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-shape-round"
     role="radiogroup"
     tabindex="0"
@@ -1179,7 +1144,6 @@ exports[`renders components/segmented/demo/shape.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
         >
           <span
@@ -1217,7 +1181,6 @@ exports[`renders components/segmented/demo/shape.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
         >
           <span
@@ -1257,6 +1220,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
 >
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-lg"
     role="radiogroup"
     tabindex="0"
@@ -1274,7 +1238,6 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Daily"
         >
@@ -1290,7 +1253,6 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Weekly"
         >
@@ -1306,7 +1268,6 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Monthly"
         >
@@ -1322,7 +1283,6 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Quarterly"
         >
@@ -1338,7 +1298,6 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Yearly"
         >
@@ -1349,6 +1308,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     tabindex="0"
@@ -1366,7 +1326,6 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Daily"
         >
@@ -1382,7 +1341,6 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Weekly"
         >
@@ -1398,7 +1356,6 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Monthly"
         >
@@ -1414,7 +1371,6 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Quarterly"
         >
@@ -1430,7 +1386,6 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Yearly"
         >
@@ -1441,6 +1396,7 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
   </div>
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented ant-segmented-sm"
     role="radiogroup"
     tabindex="0"
@@ -1458,7 +1414,6 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Daily"
         >
@@ -1474,7 +1429,6 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Weekly"
         >
@@ -1490,7 +1444,6 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Monthly"
         >
@@ -1506,7 +1459,6 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Quarterly"
         >
@@ -1522,7 +1474,6 @@ exports[`renders components/segmented/demo/size.tsx correctly 1`] = `
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Yearly"
         >
@@ -1541,6 +1492,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
   <div>
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented ant-segmented-lg"
       role="radiogroup"
       style="margin-inline-end:6px"
@@ -1559,7 +1511,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-selected="true"
             class="ant-segmented-item-label"
             title="Daily"
           >
@@ -1575,7 +1526,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-selected="false"
             class="ant-segmented-item-label"
             title="Weekly"
           >
@@ -1591,7 +1541,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-selected="false"
             class="ant-segmented-item-label"
             title="Monthly"
           >
@@ -1612,6 +1561,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
   <div>
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented"
       role="radiogroup"
       style="margin-inline-end:6px"
@@ -1630,7 +1580,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-selected="true"
             class="ant-segmented-item-label"
             title="Daily"
           >
@@ -1646,7 +1595,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-selected="false"
             class="ant-segmented-item-label"
             title="Weekly"
           >
@@ -1662,7 +1610,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-selected="false"
             class="ant-segmented-item-label"
             title="Monthly"
           >
@@ -1682,6 +1629,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
   <div>
     <div
       aria-label="segmented control"
+      aria-orientation="horizontal"
       class="ant-segmented ant-segmented-sm"
       role="radiogroup"
       style="margin-inline-end:6px"
@@ -1700,7 +1648,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-selected="true"
             class="ant-segmented-item-label"
             title="Daily"
           >
@@ -1716,7 +1663,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-selected="false"
             class="ant-segmented-item-label"
             title="Weekly"
           >
@@ -1732,7 +1678,6 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
             type="radio"
           />
           <div
-            aria-selected="false"
             class="ant-segmented-item-label"
             title="Monthly"
           >
@@ -1812,6 +1757,7 @@ exports[`renders components/segmented/demo/size-consistent.tsx correctly 1`] = `
 exports[`renders components/segmented/demo/vertical.tsx correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="vertical"
   class="ant-segmented ant-segmented-vertical ant-segmented-vertical"
   role="radiogroup"
   tabindex="0"
@@ -1829,7 +1775,6 @@ exports[`renders components/segmented/demo/vertical.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
       >
         <span
@@ -1866,7 +1811,6 @@ exports[`renders components/segmented/demo/vertical.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
       >
         <span
@@ -1901,6 +1845,7 @@ exports[`renders components/segmented/demo/vertical.tsx correctly 1`] = `
 exports[`renders components/segmented/demo/with-icon.tsx correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -1918,7 +1863,6 @@ exports[`renders components/segmented/demo/with-icon.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
       >
         <span
@@ -1958,7 +1902,6 @@ exports[`renders components/segmented/demo/with-icon.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
       >
         <span
@@ -1996,6 +1939,7 @@ exports[`renders components/segmented/demo/with-icon.tsx correctly 1`] = `
 exports[`renders components/segmented/demo/with-name.tsx correctly 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -2013,7 +1957,6 @@ exports[`renders components/segmented/demo/with-name.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Daily"
       >
@@ -2029,7 +1972,6 @@ exports[`renders components/segmented/demo/with-name.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Weekly"
       >
@@ -2045,7 +1987,6 @@ exports[`renders components/segmented/demo/with-name.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Monthly"
       >
@@ -2061,7 +2002,6 @@ exports[`renders components/segmented/demo/with-name.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Quarterly"
       >
@@ -2077,7 +2017,6 @@ exports[`renders components/segmented/demo/with-name.tsx correctly 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Yearly"
       >

--- a/components/segmented/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/segmented/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Segmented render empty segmented 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -16,6 +17,7 @@ exports[`Segmented render empty segmented 1`] = `
 exports[`Segmented render label with ReactNode 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -33,7 +35,6 @@ exports[`Segmented render label with ReactNode 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Daily"
       >
@@ -49,7 +50,6 @@ exports[`Segmented render label with ReactNode 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
       >
         <div
@@ -68,7 +68,6 @@ exports[`Segmented render label with ReactNode 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
       >
         <div
@@ -85,6 +84,7 @@ exports[`Segmented render label with ReactNode 1`] = `
 exports[`Segmented render segmented ok 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -102,7 +102,6 @@ exports[`Segmented render segmented ok 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Daily"
       >
@@ -118,7 +117,6 @@ exports[`Segmented render segmented ok 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Weekly"
       >
@@ -134,7 +132,6 @@ exports[`Segmented render segmented ok 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Monthly"
       >
@@ -148,6 +145,7 @@ exports[`Segmented render segmented ok 1`] = `
 exports[`Segmented render segmented with \`block\` 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-block"
   role="radiogroup"
   tabindex="0"
@@ -165,7 +163,6 @@ exports[`Segmented render segmented with \`block\` 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Daily"
       >
@@ -181,7 +178,6 @@ exports[`Segmented render segmented with \`block\` 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Weekly"
       >
@@ -197,7 +193,6 @@ exports[`Segmented render segmented with \`block\` 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Monthly"
       >
@@ -211,6 +206,7 @@ exports[`Segmented render segmented with \`block\` 1`] = `
 exports[`Segmented render segmented with \`size#large\` 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-lg"
   role="radiogroup"
   tabindex="0"
@@ -228,7 +224,6 @@ exports[`Segmented render segmented with \`size#large\` 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Daily"
       >
@@ -244,7 +239,6 @@ exports[`Segmented render segmented with \`size#large\` 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Weekly"
       >
@@ -260,7 +254,6 @@ exports[`Segmented render segmented with \`size#large\` 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Monthly"
       >
@@ -274,6 +267,7 @@ exports[`Segmented render segmented with \`size#large\` 1`] = `
 exports[`Segmented render segmented with \`size#small\` 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-sm"
   role="radiogroup"
   tabindex="0"
@@ -291,7 +285,6 @@ exports[`Segmented render segmented with \`size#small\` 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Daily"
       >
@@ -307,7 +300,6 @@ exports[`Segmented render segmented with \`size#small\` 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Weekly"
       >
@@ -323,7 +315,6 @@ exports[`Segmented render segmented with \`size#small\` 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Monthly"
       >
@@ -337,6 +328,7 @@ exports[`Segmented render segmented with \`size#small\` 1`] = `
 exports[`Segmented render segmented with mixed options 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -354,7 +346,6 @@ exports[`Segmented render segmented with mixed options 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Daily"
       >
@@ -370,7 +361,6 @@ exports[`Segmented render segmented with mixed options 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Weekly"
       >
@@ -386,7 +376,6 @@ exports[`Segmented render segmented with mixed options 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Monthly"
       >
@@ -400,6 +389,7 @@ exports[`Segmented render segmented with mixed options 1`] = `
 exports[`Segmented render segmented with numeric options 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -417,7 +407,6 @@ exports[`Segmented render segmented with numeric options 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="1"
       >
@@ -433,7 +422,6 @@ exports[`Segmented render segmented with numeric options 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="2"
       >
@@ -449,7 +437,6 @@ exports[`Segmented render segmented with numeric options 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="3"
       >
@@ -465,7 +452,6 @@ exports[`Segmented render segmented with numeric options 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="4"
       >
@@ -481,7 +467,6 @@ exports[`Segmented render segmented with numeric options 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="5"
       >
@@ -495,6 +480,7 @@ exports[`Segmented render segmented with numeric options 1`] = `
 exports[`Segmented render segmented with options null/undefined 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-disabled"
   role="radiogroup"
 >
@@ -512,7 +498,6 @@ exports[`Segmented render segmented with options null/undefined 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
       />
     </label>
@@ -526,7 +511,6 @@ exports[`Segmented render segmented with options null/undefined 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
       />
     </label>
@@ -540,7 +524,6 @@ exports[`Segmented render segmented with options null/undefined 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title=""
       />
@@ -552,6 +535,7 @@ exports[`Segmented render segmented with options null/undefined 1`] = `
 exports[`Segmented render segmented with options: disabled 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -569,7 +553,6 @@ exports[`Segmented render segmented with options: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Daily"
       >
@@ -586,7 +569,6 @@ exports[`Segmented render segmented with options: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Weekly"
       >
@@ -602,7 +584,6 @@ exports[`Segmented render segmented with options: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Monthly"
       >
@@ -616,6 +597,7 @@ exports[`Segmented render segmented with options: disabled 1`] = `
 exports[`Segmented render segmented with string options 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -633,7 +615,6 @@ exports[`Segmented render segmented with string options 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Daily"
       >
@@ -649,7 +630,6 @@ exports[`Segmented render segmented with string options 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Weekly"
       >
@@ -665,7 +645,6 @@ exports[`Segmented render segmented with string options 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Monthly"
       >
@@ -679,6 +658,7 @@ exports[`Segmented render segmented with string options 1`] = `
 exports[`Segmented render segmented with thumb 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -696,7 +676,6 @@ exports[`Segmented render segmented with thumb 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Map"
       >
@@ -712,7 +691,6 @@ exports[`Segmented render segmented with thumb 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Transit"
       >
@@ -728,7 +706,6 @@ exports[`Segmented render segmented with thumb 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Satellite"
       >
@@ -742,6 +719,7 @@ exports[`Segmented render segmented with thumb 1`] = `
 exports[`Segmented render segmented: disabled 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-disabled"
   role="radiogroup"
 >
@@ -759,7 +737,6 @@ exports[`Segmented render segmented: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
         title="Daily"
       >
@@ -776,7 +753,6 @@ exports[`Segmented render segmented: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Weekly"
       >
@@ -793,7 +769,6 @@ exports[`Segmented render segmented: disabled 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
         title="Monthly"
       >
@@ -807,6 +782,7 @@ exports[`Segmented render segmented: disabled 1`] = `
 exports[`Segmented render with icons 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented"
   role="radiogroup"
   tabindex="0"
@@ -824,7 +800,6 @@ exports[`Segmented render with icons 1`] = `
         type="radio"
       />
       <div
-        aria-selected="true"
         class="ant-segmented-item-label"
       >
         <span
@@ -861,7 +836,6 @@ exports[`Segmented render with icons 1`] = `
         type="radio"
       />
       <div
-        aria-selected="false"
         class="ant-segmented-item-label"
       >
         <span
@@ -899,6 +873,7 @@ exports[`Segmented render with icons 1`] = `
 exports[`Segmented rtl render component should be rendered correctly in RTL direction 1`] = `
 <div
   aria-label="segmented control"
+  aria-orientation="horizontal"
   class="ant-segmented ant-segmented-rtl"
   role="radiogroup"
   tabindex="0"

--- a/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2839,6 +2839,7 @@ exports[`renders components/tabs/demo/custom-indicator.tsx extend context correc
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     style="margin-bottom: 8px;"
@@ -2856,7 +2857,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="start"
         >
@@ -2873,7 +2873,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="center"
         >
@@ -2889,7 +2888,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="end"
         >

--- a/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
@@ -2391,6 +2391,7 @@ exports[`renders components/tabs/demo/custom-indicator.tsx correctly 1`] = `
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     style="margin-bottom:8px"
@@ -2408,7 +2409,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="start"
         >
@@ -2425,7 +2425,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="center"
         >
@@ -2441,7 +2440,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="end"
         >

--- a/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4,6 +4,7 @@ exports[`renders components/tooltip/demo/arrow.tsx extend context correctly 1`] 
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     style="margin-bottom: 24px;"
@@ -22,7 +23,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Show"
         >
@@ -38,7 +38,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Hide"
         >
@@ -54,7 +53,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Center"
         >

--- a/components/tooltip/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`renders components/tooltip/demo/arrow.tsx correctly 1`] = `
 Array [
   <div
     aria-label="segmented control"
+    aria-orientation="horizontal"
     class="ant-segmented"
     role="radiogroup"
     style="margin-bottom:24px"
@@ -22,7 +23,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="true"
           class="ant-segmented-item-label"
           title="Show"
         >
@@ -38,7 +38,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Hide"
         >
@@ -54,7 +53,6 @@ Array [
           type="radio"
         />
         <div
-          aria-selected="false"
           class="ant-segmented-item-label"
           title="Center"
         >


### PR DESCRIPTION
### 🤔 This is a ...

- [x] ⌨️ Accessibility improvement

### 🔗 Related Issues

- cherry-pick https://github.com/react-component/segmented/pull/317

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Segmented duplicate role and unnecessary aria attributes on items.         |
| 🇨🇳 Chinese |    修复 Segmented 中重复的 role 和不必要的 aria 属性。       |
