### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: run e2e test
         run: ut test:site
       - name: upload site artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: site
           path: _site/
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload PR number
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pr
           path: ./pr-id.txt

--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -45,7 +45,7 @@ jobs:
           fi
 
       - name: upload site artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: real-site
           path: _site/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
           mkdir persist-coverage
           mv coverage/coverage-final.json persist-coverage/react-test-${{matrix.module}}-${{strategy.job-index}}.json
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         name: upload coverages
         with:
           name: coverage-artifacts-${{ matrix.module }}-${{ strategy.job-index }}
@@ -176,7 +176,7 @@ jobs:
         run: ut test:dekko
 
       # Artifact build files
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:
           name: build artifacts

--- a/.github/workflows/visual-regression-diff-build.yml
+++ b/.github/workflows/visual-regression-diff-build.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=4096
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         name: artifact snapshot
         with:
           name: snapshot-artifacts-${{ strategy.job-index }}
@@ -71,7 +71,7 @@ jobs:
 
       # Upload report in `visualRegressionReport`
       - name: upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ always() }}
         with:
           name: visual-regression-report
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload persist key
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: visual-regression-diff-ref
           path: ./visual-regression-pr-id.txt

--- a/.github/workflows/visual-regression-persist-start.yml
+++ b/.github/workflows/visual-regression-persist-start.yml
@@ -31,7 +31,7 @@ jobs:
 
       # Upload `imageSnapshots` on master
       - name: upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: image-snapshots
           path: imageSnapshots.tar.gz
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload persist key
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: visual-regression-ref
           path: ./visual-regression-ref.txt


### PR DESCRIPTION
### 🤔 This is a... 
- [ ] 🆕 New feature  
- [ ] 🐞 Bug fix  
- [ ] 📝 Site / documentation improvement  
- [ ] 📽️ Demo improvement  
- [ ] 💄 Component style improvement  
- [ ] 🤖 TypeScript definition improvement  
- [ ] 📦 Bundle size optimization  
- [ ] ⚡️ Performance optimization  
- [ ] ⭐️ Feature enhancement  
- [ ] 🌐 Internationalization  
- [ ] 🛠 Refactoring  
- [ ] 🎨 Code style optimization  
- [ ] ✅ Test Case  
- [ ] 🔀 Branch merge  
- [x] ⏩ Workflow  
- [ ] ⌨️ Accessibility improvement  
- [ ] ❓ Other (about what?)

### 🔗 Related Issues  
- [ ] Close #xxxx (if applicable)  
- [ ] Fix #xxxx (if applicable)

### 💡 Background and Solution  
The existing GitHub Action version `v4` of `actions/upload-artifact` is outdated and may cause compatibility issues with newer workflows. This update ensures the action remains compatible with the latest GitHub API and improves stability and functionality.

### 📝 Change Log  
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Updated `actions/upload-artifact` from `v4` to `v6` in the following workflows: `visual-regression-persist-start.yml`, `test.yml`, `site-deploy.yml`, `preview-build.yml`, `visual-regression-diff-build.yml` |
| 🇨🇳 Chinese | 以下工作流已更新 `actions/upload-artifact` 从 `v4` 到 `v6`：`visual-regression-persist-start.yml`、`test.yml`、`site-deploy.yml`、`preview-build.yml`、`visual-regression-diff-build.yml` |
---