### PR TITLE
docs: fix grammar errors in documentation

### DIFF
--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -169,7 +169,7 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ## FAQ
 
-### Why sometime search will show 2 same option when in `tags` mode? {#faq-tags-mode-duplicate}
+### Why sometimes search will show 2 same option when in `tags` mode? {#faq-tags-mode-duplicate}
 
 It's caused by option with different `label` and `value`. You can use `optionFilterProp="label"` to change filter logic instead.
 
@@ -196,7 +196,7 @@ Select will close when it lose focus. You can prevent event to handle this:
 />
 ```
 
-### Why sometime customize Option cause scroll break? {#faq-custom-option-scroll}
+### Why sometimes customize Option cause scroll break? {#faq-custom-option-scroll}
 
 Virtual scroll internal set item height as `24px`. You need to adjust `listItemHeight` when your option height is less and `listHeight` config list container height:
 

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -393,7 +393,7 @@ Table can not tell what state used in `columns.render`, so it always need fully 
 
 ### How to handle fixed column display over the mask layout? {#faq-fixed-column-zindex}
 
-Fixed column use `z-index` to make it over other columns. You will find sometime fixed columns also over your mask layout. You can set `z-index` on your mask layout to resolve.
+Fixed column use `z-index` to make it over other columns. You will find sometimes fixed columns also over your mask layout. You can set `z-index` on your mask layout to resolve.
 
 ### How to custom render Table Checkbox（For example, adding Tooltip）? {#faq-custom-checkbox-render}
 

--- a/components/tree-select/index.en-US.md
+++ b/components/tree-select/index.en-US.md
@@ -145,7 +145,7 @@ Common props ref：[Common props](/docs/react/common-props)
 
 We don't provide this since performance consideration. You can get by this way: <https://codesandbox.io/s/get-parent-node-in-onchange-eb1608>
 
-### Why sometime customize Option cause scroll break? {#faq-custom-option-scroll}
+### Why sometimes customize Option cause scroll break? {#faq-custom-option-scroll}
 
 You can ref Select [FAQ](/components/select).
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Correct grammar in documentation: "sometime" → "sometimes"
> - Applied to: Select, Table, and TreeSelect components

### 💡 Background and Solution

> - Fixed grammatical errors in FAQ sections where "sometime" should be "sometimes"
> - The word "sometime" means "at some point in time", while "sometimes" means "occasionally"
> - Updated 3 instances in documentation files to use the correct form

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | docs: fix grammar errors in documentation |
| 🇨🇳 Chinese | 文档: 修正文档中的语法错误 |