### PR TITLE
chore: bump @rc-component/form to ~1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "@rc-component/dialog": "~1.5.1",
     "@rc-component/drawer": "~1.3.0",
     "@rc-component/dropdown": "~1.0.2",
-    "@rc-component/form": "~1.5.0",
+    "@rc-component/form": "~1.6.0",
     "@rc-component/image": "~1.5.3",
     "@rc-component/input": "~1.1.2",
     "@rc-component/input-number": "~1.6.2",


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- fix 56230

### 💡 需求背景和解决方案

- 背景：`Form.List` 搭配 `useWatch` 删除元素时会出现中间态 `[1, undefined]`（见 #56230），与 v5 行为不一致。
- 方案：升级 `@rc-component/form` 至 `~1.6.0`，修正监听值在删除后的中间态，恢复直接变为 `[1]`。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix `Form.List` + `useWatch` showing `[1, undefined]` intermediate value after remove. |
| 🇨🇳 中文 | 修复 `Form.List` 搭配 `useWatch` 删除元素时出现 `[1, undefined]` 中间态的问题，删除后直接变为 `[1]`。 |