### PR TITLE
fix: the color value selection error in colorPicker

### DIFF
--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -337,6 +337,19 @@ describe('ColorPicker', () => {
     ).toEqual('background: rgb(99, 22, 22);');
   });
 
+  it('Should FF0001 color display correctly (hue 360 normalization)', async () => {
+    const { container } = render(<ColorPicker open defaultValue="#FF0001" />);
+    await waitFakeTimer();
+    const colorBlock = container.querySelector('.ant-color-picker-color-block-inner');
+    expect(colorBlock?.getAttribute('style')).toEqual('background: rgb(255, 0, 1);');
+    const sliderRail = container.querySelector('.ant-color-picker-slider-rail');
+    const railStyle = sliderRail?.getAttribute('style');
+    expect(railStyle).toBeTruthy();
+    expect(railStyle).toContain('rgb(255, 0, 0) 0%');
+    expect(railStyle).not.toContain('rgb(255, 0, 255) 0%');
+    expect(railStyle).toMatch(/linear-gradient\(90deg,/);
+  });
+
   it('Should not trigger onChange when click clear after clearing', async () => {
     const onChange = jest.fn();
     const { container } = render(

--- a/components/color-picker/components/PanelPicker/index.tsx
+++ b/components/color-picker/components/PanelPicker/index.tsx
@@ -93,6 +93,17 @@ const PanelPicker: FC = () => {
 
   const mergedPickerColor = pickerColor?.equals(activeColor) ? activeColor : pickerColor;
 
+  // Normalize HSB hue value: 360 should be treated as 0
+  const normalizedPickerColor = React.useMemo(() => {
+    if (!mergedPickerColor) return undefined;
+    const hsb = mergedPickerColor.toHsb();
+    // Normalize hue: 360 degrees should be treated as 0
+    if (hsb.h === 360) {
+      hsb.h = 0;
+    }
+    return hsb;
+  }, [mergedPickerColor]);
+
   useLayoutEffect(() => {
     setPickerColor(activeColor);
   }, [forceSync, activeColor?.toHexString()]);
@@ -190,7 +201,7 @@ const PanelPicker: FC = () => {
 
       <RcColorPicker
         prefixCls={prefixCls}
-        value={mergedPickerColor?.toHsb()}
+        value={normalizedPickerColor}
         disabledAlpha={disabledAlpha}
         onChange={(colorValue, info) => {
           onPickerChange(colorValue, true, info);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
fix: [56328](https://github.com/ant-design/ant-design/issues/56328)

### 💡 Background and Solution
Fix the issue where the color in the preview panel does not match the actual input color
Normalize HSB hue from 360 to 0 before passing to RcColorPicker to fix the underlying fast-color library bug that incorrectly converts h=360 to magenta.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where the color in the preview panel does not match the actual input color |
| 🇨🇳 Chinese | 修复输入颜色后预览面板的颜色和实际输入颜色不符 |
