### PR TITLE
fix: placeholder not hidding issue in select cn

### DIFF
--- a/components/select/__tests__/index.test.tsx
+++ b/components/select/__tests__/index.test.tsx
@@ -83,6 +83,25 @@ describe('Select', () => {
     expect(onOpenChange).toHaveBeenLastCalledWith(true);
   });
 
+  it('should toggle `ant-select-has-search-value` in tags mode even when open is false', () => {
+    const { container } = render(
+      <Select mode="tags" open={false} options={[]} placeholder="Please select" />,
+    );
+
+    const root = container.querySelector('.ant-select') as HTMLElement;
+    const input = container.querySelector('input.ant-select-input') as HTMLInputElement;
+
+    expect(root).toBeTruthy();
+    expect(input).toBeTruthy();
+    expect(root.className).not.toContain('ant-select-has-search-value');
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    expect(root.className).toContain('ant-select-has-search-value');
+
+    fireEvent.change(input, { target: { value: '' } });
+    expect(root.className).not.toContain('ant-select-has-search-value');
+  });
+
   it('should show search icon when showSearch and open', () => {
     jest.useFakeTimers();
     const { container } = render(<Select options={[{ label: '1', value: '1' }]} showSearch />);

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -260,6 +260,12 @@ const InternalSelect = <
 
   const isMultiple = mode === 'multiple' || mode === 'tags';
 
+  // Respect `showSearch` to avoid passing `onSearch` alone, which rc-select warns about.
+  // Note: rc-select enables search by default in `multiple/tags`, so we treat `isMultiple` as showSearch=true
+  // when user did not explicitly set `showSearch`.
+  const mergedShowSearch =
+    (rest as Pick<SelectProps, 'showSearch'>).showSearch ?? showSearch ?? isMultiple;
+
   // Track searchValue for multiple/tags to handle edge cases in rc-select:
   // In tags mode, when `open={false}`, placeholder stays rendered even if user typed.
   // We add a root class when searchValue is non-empty and let CSS hide placeholder accordingly.
@@ -319,7 +325,7 @@ const InternalSelect = <
   const selectProps = omit(
     {
       ...rest,
-      onSearch: mergedOnSearch,
+      ...(mergedShowSearch ? { onSearch: mergedOnSearch } : {}),
       ...(searchValueProp !== undefined ? { searchValue: searchValueProp } : {}),
     },
     ['suffixIcon', 'itemIcon' as any],
@@ -382,7 +388,7 @@ const InternalSelect = <
       [`${prefixCls}-rtl`]: direction === 'rtl',
       [`${prefixCls}-${variant}`]: enableVariantCls,
       [`${prefixCls}-in-form-item`]: isFormItemInput,
-      [`${prefixCls}-has-search-value`]: isMultiple && !!mergedSearchValue,
+      [`${prefixCls}-has-search-value`]: isMultiple && mergedShowSearch && !!mergedSearchValue,
     },
     getStatusClassNames(prefixCls, mergedStatus, hasFeedback),
     compactItemClassnames,

--- a/components/select/style/select-input-multiple.ts
+++ b/components/select/style/select-input-multiple.ts
@@ -141,12 +141,11 @@ const genSelectInputMultipleStyle: GenerateStyle<SelectToken> = (token) => {
         },
       },
 
-      // Fix: Hide placeholder when Select is focused (user is typing or about to type)
-      // This handles the edge case in tags mode where open={false} and no options are provided
-      // In this case, RC Select doesn't properly hide the placeholder when typing
-      // Using :focus-within to detect when the input inside has focus
+      // Fix: In `tags` mode with `open={false}`, rc-select keeps rendering placeholder even after typing.
+      // We add `${componentCls}-has-search-value` on the root when searchValue is non-empty,
+      // and hide placeholder only in that state (so focus/hover with empty input still shows placeholder).
       // See: https://github.com/ant-design/ant-design/issues/56587
-      [`&:focus-within`]: {
+      [`&${componentCls}-has-search-value`]: {
         [`${componentCls}-placeholder`]: {
           display: 'none',
         },

--- a/components/select/style/select-input-multiple.ts
+++ b/components/select/style/select-input-multiple.ts
@@ -145,7 +145,7 @@ const genSelectInputMultipleStyle: GenerateStyle<SelectToken> = (token) => {
       // This handles the edge case in tags mode where open={false} and no options are provided
       // In this case, RC Select doesn't properly hide the placeholder when typing
       // Using :focus-within to detect when the input inside has focus
-      // See: https://github.com/ant-design/ant-design/issues/xxxxx
+      // See: https://github.com/ant-design/ant-design/issues/56587
       [`&:focus-within`]: {
         [`${componentCls}-placeholder`]: {
           display: 'none',

--- a/components/select/style/select-input-multiple.ts
+++ b/components/select/style/select-input-multiple.ts
@@ -141,6 +141,17 @@ const genSelectInputMultipleStyle: GenerateStyle<SelectToken> = (token) => {
         },
       },
 
+      // Fix: Hide placeholder when Select is focused (user is typing or about to type)
+      // This handles the edge case in tags mode where open={false} and no options are provided
+      // In this case, RC Select doesn't properly hide the placeholder when typing
+      // Using :focus-within to detect when the input inside has focus
+      // See: https://github.com/ant-design/ant-design/issues/xxxxx
+      [`&:focus-within`]: {
+        [`${componentCls}-placeholder`]: {
+          display: 'none',
+        },
+      },
+
       // ========================================================
       // ==                        Size                        ==
       // ========================================================


### PR DESCRIPTION
Fixed: https://github.com/ant-design/ant-design/issues/56587

Fixed an issue where the placeholder text remains visible when typing in Select component with mode="tags", open={false}, and no options provided.

**After fix:**
<img width="484" height="204" alt="image" src="https://github.com/user-attachments/assets/e0621995-8236-490c-a1aa-1f23288cdcae" />


[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #[56587](https://github.com/ant-design/ant-design/issues/56587), fix #[56587](https://github.com/ant-design/ant-design/issues/56587)

### 💡 Background and Solution

**What was the problem?**
In tags mode, when the Select component has:
- mode="tags"
- open={false} (dropdown forced closed)
- No options prop or empty options array
The placeholder text does not disappear when the user starts typing, causing the placeholder to overlap with the input text.
**What changed?**
Added a CSS rule in select-input-multiple.ts using :focus-within pseudo-class to hide the placeholder when the Select input receives focus. This ensures the placeholder is hidden as soon as the user clicks into or focuses the input field, regardless of whether options are provided or the dropdown is open.
**How to verify?**
- Create a Select with mode="tags", open={false}, and no options
- Click into the input field and start typing
- Placeholder should disappear immediately when focused

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Select: Fix Select placeholder remaining visible when typing in tags mode with open={false} and no options provided.      |
| 🇨🇳 Chinese |     Select: 修复 Select 在 tags 模式下，当设置 open={false} 且没有提供 options 时，输入内容后 placeholder 仍然显示的问题。      |


Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=191128130