### PR TITLE
fix(Select): correct clear icon position in sm size

### DIFF
--- a/components/select/__tests__/index.test.tsx
+++ b/components/select/__tests__/index.test.tsx
@@ -325,4 +325,15 @@ describe('Select', () => {
     expect(button!.className.includes('compact')).toBeFalsy();
     expect(input!.className.includes('compact')).toBeFalsy();
   });
+
+  it('aligns clear icon inset with small size padding', () => {
+    const { container } = render(
+      <Select size="small" allowClear options={[{ value: '1', label: '1' }]} value="1" />,
+    );
+
+    const ele = container.querySelector<HTMLElement>('.ant-select-clear');
+    if (ele) {
+      expect(getComputedStyle(ele).insetInlineEnd).toBe('var(--select-padding-horizontal)');
+    }
+  });
 });

--- a/components/select/__tests__/index.test.tsx
+++ b/components/select/__tests__/index.test.tsx
@@ -162,6 +162,17 @@ describe('Select', () => {
         );
       }
     });
+
+    it('aligns clear icon inset with small size padding', () => {
+      const { container } = render(
+        <Select size="small" allowClear options={[{ value: '1', label: '1' }]} value="1" />,
+      );
+
+      const ele = container.querySelector<HTMLElement>('.ant-select-clear');
+      if (ele) {
+        expect(getComputedStyle(ele).insetInlineEnd).toBe('var(--select-padding-horizontal)');
+      }
+    });
   });
 
   describe('Deprecated', () => {
@@ -324,16 +335,5 @@ describe('Select', () => {
     const input = popupElement!.querySelector('input');
     expect(button!.className.includes('compact')).toBeFalsy();
     expect(input!.className.includes('compact')).toBeFalsy();
-  });
-
-  it('aligns clear icon inset with small size padding', () => {
-    const { container } = render(
-      <Select size="small" allowClear options={[{ value: '1', label: '1' }]} value="1" />,
-    );
-
-    const ele = container.querySelector<HTMLElement>('.ant-select-clear');
-    if (ele) {
-      expect(getComputedStyle(ele).insetInlineEnd).toBe('var(--select-padding-horizontal)');
-    }
   });
 });

--- a/components/select/__tests__/index.test.tsx
+++ b/components/select/__tests__/index.test.tsx
@@ -162,17 +162,6 @@ describe('Select', () => {
         );
       }
     });
-
-    it('aligns clear icon inset with small size padding', () => {
-      const { container } = render(
-        <Select size="small" allowClear options={[{ value: '1', label: '1' }]} value="1" />,
-      );
-
-      const ele = container.querySelector<HTMLElement>('.ant-select-clear');
-      if (ele) {
-        expect(getComputedStyle(ele).insetInlineEnd).toBe('var(--select-padding-horizontal)');
-      }
-    });
   });
 
   describe('Deprecated', () => {

--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -231,6 +231,10 @@ const genSelectInputStyle: GenerateStyle<SelectToken> = (token) => {
           '--select-height': token.controlHeightSM,
           '--select-padding-horizontal': calc(token.paddingXS).sub(token.lineWidth).equal(),
           '--select-border-radius': token.borderRadiusSM,
+
+          [`${componentCls}-clear`]: {
+            insetInlineEnd: calc(token.paddingXS).sub(token.lineWidth).equal(),
+          },
         },
 
         '&-lg': {

--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -233,7 +233,7 @@ const genSelectInputStyle: GenerateStyle<SelectToken> = (token) => {
           '--select-border-radius': token.borderRadiusSM,
 
           [`${componentCls}-clear`]: {
-            insetInlineEnd: calc(token.paddingXS).sub(token.lineWidth).equal(),
+            insetInlineEnd: 'var(--select-padding-horizontal)',
           },
         },
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

---

### 🔗 相关 Issue

- Fix #56523

---

### 💡 需求背景和解决方案

#### 问题背景
在 `Select` 组件的 **small（sm）尺寸**下，`clear` 图标的 `insetInlineEnd`
未与对应尺寸的横向 padding 计算保持一致，  
导致在部分主题或自定义 token 场景中出现 **视觉偏移**。

#### 解决方案
在 `&-sm` 样式作用域中，为 `clear` 图标补充与 sm 尺寸一致的
`insetInlineEnd` 计算逻辑：

- 使用 `paddingXS - lineWidth` 作为最终偏移值
- 与 `--select-padding-horizontal` 的计算方式保持一致
- 不影响其他尺寸（md / lg）的现有表现

该修改仅影响样式计算逻辑，不涉及 API 变更。

---

### 📝 更新日志

| 语言 | 更新描述 |
| ---- | -------- |
| 🇺🇸 English | Fixed clear icon alignment issue in Select small size. |
| 🇨🇳 中文 | 修复 Select 组件 small 尺寸下清除图标位置偏移的问题。 |
