### PR TITLE
fix(docs): use React 18 UMD for CodePen demos

### DIFF
--- a/.dumi/theme/builtins/Previewer/Actions.tsx
+++ b/.dumi/theme/builtins/Previewer/Actions.tsx
@@ -127,8 +127,8 @@ const Actions: React.FC<ActionsProps> = ({
     editors: '001',
     css: '',
     js_external: [
-      'react@19/cjs/react.development.js',
-      'react-dom@19/cjs/react-dom.development.js',
+      'react@18/umd/react.production.min.js',
+      'react-dom@18/umd/react-dom.production.min.js',
       'dayjs@1/dayjs.min.js',
       `antd@${pkg.version}/dist/antd-with-locales.min.js`,
       `@ant-design/icons/dist/index.umd.js`,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Closes #56448


### 💡 Background and Solution

The “Open in CodePen” button was broken for Ant Design v6 demos.

**Root cause:**
The CodePen integration loads React via CDN and assumes UMD globals (`window.React`, `window.ReactDOM`).  
However, React 19 no longer ships browser-usable UMD bundles. The previous configuration attempted to load React 19 CommonJS builds (`react@19/cjs/*`), which are not valid in the browser and result in MIME errors and `ReactDOM is not defined`.

**Solution:**
Switch the CodePen-only React dependencies to React 18 UMD builds:
- `react@18/umd/react.production.min.js`
- `react-dom@18/umd/react-dom.production.min.js`

This restores the required global variables for CodePen while remaining compatible with Ant Design v6, which supports React `>=18` via peer dependencies.

Other playgrounds (CodeSandbox, StackBlitz) are unchanged.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix broken “Open in CodePen” demos caused by invalid React 19 CDN usage       |
| 🇨🇳 Chinese |           |

### 🧪 Testing
- Opened https://ant.design/components/button-cn#button-demo-basic
- Clicked “Open in CodePen”
- Verified the demo loads and renders without console errors

### ⚠️ Notes
- This PR intentionally keeps the existing UMD-based CodePen pipeline.
- A future enhancement could add ESM-based CodePen support for React 19, but that is out of scope for this bug fix.
