### PR TITLE
feat: ConfigProvider support pagination.totalBoundaryShowSizeChanger

### DIFF
--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -261,7 +261,7 @@ const Pagination: React.FC<PaginationProps> = (props) => {
     <>
       {token.wireframe && <BorderedStyle prefixCls={prefixCls} />}
       <RcPagination
-        contextTotalBoundaryShowSizeChanger={contextTotalBoundaryShowSizeChanger}
+        totalBoundaryShowSizeChanger={contextTotalBoundaryShowSizeChanger}
         {...iconsProps}
         {...restProps}
         styles={mergedStyles}

--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -57,6 +57,7 @@ export type PaginationPosition = 'top' | 'bottom' | 'both';
 
 export interface PaginationConfig extends Omit<PaginationProps, 'rootClassName'> {
   position?: PaginationPosition;
+  contextTotalBoundaryShowSizeChanger?: number;
 }
 
 export type { PaginationLocale };
@@ -90,6 +91,7 @@ const Pagination: React.FC<PaginationProps> = (props) => {
     style: contextStyle,
     classNames: contextClassNames,
     styles: contextStyles,
+    totalBoundaryShowSizeChanger: contextTotalBoundaryShowSizeChanger,
   } = useComponentConfig('pagination');
   const prefixCls = getPrefixCls('pagination', customizePrefixCls);
 
@@ -259,6 +261,7 @@ const Pagination: React.FC<PaginationProps> = (props) => {
     <>
       {token.wireframe && <BorderedStyle prefixCls={prefixCls} />}
       <RcPagination
+        contextTotalBoundaryShowSizeChanger={contextTotalBoundaryShowSizeChanger}
         {...iconsProps}
         {...restProps}
         styles={mergedStyles}


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

使用 `ConfigProvider` 全局改变 `totalBoundaryShowSizeChanger` 默认值

```jsx
<ConfigProvider pagination={{ totalBoundaryShowSizeChanger: 1000 }}>
  <Pagination defaultCurrent={6} total={500} />
</ConfigProvider>
```

### 💡 Background and Solution

https://github.com/ant-design/ant-design/discussions/56407

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    ConfigProvider support pagination.totalBoundaryShowSizeChanger       |
| 🇨🇳 Chinese |     ConfigProvider 支持 pagination.totalBoundaryShowSizeChanger      |
