### PR TITLE
feat: ColorPicker semantic support ColorBlock customize

### DIFF
--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -225,7 +225,7 @@ const ColorPicker: CompoundedComponent = (props) => {
   const rootCls = useCSSVarCls(prefixCls);
   const [hashId, cssVarCls] = useStyle(prefixCls, rootCls);
   const rtlCls = { [`${prefixCls}-rtl`]: direction };
-  const mergedRootCls = clsx(mergedClassNames.root, rootClassName, cssVarCls, rootCls, rtlCls);
+  const mergedRootCls = clsx(rootClassName, cssVarCls, rootCls, rtlCls);
   const mergedCls = clsx(
     getStatusClassNames(prefixCls, contextStatus),
     {
@@ -262,7 +262,7 @@ const ColorPicker: CompoundedComponent = (props) => {
     destroyOnHidden: destroyOnHidden ?? !!destroyTooltipOnHide,
   };
 
-  const mergedStyle: React.CSSProperties = { ...mergedStyles.root, ...contextStyle, ...style };
+  const mergedStyle: React.CSSProperties = { ...contextStyle, ...style };
 
   // ============================ zIndex ============================
 
@@ -305,6 +305,8 @@ const ColorPicker: CompoundedComponent = (props) => {
           open={popupOpen}
           className={mergedCls}
           style={mergedStyle}
+          classNames={mergedClassNames}
+          styles={mergedStyles}
           prefixCls={prefixCls}
           disabled={mergedDisabled}
           showText={showText}

--- a/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -9465,7 +9465,7 @@ exports[`renders components/color-picker/demo/style-class.tsx extend context cor
     >
       <div
         aria-describedby="test-id"
-        class="ant-color-picker-trigger acss-pbemrr css-var-test-id ant-color-picker-css-var"
+        class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var acss-pbemrr"
       >
         <div
           class="ant-color-picker-color-block"
@@ -9477,7 +9477,7 @@ exports[`renders components/color-picker/demo/style-class.tsx extend context cor
         </div>
       </div>
       <div
-        class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-popover-css-var css-var-test-id css-var-test-id ant-color-picker acss-pbemrr css-var-test-id ant-color-picker-css-var ant-popover-placement-bottomLeft"
+        class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-popover-css-var css-var-test-id css-var-test-id ant-color-picker css-var-test-id ant-color-picker-css-var ant-popover-placement-bottomLeft"
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; border: 1px solid rgb(255, 255, 255);"
       >
         <div
@@ -9832,7 +9832,7 @@ exports[`renders components/color-picker/demo/style-class.tsx extend context cor
     >
       <div
         aria-describedby="test-id"
-        class="ant-color-picker-trigger ant-color-picker-lg acss-pbemrr css-var-test-id ant-color-picker-css-var"
+        class="ant-color-picker-trigger ant-color-picker-lg css-var-test-id ant-color-picker-css-var acss-pbemrr"
       >
         <div
           class="ant-color-picker-color-block"
@@ -9844,7 +9844,7 @@ exports[`renders components/color-picker/demo/style-class.tsx extend context cor
         </div>
       </div>
       <div
-        class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-popover-css-var css-var-test-id css-var-test-id ant-color-picker acss-pbemrr css-var-test-id ant-color-picker-css-var ant-popover-placement-bottomLeft"
+        class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-popover-css-var css-var-test-id css-var-test-id ant-color-picker css-var-test-id ant-color-picker-css-var ant-popover-placement-bottomLeft"
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; border: 1px solid rgb(114, 46, 209);"
       >
         <div

--- a/components/color-picker/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo.test.tsx.snap
@@ -552,7 +552,7 @@ exports[`renders components/color-picker/demo/style-class.tsx correctly 1`] = `
       class="ant-flex css-var-test-id ant-flex-gap-small"
     >
       <div
-        class="ant-color-picker-trigger acss-pbemrr css-var-test-id ant-color-picker-css-var"
+        class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var acss-pbemrr"
       >
         <div
           class="ant-color-picker-color-block"
@@ -572,7 +572,7 @@ exports[`renders components/color-picker/demo/style-class.tsx correctly 1`] = `
       class="ant-flex css-var-test-id ant-flex-gap-small"
     >
       <div
-        class="ant-color-picker-trigger ant-color-picker-lg acss-pbemrr css-var-test-id ant-color-picker-css-var"
+        class="ant-color-picker-trigger ant-color-picker-lg css-var-test-id ant-color-picker-css-var acss-pbemrr"
       >
         <div
           class="ant-color-picker-color-block"

--- a/components/color-picker/components/ColorClear.tsx
+++ b/components/color-picker/components/ColorClear.tsx
@@ -8,9 +8,11 @@ interface ColorClearProps {
   prefixCls: string;
   value?: AggregationColor;
   onChange?: (value: AggregationColor) => void;
+  className?: string;
+  style?: React.CSSProperties;
 }
 
-const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, onChange }) => {
+const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, onChange, className, style }) => {
   const handleClick = () => {
     if (onChange && value && !value.cleared) {
       const hsba = value.toHsb();
@@ -21,7 +23,13 @@ const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, onChange }) => {
       onChange(genColor);
     }
   };
-  return <div className={`${prefixCls}-clear`} onClick={handleClick} />;
+  return (
+    <div
+      className={`${prefixCls}-clear${className ? ` ${className}` : ''}`}
+      style={style}
+      onClick={handleClick}
+    />
+  );
 };
 
 export default ColorClear;

--- a/components/color-picker/components/ColorClear.tsx
+++ b/components/color-picker/components/ColorClear.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import React from 'react';
+import clsx from 'clsx';
 
 import type { AggregationColor } from '../color';
 import { generateColor } from '../util';
@@ -13,7 +14,7 @@ interface ColorClearProps {
 }
 
 const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, onChange, className, style }) => {
-  const handleClick = () => {
+  const onClick = () => {
     if (onChange && value && !value.cleared) {
       const hsba = value.toHsb();
       hsba.a = 0;
@@ -23,13 +24,7 @@ const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, onChange, className
       onChange(genColor);
     }
   };
-  return (
-    <div
-      className={`${prefixCls}-clear${className ? ` ${className}` : ''}`}
-      style={style}
-      onClick={handleClick}
-    />
-  );
+  return <div className={clsx(`${prefixCls}-clear`, className)} style={style} onClick={onClick} />;
 };
 
 export default ColorClear;

--- a/components/color-picker/components/ColorTrigger.tsx
+++ b/components/color-picker/components/ColorTrigger.tsx
@@ -25,8 +25,8 @@ export interface ColorTriggerProps {
   showText?: ColorPickerProps['showText'];
   className?: string;
   style?: CSSProperties;
-  classNames?: ColorPickerSemanticClassNames;
-  styles?: ColorPickerSemanticStyles;
+  classNames: ColorPickerSemanticClassNames;
+  styles: ColorPickerSemanticStyles;
   onClick?: MouseEventHandler<HTMLDivElement>;
   onMouseEnter?: MouseEventHandler<HTMLDivElement>;
   onMouseLeave?: MouseEventHandler<HTMLDivElement>;
@@ -42,8 +42,8 @@ const ColorTrigger = forwardRef<HTMLDivElement, ColorTriggerProps>((props, ref) 
     format,
     className,
     style,
-    classNames = {},
-    styles = {},
+    classNames,
+    styles,
     showText,
     activeIndex,
     ...rest

--- a/components/color-picker/components/ColorTrigger.tsx
+++ b/components/color-picker/components/ColorTrigger.tsx
@@ -7,7 +7,12 @@ import { clsx } from 'clsx';
 
 import { useLocale } from '../../locale';
 import type { AggregationColor } from '../color';
-import type { ColorFormatType, ColorPickerProps } from '../interface';
+import type {
+  ColorFormatType,
+  ColorPickerProps,
+  ColorPickerSemanticClassNames,
+  ColorPickerSemanticStyles,
+} from '../interface';
 import { getColorAlpha } from '../util';
 import ColorClear from './ColorClear';
 
@@ -20,6 +25,8 @@ export interface ColorTriggerProps {
   showText?: ColorPickerProps['showText'];
   className?: string;
   style?: CSSProperties;
+  classNames?: ColorPickerSemanticClassNames;
+  styles?: ColorPickerSemanticStyles;
   onClick?: MouseEventHandler<HTMLDivElement>;
   onMouseEnter?: MouseEventHandler<HTMLDivElement>;
   onMouseLeave?: MouseEventHandler<HTMLDivElement>;
@@ -27,8 +34,20 @@ export interface ColorTriggerProps {
 }
 
 const ColorTrigger = forwardRef<HTMLDivElement, ColorTriggerProps>((props, ref) => {
-  const { color, prefixCls, open, disabled, format, className, showText, activeIndex, ...rest } =
-    props;
+  const {
+    color,
+    prefixCls,
+    open,
+    disabled,
+    format,
+    className,
+    style,
+    classNames = {},
+    styles = {},
+    showText,
+    activeIndex,
+    ...rest
+  } = props;
 
   const colorTriggerPrefixCls = `${prefixCls}-trigger`;
   const colorTextPrefixCls = `${colorTriggerPrefixCls}-text`;
@@ -85,9 +104,16 @@ const ColorTrigger = forwardRef<HTMLDivElement, ColorTriggerProps>((props, ref) 
   const containerNode = useMemo<React.ReactNode>(
     () =>
       color.cleared ? (
-        <ColorClear prefixCls={prefixCls} />
+        <ColorClear prefixCls={prefixCls} className={classNames.body} style={styles.body} />
       ) : (
-        <ColorBlock prefixCls={prefixCls} color={color.toCssString()} />
+        <ColorBlock
+          prefixCls={prefixCls}
+          color={color.toCssString()}
+          className={classNames.body}
+          innerClassName={classNames.content}
+          style={styles.body}
+          innerStyle={styles.content}
+        />
       ),
     [color, prefixCls],
   );
@@ -95,14 +121,25 @@ const ColorTrigger = forwardRef<HTMLDivElement, ColorTriggerProps>((props, ref) 
   return (
     <div
       ref={ref}
-      className={clsx(colorTriggerPrefixCls, className, {
+      className={clsx(colorTriggerPrefixCls, className, classNames.root, {
         [`${colorTriggerPrefixCls}-active`]: open,
         [`${colorTriggerPrefixCls}-disabled`]: disabled,
       })}
+      style={{
+        ...styles.root,
+        ...style,
+      }}
       {...pickAttrs(rest)}
     >
       {containerNode}
-      {showText && <div className={colorTextPrefixCls}>{desc}</div>}
+      {showText && (
+        <div
+          className={clsx(colorTextPrefixCls, classNames.description)}
+          style={styles.description}
+        >
+          {desc}
+        </div>
+      )}
     </div>
   );
 });

--- a/components/color-picker/components/ColorTrigger.tsx
+++ b/components/color-picker/components/ColorTrigger.tsx
@@ -115,7 +115,7 @@ const ColorTrigger = forwardRef<HTMLDivElement, ColorTriggerProps>((props, ref) 
           innerStyle={styles.content}
         />
       ),
-    [color, prefixCls],
+    [color, prefixCls, classNames.body, classNames.content, styles.body, styles.content],
   );
 
   return (

--- a/components/color-picker/demo/_semantic.tsx
+++ b/components/color-picker/demo/_semantic.tsx
@@ -1,17 +1,23 @@
 import React from 'react';
 import type { ColorPickerProps } from 'antd';
-import { ColorPicker } from 'antd';
+import { ColorPicker, Flex } from 'antd';
 
-import SemanticPreview from '../../../.dumi/theme/common/SemanticPreview';
 import useLocale from '../../../.dumi/hooks/useLocale';
+import SemanticPreview from '../../../.dumi/theme/common/SemanticPreview';
 
 const locales = {
   cn: {
     root: '触发器容器，包含边框样式、过渡动画、尺寸控制等样式，显示颜色块和文本内容',
+    body: '色块容器，包含底色、边框等样式',
+    content: '色块颜色元素，包含实际选择的颜色样式',
+    description: '描述文本内容，包含字体样式、颜色等样式',
     'popup.root': '弹出面板根容器，包含背景色、阴影效果、色彩选择面板、滑块控制和预设颜色等样式',
   },
   en: {
     root: 'Trigger container with border styles, transition animations, size controls, displaying color block and text content',
+    body: 'Color block container with background color, border styles',
+    content: 'Color block element with actual selected color styles',
+    description: 'Description text content with font styles and color',
     'popup.root':
       'Popup panel root container with background color, shadow effects, color selection panel, slider controls and preset colors',
   },
@@ -20,10 +26,11 @@ const locales = {
 const Block: React.FC<Readonly<ColorPickerProps>> = (props) => {
   const divRef = React.useRef<HTMLDivElement>(null);
   return (
-    <div ref={divRef} style={{ height: 300 }}>
+    <Flex ref={divRef} style={{ height: 300 }} align="flex-start" gap="small">
       <ColorPicker
         defaultValue="#1677ff"
         open
+        showText
         {...props}
         getPopupContainer={() => divRef!.current!}
         styles={{
@@ -32,7 +39,8 @@ const Block: React.FC<Readonly<ColorPickerProps>> = (props) => {
           },
         }}
       />
-    </div>
+      <ColorPicker open={false} allowClear {...props} />
+    </Flex>
   );
 };
 
@@ -43,6 +51,9 @@ const App: React.FC = () => {
       componentName="ColorPicker"
       semantics={[
         { name: 'root', desc: locale.root },
+        { name: 'body', desc: locale.body },
+        { name: 'content', desc: locale.content },
+        { name: 'description', desc: locale.description },
         { name: 'popup.root', desc: locale['popup.root'] },
       ]}
     >

--- a/components/color-picker/interface.ts
+++ b/components/color-picker/interface.ts
@@ -59,10 +59,16 @@ export type ColorPickerSemanticName = keyof ColorPickerSemanticClassNames &
 
 export type ColorPickerSemanticClassNames = {
   root?: string;
+  body?: string;
+  content?: string;
+  description?: string;
 };
 
 export type ColorPickerSemanticStyles = {
   root?: React.CSSProperties;
+  body?: React.CSSProperties;
+  content?: React.CSSProperties;
+  description?: React.CSSProperties;
 };
 
 export type ColorPickerClassNamesType = SemanticClassNamesType<

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@rc-component/cascader": "~1.11.0",
     "@rc-component/checkbox": "~1.0.1",
     "@rc-component/collapse": "~1.2.0",
-    "@rc-component/color-picker": "~3.0.3",
+    "@rc-component/color-picker": "~3.1.0",
     "@rc-component/dialog": "~1.8.0",
     "@rc-component/drawer": "~1.4.0",
     "@rc-component/dropdown": "~1.0.2",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     ColorPicker picker block support semantic structure and fix `root` semantic uncorrectly applied to the popup element.        |
| 🇨🇳 Chinese |    ColorPicker 选择块支持语义化结构，并且修复 `root` 语义化错误的应用到弹出元素上的问题。       |
