### PR TITLE
feat(Input.OTP): add autoComplete prop support

### DIFF
--- a/components/input/OTP/index.tsx
+++ b/components/input/OTP/index.tsx
@@ -68,6 +68,8 @@ export interface OTPProps
 
   type?: React.HTMLInputTypeAttribute;
 
+  autoComplete?: string;
+
   onInput?: (value: string[]) => void;
 
   classNames?: OTPClassNamesType;
@@ -115,6 +117,7 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
     autoFocus,
     mask,
     type,
+    autoComplete,
     onInput,
     onFocus,
     inputMode,
@@ -307,6 +310,7 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
     mask,
     type,
     inputMode,
+    autoComplete,
   };
 
   return (

--- a/components/input/__tests__/otp.test.tsx
+++ b/components/input/__tests__/otp.test.tsx
@@ -192,7 +192,11 @@ describe('Input.OTP', () => {
 
   it('support autoComplete', () => {
     const { container } = render(<OTP autoComplete="one-time-code" />);
-    expect(container.querySelector('input')).toHaveAttribute('autocomplete', 'one-time-code');
+    const inputs = container.querySelectorAll('input');
+    expect(inputs).toHaveLength(6);
+    inputs.forEach((input) => {
+      expect(input).toHaveAttribute('autocomplete', 'one-time-code');
+    });
   });
 
   it('should call onInput with a string array when input changes', () => {

--- a/components/input/__tests__/otp.test.tsx
+++ b/components/input/__tests__/otp.test.tsx
@@ -190,6 +190,11 @@ describe('Input.OTP', () => {
     expect(container.querySelector('input')).toHaveAttribute('type', 'number');
   });
 
+  it('support autoComplete', () => {
+    const { container } = render(<OTP autoComplete="one-time-code" />);
+    expect(container.querySelector('input')).toHaveAttribute('autocomplete', 'one-time-code');
+  });
+
   it('should call onInput with a string array when input changes', () => {
     const onInput = jest.fn();
     const { container } = render(<OTP length={4} onInput={onInput} />);

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -137,6 +137,7 @@ Added in `5.16.0`.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
+| autoComplete | The autocomplete attribute for input elements, e.g. `one-time-code` for OTP autofill | string | - |  |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-otp), string> \| (info: { props }) => Record<[SemanticDOM](#semantic-otp), string> | - |  |
 | defaultValue | Default value | string | - |  |
 | disabled | Whether the input is disabled | boolean | false |  |

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -137,7 +137,7 @@ Added in `5.16.0`.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| autoComplete | The autocomplete attribute for input elements, e.g. `one-time-code` for OTP autofill | string | - | 5.25.0 |
+| autoComplete | The autocomplete attribute for input elements, e.g. `one-time-code` for OTP autofill | string | - | 6.3.0 |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-otp), string> \| (info: { props }) => Record<[SemanticDOM](#semantic-otp), string> | - |  |
 | defaultValue | Default value | string | - |  |
 | disabled | Whether the input is disabled | boolean | false |  |

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -137,7 +137,7 @@ Added in `5.16.0`.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| autoComplete | The autocomplete attribute for input elements, e.g. `one-time-code` for OTP autofill | string | - |  |
+| autoComplete | The autocomplete attribute for input elements, e.g. `one-time-code` for OTP autofill | string | - | 5.25.0 |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-otp), string> \| (info: { props }) => Record<[SemanticDOM](#semantic-otp), string> | - |  |
 | defaultValue | Default value | string | - |  |
 | disabled | Whether the input is disabled | boolean | false |  |

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -138,6 +138,7 @@ interface CountConfig {
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
+| autoComplete | 输入元素的 autocomplete 属性，例如 `one-time-code` 可用于 OTP 自动填充 | string | - |  |
 | classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-otp), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-otp), string> | - |  |
 | defaultValue | 默认值 | string | - |  |
 | disabled | 是否禁用 | boolean | false |  |

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -138,7 +138,7 @@ interface CountConfig {
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| autoComplete | 输入元素的 autocomplete 属性，例如 `one-time-code` 可用于 OTP 自动填充 | string | - |  |
+| autoComplete | 输入元素的 autocomplete 属性，例如 `one-time-code` 可用于 OTP 自动填充 | string | - | 5.25.0 |
 | classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-otp), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-otp), string> | - |  |
 | defaultValue | 默认值 | string | - |  |
 | disabled | 是否禁用 | boolean | false |  |

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -138,7 +138,7 @@ interface CountConfig {
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| autoComplete | 输入元素的 autocomplete 属性，例如 `one-time-code` 可用于 OTP 自动填充 | string | - | 5.25.0 |
+| autoComplete | 输入元素的 autocomplete 属性，例如 `one-time-code` 可用于 OTP 自动填充 | string | - | 6.3.0 |
 | classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-otp), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-otp), string> | - |  |
 | defaultValue | 默认值 | string | - |  |
 | disabled | 是否禁用 | boolean | false |  |


### PR DESCRIPTION
## Summary
- Add `autoComplete` prop to `Input.OTP` component to support browser/password manager OTP autofill
- This enables Safari and other password managers to autofill OTP codes when `autoComplete="one-time-code"` is set

## Usage
```tsx
<Input.OTP length={6} autoFocus autoComplete="one-time-code" />
```

## Changes
- Added `autoComplete` prop to `OTPProps` interface
- Pass `autoComplete` through `inputSharedProps` to underlying inputs
- Added test case for `autoComplete` prop
- Updated documentation (EN & CN)

Closes #53188