### PR TITLE
Trigger type on wave config

### DIFF
--- a/components/_util/__tests__/wave.test.tsx
+++ b/components/_util/__tests__/wave.test.tsx
@@ -4,8 +4,10 @@ import { clsx } from 'clsx';
 import mountTest from '../../../tests/shared/mountTest';
 import { act, fireEvent, getByText, render, waitFakeTimer } from '../../../tests/utils';
 import Checkbox from '../../checkbox';
+import ConfigProvider from '../../config-provider';
 import Wave from '../wave';
 import { TARGET_CLS } from '../wave/interface';
+import useWave from '../wave/useWave';
 
 (global as any).isVisible = true;
 
@@ -377,5 +379,63 @@ describe('Wave component', () => {
     expect(style['--wave-color']).toEqual('rgb(255, 0, 0)');
 
     unmount();
+  });
+
+  describe('trigger types', () => {
+    it('should trigger on click by default', () => {
+      const { container } = render(
+        <Wave>
+          <button type="button">Button</button>
+        </Wave>,
+      );
+
+      fireEvent.click(container.querySelector('button')!);
+      waitRaf();
+      expect(document.querySelector('.ant-wave')).toBeTruthy();
+    });
+
+    it('should trigger on mousedown when configured', () => {
+      const { container } = render(
+        <ConfigProvider wave={{ triggerType: 'onMouseDown' }}>
+          <Wave>
+            <button type="button">Button</button>
+          </Wave>
+        </ConfigProvider>,
+      );
+
+      const button = container.querySelector('button')!;
+
+      fireEvent.click(button);
+      waitRaf();
+      expect(document.querySelector('.ant-wave')).toBeFalsy();
+
+      // Should trigger on mousedown
+      fireEvent.mouseDown(button);
+      waitRaf();
+      expect(document.querySelector('.ant-wave')).toBeTruthy();
+    });
+
+    it('should trigger on pointerdown when configured', () => {
+      const { container } = render(
+        <ConfigProvider wave={{ triggerType: 'onPointerDown' }}>
+          <Wave>
+            <button type="button">Button</button>
+          </Wave>
+        </ConfigProvider>,
+      );
+
+      const button = container.querySelector('button')!;
+      fireEvent.click(button);
+
+      waitRaf();
+
+      expect(document.querySelector('.ant-wave')).toBeFalsy();
+
+      fireEvent.pointerDown(button);
+
+      waitRaf();
+
+      expect(document.querySelector('.ant-wave')).toBeTruthy();
+    });
   });
 });

--- a/components/_util/wave/index.ts
+++ b/components/_util/wave/index.ts
@@ -19,7 +19,7 @@ export interface WaveProps {
 
 const Wave: React.FC<WaveProps> = (props) => {
   const { children, disabled, component, colorSource } = props;
-  const { getPrefixCls } = useContext<ConfigConsumerProps>(ConfigContext);
+  const { getPrefixCls, wave } = useContext<ConfigConsumerProps>(ConfigContext);
 
   const containerRef = useRef<HTMLElement | null>(null);
 
@@ -38,7 +38,7 @@ const Wave: React.FC<WaveProps> = (props) => {
     }
 
     // Click handler
-    const onClick = (e: MouseEvent) => {
+    const onClick = (e: Event) => {
       // Fix radio button click twice
       if (
         !isVisible(e.target as HTMLElement) ||
@@ -52,15 +52,26 @@ const Wave: React.FC<WaveProps> = (props) => {
       ) {
         return;
       }
-      showWave(e);
+      showWave(e as MouseEvent);
     };
 
+    const triggerType = wave?.triggerType || 'onClick';
+
+    const eventName =
+      {
+        onClick: 'click',
+        onMouseDown: 'mousedown',
+        onMouseUp: 'mouseup',
+        onPointerDown: 'pointerdown',
+        onPointerUp: 'pointerup',
+      }[triggerType] || 'click';
+
     // Bind events
-    node.addEventListener('click', onClick, true);
+    node.addEventListener(eventName, onClick, true);
     return () => {
-      node.removeEventListener('click', onClick, true);
+      node.removeEventListener(eventName, onClick, true);
     };
-  }, [disabled]);
+  }, [disabled, wave]);
 
   // ============================== Render ==============================
   if (!React.isValidElement(children)) {

--- a/components/config-provider/__tests__/wave.test.tsx
+++ b/components/config-provider/__tests__/wave.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ConfigProvider from '..';
 import { fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 import Button from '../../button';
+import { ConfigContext } from '../context';
 
 jest.mock('@rc-component/util/lib/Dom/isVisible', () => () => true);
 
@@ -47,5 +48,16 @@ describe('ConfigProvider.Wave', () => {
 
     expect(onClick).toHaveBeenCalled();
     expect(showEffect).toHaveBeenCalled();
+  });
+
+  it('should pass wave config to context', () => {
+    const { container } = render(
+      <ConfigProvider wave={{ triggerType: 'onPointerDown' }}>
+        <ConfigContext.Consumer>
+          {(context) => <div id="trigger">{context.wave?.triggerType}</div>}
+        </ConfigContext.Consumer>
+      </ConfigProvider>,
+    );
+    expect(container.querySelector('#trigger')?.textContent).toBe('onPointerDown');
   });
 });

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -167,8 +167,9 @@ export interface ComponentStyleConfig {
   style?: React.CSSProperties;
 }
 
-export interface TableConfig<RecordType extends AnyObject = AnyObject>
-  extends ComponentStyleConfig {
+export interface TableConfig<
+  RecordType extends AnyObject = AnyObject,
+> extends ComponentStyleConfig {
   expandable?: {
     expandIcon?: NonNullable<TableProps['expandable']>['expandIcon'];
   };
@@ -400,6 +401,8 @@ export const Variants = ['outlined', 'borderless', 'filled', 'underlined'] as co
 
 export type Variant = (typeof Variants)[number];
 
+export type TriggerType = 'onClick' | 'onPointerDown' | 'onPointerUp' | 'onMouseDown' | 'onMouseUp';
+
 export interface WaveConfig {
   /**
    * @descCN 是否禁用水波纹效果。
@@ -412,6 +415,12 @@ export interface WaveConfig {
    * @descEN Customized wave effect.
    */
   showEffect?: ShowWaveEffect;
+  /**
+   * @descCN 触发水波纹效果的事件。
+   * @descEN The event that triggers the wave effect.
+   * @default 'onClick'
+   */
+  triggerType?: TriggerType;
 }
 
 export interface ConfigComponentProps {


### PR DESCRIPTION

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ x] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - close: #56286

### 💡 Background and Solution

> - Users wanted more ways to interact with wave 
> - Implemented trigger types based on mouseUp/Down, PointerUp/Down, and onClick

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Implemented onPointerUp/Down, onMouseUp/Down and onClick for wave trigger types    |
| 🇨🇳 Chinese |  在波形触发类型中实现了 onPointerUp/Down、onMouseUp/Down 和 onClick     |
