### PR TITLE
feat: upload support to setting upload button class names style

### DIFF
--- a/components/tag/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tag/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -650,7 +650,7 @@ Array [
       </span>
       <span
         class="ant-tag ant-tag-filled css-var-test-id"
-        style="background-color: rgb(232, 246, 253); color: rgb(45, 183, 245);"
+        style="background-color: rgb(231, 246, 254); color: rgb(45, 183, 245);"
       >
         #2db7f5
       </span>
@@ -662,7 +662,7 @@ Array [
       </span>
       <span
         class="ant-tag ant-tag-filled css-var-test-id"
-        style="background-color: rgb(230, 244, 254); color: rgb(16, 142, 233);"
+        style="background-color: rgb(231, 244, 253); color: rgb(16, 142, 233);"
       >
         #108ee9
       </span>
@@ -742,7 +742,7 @@ Array [
       </span>
       <span
         class="ant-tag ant-tag-outlined css-var-test-id"
-        style="background-color: rgb(232, 246, 253); color: rgb(45, 183, 245); border-color: rgb(45, 183, 245);"
+        style="background-color: rgb(231, 246, 254); color: rgb(45, 183, 245); border-color: rgb(45, 183, 245);"
       >
         #2db7f5
       </span>
@@ -754,7 +754,7 @@ Array [
       </span>
       <span
         class="ant-tag ant-tag-outlined css-var-test-id"
-        style="background-color: rgb(230, 244, 254); color: rgb(16, 142, 233); border-color: rgb(16, 142, 233);"
+        style="background-color: rgb(231, 244, 253); color: rgb(16, 142, 233); border-color: rgb(16, 142, 233);"
       >
         #108ee9
       </span>
@@ -1270,7 +1270,7 @@ Array [
   >
     <span
       class="ant-tag ant-tag-filled css-var-test-id"
-      style="background-color: rgb(234, 243, 250); color: rgb(85, 172, 238);"
+      style="background-color: rgb(232, 244, 253); color: rgb(85, 172, 238);"
     >
       <span
         aria-label="twitter"
@@ -1297,7 +1297,7 @@ Array [
     </span>
     <span
       class="ant-tag ant-tag-filled css-var-test-id"
-      style="background-color: rgb(253, 231, 231); color: rgb(205, 32, 31);"
+      style="background-color: rgb(252, 233, 233); color: rgb(205, 32, 31);"
     >
       <span
         aria-label="youtube"
@@ -1324,7 +1324,7 @@ Array [
     </span>
     <span
       class="ant-tag ant-tag-filled css-var-test-id"
-      style="background-color: rgb(234, 239, 250); color: rgb(59, 89, 153);"
+      style="background-color: rgb(237, 240, 248); color: rgb(59, 89, 153);"
     >
       <span
         aria-label="facebook"
@@ -1351,7 +1351,7 @@ Array [
     </span>
     <span
       class="ant-tag ant-tag-filled css-var-test-id"
-      style="background-color: rgb(234, 243, 250); color: rgb(85, 172, 238);"
+      style="background-color: rgb(232, 244, 253); color: rgb(85, 172, 238);"
     >
       <span
         aria-label="linkedin"

--- a/components/tag/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.tsx.snap
@@ -660,7 +660,7 @@ Array [
       </span>
       <span
         class="ant-tag ant-tag-filled css-var-test-id"
-        style="background-color:#e8f6fd;color:#2db7f5"
+        style="background-color:#e7f6fe;color:#2db7f5"
       >
         #2db7f5
       </span>
@@ -672,7 +672,7 @@ Array [
       </span>
       <span
         class="ant-tag ant-tag-filled css-var-test-id"
-        style="background-color:#e6f4fe;color:#108ee9"
+        style="background-color:#e7f4fd;color:#108ee9"
       >
         #108ee9
       </span>
@@ -760,7 +760,7 @@ Array [
       </span>
       <span
         class="ant-tag ant-tag-outlined css-var-test-id"
-        style="background-color:#e8f6fd;color:#2db7f5;border-color:#2db7f5"
+        style="background-color:#e7f6fe;color:#2db7f5;border-color:#2db7f5"
       >
         #2db7f5
       </span>
@@ -772,7 +772,7 @@ Array [
       </span>
       <span
         class="ant-tag ant-tag-outlined css-var-test-id"
-        style="background-color:#e6f4fe;color:#108ee9;border-color:#108ee9"
+        style="background-color:#e7f4fd;color:#108ee9;border-color:#108ee9"
       >
         #108ee9
       </span>
@@ -1260,7 +1260,7 @@ Array [
   >
     <span
       class="ant-tag ant-tag-filled css-var-test-id"
-      style="background-color:#eaf3fa;color:#55acee"
+      style="background-color:#e8f4fd;color:#55acee"
     >
       <span
         aria-label="twitter"
@@ -1287,7 +1287,7 @@ Array [
     </span>
     <span
       class="ant-tag ant-tag-filled css-var-test-id"
-      style="background-color:#fde7e7;color:#cd201f"
+      style="background-color:#fce9e9;color:#cd201f"
     >
       <span
         aria-label="youtube"
@@ -1314,7 +1314,7 @@ Array [
     </span>
     <span
       class="ant-tag ant-tag-filled css-var-test-id"
-      style="background-color:#eaeffa;color:#3b5999"
+      style="background-color:#edf0f8;color:#3b5999"
     >
       <span
         aria-label="facebook"
@@ -1341,7 +1341,7 @@ Array [
     </span>
     <span
       class="ant-tag ant-tag-filled css-var-test-id"
-      style="background-color:#eaf3fa;color:#55acee"
+      style="background-color:#e8f4fd;color:#55acee"
     >
       <span
         aria-label="linkedin"

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -501,13 +501,18 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
     );
   }
 
-  const uploadBtnCls = clsx(prefixCls, `${prefixCls}-select`, {
-    [`${prefixCls}-disabled`]: mergedDisabled,
-    [`${prefixCls}-hidden`]: !children,
-  });
+  const uploadBtnCls = clsx(
+    prefixCls,
+    `${prefixCls}-select`,
+    {
+      [`${prefixCls}-disabled`]: mergedDisabled,
+      [`${prefixCls}-hidden`]: !children,
+    },
+    mergedClassNames.uploadButton,
+  );
 
   const uploadButton = (
-    <div className={uploadBtnCls} style={mergedStyle}>
+    <div className={uploadBtnCls} style={{ ...mergedStyle, ...mergedStyles.uploadButton }}>
       <RcUpload {...rcUploadProps} ref={upload} />
     </div>
   );

--- a/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4287,6 +4287,7 @@ exports[`renders components/upload/demo/style-class.tsx extend context correctly
   >
     <div
       class="ant-upload ant-upload-select"
+      style="background-color: rgba(84, 89, 172, 0.1); padding: 8px; border-radius: 4px;"
     >
       <span
         class="ant-upload"
@@ -4587,6 +4588,7 @@ exports[`renders components/upload/demo/style-class.tsx extend context correctly
   >
     <div
       class="ant-upload ant-upload-select"
+      style="background-color: rgba(84, 89, 172, 0.2); padding: 8px; border-radius: 4px;"
     >
       <span
         class="ant-upload"

--- a/components/upload/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/upload/__tests__/__snapshots__/demo.test.ts.snap
@@ -4007,6 +4007,7 @@ exports[`renders components/upload/demo/style-class.tsx correctly 1`] = `
   >
     <div
       class="ant-upload ant-upload-select"
+      style="background-color:rgba(84, 89, 172, 0.1);padding:8px;border-radius:4px"
     >
       <span
         class="ant-upload"
@@ -4286,6 +4287,7 @@ exports[`renders components/upload/demo/style-class.tsx correctly 1`] = `
   >
     <div
       class="ant-upload ant-upload-select"
+      style="background-color:rgba(84, 89, 172, 0.2);padding:8px;border-radius:4px"
     >
       <span
         class="ant-upload"

--- a/components/upload/__tests__/semantic.test.tsx
+++ b/components/upload/__tests__/semantic.test.tsx
@@ -13,6 +13,7 @@ describe('Upload.Semantic', () => {
           root: 'test-upload-root',
           list: 'test-upload-list',
           item: 'test-upload-item',
+          uploadButton: 'test-upload-button',
         }}
         defaultFileList={[
           {
@@ -29,6 +30,7 @@ describe('Upload.Semantic', () => {
     expect(container.querySelector('.test-upload-root')).toBeTruthy();
     expect(container.querySelector('.test-upload-list')).toBeTruthy();
     expect(container.querySelector('.test-upload-item')).toBeTruthy();
+    expect(container.querySelector('.test-upload-button')).toBeTruthy();
   });
 
   it('should work with classNames function', () => {
@@ -60,6 +62,7 @@ describe('Upload.Semantic', () => {
           root: { backgroundColor: 'rgb(255, 0, 0)' },
           list: { backgroundColor: 'rgb(0, 0, 255)' },
           item: { backgroundColor: 'rgb(0, 128, 0)' },
+          uploadButton: { backgroundColor: 'rgb(255, 255, 0)' },
         }}
         defaultFileList={[{ uid: '1', name: 'test.txt', status: 'done' }]}
       >
@@ -78,6 +81,10 @@ describe('Upload.Semantic', () => {
     const itemElement = container.querySelector<HTMLElement>('.ant-upload-list-item');
     expect(itemElement).toBeTruthy();
     expect(itemElement).toHaveStyle({ backgroundColor: 'rgb(0, 128, 0)' });
+
+    const uploadButtonElement = container.querySelector<HTMLElement>('.ant-upload-select');
+    expect(uploadButtonElement).toBeTruthy();
+    expect(uploadButtonElement).toHaveStyle({ backgroundColor: 'rgb(255, 255, 0)' });
   });
 
   it('should work with styles function', () => {

--- a/components/upload/demo/_semantic.tsx
+++ b/components/upload/demo/_semantic.tsx
@@ -11,11 +11,14 @@ const locales = {
     root: '根元素容器，包含布局样式、禁用状态文字颜色、用户选择控制、鼠标样式等基础样式',
     list: '文件列表容器，包含布局排列、过渡动画、间距控制等样式',
     item: '文件项元素，包含内边距、背景色、边框样式、悬停效果、状态颜色、过渡动画等样式',
+    uploadButton: '上传按钮容器，包含按钮样式、禁用状态、隐藏控制等样式',
   },
   en: {
     root: 'Root container element with layout styles, disabled text color, user-select control, cursor styles and other basic styles',
     list: 'File list container with layout arrangement, transition animations, spacing control and other styles',
     item: 'File item element with padding, background color, border styles, hover effects, status colors, transition animations and other styles',
+    uploadButton:
+      'Upload button container with button styles, disabled state, visibility control and other styles',
   },
 };
 
@@ -65,6 +68,7 @@ const App: React.FC = () => {
         { name: 'root', desc: locale.root, version: '6.0.0' },
         { name: 'list', desc: locale.list, version: '6.0.0' },
         { name: 'item', desc: locale.item, version: '6.0.0' },
+        { name: 'uploadButton', desc: locale.uploadButton, version: '6.2.0' },
       ]}
     >
       <Block />

--- a/components/upload/demo/style-class.tsx
+++ b/components/upload/demo/style-class.tsx
@@ -17,6 +17,11 @@ const stylesObject: UploadProps<any>['styles'] = {
     backgroundColor: 'rgba(5, 5, 5, 0.06)',
     height: 30,
   },
+  uploadButton: {
+    backgroundColor: 'rgba(84, 89, 172, 0.1)',
+    padding: 8,
+    borderRadius: 4,
+  },
 };
 
 const stylesFn: UploadProps<any>['styles'] = (info) => {
@@ -27,6 +32,11 @@ const stylesFn: UploadProps<any>['styles'] = (info) => {
         borderRadius: 2,
         backgroundColor: 'rgba(5, 5, 5, 0.06)',
         height: 30,
+      },
+      uploadButton: {
+        backgroundColor: 'rgba(84, 89, 172, 0.2)',
+        padding: 8,
+        borderRadius: 4,
       },
     } satisfies UploadProps<any>['styles'];
   }

--- a/components/upload/interface.ts
+++ b/components/upload/interface.ts
@@ -94,12 +94,14 @@ export type UploadSemanticClassNames = {
   root?: string;
   list?: string;
   item?: string;
+  uploadButton?: string;
 };
 
 export type UploadSemanticStyles = {
   root?: React.CSSProperties;
   list?: React.CSSProperties;
   item?: React.CSSProperties;
+  uploadButton?: React.CSSProperties;
 };
 
 export type UploadClassNamesType<T = any> = SemanticClassNamesType<


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
issues: [56571](https://github.com/ant-design/ant-design/issues/56571)

### 💡 Background and Solution
Upload component lacks semantic customization support for the upload button container.
Add uploadButton to classNames and styles props for controlling the upload button container (ant-upload-select) styles.

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | upload add classNames.uploadButton and styles.uploadButton props |
| 🇨🇳 Chinese | upload 新增 classNames.uploadButton 和 styles.uploadButton 属性 |
