### PR TITLE
chore(a11y): remove redundant alt text from component icon

### DIFF
--- a/.dumi/theme/builtins/ComponentOverview/index.tsx
+++ b/.dumi/theme/builtins/ComponentOverview/index.tsx
@@ -227,7 +227,7 @@ const Overview: React.FC = () => {
                             src={
                               isDark && component.coverDark ? component.coverDark : component.cover
                             }
-                            alt={component.title}
+                            alt=""
                           />
                         </div>
                       </Card>


### PR DESCRIPTION
### 🤔 This is a ...
- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Fixes accessibility violations detected on the [Ant Design Components Overview page](https://ant.design/components/overview/).

### 💡 Background and Solution

**Problem:**
When running [IBM Accessibility Checker](https://github.com/IBMa/equal-access) (Version 4.0.9) on the [Components Overview page](https://ant.design/components/overview/), 77 accessibility violations (Link text is repeated in an image 'alt' value within the same link) were reported.
The component overview page contains accessibility violations where decorative images have redundant alt text. According to WCAG guidelines, when an image is contained within a link and the link text already describes the destination, the image alt attribute should be empty to avoid redundancy for screen reader users.

<img width="2560" height="833" alt="image" src="https://github.com/user-attachments/assets/71f96f29-c083-4682-8f6c-8e6587a04920" />

**As shown in this screenshot, there are 77 violations "The text alternative for an image within a link should not repeat the link text or adjacent link text"**


**Solution:**
This PR fixes these accessibility violations by removing redundant alt text from decorative component preview images in the Component Overview page. 

**Generated Patch:**
```
--- a/.dumi/theme/builtins/ComponentOverview/index.tsx
+++ b/.dumi/theme/builtins/ComponentOverview/index.tsx
@@ -227,7 +227,7 @@ const Overview: React.FC = () => {
                             src={
                               isDark && component.coverDark ? component.coverDark : component.cover
                             }
-                            alt={component.title}
+                            alt=""
                           />
                         </div>
                       </Card>
```

**Fix Before:**

<img width="2560" height="833" alt="image" src="https://github.com/user-attachments/assets/3d944647-0a28-45ef-8a6d-6c141ec08877" />

**Fix After:**

<img width="2560" height="850" alt="image" src="https://github.com/user-attachments/assets/0f9e06ea-79f3-48c2-8aef-2aad994f89c7" />

Here we can see that 77 (99-22) violations have been resolved.

Note: The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications. The generated fixes were manually reviewed and validated before submission.


**Changes:**
- Changed `alt={component.title}` to `alt=""` for component preview images
- This ensures screen readers don't announce the component name twice (once from the link text, once from the image alt)

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix redundant alt text on component overview page images to improve screen reader experience |
| 🇨🇳 Chinese | 修复组件概览页面图片的冗余 alt 文本，改善屏幕阅读器体验 |