### PR TITLE
feat: add controlled collapsed support for Splitter.Panel

### DIFF
--- a/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -323,32 +323,108 @@ exports[`renders components/splitter/demo/control.tsx extend context correctly 1
     </div>
   </div>
   <div
-    class="ant-flex css-var-test-id ant-flex-justify-space-between ant-flex-gap-middle"
+    class="ant-splitter ant-splitter-horizontal css-var-test-id ant-splitter-css-var"
+    style="height: 200px; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);"
   >
-    <button
-      aria-checked="true"
-      class="ant-switch css-var-test-id ant-switch-checked"
-      role="switch"
-      type="button"
+    <div
+      class="ant-splitter-panel"
+      style="flex-basis: 50%; flex-grow: 0;"
     >
       <div
-        class="ant-switch-handle"
-      />
-      <span
-        class="ant-switch-inner"
+        class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-center"
+        style="height: 100%;"
       >
-        <span
-          class="ant-switch-inner-checked"
+        <h5
+          class="ant-typography ant-typography-secondary css-var-test-id"
+          style="white-space: nowrap;"
         >
-          Enabled
-        </span>
-        <span
-          class="ant-switch-inner-unchecked"
+          First
+        </h5>
+      </div>
+    </div>
+    <div
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="50"
+      class="ant-splitter-bar"
+      role="separator"
+    >
+      <div
+        class="ant-splitter-bar-dragger"
+      />
+    </div>
+    <div
+      class="ant-splitter-panel"
+      style="flex-basis: 50%; flex-grow: 0;"
+    >
+      <div
+        class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-center"
+        style="height: 100%;"
+      >
+        <h5
+          class="ant-typography ant-typography-secondary css-var-test-id"
+          style="white-space: nowrap;"
         >
-          Disabled
+          Second
+        </h5>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-flex css-var-test-id ant-flex-justify-space-between ant-flex-gap-middle"
+  >
+    <div
+      class="ant-flex css-var-test-id ant-flex-gap-middle"
+    >
+      <button
+        aria-checked="true"
+        class="ant-switch css-var-test-id ant-switch-checked"
+        role="switch"
+        type="button"
+      >
+        <div
+          class="ant-switch-handle"
+        />
+        <span
+          class="ant-switch-inner"
+        >
+          <span
+            class="ant-switch-inner-checked"
+          >
+            Enabled
+          </span>
+          <span
+            class="ant-switch-inner-unchecked"
+          >
+            Disabled
+          </span>
         </span>
-      </span>
-    </button>
+      </button>
+      <button
+        aria-checked="false"
+        class="ant-switch css-var-test-id"
+        role="switch"
+        type="button"
+      >
+        <div
+          class="ant-switch-handle"
+        />
+        <span
+          class="ant-switch-inner"
+        >
+          <span
+            class="ant-switch-inner-checked"
+          >
+            Collapsed
+          </span>
+          <span
+            class="ant-switch-inner-unchecked"
+          >
+            Expanded
+          </span>
+        </span>
+      </button>
+    </div>
     <button
       class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
       type="button"

--- a/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
@@ -319,32 +319,108 @@ exports[`renders components/splitter/demo/control.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    class="ant-flex css-var-test-id ant-flex-justify-space-between ant-flex-gap-middle"
+    class="ant-splitter ant-splitter-horizontal css-var-test-id ant-splitter-css-var"
+    style="height:200px;box-shadow:0 0 10px rgba(0, 0, 0, 0.1)"
   >
-    <button
-      aria-checked="true"
-      class="ant-switch css-var-test-id ant-switch-checked"
-      role="switch"
-      type="button"
+    <div
+      class="ant-splitter-panel"
+      style="flex-basis:50%;flex-grow:0"
     >
       <div
-        class="ant-switch-handle"
-      />
-      <span
-        class="ant-switch-inner"
+        class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-center"
+        style="height:100%"
       >
-        <span
-          class="ant-switch-inner-checked"
+        <h5
+          class="ant-typography ant-typography-secondary css-var-test-id"
+          style="white-space:nowrap"
         >
-          Enabled
-        </span>
-        <span
-          class="ant-switch-inner-unchecked"
+          First
+        </h5>
+      </div>
+    </div>
+    <div
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="50"
+      class="ant-splitter-bar"
+      role="separator"
+    >
+      <div
+        class="ant-splitter-bar-dragger"
+      />
+    </div>
+    <div
+      class="ant-splitter-panel"
+      style="flex-basis:50%;flex-grow:0"
+    >
+      <div
+        class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-center"
+        style="height:100%"
+      >
+        <h5
+          class="ant-typography ant-typography-secondary css-var-test-id"
+          style="white-space:nowrap"
         >
-          Disabled
+          Second
+        </h5>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-flex css-var-test-id ant-flex-justify-space-between ant-flex-gap-middle"
+  >
+    <div
+      class="ant-flex css-var-test-id ant-flex-gap-middle"
+    >
+      <button
+        aria-checked="true"
+        class="ant-switch css-var-test-id ant-switch-checked"
+        role="switch"
+        type="button"
+      >
+        <div
+          class="ant-switch-handle"
+        />
+        <span
+          class="ant-switch-inner"
+        >
+          <span
+            class="ant-switch-inner-checked"
+          >
+            Enabled
+          </span>
+          <span
+            class="ant-switch-inner-unchecked"
+          >
+            Disabled
+          </span>
         </span>
-      </span>
-    </button>
+      </button>
+      <button
+        aria-checked="false"
+        class="ant-switch css-var-test-id"
+        role="switch"
+        type="button"
+      >
+        <div
+          class="ant-switch-handle"
+        />
+        <span
+          class="ant-switch-inner"
+        >
+          <span
+            class="ant-switch-inner-checked"
+          >
+            Collapsed
+          </span>
+          <span
+            class="ant-switch-inner-unchecked"
+          >
+            Expanded
+          </span>
+        </span>
+      </button>
+    </div>
     <button
       class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
       type="button"

--- a/components/splitter/__tests__/index.test.tsx
+++ b/components/splitter/__tests__/index.test.tsx
@@ -81,6 +81,20 @@ describe('Splitter', () => {
     expect(panels?.[2]).toHaveStyle('flex-basis: 35px');
   });
 
+  it('should render collapsed panel size as 0', async () => {
+    const { container } = render(
+      <SplitterDemo items={[{ size: 20, collapsed: true }, { size: 80 }]} />,
+    );
+
+    await resizeSplitter();
+
+    const panels = container.querySelectorAll('.ant-splitter-panel');
+
+    expect(panels?.[0]).toHaveStyle('flex-basis: 0px');
+    expect(panels?.[0]).toHaveClass('ant-splitter-panel-hidden');
+    expect(panels?.[1]).toHaveStyle('flex-basis: 100px');
+  });
+
   it('The layout should work fine', () => {
     const { container, rerender } = render(<SplitterDemo />);
     expect(container.querySelector('.ant-splitter-horizontal')).toBeTruthy();

--- a/components/splitter/__tests__/size.test.tsx
+++ b/components/splitter/__tests__/size.test.tsx
@@ -107,4 +107,19 @@ describe('useSizes', () => {
 
     expect(postPxSizes).toEqual([500, 500]);
   });
+
+  it('should force size to 0 when collapsed', () => {
+    const items = [
+      {
+        size: 100,
+        collapsed: true,
+      },
+      {},
+    ];
+
+    const { result } = renderHook(() => useSizes(items, containerSize));
+    const [sizes] = result.current;
+
+    expect(sizes).toEqual([0, 1000]);
+  });
 });

--- a/components/splitter/demo/control.tsx
+++ b/components/splitter/demo/control.tsx
@@ -12,27 +12,59 @@ const Desc: React.FC<Readonly<{ text?: string | number }>> = (props) => (
 const App: React.FC = () => {
   const [sizes, setSizes] = React.useState<(number | string)[]>(['50%', '50%']);
   const [enabled, setEnabled] = React.useState(true);
+  const [collapsed, setCollapsed] = React.useState(false);
+  const [collapsedPanels, setCollapsedPanels] = React.useState<boolean[]>([false, false]);
   return (
     <Flex vertical gap="middle">
       <Splitter
         onResize={setSizes}
         style={{ height: 200, boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)' }}
       >
-        <Splitter.Panel size={sizes[0]} resizable={enabled}>
+        <Splitter.Panel size={sizes[0]} resizable={enabled} collapsed={collapsed}>
           <Desc text="First" />
         </Splitter.Panel>
         <Splitter.Panel size={sizes[1]}>
           <Desc text="Second" />
         </Splitter.Panel>
       </Splitter>
+      <Splitter
+        onCollapse={(nextCollapsed) => setCollapsedPanels(nextCollapsed)}
+        style={{ height: 200, boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)' }}
+      >
+        <Splitter.Panel
+          collapsible
+          defaultSize="50%"
+          resizable={enabled}
+          collapsed={collapsedPanels[0]}
+        >
+          <Desc text="First" />
+        </Splitter.Panel>
+        <Splitter.Panel collapsible defaultSize="50%" collapsed={collapsedPanels[1]}>
+          <Desc text="Second" />
+        </Splitter.Panel>
+      </Splitter>
       <Flex gap="middle" justify="space-between">
-        <Switch
-          value={enabled}
-          onChange={() => setEnabled(!enabled)}
-          checkedChildren="Enabled"
-          unCheckedChildren="Disabled"
-        />
-        <Button onClick={() => setSizes(['50%', '50%'])}>Reset</Button>
+        <Flex gap="middle">
+          <Switch
+            value={enabled}
+            onChange={() => setEnabled(!enabled)}
+            checkedChildren="Enabled"
+            unCheckedChildren="Disabled"
+          />
+          <Switch
+            value={collapsed}
+            onChange={() => setCollapsed(!collapsed)}
+            checkedChildren="Collapsed"
+            unCheckedChildren="Expanded"
+          />
+        </Flex>
+        <Button
+          onClick={() => {
+            setSizes(['50%', '50%']);
+          }}
+        >
+          Reset
+        </Button>
       </Flex>
     </Flex>
   );

--- a/components/splitter/hooks/useSizes.ts
+++ b/components/splitter/hooks/useSizes.ts
@@ -17,6 +17,7 @@ function isPtg(itemSize: string | number | undefined): itemSize is string {
  */
 export default function useSizes(items: PanelProps[], containerSize?: number) {
   const propSizes = items.map((item) => item.size);
+  const propCollapsed = items.map((item) => item.collapsed);
 
   const itemsCount = items.length;
 
@@ -32,11 +33,15 @@ export default function useSizes(items: PanelProps[], containerSize?: number) {
     const mergedSizes: PanelProps['size'][] = [];
 
     for (let i = 0; i < itemsCount; i += 1) {
-      mergedSizes[i] = propSizes[i] ?? innerSizes[i];
+      if (propCollapsed[i]) {
+        mergedSizes[i] = 0;
+      } else {
+        mergedSizes[i] = propSizes[i] ?? innerSizes[i];
+      }
     }
 
     return mergedSizes;
-  }, [itemsCount, innerSizes, propSizes]);
+  }, [itemsCount, innerSizes, propSizes, propCollapsed]);
 
   const postPercentMinSizes = React.useMemo(
     () =>

--- a/components/splitter/index.en-US.md
+++ b/components/splitter/index.en-US.md
@@ -65,7 +65,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | min | Minimum threshold support number for px or 'percent%' usage | `number \| string` | - | - |
 | resizable | Whether to enable drag and drop | `boolean` | `true` | - |
 | size | Controlled panel size support number for px or 'percent%' usage | `number \| string` | - | - |
-| collapsed | Controlled collapsed state | boolean | - | 6.2.2 |
+| collapsed | Controlled collapsed state | boolean | - | 6.3.0 |
 
 ## Semantic DOM
 

--- a/components/splitter/index.en-US.md
+++ b/components/splitter/index.en-US.md
@@ -65,6 +65,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | min | Minimum threshold support number for px or 'percent%' usage | `number \| string` | - | - |
 | resizable | Whether to enable drag and drop | `boolean` | `true` | - |
 | size | Controlled panel size support number for px or 'percent%' usage | `number \| string` | - | - |
+| collapsed | Controlled collapsed state | boolean | - | 6.2.2 |
 
 ## Semantic DOM
 

--- a/components/splitter/index.zh-CN.md
+++ b/components/splitter/index.zh-CN.md
@@ -66,6 +66,7 @@ demo:
 | min | 最小阈值，支持数字 px 或者文字 '百分比%' 类型 | `number \| string` | - | - |
 | resizable | 是否开启拖拽伸缩 | `boolean` | `true` | - |
 | size | 受控面板大小，支持数字 px 或者文字 '百分比%' 类型 | `number \| string` | - | - |
+| collapsed | 受控的收起状态 | boolean | - | 6.2.2 |
 
 ## Semantic DOM
 

--- a/components/splitter/index.zh-CN.md
+++ b/components/splitter/index.zh-CN.md
@@ -66,7 +66,7 @@ demo:
 | min | 最小阈值，支持数字 px 或者文字 '百分比%' 类型 | `number \| string` | - | - |
 | resizable | 是否开启拖拽伸缩 | `boolean` | `true` | - |
 | size | 受控面板大小，支持数字 px 或者文字 '百分比%' 类型 | `number \| string` | - | - |
-| collapsed | 受控的收起状态 | boolean | - | 6.2.2 |
+| collapsed | 受控的收起状态 | boolean | - | 6.3.0 |
 
 ## Semantic DOM
 

--- a/components/splitter/interface.ts
+++ b/components/splitter/interface.ts
@@ -74,6 +74,7 @@ export interface PanelProps {
   min?: number | string;
   max?: number | string;
   size?: number | string;
+  collapsed?: boolean;
   collapsible?:
     | boolean
     | { start?: boolean; end?: boolean; showCollapsibleIcon?: ShowCollapsibleIconMode };


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

> close #56631

### 💡 需求背景和解决方案

> 1. Splitter 缺少 `collapsed` 受控属性，无法由外部控制面板收起状态。
> 2. 为 `Splitter.Panel` 增加 `collapsed`，并补充文档、示例与测试。
> 3. 无 UI 视觉变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Add controlled `collapsed` support for `Splitter.Panel`. |
| 🇨🇳 中文 | 新增 `Splitter.Panel` 的 `collapsed` 受控能力。 |
