### PR TITLE
fix: align pagination container items vertically

### DIFF
--- a/components/pagination/style/index.ts
+++ b/components/pagination/style/index.ts
@@ -589,6 +589,7 @@ const genPaginationStyle: GenerateStyle<PaginationToken, CSSObject> = (token) =>
 
       ...resetComponent(token),
       display: 'flex',
+      alignItems: 'center',
 
       '&-start': {
         justifyContent: 'start',

--- a/components/pagination/style/index.ts
+++ b/components/pagination/style/index.ts
@@ -478,7 +478,7 @@ const genPaginationJumpStyle: GenerateStyle<PaginationToken, CSSObject> = (token
         height: varRef(`item-size-actual`),
         marginInlineStart: token.marginXS,
         lineHeight: varRef(`item-size-actual`),
-        verticalAlign: 'top',
+        verticalAlign: 'baseline',
 
         input: {
           ...genBasicInputStyle(token),


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- fix #56586 https://github.com/ant-design/ant-design/issues/56586

### 💡 Background and Solution

When using `ConfigProvider` with a larger `fontSize`, Pagination items and the size changer become vertically misaligned, especially with `size="small"` and `showSizeChanger`.  
This change aligns the Pagination container items vertically so all elements (total text, page items, ellipsis, and Select) line up consistently.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Pagination: Fix vertical misalignment of items when global `fontSize` is increased. |
| 🇨🇳 Chinese | 🐞 Pagination：修复全局 `fontSize` 变大时各元素上下错位的问题。 |