### PR TITLE
fix: import a single DownOutlined icon from antd-icons

### DIFF
--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DownOutlined } from '@ant-design/icons';
+import { DownOutlined } from '@ant-design/icons/DownOutlined';
 import { toArray } from '@rc-component/util';
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
 import { clsx } from 'clsx';

--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DownOutlined } from '@ant-design/icons/DownOutlined';
+import DownOutlined from '@ant-design/icons/DownOutlined';
 import { toArray } from '@rc-component/util';
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
 import { clsx } from 'clsx';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

https://github.com/ant-design/ant-design/pull/56250


### 💡 Background and Solution

DownOutlined 图标的导入方式在这个 pr (https://github.com/ant-design/ant-design/pull/56250) 中被修改了，导致 dropdownIcon 不传时报错，此时 antd-icons 可能还未加载（由于 webpack 配置了 externals，import {} from 'antd-icons' 这样的整个导入会被替换）
单独导入的方法 '@ant-design/icons/DownOutlined' 可以确保 antd 独立打包单个图标，而非整个包，更不容易报错

<img width="1885" height="380" alt="image" src="https://github.com/user-attachments/assets/58dbba1b-0a15-4fa2-bf56-aed7f2d8a6da" />


<img width="3265" height="271" alt="image" src="https://github.com/user-attachments/assets/a69bcf66-02ea-4137-9c5c-c2b3c3fcf3bb" />
<img width="3291" height="263" alt="image" src="https://github.com/user-attachments/assets/4b2dcd5f-e094-4c7a-b0d3-b5dd2f916843" />



### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |fix(Breadcrumb): Optimize the import method of the default dropdown icon in Breadcrumb.|
| 🇨🇳 Chinese |fix(Breadcrumb): 优化 Breadcrumb 中默认 dropdownIcon 图标的导入方式|
