### PR TITLE
fix(Drawer): replace insetInline properties with left/right in drawer style

### DIFF
--- a/components/drawer/style/index.ts
+++ b/components/drawer/style/index.ts
@@ -278,7 +278,10 @@ const genDrawerStyle: GenerateStyle<DrawerToken> = (token) => {
       [`${draggerCls}-left`]: {
         top: 0,
         bottom: 0,
-        insetInlineEnd: 0,
+        right: {
+          _skip_check_: true,
+          value: 0,
+        },
         width: draggerSize,
         cursor: 'col-resize',
       },
@@ -286,7 +289,10 @@ const genDrawerStyle: GenerateStyle<DrawerToken> = (token) => {
       [`${draggerCls}-right`]: {
         top: 0,
         bottom: 0,
-        insetInlineStart: 0,
+        left: {
+          _skip_check_: true,
+          value: 0,
+        },
         width: draggerSize,
         cursor: 'col-resize',
       },


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
issue: [56692](https://github.com/ant-design/ant-design/issues/56692)

### 💡 Background and Solution
After enabling RTL mode, the dragger position of the drawer component is incorrect.
Adjust drawer CSS styles

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the drawer component's dragger position error in RTL mode |
| 🇨🇳 Chinese | 修复drawer组件在rtl模式dragger位置错误 |
