### PR TITLE
fix(Button): child element's className being cleared when rendering two Chinese characters.

### DIFF
--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -115,6 +115,23 @@ describe('Button', () => {
     expect(container.querySelector('.ant-btn')).toHaveClass('ant-btn-two-chinese-chars');
   });
 
+  it('should preserve className when rendering two Chinese characters in child element', () => {
+    const { container } = render(
+      <Button>
+        <span className="custom-class" style={{ color: 'red' }}>
+          按钮
+        </span>
+      </Button>,
+    );
+
+    const span = container.querySelector('span.custom-class');
+    expect(span).toBeTruthy();
+    expect(span).toHaveClass('custom-class');
+    expect(span).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+    // Should insert space between Chinese characters
+    expect(span).toHaveTextContent('按 钮');
+  });
+
   // https://github.com/ant-design/ant-design/issues/18118
   it('should not insert space to link or text button', () => {
     const wrapper1 = render(<Button type="link">按钮</Button>);

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -115,6 +115,7 @@ describe('Button', () => {
     expect(container.querySelector('.ant-btn')).toHaveClass('ant-btn-two-chinese-chars');
   });
 
+  // https://github.com/ant-design/ant-design/issues/56591
   it('should preserve className when rendering two Chinese characters in child element', () => {
     const { container } = render(
       <Button>
@@ -128,7 +129,6 @@ describe('Button', () => {
     expect(span).toBeTruthy();
     expect(span).toHaveClass('custom-class');
     expect(span).toHaveStyle({ color: 'rgb(255, 0, 0)' });
-    // Should insert space between Chinese characters
     expect(span).toHaveTextContent('按 钮');
   });
 

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -119,7 +119,7 @@ describe('Button', () => {
   it('should preserve className when rendering two Chinese characters in child element', () => {
     const { container } = render(
       <Button>
-        <span className="custom-class" style={{ color: 'red' }}>
+        <span className="custom-class" style={{ color: 'rgb(255, 0, 0)' }}>
           按钮
         </span>
       </Button>,

--- a/components/button/buttonHelpers.tsx
+++ b/components/button/buttonHelpers.tsx
@@ -54,8 +54,8 @@ function splitCNCharsBySpace(
     return cloneElement(child, (oriProps) => ({
       ...oriProps,
       children: oriProps.children.split('').join(SPACE),
-      className,
-      style,
+      className: clsx(oriProps.className, className) || undefined,
+      style: { ...oriProps.style, ...style },
     }));
   }
 


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
- fix https://github.com/ant-design/ant-design/issues/56591

### 💡 Background and Solution
When Button's children is a tag element containing two Chinese characters, the component overwrites the child element's original className and style attributes while inserting spaces between characters, causing custom styles to be lost.
Modified lines 54-59 in the splitCNCharsBySpace function in buttonHelpers.tsx to merge className and style instead of overwriting

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix child element's `className` being cleared when rendering two Chinese characters |
| 🇨🇳 Chinese | 修复 children 为包含两个中文字符的标签时，原有 `className` 被清空的问题 |
