### PR TITLE
fix(Button): default button token

### DIFF
--- a/components/button/style/variant.ts
+++ b/components/button/style/variant.ts
@@ -218,9 +218,9 @@ const genVariantStyle: GenerateStyle<ButtonToken> = (token) => {
           [varName('color-light-hover')]: token.colorFillSecondary,
           [varName('color-light-active')]: token.colorFill,
 
-          [varName('text-color')]: token.colorText,
-          [varName('text-color-hover')]: token.defaultHoverBorderColor,
-          [varName('text-color-active')]: token.defaultActiveBorderColor,
+          [varName('text-color')]: token.defaultColor,
+          [varName('text-color-hover')]: token.defaultHoverColor,
+          [varName('text-color-active')]: token.defaultActiveColor,
           [varName('shadow')]: token.defaultShadow,
 
           [`&${componentCls}-variant-solid`]: {


### PR DESCRIPTION
### 🤔 This is a ...
- [ ] 🐞 Bug fix

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

按照定义修改 button token的引用
<img width="3018" height="1130" alt="image" src="https://github.com/user-attachments/assets/b47663cd-e64f-4f30-9396-671275355aa8" />


原有的 defaultHoverColor 引用的 defaultHoverBoderColor，导致在分别设置 defaultHoverColor 和 defaultHoverBoderColor时，前者永远会被后者覆盖。同样的 defaultActiveColor也有这个问题。
![3BBBDC2A-DEEB-40FD-9F48-D07A9AB3218F_4_5005_c](https://github.com/user-attachments/assets/1a91c1ff-e1bb-4fea-b0f7-fb22fb7ffcc6)
![8B148841-657F-457E-B612-F3BACA38AB5E_4_5005_c](https://github.com/user-attachments/assets/fe49fcd6-e836-4f7d-8f71-36150e44d9f0)
![117F6916-A7A9-45A5-BCCC-B3FB9DC7B152_4_5005_c](https://github.com/user-attachments/assets/56a3eb80-5aee-4e66-964f-6db636199e29)


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    default style button in hover or active status refer error token       |
| 🇨🇳 Chinese |   default 样式按钮 hover 和 active token引用错误        |
