### PR TITLE
fix: Slider's tooltip displays unexpectedly when overflowing the container

### DIFF
--- a/components/slider/SliderTooltip.tsx
+++ b/components/slider/SliderTooltip.tsx
@@ -33,8 +33,6 @@ const SliderTooltip = React.forwardRef<SliderRef, SliderTooltipProps>((props, re
     });
   }
 
-  console.log('kiner: mergedOpen', mergedOpen, open, draggingDelete);
-
   // Check if tooltip overflows container and adjust placement
   const checkAndAdjustPlacement = React.useCallback(() => {
     const tooltipRef = innerRef.current;

--- a/components/slider/SliderTooltip.tsx
+++ b/components/slider/SliderTooltip.tsx
@@ -35,7 +35,6 @@ const SliderTooltip = React.forwardRef<SliderRef, SliderTooltipProps>((props, re
 
   // 检测 tooltip 是否超出容器并调整 placement
   const checkAndAdjustPlacement = React.useCallback(() => {
-    console.log('checkAndAdjustPlacement');
     if (!mergedOpen) {
       return;
     }

--- a/components/slider/SliderTooltip.tsx
+++ b/components/slider/SliderTooltip.tsx
@@ -33,7 +33,7 @@ const SliderTooltip = React.forwardRef<SliderRef, SliderTooltipProps>((props, re
     });
   }
 
-  // 检测 tooltip 是否超出容器并调整 placement
+  // Check if tooltip overflows container and adjust placement
   const checkAndAdjustPlacement = React.useCallback(() => {
     if (!mergedOpen) {
       return;
@@ -51,51 +51,51 @@ const SliderTooltip = React.forwardRef<SliderRef, SliderTooltipProps>((props, re
       return;
     }
 
-    // 获取容器
+    // Get container
     const container = getPopupContainer
       ? getPopupContainer(triggerElement)
       : document.body;
 
-    // 获取容器边界
+    // Get container boundaries
     const containerRect = container === document.body
       ? { left: 0, top: 0, right: window.innerWidth, bottom: window.innerHeight }
       : container.getBoundingClientRect();
 
-    // 获取 tooltip 的位置
+    // Get tooltip position
     const popupRect = popupElement.getBoundingClientRect();
 
-    // 获取原始 placement
+    // Get original placement
     const originalPlacement = placement || 'top';
     
-    // 检查 tooltip 是否超出容器
+    // Check if tooltip overflows container
     const isOverflowLeft = popupRect.left < containerRect.left;
     const isOverflowRight = popupRect.right > containerRect.right;
     const isOverflowTop = popupRect.top < containerRect.top;
     const isOverflowBottom = popupRect.bottom > containerRect.bottom;
 
-    // 如果原始 placement 是 top 或 bottom（水平模式），检查左右溢出
+    // If original placement is top or bottom (horizontal mode), check horizontal overflow
     if (originalPlacement === 'top' || originalPlacement === 'bottom') {
       if (isOverflowLeft) {
-        // 左侧超出，改为右侧展示
+        // Left overflow, change to right placement
         setAdjustedPlacement('right');
       } else if (isOverflowRight) {
-        // 右侧超出，改为左侧展示
+        // Right overflow, change to left placement
         setAdjustedPlacement('left');
       } else {
-        // 没有左右溢出，恢复原始 placement
+        // No horizontal overflow, restore original placement
         setAdjustedPlacement(placement);
       }
     }
-    // 如果原始 placement 是 left 或 right（垂直模式），检查上下溢出
+    // If original placement is left or right (vertical mode), check vertical overflow
     else if (originalPlacement === 'left' || originalPlacement === 'right') {
       if (isOverflowTop) {
-        // 顶部超出，改为底部展示
+        // Top overflow, change to bottom placement
         setAdjustedPlacement('bottom');
       } else if (isOverflowBottom) {
-        // 底部超出，改为顶部展示
+        // Bottom overflow, change to top placement
         setAdjustedPlacement('top');
       } else {
-        // 没有上下溢出，恢复原始 placement
+        // No vertical overflow, restore original placement
         setAdjustedPlacement(placement);
       }
     }
@@ -113,7 +113,7 @@ const SliderTooltip = React.forwardRef<SliderRef, SliderTooltipProps>((props, re
   const scheduleAdjustPlacement = React.useCallback(() => {
     cancelAdjustPlacement();
     adjustPlacementRef.current = raf(() => {
-      // 再次使用 raf 确保 tooltip 已经定位
+      // Use raf again to ensure tooltip is positioned
       adjustPlacementRef.current = raf(() => {
         checkAndAdjustPlacement();
         adjustPlacementRef.current = null;
@@ -132,12 +132,12 @@ const SliderTooltip = React.forwardRef<SliderRef, SliderTooltipProps>((props, re
     } else {
       cancelKeepAlign();
       cancelAdjustPlacement();
-      // 关闭时重置 placement
+      // Reset placement when closed
       setAdjustedPlacement(placement);
     }
   }, [mergedOpen, props.title, value, placement, scheduleAdjustPlacement, cancelAdjustPlacement]);
 
-  // 监听 tooltip 位置变化
+  // Listen to tooltip position changes
   React.useEffect(() => {
     if (!mergedOpen) {
       return;

--- a/components/slider/SliderTooltip.tsx
+++ b/components/slider/SliderTooltip.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import raf from '@rc-component/util/lib/raf';
 import { composeRef } from '@rc-component/util/lib/ref';
 import type { SliderRef } from '@rc-component/slider/lib/Slider';
 
-import type { TooltipProps } from '../tooltip';
+import type { TooltipProps, TooltipPlacement } from '../tooltip';
 import Tooltip from '../tooltip';
 
 export type SliderTooltipProps = TooltipProps & {
@@ -13,8 +13,9 @@ export type SliderTooltipProps = TooltipProps & {
 };
 
 const SliderTooltip = React.forwardRef<SliderRef, SliderTooltipProps>((props, ref) => {
-  const { open, draggingDelete, value } = props;
+  const { open, draggingDelete, value, placement, getPopupContainer } = props;
   const innerRef = useRef<any>(null);
+  const [adjustedPlacement, setAdjustedPlacement] = useState<TooltipPlacement | undefined>(placement);
 
   const mergedOpen = open && !draggingDelete;
 
@@ -32,17 +33,131 @@ const SliderTooltip = React.forwardRef<SliderRef, SliderTooltipProps>((props, re
     });
   }
 
+  // 检测 tooltip 是否超出容器并调整 placement
+  const checkAndAdjustPlacement = React.useCallback(() => {
+    console.log('checkAndAdjustPlacement');
+    if (!mergedOpen) {
+      return;
+    }
+
+    const tooltipRef = innerRef.current;
+    if (!tooltipRef) {
+      return;
+    }
+
+    const popupElement = tooltipRef.popupElement;
+    const triggerElement = tooltipRef.nativeElement;
+
+    if (!popupElement || !triggerElement) {
+      return;
+    }
+
+    // 获取容器
+    const container = getPopupContainer
+      ? getPopupContainer(triggerElement)
+      : document.body;
+
+    // 获取容器边界
+    const containerRect = container === document.body
+      ? { left: 0, top: 0, right: window.innerWidth, bottom: window.innerHeight }
+      : container.getBoundingClientRect();
+
+    // 获取 tooltip 的位置
+    const popupRect = popupElement.getBoundingClientRect();
+
+    // 获取原始 placement
+    const originalPlacement = placement || 'top';
+    
+    // 检查 tooltip 是否超出容器
+    const isOverflowLeft = popupRect.left < containerRect.left;
+    const isOverflowRight = popupRect.right > containerRect.right;
+    const isOverflowTop = popupRect.top < containerRect.top;
+    const isOverflowBottom = popupRect.bottom > containerRect.bottom;
+
+    // 如果原始 placement 是 top 或 bottom（水平模式），检查左右溢出
+    if (originalPlacement === 'top' || originalPlacement === 'bottom') {
+      if (isOverflowLeft) {
+        // 左侧超出，改为右侧展示
+        setAdjustedPlacement('right');
+      } else if (isOverflowRight) {
+        // 右侧超出，改为左侧展示
+        setAdjustedPlacement('left');
+      } else {
+        // 没有左右溢出，恢复原始 placement
+        setAdjustedPlacement(placement);
+      }
+    }
+    // 如果原始 placement 是 left 或 right（垂直模式），检查上下溢出
+    else if (originalPlacement === 'left' || originalPlacement === 'right') {
+      if (isOverflowTop) {
+        // 顶部超出，改为底部展示
+        setAdjustedPlacement('bottom');
+      } else if (isOverflowBottom) {
+        // 底部超出，改为顶部展示
+        setAdjustedPlacement('top');
+      } else {
+        // 没有上下溢出，恢复原始 placement
+        setAdjustedPlacement(placement);
+      }
+    }
+  }, [mergedOpen, placement, getPopupContainer]);
+
+  const adjustPlacementRef = useRef<number | null>(null);
+
+  const cancelAdjustPlacement = React.useCallback(() => {
+    if (adjustPlacementRef.current !== null) {
+      raf.cancel(adjustPlacementRef.current);
+      adjustPlacementRef.current = null;
+    }
+  }, []);
+
+  const scheduleAdjustPlacement = React.useCallback(() => {
+    cancelAdjustPlacement();
+    adjustPlacementRef.current = raf(() => {
+      // 再次使用 raf 确保 tooltip 已经定位
+      adjustPlacementRef.current = raf(() => {
+        checkAndAdjustPlacement();
+        adjustPlacementRef.current = null;
+      });
+    });
+  }, [cancelAdjustPlacement, checkAndAdjustPlacement]);
+
   React.useEffect(() => {
     if (mergedOpen) {
       keepAlign();
+      scheduleAdjustPlacement();
+      return () => {
+        cancelKeepAlign();
+        cancelAdjustPlacement();
+      };
     } else {
       cancelKeepAlign();
+      cancelAdjustPlacement();
+      // 关闭时重置 placement
+      setAdjustedPlacement(placement);
+    }
+  }, [mergedOpen, props.title, value, placement, scheduleAdjustPlacement, cancelAdjustPlacement]);
+
+  // 监听 tooltip 位置变化
+  React.useEffect(() => {
+    if (!mergedOpen) {
+      return;
     }
 
-    return cancelKeepAlign;
-  }, [mergedOpen, props.title, value]);
+    const handleResize = () => {
+      scheduleAdjustPlacement();
+    };
 
-  return <Tooltip ref={composeRef(innerRef, ref)} {...props} open={mergedOpen} />;
+    window.addEventListener('resize', handleResize);
+    window.addEventListener('scroll', handleResize, true);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('scroll', handleResize, true);
+    };
+  }, [mergedOpen, scheduleAdjustPlacement]);
+
+  return <Tooltip ref={composeRef(innerRef, ref)} {...props} open={mergedOpen} placement={adjustedPlacement} />;
 });
 
 if (process.env.NODE_ENV !== 'production') {

--- a/components/slider/SliderTooltip.tsx
+++ b/components/slider/SliderTooltip.tsx
@@ -33,12 +33,10 @@ const SliderTooltip = React.forwardRef<SliderRef, SliderTooltipProps>((props, re
     });
   }
 
+  console.log('kiner: mergedOpen', mergedOpen, open, draggingDelete);
+
   // Check if tooltip overflows container and adjust placement
   const checkAndAdjustPlacement = React.useCallback(() => {
-    if (!mergedOpen) {
-      return;
-    }
-
     const tooltipRef = innerRef.current;
 
     const popupElement = tooltipRef.popupElement;

--- a/components/slider/SliderTooltip.tsx
+++ b/components/slider/SliderTooltip.tsx
@@ -4,7 +4,7 @@ import raf from '@rc-component/util/lib/raf';
 import { composeRef } from '@rc-component/util/lib/ref';
 import type { SliderRef } from '@rc-component/slider/lib/Slider';
 
-import type { TooltipProps, TooltipPlacement } from '../tooltip';
+import type { TooltipPlacement, TooltipProps } from '../tooltip';
 import Tooltip from '../tooltip';
 
 export type SliderTooltipProps = TooltipProps & {

--- a/components/slider/SliderTooltip.tsx
+++ b/components/slider/SliderTooltip.tsx
@@ -40,9 +40,6 @@ const SliderTooltip = React.forwardRef<SliderRef, SliderTooltipProps>((props, re
     }
 
     const tooltipRef = innerRef.current;
-    if (!tooltipRef) {
-      return;
-    }
 
     const popupElement = tooltipRef.popupElement;
     const triggerElement = tooltipRef.nativeElement;

--- a/components/slider/__tests__/index.test.tsx
+++ b/components/slider/__tests__/index.test.tsx
@@ -17,6 +17,36 @@ jest.mock('../../tooltip', () => {
   const ReactReal: typeof React = jest.requireActual('react');
   const Tooltip = jest.requireActual('../../tooltip');
   const TooltipComponent = Tooltip.default;
+  
+  // Create mock default element factory inside mock
+  const createMockElement = (): HTMLElement => ({
+    getBoundingClientRect: jest.fn(() => ({
+      left: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      toJSON: jest.fn(),
+    })),
+  } as any);
+  
+  const createMockDivElement = (): HTMLDivElement => ({
+    getBoundingClientRect: jest.fn(() => ({
+      left: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      toJSON: jest.fn(),
+    })),
+  } as any);
+  
   return ReactReal.forwardRef<TooltipRef, TooltipProps>((props, ref) => {
     (global as any).tooltipProps = props;
     const internalRef = ReactReal.useRef<TooltipRef>(null);
@@ -27,17 +57,17 @@ jest.mock('../../tooltip', () => {
         return {
           forceAlign: mockRef.forceAlign || jest.fn(),
           get nativeElement() {
-            return mockRef.nativeElement || document.createElement('div');
+            return mockRef.nativeElement || createMockElement();
           },
           get popupElement() {
-            return mockRef.popupElement || document.createElement('div');
+            return mockRef.popupElement || createMockDivElement();
           },
         } as TooltipRef;
       }
       return internalRef.current || {
         forceAlign: jest.fn(),
-        nativeElement: document.createElement('div'),
-        popupElement: document.createElement('div'),
+        nativeElement: createMockElement(),
+        popupElement: createMockDivElement(),
       } as TooltipRef;
     });
     

--- a/components/slider/__tests__/index.test.tsx
+++ b/components/slider/__tests__/index.test.tsx
@@ -793,4 +793,17 @@ describe('Slider', () => {
       expect(tooltipProps().open).toBe(false);
     });
   });
+  // 覆盖 components/slider/SliderTooltip.tsx 39 行的用例
+  // const mergedOpen = open && !draggingDelete;
+  // ...
+  //  if (!mergedOpen) {
+  //   return;
+  // }
+  it('should not display tooltip when mergedOpen is false', async () => {
+    render(<SliderTooltip title="30" open={false} placement="top" />);
+    await waitFakeTimer();
+    // When mergedOpen is false, tooltip should not be displayed
+    expect(tooltipProps().open).toBe(false);
+  });
+  // 覆盖 components/slider/SliderTooltip.tsx 44 行的用例
 });

--- a/components/slider/__tests__/index.test.tsx
+++ b/components/slider/__tests__/index.test.tsx
@@ -793,17 +793,4 @@ describe('Slider', () => {
       expect(tooltipProps().open).toBe(false);
     });
   });
-  // 覆盖 components/slider/SliderTooltip.tsx 39 行的用例
-  // const mergedOpen = open && !draggingDelete;
-  // ...
-  //  if (!mergedOpen) {
-  //   return;
-  // }
-  it('should not display tooltip when mergedOpen is false', async () => {
-    render(<SliderTooltip title="30" open={false} placement="top" />);
-    await waitFakeTimer();
-    // When mergedOpen is false, tooltip should not be displayed
-    expect(tooltipProps().open).toBe(false);
-  });
-  // 覆盖 components/slider/SliderTooltip.tsx 44 行的用例
 });

--- a/components/slider/__tests__/index.test.tsx
+++ b/components/slider/__tests__/index.test.tsx
@@ -232,7 +232,7 @@ describe('Slider', () => {
     let mockContainer: HTMLElement;
 
     beforeEach(() => {
-      // 创建 mock 元素
+      // Create mock elements
       mockPopupElement = document.createElement('div');
       mockTriggerElement = document.createElement('div');
       mockContainer = document.createElement('div');
@@ -275,7 +275,7 @@ describe('Slider', () => {
         toJSON: jest.fn(),
       }));
 
-      // Mock window.innerWidth 和 innerHeight
+      // Mock window.innerWidth and innerHeight
       Object.defineProperty(window, 'innerWidth', {
         writable: true,
         configurable: true,
@@ -299,8 +299,8 @@ describe('Slider', () => {
       const { container } = render(<Slider defaultValue={30} tooltip={{ open: false }} />);
       fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
       await waitFakeTimer();
-      // 当 open 为 false 时，mergedOpen 为 false，不应该执行检测逻辑
-      // 由于 tooltip 未打开，无法获取 tooltipProps
+      // When open is false, mergedOpen is false, should not execute detection logic
+      // Since tooltip is not open, cannot get tooltipProps
       expect(container.querySelector('.ant-slider-handle')).toBeTruthy();
     });
 
@@ -308,7 +308,7 @@ describe('Slider', () => {
       const ref = React.createRef<any>();
       render(<SliderTooltip title="30" open ref={ref} />);
       await waitFakeTimer();
-      // 组件应该正常渲染，不会崩溃
+      // Component should render normally without crashing
       expect(ref.current).toBeDefined();
     });
 
@@ -316,7 +316,7 @@ describe('Slider', () => {
       const { container } = render(<Slider defaultValue={30} tooltip={{ open: true }} />);
       fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
       await waitFakeTimer();
-      // 应该使用 document.body 作为容器
+      // Should use document.body as container
       expect(tooltipProps().placement).toBeDefined();
     });
 
@@ -337,7 +337,7 @@ describe('Slider', () => {
 
     describe('horizontal mode (placement: top/bottom)', () => {
       it('should adjust to right when tooltip overflows left with placement top', async () => {
-        // Mock 左侧溢出
+        // Mock left overflow
         mockPopupElement.getBoundingClientRect = jest.fn(() => ({
           left: -50,
           top: 100,
@@ -355,12 +355,12 @@ describe('Slider', () => {
         );
         fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
         await waitFakeTimer();
-        // 应该调整为 right
+        // Should adjust to right
         expect(tooltipProps().placement).toBe('right');
       });
 
       it('should adjust to left when tooltip overflows right with placement top', async () => {
-        // Mock 右侧溢出
+        // Mock right overflow
         mockPopupElement.getBoundingClientRect = jest.fn(() => ({
           left: 950,
           top: 100,
@@ -378,12 +378,12 @@ describe('Slider', () => {
         );
         fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
         await waitFakeTimer();
-        // 应该调整为 left
+        // Should adjust to left
         expect(tooltipProps().placement).toBe('left');
       });
 
       it('should keep original placement when no overflow with placement top', async () => {
-        // Mock 没有溢出
+        // Mock no overflow
         mockPopupElement.getBoundingClientRect = jest.fn(() => ({
           left: 100,
           top: 100,
@@ -401,12 +401,12 @@ describe('Slider', () => {
         );
         fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
         await waitFakeTimer();
-        // 应该保持原始 placement
+        // Should keep original placement
         expect(tooltipProps().placement).toBe('top');
       });
 
       it('should adjust to right when tooltip overflows left with placement bottom', async () => {
-        // Mock 左侧溢出
+        // Mock left overflow
         mockPopupElement.getBoundingClientRect = jest.fn(() => ({
           left: -50,
           top: 100,
@@ -424,12 +424,12 @@ describe('Slider', () => {
         );
         fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
         await waitFakeTimer();
-        // 应该调整为 right
+        // Should adjust to right
         expect(tooltipProps().placement).toBe('right');
       });
 
       it('should adjust to left when tooltip overflows right with placement bottom', async () => {
-        // Mock 右侧溢出
+        // Mock right overflow
         mockPopupElement.getBoundingClientRect = jest.fn(() => ({
           left: 950,
           top: 100,
@@ -447,12 +447,12 @@ describe('Slider', () => {
         );
         fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
         await waitFakeTimer();
-        // 应该调整为 left
+        // Should adjust to left
         expect(tooltipProps().placement).toBe('left');
       });
 
       it('should keep original placement when no overflow with placement bottom', async () => {
-        // Mock 没有溢出
+        // Mock no overflow
         mockPopupElement.getBoundingClientRect = jest.fn(() => ({
           left: 100,
           top: 100,
@@ -470,14 +470,14 @@ describe('Slider', () => {
         );
         fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
         await waitFakeTimer();
-        // 应该保持原始 placement
+        // Should keep original placement
         expect(tooltipProps().placement).toBe('bottom');
       });
     });
 
     describe('vertical mode (placement: left/right)', () => {
       it('should adjust to bottom when tooltip overflows top with placement left', async () => {
-        // Mock 顶部溢出
+        // Mock top overflow
         mockPopupElement.getBoundingClientRect = jest.fn(() => ({
           left: 100,
           top: -50,
@@ -495,12 +495,12 @@ describe('Slider', () => {
         );
         fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
         await waitFakeTimer();
-        // 应该调整为 bottom
+        // Should adjust to bottom
         expect(tooltipProps().placement).toBe('bottom');
       });
 
       it('should adjust to top when tooltip overflows bottom with placement left', async () => {
-        // Mock 底部溢出
+        // Mock bottom overflow
         mockPopupElement.getBoundingClientRect = jest.fn(() => ({
           left: 100,
           top: 950,
@@ -518,12 +518,12 @@ describe('Slider', () => {
         );
         fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
         await waitFakeTimer();
-        // 应该调整为 top
+        // Should adjust to top
         expect(tooltipProps().placement).toBe('top');
       });
 
       it('should keep original placement when no overflow with placement left', async () => {
-        // Mock 没有溢出
+        // Mock no overflow
         mockPopupElement.getBoundingClientRect = jest.fn(() => ({
           left: 100,
           top: 100,
@@ -541,12 +541,12 @@ describe('Slider', () => {
         );
         fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
         await waitFakeTimer();
-        // 应该保持原始 placement
+        // Should keep original placement
         expect(tooltipProps().placement).toBe('left');
       });
 
       it('should adjust to bottom when tooltip overflows top with placement right', async () => {
-        // Mock 顶部溢出
+        // Mock top overflow
         mockPopupElement.getBoundingClientRect = jest.fn(() => ({
           left: 100,
           top: -50,
@@ -564,12 +564,12 @@ describe('Slider', () => {
         );
         fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
         await waitFakeTimer();
-        // 应该调整为 bottom
+        // Should adjust to bottom
         expect(tooltipProps().placement).toBe('bottom');
       });
 
       it('should adjust to top when tooltip overflows bottom with placement right', async () => {
-        // Mock 底部溢出
+        // Mock bottom overflow
         mockPopupElement.getBoundingClientRect = jest.fn(() => ({
           left: 100,
           top: 950,
@@ -587,12 +587,12 @@ describe('Slider', () => {
         );
         fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
         await waitFakeTimer();
-        // 应该调整为 top
+        // Should adjust to top
         expect(tooltipProps().placement).toBe('top');
       });
 
       it('should keep original placement when no overflow with placement right', async () => {
-        // Mock 没有溢出
+        // Mock no overflow
         mockPopupElement.getBoundingClientRect = jest.fn(() => ({
           left: 100,
           top: 100,
@@ -610,7 +610,7 @@ describe('Slider', () => {
         );
         fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
         await waitFakeTimer();
-        // 应该保持原始 placement
+        // Should keep original placement
         expect(tooltipProps().placement).toBe('right');
       });
     });
@@ -622,10 +622,10 @@ describe('Slider', () => {
       fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
       await waitFakeTimer();
 
-      // 关闭 tooltip
+      // Close tooltip
       rerender(<Slider defaultValue={30} tooltip={{ open: false, placement: 'top' }} />);
       await waitFakeTimer();
-      // placement 应该被重置
+      // Placement should be reset
       expect(tooltipProps().placement).toBe('top');
     });
 
@@ -636,10 +636,10 @@ describe('Slider', () => {
       fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
       await waitFakeTimer();
 
-      // 改变 value
+      // Change value
       rerender(<Slider value={100} tooltip={{ open: true, placement: 'top' }} />);
       await waitFakeTimer();
-      // 应该重新检测并调整
+      // Should re-detect and adjust
       expect(tooltipProps().placement).toBeDefined();
     });
 
@@ -650,7 +650,7 @@ describe('Slider', () => {
       fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
       await waitFakeTimer();
 
-      // 改变 title（通过 formatter）
+      // Change title (via formatter)
       rerender(
         <Slider
           defaultValue={30}
@@ -658,7 +658,7 @@ describe('Slider', () => {
         />,
       );
       await waitFakeTimer();
-      // 应该重新检测并调整
+      // Should re-detect and adjust
       expect(tooltipProps().placement).toBeDefined();
     });
 
@@ -669,13 +669,13 @@ describe('Slider', () => {
       fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
       await waitFakeTimer();
 
-      // 触发 resize 事件
+      // Trigger resize event
       act(() => {
         window.dispatchEvent(new Event('resize'));
         jest.runAllTimers();
       });
       await waitFakeTimer();
-      // 应该重新检测并调整
+      // Should re-detect and adjust
       expect(tooltipProps().placement).toBeDefined();
     });
 
@@ -686,13 +686,13 @@ describe('Slider', () => {
       fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
       await waitFakeTimer();
 
-      // 触发 scroll 事件
+      // Trigger scroll event
       act(() => {
         window.dispatchEvent(new Event('scroll'));
         jest.runAllTimers();
       });
       await waitFakeTimer();
-      // 应该重新检测并调整
+      // Should re-detect and adjust
       expect(tooltipProps().placement).toBeDefined();
     });
 
@@ -700,14 +700,14 @@ describe('Slider', () => {
       const { container } = render(<Slider defaultValue={30} tooltip={{ open: true }} />);
       fireEvent.mouseEnter(container.querySelector('.ant-slider-handle')!);
       await waitFakeTimer();
-      // 应该使用默认的 top
+      // Should use default top
       expect(tooltipProps().placement).toBeDefined();
     });
 
     it('should handle draggingDelete prop', async () => {
       render(<SliderTooltip title="30" open draggingDelete placement="top" />);
       await waitFakeTimer();
-      // 当 draggingDelete 为 true 时，tooltip 不应该显示
+      // When draggingDelete is true, tooltip should not be displayed
       expect(tooltipProps().open).toBe(false);
     });
   });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [X] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Auto-adjust Slider's tooltip placement when it overflows the container to prevent visual issues.


https://github.com/user-attachments/assets/62d66a99-76ad-4dc1-a8b9-3e570ac267b3


https://github.com/user-attachments/assets/5ecf20f9-b9ad-40b1-bce4-38efb6f2b5d4



> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

fix #56632

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Auto-adjust Slider's tooltip placement when it overflows the container to prevent visual issues. |
| 🇨🇳 Chinese | 当滑块的提示框超出容器范围时，自动调整其位置，以避免出现视觉异常问题。 |
