### PR TITLE
feat: Tooltips/Popovers/Popconfirm can be closed by pressing the Escape key by default

### DIFF
--- a/components/popconfirm/__tests__/index.test.tsx
+++ b/components/popconfirm/__tests__/index.test.tsx
@@ -430,7 +430,7 @@ describe('Popconfirm', () => {
     );
 
     expect(errorSpy).toHaveBeenCalledWith(
-      'Warning: [antd: Popconfirm] `onOpenChange` only accept `open` argument. The second event argument is internal usage and not support.',
+      'The second `onOpenChange` parameter is internal and unsupported. Please lock to a previous version if needed.',
     );
 
     errorSpy.mockRestore();

--- a/components/popconfirm/__tests__/index.test.tsx
+++ b/components/popconfirm/__tests__/index.test.tsx
@@ -430,7 +430,7 @@ describe('Popconfirm', () => {
     );
 
     expect(errorSpy).toHaveBeenCalledWith(
-      'The second `onOpenChange` parameter is internal and unsupported. Please lock to a previous version if needed.',
+      'Warning: [antd: Popconfirm] The second `onOpenChange` parameter is internal and unsupported. Please lock to a previous version if needed.',
     );
 
     errorSpy.mockRestore();

--- a/components/popconfirm/__tests__/index.test.tsx
+++ b/components/popconfirm/__tests__/index.test.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { spyElementPrototype } from '@rc-component/util/lib/test/domHook';
+import { warning } from '@rc-component/util';
 
 import Popconfirm from '..';
+import { TriggerMockContext } from '../../../tests/shared/demoTestContext';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 import Button from '../../button';
 import ConfigProvider from '../../config-provider';
+
+const { resetWarned } = warning;
 
 // TODO: Remove this. Mock for React 19
 jest.mock('react-dom', () => {
@@ -23,11 +27,6 @@ jest.mock('react-dom', () => {
 describe('Popconfirm', () => {
   mountTest(() => <Popconfirm title="test" />);
   rtlTest(() => <Popconfirm title="test" />);
-
-  const eventObject = expect.objectContaining({
-    target: expect.anything(),
-    preventDefault: expect.any(Function),
-  });
 
   beforeAll(() => {
     spyElementPrototype(HTMLElement, 'offsetParent', {
@@ -62,11 +61,11 @@ describe('Popconfirm', () => {
 
     const triggerNode = wrapper.container.querySelectorAll('span')[0];
     fireEvent.click(triggerNode);
-    expect(onOpenChange).toHaveBeenLastCalledWith(true, undefined);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
     expect(wrapper.container.querySelectorAll('.popconfirm-test').length).toBe(1);
 
     fireEvent.click(triggerNode);
-    expect(onOpenChange).toHaveBeenLastCalledWith(false, undefined);
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
   });
 
   it('should show overlay when trigger is clicked', async () => {
@@ -145,9 +144,7 @@ describe('Popconfirm', () => {
   it('should trigger onConfirm and onCancel', async () => {
     const confirm = jest.fn();
     const cancel = jest.fn();
-    const onOpenChange = jest.fn((_, e) => {
-      e?.persist?.();
-    });
+    const onOpenChange = jest.fn();
     const popconfirm = render(
       <Popconfirm title="code" onConfirm={confirm} onCancel={cancel} onOpenChange={onOpenChange}>
         <span>show me your code</span>
@@ -159,14 +156,14 @@ describe('Popconfirm', () => {
 
     fireEvent.click(popconfirm.container.querySelector('.ant-btn-primary')!);
     expect(confirm).toHaveBeenCalled();
-    expect(onOpenChange).toHaveBeenLastCalledWith(false, eventObject);
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
 
     fireEvent.click(triggerNode);
     await waitFakeTimer();
 
     fireEvent.click(popconfirm.container.querySelector('.ant-btn')!);
     expect(cancel).toHaveBeenCalled();
-    expect(onOpenChange).toHaveBeenLastCalledWith(false, eventObject);
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
   });
 
   it('should support onConfirm to return Promise', async () => {
@@ -174,9 +171,7 @@ describe('Popconfirm', () => {
       new Promise((res) => {
         setTimeout(res, 300);
       });
-    const onOpenChange = jest.fn((_, e) => {
-      e?.persist?.();
-    });
+    const onOpenChange = jest.fn();
     const popconfirm = render(
       <Popconfirm title="code" onConfirm={confirm} onOpenChange={onOpenChange}>
         <span>show me your code</span>
@@ -189,7 +184,7 @@ describe('Popconfirm', () => {
 
     fireEvent.click(popconfirm.container.querySelectorAll('.ant-btn')[0]);
     await waitFakeTimer();
-    expect(onOpenChange).toHaveBeenCalledWith(false, eventObject);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it('should support customize icon', () => {
@@ -243,19 +238,24 @@ describe('Popconfirm', () => {
   });
 
   it('should be closed by pressing ESC', () => {
-    const onOpenChange = jest.fn((_, e) => {
-      e?.persist?.();
-    });
+    const onOpenChange = jest.fn();
     const wrapper = render(
-      <Popconfirm title="title" mouseEnterDelay={0} mouseLeaveDelay={0} onOpenChange={onOpenChange}>
-        <span>Delete</span>
-      </Popconfirm>,
+      <TriggerMockContext.Provider value={{ mock: false }}>
+        <Popconfirm
+          title="title"
+          mouseEnterDelay={0}
+          mouseLeaveDelay={0}
+          onOpenChange={onOpenChange}
+        >
+          <span>Delete</span>
+        </Popconfirm>
+      </TriggerMockContext.Provider>,
     );
     const triggerNode = wrapper.container.querySelectorAll('span')[0];
     fireEvent.click(triggerNode);
-    expect(onOpenChange).toHaveBeenLastCalledWith(true, undefined);
-    fireEvent.keyDown(triggerNode, { key: 'Escape', keyCode: 27 });
-    expect(onOpenChange).toHaveBeenLastCalledWith(false, eventObject);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
   });
 
   it('should not warn memory leaking if setState in async callback', async () => {
@@ -416,5 +416,23 @@ describe('Popconfirm', () => {
     // Click the toggleArrow button again to show the arrow
     fireEvent.click(toggleArrowBtn!);
     expect(getTooltipArrow()).not.toBeNull();
+  });
+
+  it('should warn when onOpenChange has more than one argument', () => {
+    resetWarned();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const onOpenChange = (_open: boolean, _e?: React.MouseEvent) => {};
+    render(
+      <Popconfirm title="test" onOpenChange={onOpenChange}>
+        <span>Delete</span>
+      </Popconfirm>,
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Warning: [antd: Popconfirm] `onOpenChange` only accept `open` argument. The second event argument is internal usage and not support.',
+    );
+
+    errorSpy.mockRestore();
   });
 });

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -6,6 +6,7 @@ import { clsx } from 'clsx';
 import type { RenderFunction } from '../_util/getRenderPropValue';
 import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks';
 import { useMergeSemantic } from '../_util/hooks';
+import { devUseWarning } from '../_util/warning';
 import type { ButtonProps, LegacyButtonType } from '../button/Button';
 import { useComponentConfig } from '../config-provider/context';
 import type { PopoverProps, PopoverSemanticClassNames, PopoverSemanticStyles } from '../popover';
@@ -35,10 +36,7 @@ export interface PopconfirmProps extends AbstractTooltipProps {
   cancelButtonProps?: ButtonProps;
   showCancel?: boolean;
   icon?: React.ReactNode;
-  onOpenChange?: (
-    open: boolean,
-    e?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLDivElement>,
-  ) => void;
+  onOpenChange?: (open: boolean) => void;
   onPopupClick?: (e: React.MouseEvent<HTMLElement>) => void;
   classNames?: PopconfirmClassNamesType;
   styles?: PopconfirmStylesType;
@@ -77,28 +75,39 @@ const InternalPopconfirm = React.forwardRef<TooltipRef, PopconfirmProps>((props,
   const mergedArrow = useMergedArrow(popconfirmArrow, contextArrow);
   const mergedTrigger = trigger || contextTrigger || 'click';
 
-  const settingOpen: PopoverProps['onOpenChange'] = (value, e) => {
+  // ========================== Warning ===========================
+  if (process.env.NODE_ENV !== 'production') {
+    const warning = devUseWarning('Popconfirm');
+
+    warning(
+      !onOpenChange || onOpenChange.length <= 1,
+      'usage',
+      '`onOpenChange` only accept `open` argument. The second event argument is internal usage and not support.',
+    );
+  }
+
+  const settingOpen: PopoverProps['onOpenChange'] = (value) => {
     setOpen(value);
-    onOpenChange?.(value, e);
+    onOpenChange?.(value);
   };
 
-  const close = (e: React.MouseEvent<HTMLButtonElement>) => {
-    settingOpen(false, e);
+  const close = () => {
+    settingOpen(false);
   };
 
   const onConfirm = (e: React.MouseEvent<HTMLButtonElement>) => props.onConfirm?.call(this, e);
 
   const onCancel = (e: React.MouseEvent<HTMLButtonElement>) => {
-    settingOpen(false, e);
+    settingOpen(false);
     props.onCancel?.call(this, e);
   };
 
-  const onInternalOpenChange: PopoverProps['onOpenChange'] = (value, e) => {
+  const onInternalOpenChange: PopoverProps['onOpenChange'] = (value) => {
     const { disabled = false } = props;
     if (disabled) {
       return;
     }
-    settingOpen(value, e);
+    settingOpen(value);
   };
 
   const prefixCls = getPrefixCls('popconfirm', customizePrefixCls);

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -82,7 +82,7 @@ const InternalPopconfirm = React.forwardRef<TooltipRef, PopconfirmProps>((props,
     warning(
       !onOpenChange || onOpenChange.length <= 1,
       'usage',
-      '`onOpenChange` only accept `open` argument. The second event argument is internal usage and not support.',
+      'The second `onOpenChange` parameter is internal and unsupported. Please lock to a previous version if needed.',
     );
   }
 

--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -214,7 +214,7 @@ describe('Popover', () => {
     );
 
     expect(errorSpy).toHaveBeenCalledWith(
-      'The second `onOpenChange` parameter is internal and unsupported. Please lock to a previous version if needed.',
+      'Warning: [antd: Popover] The second `onOpenChange` parameter is internal and unsupported. Please lock to a previous version if needed.',
     );
 
     errorSpy.mockRestore();

--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -214,7 +214,7 @@ describe('Popover', () => {
     );
 
     expect(errorSpy).toHaveBeenCalledWith(
-      'Warning: [antd: Popover] `onOpenChange` only accept `open` argument. The second event argument is internal usage and not support.',
+      'The second `onOpenChange` parameter is internal and unsupported. Please lock to a previous version if needed.',
     );
 
     errorSpy.mockRestore();

--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -1,20 +1,19 @@
 import React from 'react';
+import { warning } from '@rc-component/util';
 
 import Popover from '..';
+import { TriggerMockContext } from '../../../tests/shared/demoTestContext';
 import mountTest from '../../../tests/shared/mountTest';
 import { fireEvent, render } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
 import type { TooltipRef } from '../../tooltip';
 
+const { resetWarned } = warning;
+
 const { _InternalPanelDoNotUseOrYouWillBeFired: InternalPanelDoNotUseOrYouWillBeFired } = Popover;
 
 describe('Popover', () => {
   mountTest(Popover);
-
-  const eventObject = expect.objectContaining({
-    target: expect.anything(),
-    preventDefault: expect.any(Function),
-  });
 
   it('should show overlay when trigger is clicked', () => {
     const ref = React.createRef<TooltipRef>();
@@ -110,19 +109,19 @@ describe('Popover', () => {
   });
 
   it('should be closed by pressing ESC', () => {
-    const onOpenChange = jest.fn((_, e) => {
-      e?.persist?.();
-    });
+    const onOpenChange = jest.fn();
     const wrapper = render(
-      <Popover title="Title" trigger="click" onOpenChange={onOpenChange}>
-        <span>Delete</span>
-      </Popover>,
+      <TriggerMockContext.Provider value={{ mock: false }}>
+        <Popover title="Title" trigger="click" onOpenChange={onOpenChange}>
+          <span>Delete</span>
+        </Popover>
+      </TriggerMockContext.Provider>,
     );
     const triggerNode = wrapper.container.querySelectorAll('span')[0];
     fireEvent.click(triggerNode);
-    expect(onOpenChange).toHaveBeenLastCalledWith(true, undefined);
-    fireEvent.keyDown(triggerNode, { key: 'Escape', keyCode: 27 });
-    expect(onOpenChange).toHaveBeenLastCalledWith(false, eventObject);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
   });
 
   it('should not display overlay when the content is null/undefined', () => {
@@ -201,5 +200,23 @@ describe('Popover', () => {
     // Click the toggleArrow button again to show the arrow
     fireEvent.click(toggleArrowBtn!);
     expect(getTooltipArrow()).not.toBeNull();
+  });
+
+  it('should warn when onOpenChange has more than one argument', () => {
+    resetWarned();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const onOpenChange = (_open: boolean, _e?: React.MouseEvent) => {};
+    render(
+      <Popover title="test" onOpenChange={onOpenChange}>
+        <span>Show</span>
+      </Popover>,
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Warning: [antd: Popover] `onOpenChange` only accept `open` argument. The second event argument is internal usage and not support.',
+    );
+
+    errorSpy.mockRestore();
   });
 });

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -87,7 +87,7 @@ const InternalPopover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) 
     warning(
       !onOpenChange || onOpenChange.length <= 1,
       'usage',
-      '`onOpenChange` only accept `open` argument. The second event argument is internal usage and not support.',
+      'The second `onOpenChange` parameter is internal and unsupported. Please lock to a previous version if needed.',
     );
   }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] ⌨️ Accessibility improvement

### 🔗 Related Issues

- ref https://github.com/react-component/trigger/pull/594

该 PR 移除了 Popconfirm/Popover 的 `onOpenChange` 方法中的第二个参数

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Tooltips/Popovers/Popconfirm can be closed by pressing the Escape key by default       |
| 🇨🇳 Chinese |    Tooltip/Popover/Popconfirm 默认情况下可以通过 ESC 关闭       |
