### PR TITLE
feat: Drawer support focusable

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -13929,12 +13929,6 @@ exports[`ConfigProvider components Drawer configProvider 1`] = `
     class="config-drawer-mask config-drawer-mask-motion-appear config-drawer-mask-motion-appear-start config-drawer-mask-motion config-drawer-mask-blur"
   />
   <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
-  <div
     class="config-drawer-content-wrapper config-drawer-panel-motion-right-appear config-drawer-panel-motion-right-appear-start config-drawer-panel-motion-right"
     style="width: 378px;"
   >
@@ -13982,12 +13976,6 @@ exports[`ConfigProvider components Drawer configProvider 1`] = `
       />
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -14000,12 +13988,6 @@ exports[`ConfigProvider components Drawer configProvider componentDisabled 1`] =
     class="config-drawer-mask config-drawer-mask-motion-appear config-drawer-mask-motion-appear-start config-drawer-mask-motion config-drawer-mask-blur"
   />
   <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
-  <div
     class="config-drawer-content-wrapper config-drawer-panel-motion-right-appear config-drawer-panel-motion-right-appear-start config-drawer-panel-motion-right"
     style="width: 378px;"
   >
@@ -14053,12 +14035,6 @@ exports[`ConfigProvider components Drawer configProvider componentDisabled 1`] =
       />
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -14071,12 +14047,6 @@ exports[`ConfigProvider components Drawer configProvider componentSize large 1`]
     class="config-drawer-mask config-drawer-mask-motion-appear config-drawer-mask-motion-appear-start config-drawer-mask-motion config-drawer-mask-blur"
   />
   <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
-  <div
     class="config-drawer-content-wrapper config-drawer-panel-motion-right-appear config-drawer-panel-motion-right-appear-start config-drawer-panel-motion-right"
     style="width: 378px;"
   >
@@ -14124,12 +14094,6 @@ exports[`ConfigProvider components Drawer configProvider componentSize large 1`]
       />
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -14142,12 +14106,6 @@ exports[`ConfigProvider components Drawer configProvider componentSize middle 1`
     class="config-drawer-mask config-drawer-mask-motion-appear config-drawer-mask-motion-appear-start config-drawer-mask-motion config-drawer-mask-blur"
   />
   <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
-  <div
     class="config-drawer-content-wrapper config-drawer-panel-motion-right-appear config-drawer-panel-motion-right-appear-start config-drawer-panel-motion-right"
     style="width: 378px;"
   >
@@ -14195,12 +14153,6 @@ exports[`ConfigProvider components Drawer configProvider componentSize middle 1`
       />
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -14213,12 +14165,6 @@ exports[`ConfigProvider components Drawer configProvider componentSize small 1`]
     class="config-drawer-mask config-drawer-mask-motion-appear config-drawer-mask-motion-appear-start config-drawer-mask-motion config-drawer-mask-blur"
   />
   <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
-  <div
     class="config-drawer-content-wrapper config-drawer-panel-motion-right-appear config-drawer-panel-motion-right-appear-start config-drawer-panel-motion-right"
     style="width: 378px;"
   >
@@ -14266,12 +14212,6 @@ exports[`ConfigProvider components Drawer configProvider componentSize small 1`]
       />
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -14282,12 +14222,6 @@ exports[`ConfigProvider components Drawer normal 1`] = `
 >
   <div
     class="ant-drawer-mask ant-drawer-mask-motion-appear ant-drawer-mask-motion-appear-start ant-drawer-mask-motion ant-drawer-mask-blur"
-  />
-  <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
   />
   <div
     class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-appear ant-drawer-panel-motion-right-appear-start ant-drawer-panel-motion-right"
@@ -14337,12 +14271,6 @@ exports[`ConfigProvider components Drawer normal 1`] = `
       />
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -14353,12 +14281,6 @@ exports[`ConfigProvider components Drawer prefixCls 1`] = `
 >
   <div
     class="prefix-Drawer-mask prefix-Drawer-mask-motion-appear prefix-Drawer-mask-motion-appear-start prefix-Drawer-mask-motion prefix-Drawer-mask-blur"
-  />
-  <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
   />
   <div
     class="prefix-Drawer-content-wrapper prefix-Drawer-panel-motion-right-appear prefix-Drawer-panel-motion-right-appear-start prefix-Drawer-panel-motion-right"
@@ -14408,12 +14330,6 @@ exports[`ConfigProvider components Drawer prefixCls 1`] = `
       />
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 

--- a/components/drawer/__tests__/Drawer.test.tsx
+++ b/components/drawer/__tests__/Drawer.test.tsx
@@ -507,6 +507,27 @@ describe('Drawer', () => {
     expect(container.querySelector('#test')).toBeTruthy();
   });
 
+  it('focusable default config should pass to classNames', () => {
+    const classNames = jest.fn(() => ({}));
+
+    render(
+      <Drawer open getContainer={false} classNames={classNames}>
+        Here is content of Drawer
+      </Drawer>,
+    );
+
+    expect(classNames).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({
+          focusable: {
+            trap: false,
+            focusTriggerAfterClose: true,
+          },
+        }),
+      }),
+    );
+  });
+
   describe('Drawer mask blur className', () => {
     const testCases: [
       mask?: MaskType,

--- a/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -9,12 +9,6 @@ exports[`Drawer Drawer loading have a spinner 1`] = `
     class="ant-drawer-mask ant-drawer-mask-blur"
   />
   <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
-  <div
     class="ant-drawer-content-wrapper"
     style="width: 378px;"
   >
@@ -82,12 +76,6 @@ exports[`Drawer Drawer loading have a spinner 1`] = `
       </div>
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -98,12 +86,6 @@ exports[`Drawer Drawer mask blur className should support closable placement wit
 >
   <div
     class="ant-drawer-mask ant-drawer-mask-blur"
-  />
-  <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
   />
   <div
     class="ant-drawer-content-wrapper"
@@ -154,12 +136,6 @@ exports[`Drawer Drawer mask blur className should support closable placement wit
       </div>
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -170,12 +146,6 @@ exports[`Drawer Drawer mask blur className should support closable placement wit
 >
   <div
     class="ant-drawer-mask ant-drawer-mask-blur"
-  />
-  <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
   />
   <div
     class="ant-drawer-content-wrapper"
@@ -227,12 +197,6 @@ exports[`Drawer Drawer mask blur className should support closable placement wit
       </div>
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -243,12 +207,6 @@ exports[`Drawer className is test_drawer 1`] = `
 >
   <div
     class="ant-drawer-mask ant-drawer-mask-blur"
-  />
-  <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
   />
   <div
     class="ant-drawer-content-wrapper"
@@ -300,12 +258,6 @@ exports[`Drawer className is test_drawer 1`] = `
       </div>
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -316,12 +268,6 @@ exports[`Drawer closable is false 1`] = `
 >
   <div
     class="ant-drawer-mask ant-drawer-mask-blur"
-  />
-  <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
   />
   <div
     class="ant-drawer-content-wrapper"
@@ -339,12 +285,6 @@ exports[`Drawer closable is false 1`] = `
       </div>
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -360,12 +300,6 @@ exports[`Drawer getContainer return undefined 2`] = `
   >
     <div
       class="ant-drawer-mask ant-drawer-mask-blur"
-    />
-    <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
     />
     <div
       class="ant-drawer-content-wrapper"
@@ -417,12 +351,6 @@ exports[`Drawer getContainer return undefined 2`] = `
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -434,12 +362,6 @@ exports[`Drawer have a footer 1`] = `
 >
   <div
     class="ant-drawer-mask ant-drawer-mask-blur"
-  />
-  <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
   />
   <div
     class="ant-drawer-content-wrapper"
@@ -496,12 +418,6 @@ exports[`Drawer have a footer 1`] = `
       </div>
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -512,12 +428,6 @@ exports[`Drawer have a title 1`] = `
 >
   <div
     class="ant-drawer-mask ant-drawer-mask-blur"
-  />
-  <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
   />
   <div
     class="ant-drawer-content-wrapper"
@@ -576,12 +486,6 @@ exports[`Drawer have a title 1`] = `
       </div>
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -592,12 +496,6 @@ exports[`Drawer render correctly 1`] = `
 >
   <div
     class="ant-drawer-mask ant-drawer-mask-blur"
-  />
-  <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
   />
   <div
     class="ant-drawer-content-wrapper"
@@ -649,12 +547,6 @@ exports[`Drawer render correctly 1`] = `
       </div>
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -665,12 +557,6 @@ exports[`Drawer render top drawer 1`] = `
 >
   <div
     class="ant-drawer-mask ant-drawer-mask-blur"
-  />
-  <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
   />
   <div
     class="ant-drawer-content-wrapper"
@@ -722,12 +608,6 @@ exports[`Drawer render top drawer 1`] = `
       </div>
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -744,12 +624,6 @@ exports[`Drawer style migrate match between styles and deprecated style prop 1`]
       style="font-size: 15px;"
     />
     <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
-    <div
       class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-enter ant-drawer-panel-motion-right-enter-start ant-drawer-panel-motion-right"
       style="width: 378px; font-size: 14px;"
     >
@@ -810,12 +684,6 @@ exports[`Drawer style migrate match between styles and deprecated style prop 1`]
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -831,12 +699,6 @@ exports[`Drawer style migrate match between styles and deprecated style prop 2`]
       style="font-size: 15px;"
     />
     <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
-    <div
       class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-enter ant-drawer-panel-motion-right-enter-start ant-drawer-panel-motion-right"
       style="width: 378px; font-size: 14px;"
     >
@@ -897,12 +759,6 @@ exports[`Drawer style migrate match between styles and deprecated style prop 2`]
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -915,12 +771,6 @@ exports[`Drawer style/drawerStyle/headerStyle/bodyStyle should work 1`] = `
 >
   <div
     class="ant-drawer-mask ant-drawer-mask-blur"
-  />
-  <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
   />
   <div
     class="ant-drawer-content-wrapper"
@@ -975,12 +825,6 @@ exports[`Drawer style/drawerStyle/headerStyle/bodyStyle should work 1`] = `
       </div>
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -991,12 +835,6 @@ exports[`Drawer support closeIcon 1`] = `
 >
   <div
     class="ant-drawer-mask ant-drawer-mask-blur"
-  />
-  <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
   />
   <div
     class="ant-drawer-content-wrapper"
@@ -1031,11 +869,5 @@ exports[`Drawer support closeIcon 1`] = `
       </div>
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;

--- a/components/drawer/__tests__/__snapshots__/DrawerEvent.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/DrawerEvent.test.tsx.snap
@@ -9,12 +9,6 @@ exports[`Drawer render correctly 1`] = `
     class="ant-drawer-mask ant-drawer-mask-motion-leave ant-drawer-mask-motion-leave-start ant-drawer-mask-motion ant-drawer-mask-blur"
   />
   <div
-    aria-hidden="true"
-    data-sentinel="start"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
-  <div
     class="ant-drawer-content-wrapper ant-drawer-panel-motion-right-leave ant-drawer-panel-motion-right-leave-start ant-drawer-panel-motion-right"
     style="width: 378px;"
   >
@@ -64,11 +58,5 @@ exports[`Drawer render correctly 1`] = `
       </div>
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-sentinel="end"
-    style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-    tabindex="0"
-  />
 </div>
 `;

--- a/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
@@ -18,12 +18,6 @@ Array [
       class="ant-drawer-mask ant-drawer-mask-blur"
     />
     <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
-    <div
       class="ant-drawer-content-wrapper"
       style="width: 378px;"
     >
@@ -88,12 +82,6 @@ Array [
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>,
 ]
 `;
@@ -138,12 +126,6 @@ Array [
       class="ant-drawer-mask acss-c0hvaj ant-drawer-mask-blur"
     />
     <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
-    <div
       class="ant-drawer-content-wrapper"
       style="width: 378px;"
     >
@@ -217,12 +199,6 @@ Array [
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>,
   <div
     class="ant-drawer ant-drawer-right css-var-test-id ant-drawer-open ant-drawer-inline"
@@ -232,12 +208,6 @@ Array [
       class="ant-drawer-mask acss-c0hvaj ant-drawer-mask-blur"
     />
     <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
-    <div
       class="ant-drawer-content-wrapper"
       style="width: 378px;"
     >
@@ -311,12 +281,6 @@ Array [
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>,
 ]
 `;
@@ -339,12 +303,6 @@ Array [
   >
     <div
       class="ant-drawer-mask ant-drawer-mask-blur"
-    />
-    <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
     />
     <div
       class="ant-drawer-content-wrapper"
@@ -411,12 +369,6 @@ Array [
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>,
 ]
 `;
@@ -507,12 +459,6 @@ exports[`renders components/drawer/demo/config-provider.tsx extend context corre
       class="ant-drawer-mask ant-drawer-mask-blur"
     />
     <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
-    <div
       class="ant-drawer-content-wrapper"
       style="width: 378px;"
     >
@@ -577,12 +523,6 @@ exports[`renders components/drawer/demo/config-provider.tsx extend context corre
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -713,12 +653,6 @@ Array [
       class="ant-drawer-mask ant-drawer-mask-blur"
     />
     <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
-    <div
       class="ant-drawer-content-wrapper"
       style="width: 500px;"
     >
@@ -815,12 +749,6 @@ Array [
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>,
 ]
 `;
@@ -869,12 +797,6 @@ Array [
   >
     <div
       class="ant-drawer-mask ant-drawer-mask-blur"
-    />
-    <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
     />
     <div
       class="ant-drawer-content-wrapper"
@@ -2866,12 +2788,6 @@ Array [
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>,
 ]
 `;
@@ -2894,12 +2810,6 @@ Array [
   >
     <div
       class="ant-drawer-mask ant-drawer-mask-blur"
-    />
-    <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
     />
     <div
       class="ant-drawer-content-wrapper"
@@ -2978,12 +2888,6 @@ Array [
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>,
 ]
 `;
@@ -3018,12 +2922,6 @@ exports[`renders components/drawer/demo/mask.tsx extend context correctly 1`] = 
         class="ant-drawer-mask ant-drawer-mask-blur"
       />
       <div
-        aria-hidden="true"
-        data-sentinel="start"
-        style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-        tabindex="0"
-      />
-      <div
         class="ant-drawer-content-wrapper"
         style="width: 378px;"
       >
@@ -3088,12 +2986,6 @@ exports[`renders components/drawer/demo/mask.tsx extend context correctly 1`] = 
           </div>
         </div>
       </div>
-      <div
-        aria-hidden="true"
-        data-sentinel="end"
-        style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-        tabindex="0"
-      />
     </div>
   </div>
   <div
@@ -3119,12 +3011,6 @@ exports[`renders components/drawer/demo/mask.tsx extend context correctly 1`] = 
         class="ant-drawer-mask"
       />
       <div
-        aria-hidden="true"
-        data-sentinel="start"
-        style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-        tabindex="0"
-      />
-      <div
         class="ant-drawer-content-wrapper"
         style="width: 378px;"
       >
@@ -3189,12 +3075,6 @@ exports[`renders components/drawer/demo/mask.tsx extend context correctly 1`] = 
           </div>
         </div>
       </div>
-      <div
-        aria-hidden="true"
-        data-sentinel="end"
-        style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-        tabindex="0"
-      />
     </div>
   </div>
   <div
@@ -3217,12 +3097,6 @@ exports[`renders components/drawer/demo/mask.tsx extend context correctly 1`] = 
       tabindex="-1"
     >
       <div
-        aria-hidden="true"
-        data-sentinel="start"
-        style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-        tabindex="0"
-      />
-      <div
         class="ant-drawer-content-wrapper"
         style="width: 378px;"
       >
@@ -3287,12 +3161,6 @@ exports[`renders components/drawer/demo/mask.tsx extend context correctly 1`] = 
           </div>
         </div>
       </div>
-      <div
-        aria-hidden="true"
-        data-sentinel="end"
-        style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-        tabindex="0"
-      />
     </div>
   </div>
 </div>
@@ -3316,12 +3184,6 @@ Array [
   >
     <div
       class="ant-drawer-mask ant-drawer-mask-blur"
-    />
-    <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
     />
     <div
       class="ant-drawer-content-wrapper"
@@ -3367,12 +3229,6 @@ Array [
               class="ant-drawer-mask ant-drawer-mask-blur"
             />
             <div
-              aria-hidden="true"
-              data-sentinel="start"
-              style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-              tabindex="0"
-            />
-            <div
               class="ant-drawer-content-wrapper"
               style="width: 320px;"
             >
@@ -3403,22 +3259,10 @@ Array [
                 </div>
               </div>
             </div>
-            <div
-              aria-hidden="true"
-              data-sentinel="end"
-              style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-              tabindex="0"
-            />
           </div>
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>,
 ]
 `;
@@ -3439,12 +3283,6 @@ Array [
     class="ant-drawer ant-drawer-right no-mask css-var-test-id ant-drawer-open ant-drawer-inline"
     tabindex="-1"
   >
-    <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
     <div
       class="ant-drawer-content-wrapper"
       style="width: 378px;"
@@ -3510,12 +3348,6 @@ Array [
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>,
 ]
 `;
@@ -3646,12 +3478,6 @@ Array [
       class="ant-drawer-mask ant-drawer-mask-blur"
     />
     <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
-    <div
       class="ant-drawer-content-wrapper"
       style="width: 378px;"
     >
@@ -3690,12 +3516,6 @@ Array [
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>,
 ]
 `;
@@ -3727,12 +3547,6 @@ exports[`renders components/drawer/demo/render-in-current.tsx extend context cor
       class="ant-drawer-mask ant-drawer-mask-blur"
     />
     <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
-    <div
       class="ant-drawer-content-wrapper"
       style="width: 378px;"
     >
@@ -3765,12 +3579,6 @@ exports[`renders components/drawer/demo/render-in-current.tsx extend context cor
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -3968,12 +3776,6 @@ Array [
       class="ant-drawer-mask ant-drawer-mask-blur"
     />
     <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
-    <div
       class="ant-drawer-content-wrapper"
       style="width: 256px;"
     >
@@ -4038,12 +3840,6 @@ Array [
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>,
 ]
 `;
@@ -4178,12 +3974,6 @@ exports[`renders components/drawer/demo/scroll-debug.tsx extend context correctl
       class="ant-drawer-mask ant-drawer-mask-blur"
     />
     <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
-    <div
       class="ant-drawer-content-wrapper"
       style="width: 378px; transform: translateX(-180px);"
     >
@@ -4246,12 +4036,6 @@ exports[`renders components/drawer/demo/scroll-debug.tsx extend context correctl
               class="ant-drawer-mask ant-drawer-mask-blur"
             />
             <div
-              aria-hidden="true"
-              data-sentinel="start"
-              style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-              tabindex="0"
-            />
-            <div
               class="ant-drawer-content-wrapper"
               style="width: 378px;"
             >
@@ -4308,22 +4092,10 @@ exports[`renders components/drawer/demo/scroll-debug.tsx extend context correctl
                 </div>
               </div>
             </div>
-            <div
-              aria-hidden="true"
-              data-sentinel="end"
-              style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-              tabindex="0"
-            />
           </div>
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>
   <div
     class="ant-drawer ant-drawer-right css-var-test-id ant-drawer-open ant-drawer-inline"
@@ -4331,12 +4103,6 @@ exports[`renders components/drawer/demo/scroll-debug.tsx extend context correctl
   >
     <div
       class="ant-drawer-mask ant-drawer-mask-blur"
-    />
-    <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
     />
     <div
       class="ant-drawer-content-wrapper"
@@ -4395,12 +4161,6 @@ exports[`renders components/drawer/demo/scroll-debug.tsx extend context correctl
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -4571,12 +4331,6 @@ Array [
       class="ant-drawer-mask ant-drawer-mask-blur"
     />
     <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
-    <div
       class="ant-drawer-content-wrapper"
       style="width: 378px;"
     >
@@ -4673,12 +4427,6 @@ Array [
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>,
 ]
 `;
@@ -4712,12 +4460,6 @@ exports[`renders components/drawer/demo/style-class.tsx extend context correctly
     <div
       class="ant-drawer-mask ant-drawer-mask-blur"
       style="background-image: linear-gradient(to top, #18181b 0, rgba(21, 21, 22, 0.2) 100%);"
-    />
-    <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
     />
     <div
       class="ant-drawer-content-wrapper"
@@ -4810,12 +4552,6 @@ exports[`renders components/drawer/demo/style-class.tsx extend context correctly
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>
   <div
     class="ant-drawer ant-drawer-right css-var-test-id ant-drawer-open ant-drawer-inline"
@@ -4823,12 +4559,6 @@ exports[`renders components/drawer/demo/style-class.tsx extend context correctly
   >
     <div
       class="ant-drawer-mask ant-drawer-mask-blur"
-    />
-    <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
     />
     <div
       class="ant-drawer-content-wrapper"
@@ -4950,12 +4680,6 @@ exports[`renders components/drawer/demo/style-class.tsx extend context correctly
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>
 </div>
 `;
@@ -5078,12 +4802,6 @@ Array [
   >
     <div
       class="ant-drawer-mask ant-drawer-mask-blur"
-    />
-    <div
-      aria-hidden="true"
-      data-sentinel="start"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
     />
     <div
       class="ant-drawer-content-wrapper"
@@ -5383,12 +5101,6 @@ Array [
         </div>
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-sentinel="end"
-      style="width: 0px; height: 0px; overflow: hidden; outline: none; position: absolute;"
-      tabindex="0"
-    />
   </div>,
 ]
 `;

--- a/components/drawer/index.en-US.md
+++ b/components/drawer/index.en-US.md
@@ -64,6 +64,7 @@ v5 uses `rootClassName` & `rootStyle` to configure the outermost element style, 
 | extra | Extra actions area at corner | ReactNode | - | 4.17.0 |
 | footer | The footer for Drawer | ReactNode | - |  |
 | forceRender | Pre-render Drawer component forcibly | boolean | false |  |
+| focusable | Configuration for focus management in the Drawer | `{ trap?: boolean, focusTriggerAfterClose?: boolean }` | - | 6.2.0 |
 | getContainer | mounted node and display window for Drawer | HTMLElement \| () => HTMLElement \| Selectors \| false | body |  |
 | headerStyle | Style of the drawer header part | CSSProperties | - |  |
 | ~~height~~ | Placement is `top` or `bottom`, height of the Drawer dialog, please use `size` instead | string \| number | 378 |  |

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -19,6 +19,8 @@ import { usePanelRef } from '../watermark/context';
 import type { DrawerClassNamesType, DrawerPanelProps, DrawerStylesType } from './DrawerPanel';
 import DrawerPanel from './DrawerPanel';
 import useStyle from './style';
+import type { FocusableConfig, OmitFocusType } from './useFocusable';
+import useFocusable from './useFocusable';
 
 const _SizeTypes = ['default', 'large'] as const;
 
@@ -38,7 +40,13 @@ export interface DrawerResizableConfig {
 export interface DrawerProps
   extends Omit<
       RcDrawerProps,
-      'maskStyle' | 'destroyOnClose' | 'mask' | 'resizable' | 'classNames' | 'styles'
+      | 'maskStyle'
+      | 'destroyOnClose'
+      | 'mask'
+      | 'resizable'
+      | 'classNames'
+      | 'styles'
+      | OmitFocusType
     >,
     Omit<DrawerPanelProps, 'prefixCls' | 'ariaId'> {
   size?: sizeType | number | string;
@@ -52,6 +60,8 @@ export interface DrawerProps
    */
   destroyOnHidden?: boolean;
   mask?: MaskType;
+
+  focusable?: Omit<FocusableConfig, 'autoFocusButton'>;
 }
 
 const defaultPushState: PushState = { distance: 180 };
@@ -79,6 +89,9 @@ const Drawer: React.FC<DrawerProps> & {
     className,
     resizable,
     'aria-labelledby': ariaLabelledby,
+
+    // Focus
+    focusable,
 
     // Deprecated
     maskStyle,
@@ -190,14 +203,17 @@ const Drawer: React.FC<DrawerProps> & {
   const innerPanelRef = usePanelRef();
   const mergedPanelRef = composeRef(panelRef, innerPanelRef) as React.Ref<HTMLDivElement>;
 
-  // ============================ zIndex ============================
+  // =========================== zIndex ===========================
   const [zIndex, contextZIndex] = useZIndex('Drawer', rest.zIndex);
+
+  // ============================ Mask ============================
+  const [mergedMask, maskBlurClassName] = useMergedMask(drawerMask, contextMask, prefixCls);
+
+  // ========================== Focusable =========================
+  const mergedFocusable = useFocusable(focusable, getContainer !== false && mergedMask);
 
   // =========================== Render ===========================
   const { classNames, styles, rootStyle } = rest;
-
-  const [mergedMask, maskBlurClassName] = useMergedMask(drawerMask, contextMask, prefixCls);
-
   const mergedProps: DrawerProps = {
     ...props,
     zIndex,
@@ -205,6 +221,7 @@ const Drawer: React.FC<DrawerProps> & {
     mask: mergedMask,
     defaultSize,
     push,
+    focusable: mergedFocusable,
   };
 
   const [mergedClassNames, mergedStyles] = useMergeSemantic<
@@ -263,6 +280,9 @@ const Drawer: React.FC<DrawerProps> & {
           {...(resizable ? { resizable } : {})}
           aria-labelledby={ariaLabelledby ?? ariaId}
           destroyOnHidden={destroyOnHidden ?? destroyOnClose}
+          // Focusable
+          focusTriggerAfterClose={mergedFocusable.focusTriggerAfterClose}
+          focusTrap={mergedFocusable.trap}
         >
           <DrawerPanel
             prefixCls={prefixCls}

--- a/components/drawer/index.zh-CN.md
+++ b/components/drawer/index.zh-CN.md
@@ -64,6 +64,7 @@ v5 使用 `rootClassName` 与 `rootStyle` 来配置最外层元素样式。原 v
 | extra | 抽屉右上角的操作区域 | ReactNode | - | 4.17.0 |
 | footer | 抽屉的页脚 | ReactNode | - |  |
 | forceRender | 预渲染 Drawer 内元素 | boolean | false |  |
+| focusable | 抽屉内焦点管理的配置 | `{ trap?: boolean, focusTriggerAfterClose?: boolean }` | - | 6.2.0 |
 | getContainer | 指定 Drawer 挂载的节点，**并在容器内展现**，`false` 为挂载在当前位置 | HTMLElement \| () => HTMLElement \| Selectors \| false | body |  |
 | ~~height~~ | 高度，在 `placement` 为 `top` 或 `bottom` 时使用，请使用 `size` 替换 | string \| number | 378 |  |
 | keyboard | 是否支持键盘 esc 关闭 | boolean | true |  |

--- a/components/drawer/useFocusable.ts
+++ b/components/drawer/useFocusable.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+
+export type OmitFocusType = 'autoFocusButton' | 'focusTriggerAfterClose' | 'focusTrap';
+
+export interface FocusableConfig {
+  autoFocusButton?: 'ok' | 'cancel' | false;
+  focusTriggerAfterClose?: boolean;
+  trap?: boolean;
+}
+
+export default function useFocusable(
+  focusable?: FocusableConfig,
+  defaultTrap?: boolean,
+  autoFocusButton?: 'ok' | 'cancel' | false,
+  focusTriggerAfterClose?: boolean,
+) {
+  return useMemo(
+    () => ({
+      trap: defaultTrap ?? true,
+      autoFocusButton: autoFocusButton ?? 'ok',
+      focusTriggerAfterClose: focusTriggerAfterClose ?? true,
+      ...focusable,
+    }),
+    [focusable, autoFocusButton, focusTriggerAfterClose, defaultTrap],
+  );
+}

--- a/components/drawer/useFocusable.ts
+++ b/components/drawer/useFocusable.ts
@@ -8,19 +8,14 @@ export interface FocusableConfig {
   trap?: boolean;
 }
 
-export default function useFocusable(
-  focusable?: FocusableConfig,
-  defaultTrap?: boolean,
-  autoFocusButton?: 'ok' | 'cancel' | false,
-  focusTriggerAfterClose?: boolean,
-) {
-  return useMemo(
-    () => ({
+export default function useFocusable(focusable?: FocusableConfig, defaultTrap?: boolean) {
+  return useMemo(() => {
+    const ret = {
       trap: defaultTrap ?? true,
-      autoFocusButton: autoFocusButton ?? 'ok',
-      focusTriggerAfterClose: focusTriggerAfterClose ?? true,
+      focusTriggerAfterClose: true,
       ...focusable,
-    }),
-    [focusable, autoFocusButton, focusTriggerAfterClose, defaultTrap],
-  );
+    };
+
+    return ret;
+  }, [focusable, defaultTrap]);
 }

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@rc-component/collapse": "~1.1.2",
     "@rc-component/color-picker": "~3.0.3",
     "@rc-component/dialog": "~1.7.0",
-    "@rc-component/drawer": "~1.3.0",
+    "@rc-component/drawer": "~1.4.0",
     "@rc-component/dropdown": "~1.0.2",
     "@rc-component/form": "~1.6.0",
     "@rc-component/image": "~1.6.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Drawer support `focusable` to configure focus behavior, such as focus trapping and returning focus on close.     |
| 🇨🇳 Chinese |    Drawer 新增 `focusable` 以配置展开后的焦点行为，支持配置锁定焦点在框内、关闭后是否返回焦点。       |
