### PR TITLE
fix(Propover): Isolate `Form.Item` status from popup-type components

### DIFF
--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -27,6 +27,7 @@ import Radio from '../../radio';
 import Select from '../../select';
 import Slider from '../../slider';
 import Switch from '../../switch';
+import Popover from '../../popover';
 import TreeSelect from '../../tree-select';
 import Upload from '../../upload';
 import type { NamePath } from '../interface';
@@ -1850,6 +1851,11 @@ describe('Form', () => {
             <Select className="drawer-select" />
           </Drawer>
         </Form.Item>
+        <Form.Item validateStatus="error">
+          <Popover open content={<Input className="custom-popup-input" />}>
+            <span>issue#56615</span>
+          </Popover>
+        </Form.Item>
       </Form>
     );
     const { container } = render(<Demo />, { container: document.body });
@@ -1857,6 +1863,11 @@ describe('Form', () => {
     expect(container.querySelector('.modal-select')).not.toHaveClass('status-error');
     expect(container.querySelector('.drawer-select')).not.toHaveClass('in-form-item');
     expect(container.querySelector('.drawer-select')).not.toHaveClass('status-error');
+
+    // https://github.com/ant-design/ant-design/issues/56615
+    expect(container.querySelector('.custom-popup-input')).not.toHaveClass(
+      'ant-input-status-error',
+    );
   });
 
   // eslint-disable-next-line jest/no-disabled-tests

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -270,7 +270,7 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
   }, [overlay, title]);
 
   const memoOverlayWrapper = (
-    <ContextIsolator space>
+    <ContextIsolator space form>
       {typeof memoOverlay === 'function' ? memoOverlay() : memoOverlay}
     </ContextIsolator>
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #56615

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      fix(Propover): Isolate `Form.Item` status from popup-type components     |
| 🇨🇳 Chinese |     隔离 Form.Item 状态与 Popup 类组件的关联      |
