### PR TITLE
style: refactor pagination layout to inline-flex

### DIFF
--- a/components/pagination/style/index.ts
+++ b/components/pagination/style/index.ts
@@ -589,6 +589,7 @@ const genPaginationStyle: GenerateStyle<PaginationToken, CSSObject> = (token) =>
 
       ...resetComponent(token),
       display: 'flex',
+      alignItems: 'center',
 
       '&-start': {
         justifyContent: 'start',

--- a/components/pagination/style/index.ts
+++ b/components/pagination/style/index.ts
@@ -407,7 +407,6 @@ const genPaginationJumpStyle: GenerateStyle<PaginationToken, CSSObject> = (token
     ${componentCls}-jump-next
     `]: {
       display: 'inline-flex',
-      justifyContent: 'center',
       alignItems: 'center',
       minWidth: varRef(`item-size-actual`),
       height: varRef(`item-size-actual`),

--- a/components/pagination/style/index.ts
+++ b/components/pagination/style/index.ts
@@ -261,7 +261,6 @@ const genPaginationSimpleStyle: GenerateStyle<PaginationToken, CSSObject> = (tok
       [`${componentCls}-prev, ${componentCls}-next`]: {
         height: varRef(`item-size-actual`),
         lineHeight: varRef(`item-size-actual`),
-        verticalAlign: 'top',
         [`${componentCls}-item-link`]: {
           height: varRef(`item-size-actual`),
           backgroundColor: 'transparent',
@@ -407,14 +406,15 @@ const genPaginationJumpStyle: GenerateStyle<PaginationToken, CSSObject> = (token
     ${componentCls}-jump-prev,
     ${componentCls}-jump-next
     `]: {
-      display: 'inline-block',
+      display: 'inline-flex',
+      justifyContent: 'center',
+      alignItems: 'center',
       minWidth: varRef(`item-size-actual`),
       height: varRef(`item-size-actual`),
       color: token.colorText,
       fontFamily: token.fontFamily,
       lineHeight: varRef(`item-size-actual`),
       textAlign: 'center',
-      verticalAlign: 'middle',
       listStyle: 'none',
       borderRadius: token.borderRadius,
       cursor: 'pointer',
@@ -465,20 +465,20 @@ const genPaginationJumpStyle: GenerateStyle<PaginationToken, CSSObject> = (token
     },
 
     [`${componentCls}-options`]: {
-      display: 'inline-block',
+      display: 'inline-flex',
+      alignItems: 'center',
       marginInlineStart: token.margin,
-      verticalAlign: 'middle',
 
       '&-size-changer': {
         width: 'auto',
       },
 
       '&-quick-jumper': {
-        display: 'inline-block',
+        display: 'inline-flex',
+        alignItems: 'center',
         height: varRef(`item-size-actual`),
         marginInlineStart: token.marginXS,
         lineHeight: varRef(`item-size-actual`),
-        verticalAlign: 'baseline',
 
         input: {
           ...genBasicInputStyle(token),
@@ -511,14 +511,15 @@ const genPaginationItemStyle: GenerateStyle<PaginationToken, CSSObject> = (token
 
   return {
     [`${componentCls}-item`]: {
-      display: 'inline-block',
+      display: 'inline-flex',
+      justifyContent: 'center',
+      alignItems: 'center',
       minWidth: varRef(`item-size-actual`),
       height: varRef(`item-size-actual`),
       marginInlineEnd: varRef(`item-spacing-actual`),
       fontFamily: token.fontFamily,
       lineHeight: unit(token.calc(varRef('item-size-actual')).sub(2).equal()),
       textAlign: 'center',
-      verticalAlign: 'middle',
       listStyle: 'none',
       backgroundColor: token.itemBg,
       border: `${unit(token.lineWidth)} ${token.lineType} transparent`,
@@ -619,11 +620,11 @@ const genPaginationStyle: GenerateStyle<PaginationToken, CSSObject> = (token) =>
       },
 
       [`${componentCls}-total-text`]: {
-        display: 'inline-block',
+        display: 'inline-flex',
+        alignItems: 'center',
         height: varRef(`item-size-actual`),
         marginInlineEnd: varRef(`item-spacing-actual`),
         lineHeight: unit(token.calc(varRef(`item-size-actual`)).sub(2).equal()),
-        verticalAlign: 'middle',
       },
 
       // item style

--- a/components/pagination/style/index.ts
+++ b/components/pagination/style/index.ts
@@ -478,7 +478,7 @@ const genPaginationJumpStyle: GenerateStyle<PaginationToken, CSSObject> = (token
         height: varRef(`item-size-actual`),
         marginInlineStart: token.marginXS,
         lineHeight: varRef(`item-size-actual`),
-        verticalAlign: 'top',
+        verticalAlign: 'baseline',
 
         input: {
           ...genBasicInputStyle(token),


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案

Pagination 的样式结构调整为 inline-flex 布局，统一对齐方式并简化布局逻辑。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 💄 Pagination: Refactor layout to use `inline-flex` for items and options. |
| 🇨🇳 中文 | 💄 Pagination：将页码项与选项区改为 `inline-flex` 布局。 |