### PR TITLE
fix(wave): wave fails to read ConfigProvider prefixCls causing cssVar to break

### DIFF
--- a/components/_util/__tests__/wave.test.tsx
+++ b/components/_util/__tests__/wave.test.tsx
@@ -4,7 +4,7 @@ import { clsx } from 'clsx';
 import mountTest from '../../../tests/shared/mountTest';
 import { act, fireEvent, getByText, render, waitFakeTimer } from '../../../tests/utils';
 import Checkbox from '../../checkbox';
-import { defaultPrefixCls } from '../../config-provider';
+import ConfigProvider, { defaultPrefixCls } from '../../config-provider';
 import { genCssVar } from '../../theme/util/genStyleUtils';
 import Wave from '../wave';
 import { TARGET_CLS } from '../wave/interface';
@@ -72,9 +72,9 @@ describe('Wave component', () => {
     expect(disCnt).not.toBe(0);
   });
 
-  function getWaveStyle() {
+  function getWaveStyle(prefixCls = defaultPrefixCls) {
     const styleObj: Record<string, string> = {};
-    const { style } = document.querySelector<HTMLElement>('.ant-wave')!;
+    const { style } = document.querySelector<HTMLElement>(`.${prefixCls}-wave`)!;
     style.cssText.split(';').forEach((kv) => {
       if (kv.trim()) {
         const cells = kv.split(':');
@@ -179,6 +179,29 @@ describe('Wave component', () => {
 
     const style = getWaveStyle();
     expect(style[varName('color')]).toBe('rgb(0, 0, 255)');
+
+    unmount();
+  });
+
+  it('support custom prefixCls and cssVar prefix', () => {
+    const customPrefixCls = 'custom-ant';
+    const [customVarName] = genCssVar(customPrefixCls, 'wave');
+
+    const { container, unmount } = render(
+      <ConfigProvider prefixCls={customPrefixCls} theme={{ cssVar: { prefix: customPrefixCls } }}>
+        <Wave>
+          <button type="button" style={{ borderColor: 'rgb(255, 0, 0)' }}>
+            button
+          </button>
+        </Wave>
+      </ConfigProvider>,
+    );
+
+    fireEvent.click(container.querySelector('button')!);
+    waitRaf();
+
+    const style = getWaveStyle(customPrefixCls);
+    expect(style[customVarName('color')]).toBe('rgb(255, 0, 0)');
 
     unmount();
   });

--- a/components/_util/wave/WaveEffect.tsx
+++ b/components/_util/wave/WaveEffect.tsx
@@ -6,7 +6,7 @@ import { composeRef } from '@rc-component/util/lib/ref';
 import { clsx } from 'clsx';
 
 import type { WaveProps } from '.';
-import { ConfigContext } from '../../config-provider';
+import { defaultPrefixCls } from '../../config-provider';
 import { genCssVar } from '../../theme/util/genStyleUtils';
 import { TARGET_CLS } from './interface';
 import type { ShowWaveEffect } from './interface';
@@ -19,19 +19,18 @@ function validateNum(value: number) {
 export interface WaveEffectProps {
   className: string;
   target: HTMLElement;
+  rootPrefixCls?: string;
   component?: string;
   colorSource?: WaveProps['colorSource'];
 }
 
 const WaveEffect: React.FC<WaveEffectProps> = (props) => {
-  const { className, target, component, colorSource } = props;
+  const { className, target, component, colorSource, rootPrefixCls } = props;
   const divRef = React.useRef<HTMLDivElement>(null);
 
-  const { getPrefixCls } = React.useContext(ConfigContext);
+  const mergedPrefix = rootPrefixCls || defaultPrefixCls;
 
-  const rootPrefixCls = getPrefixCls();
-
-  const [varName] = genCssVar(rootPrefixCls, 'wave');
+  const [varName] = genCssVar(mergedPrefix, 'wave');
 
   // ===================== Effect =====================
   const [color, setWaveColor] = React.useState<string | null>(null);

--- a/components/_util/wave/interface.ts
+++ b/components/_util/wave/interface.ts
@@ -9,6 +9,7 @@ export type ShowWaveEffect = (
   info: {
     className: string;
     token: GlobalToken;
+    rootPrefixCls?: string;
     component?: WaveComponent;
     event: MouseEvent;
     hashId: string;

--- a/components/_util/wave/useWave.ts
+++ b/components/_util/wave/useWave.ts
@@ -15,8 +15,9 @@ const useWave = (
   component?: WaveComponent,
   colorSource?: WaveProps['colorSource'],
 ) => {
-  const { wave } = React.useContext(ConfigContext);
+  const { wave, getPrefixCls } = React.useContext(ConfigContext);
   const [, token, hashId] = useToken();
+  const rootPrefixCls = getPrefixCls();
 
   const showWave = useEvent<ShowWave>((event) => {
     const node = nodeRef.current;
@@ -33,6 +34,7 @@ const useWave = (
     (showEffect || showWaveEffect)(targetNode, {
       className,
       token,
+      rootPrefixCls,
       component,
       event,
       hashId,


### PR DESCRIPTION

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 💡 Background and Solution

`WaveEffect` is not rendered within the React tree of ConfigProvider; instead, it is dynamically mounted via `render()` onto a newly created holder node that lies outside the context scope of the Provider.
As a result, when ConfigContext is accessed inside WaveEffect, only the default value (`ant`) can be retrieved, causing `getPrefixCls()` to fail.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  wave fails to read ConfigProvider prefixCls causing cssVar to break |
| 🇨🇳 Chinese |  wave 无法读取 ConfigProvider 的 prefixCls，导致 cssVar 失效 |
