### PR TITLE
refactor: replace `SuffixIcon` with `useSuffixIcon` in date-picker

### DIFF
--- a/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/components/date-picker/__tests__/DatePicker.test.tsx
@@ -491,10 +491,10 @@ describe('DatePicker', () => {
     expect(container.querySelector('.ant-picker-suffix')!.children.length).toBeTruthy();
 
     rerender(<DatePicker suffixIcon={false} />);
-    expect(container.querySelector('.ant-picker-suffix')!.children.length).toBeFalsy();
+    expect(container.querySelector('.ant-picker-suffix')).toBeFalsy();
 
     rerender(<DatePicker suffixIcon={null} />);
-    expect(container.querySelector('.ant-picker-suffix')!.children.length).toBeFalsy();
+    expect(container.querySelector('.ant-picker-suffix')).toBeFalsy();
 
     rerender(<DatePicker suffixIcon={'123'} />);
     expect(container.querySelector('.ant-picker-suffix')?.textContent).toBe('123');

--- a/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -85686,9 +85686,6 @@ exports[`renders components/date-picker/demo/suffixIcon-debug.tsx extend context
           size="12"
           value=""
         />
-        <span
-          class="ant-picker-suffix"
-        />
       </div>
     </div>
     <div
@@ -86899,9 +86896,6 @@ exports[`renders components/date-picker/demo/suffixIcon-debug.tsx extend context
           placeholder="Select date"
           size="12"
           value=""
-        />
-        <span
-          class="ant-picker-suffix"
         />
       </div>
     </div>

--- a/components/date-picker/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo.test.tsx.snap
@@ -7564,9 +7564,6 @@ exports[`renders components/date-picker/demo/suffixIcon-debug.tsx correctly 1`] 
           size="12"
           value=""
         />
-        <span
-          class="ant-picker-suffix"
-        />
       </div>
     </div>
   </div>
@@ -7627,9 +7624,6 @@ exports[`renders components/date-picker/demo/suffixIcon-debug.tsx correctly 1`] 
           placeholder="Select date"
           size="12"
           value=""
-        />
-        <span
-          class="ant-picker-suffix"
         />
       </div>
     </div>

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -26,7 +26,7 @@ import useStyle from '../style';
 import { getRangePlaceholder, useIcons } from '../util';
 import { TIME } from './constant';
 import type { PickerLocale, RangePickerProps } from './interface';
-import SuffixIcon from './SuffixIcon';
+import useSuffixIcon from './useSuffixIcon';
 import useComponents from './useComponents';
 
 const generateRangePicker = <DateType extends AnyObject = AnyObject>(
@@ -113,7 +113,7 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
     // ===================== FormItemInput =====================
     const formItemContext = useContext(FormItemInputContext);
     const { hasFeedback, status: contextStatus, feedbackIcon } = formItemContext;
-    const mergedSuffixIcon = <SuffixIcon {...{ picker, hasFeedback, feedbackIcon, suffixIcon }} />;
+    const mergedSuffixIcon = useSuffixIcon({ picker, hasFeedback, feedbackIcon, suffixIcon });
     useImperativeHandle(ref, () => innerRef.current!);
 
     const [contextLocale] = useLocale('Calendar', enUS);

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -42,7 +42,7 @@ import type {
   PickerProps,
   PickerPropsWithMultiple,
 } from './interface';
-import SuffixIcon from './SuffixIcon';
+import useSuffixIcon from './useSuffixIcon';
 import useComponents from './useComponents';
 
 const generatePicker = <DateType extends AnyObject = AnyObject>(
@@ -178,9 +178,12 @@ const generatePicker = <DateType extends AnyObject = AnyObject>(
       const formItemContext = useContext(FormItemInputContext);
       const { hasFeedback, status: contextStatus, feedbackIcon } = formItemContext;
 
-      const mergedSuffixIcon = (
-        <SuffixIcon {...{ picker: mergedPicker, hasFeedback, feedbackIcon, suffixIcon }} />
-      );
+      const mergedSuffixIcon = useSuffixIcon({
+        picker: mergedPicker,
+        hasFeedback,
+        feedbackIcon,
+        suffixIcon,
+      });
       const [contextLocale] = useLocale('DatePicker', enUS);
 
       const locale = merge(contextLocale, (props.locale || {}) as PickerLocale);

--- a/components/date-picker/generatePicker/useSuffixIcon.tsx
+++ b/components/date-picker/generatePicker/useSuffixIcon.tsx
@@ -3,21 +3,16 @@ import CalendarOutlined from '@ant-design/icons/CalendarOutlined';
 import ClockCircleOutlined from '@ant-design/icons/ClockCircleOutlined';
 import type { PickerMode } from '@rc-component/picker/interface';
 
-import { TIME } from '../generatePicker/constant';
+import { TIME } from './constant';
 
-interface SuffixIconProps {
+interface UseSuffixIconProps {
   picker?: PickerMode;
   hasFeedback?: boolean;
   feedbackIcon?: React.ReactNode;
   suffixIcon?: React.ReactNode;
 }
 
-const SuffixIcon: React.FC<SuffixIconProps> = ({
-  picker,
-  hasFeedback,
-  feedbackIcon,
-  suffixIcon,
-}) => {
+const useSuffixIcon = ({ picker, hasFeedback, feedbackIcon, suffixIcon }: UseSuffixIconProps) => {
   if (suffixIcon === null || suffixIcon === false) {
     return null;
   }
@@ -33,4 +28,4 @@ const SuffixIcon: React.FC<SuffixIconProps> = ({
   return suffixIcon;
 };
 
-export default SuffixIcon;
+export default useSuffixIcon;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

fix #56633 #56060 

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: `DatePicker` won't render suffix dom when `suffixIcon` set to null |
| 🇨🇳 Chinese | fix: 设置`suffixIcon`为null后，`DatePicker`不会渲染相关dom|
