### PR TITLE
fix: fix cursor style when Select has showSearch and disabled props

### DIFF
--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -218,6 +218,10 @@ const genSelectInputStyle: GenerateStyle<SelectToken> = (token) => {
           background: token.colorBgContainerDisabled,
           color: token.colorTextDisabled,
           cursor: 'not-allowed',
+
+          input: {
+            cursor: 'not-allowed',
+          },
         },
 
         // ==========================================================
@@ -281,7 +285,7 @@ const genSelectInputStyle: GenerateStyle<SelectToken> = (token) => {
 
       // ======================== Show Search =======================
       {
-        [`&-show-search:not(${componentCls}-customize-input)`]: {
+        [`&-show-search:not(${componentCls}-customize-input):not(${componentCls}-disabled)`]: {
           cursor: 'text',
         },
       },


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #56338

### 💡 需求背景和解决方案

> 问题：Select 同时开启 showSearch 且 disabled 时，鼠标指针不显示禁用样式，见 #56338。

1. 补充了 input 缺失的 cursor;
2. &-show-search 缺失了对 disabled 的排除优先级更高的情况 cursor 会被覆盖

### 📝 更新日志

| 语言    | 更新描述                                                                 |
| ------- | ------------------------------------------------------------------------ |
| 🇺🇸 英文 | Fix cursor style when Select is disabled with showSearch enabled.        |
| 🇨🇳 中文 | 修复 Select 在同时设置 showSearch 和 disabled 时鼠标样式不为禁用的问题。 |
