### PR TITLE
fix(ConfigProvider): use correct cssVar key for icon styles

### DIFF
--- a/components/config-provider/__tests__/cssinjs.test.tsx
+++ b/components/config-provider/__tests__/cssinjs.test.tsx
@@ -96,6 +96,33 @@ describe('ConfigProvider.DynamicTheme', () => {
     ).toBeTruthy();
   });
 
+  it('icon styles should use cssVar key from theme config', () => {
+    render(
+      <ConfigProvider theme={{ cssVar: { key: 'custom-css-var' } }}>
+        <SmileOutlined />
+      </ConfigProvider>,
+    );
+
+    const dynamicStyles = Array.from(document.querySelectorAll('style[data-css-hash]'));
+
+    // Should have styles with the custom cssVar key
+    expect(
+      dynamicStyles.some((style) => {
+        const { innerHTML } = style;
+        return innerHTML.includes('.custom-css-var');
+      }),
+    ).toBeTruthy();
+
+    // Should NOT have styles with the default css-var-root key
+    // This ensures icon styles registered inside ConfigProvider use the correct context
+    expect(
+      dynamicStyles.some((style) => {
+        const { innerHTML } = style;
+        return innerHTML.includes('.css-var-root');
+      }),
+    ).toBeFalsy();
+  });
+
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('layer should affect icon', () => {
     render(

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -91,6 +91,18 @@ import type { SizeType } from './SizeContext';
 import SizeContext, { SizeContextProvider } from './SizeContext';
 import useStyle from './style';
 
+/**
+ * This component registers icon styles inside the DesignTokenContext.Provider
+ * so that CSS variables use the correct cssVar key from the theme config.
+ */
+const IconStyle: React.FC<{ iconPrefixCls: string; csp?: CSPConfig }> = ({
+  iconPrefixCls,
+  csp,
+}) => {
+  useStyle(iconPrefixCls, csp);
+  return null;
+};
+
 export type { Variant };
 
 export { Variants };
@@ -440,8 +452,6 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
   const iconPrefixCls = customIconPrefixCls || parentContext.iconPrefixCls || defaultIconPrefixCls;
   const csp = customCsp || parentContext.csp;
 
-  useStyle(iconPrefixCls, csp);
-
   const mergedTheme = useTheme(theme, parentContext.theme, { prefixCls: getPrefixCls('') });
 
   if (process.env.NODE_ENV !== 'production') {
@@ -591,6 +601,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
 
   let childNode = (
     <>
+      <IconStyle iconPrefixCls={iconPrefixCls} csp={csp} />
       <PropWarning dropdownMatchSelectWidth={dropdownMatchSelectWidth} />
       {children}
     </>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

When using AntD v6 in zero runtime mode w/ [static-style-extract](https://github.com/ant-design/static-style-extract), we need to specify a `cssVar.key` so it has a deterministic value at both build time and run time. I noticed, however, that even with

```jsx
extractStyle((node) => (
  <ConfigProvider theme={{ ...myTheme, cssVar: { key: 'my-css-vars' } }}>{node}</ConfigProvider>
))
```

the output still contains a `css-var-root` class with all the default theme css variables.

The root cause is the `useStyle` call for icon styles is executed inside the `ConfigProvider` component body but before the `DesignTokenContext.Provider` is rendered. This causes `useToken()` to read from the parent/default context (which has no `cssVar`), falling back to the hardcoded `css-var-root` key.

To address this, this PR moves the icon style registration into a small `IconStyle` component that renders inside `childNode`, ensuring it executes after the `DesignTokenContext.Provider` is established and uses the correct `cssVar` context.



### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix ConfigProvider to ensure icon styles use correct `cssVar` key from theme config  |
| 🇨🇳 Chinese |  修复 ConfigProvider，确保图标样式使用主题配置中正确的 `cssVar` 键。 |
