### PR TITLE
site: add keepAlive animation to theme transition fix flickering after switching themes

### DIFF
--- a/.dumi/hooks/useThemeAnimation.ts
+++ b/.dumi/hooks/useThemeAnimation.ts
@@ -5,10 +5,7 @@ import theme from '../../components/theme';
 
 const duration = 0.5;
 const viewTransitionStyle = `
-@keyframes keepAlive {
-  0%, 99% {  }
-  100% { z-index: -1 }
-}
+@keyframes keepAlive {100% { z-index: -1 }}
 
 ::view-transition-old(root),
 ::view-transition-new(root) {

--- a/.dumi/hooks/useThemeAnimation.ts
+++ b/.dumi/hooks/useThemeAnimation.ts
@@ -3,10 +3,17 @@ import { removeCSS, updateCSS } from '@rc-component/util/lib/Dom/dynamicCSS';
 
 import theme from '../../components/theme';
 
+const duration = 0.5;
 const viewTransitionStyle = `
+@keyframes keepAlive {
+  0%, 99% {  }
+  100% { z-index: -1 }
+}
+
 ::view-transition-old(root),
 ::view-transition-new(root) {
-  animation: none;
+  animation: keepAlive ${duration}s linear;
+  animation-fill-mode: forwards;
   mix-blend-mode: normal;
 }
 
@@ -50,7 +57,7 @@ const useThemeAnimation = () => {
           clipPath: isDark ? [...clipPath].reverse() : clipPath,
         },
         {
-          duration: 500,
+          duration: duration * 1000,
           easing: 'ease-in',
           pseudoElement: isDark ? '::view-transition-old(root)' : '::view-transition-new(root)',
         },


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
issues: [56534](https://github.com/ant-design/ant-design/issues/56534)
- #55545

### 💡 Background and Solution
There is a flicker when the theme switch animation ends
Add an animation property to the view-transition, and set the z-index to -1 at 100% of the animation progress to prevent flickering.

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix flickering after switching themes |
| 🇨🇳 Chinese | 修复主题切换后出闪烁 |
