### PR TITLE
feat(ColorPicker): support panelControls prop

### DIFF
--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -43,6 +43,7 @@ const ColorPicker: CompoundedComponent = (props) => {
     defaultValue,
     format,
     defaultFormat,
+    panelControls,
     allowClear = false,
     presets,
     children,
@@ -308,6 +309,7 @@ const ColorPicker: CompoundedComponent = (props) => {
             gradientDragging={gradientDragging}
             onGradientDragging={setGradientDragging}
             disabledFormat={disabledFormat}
+            controls={panelControls}
           />
         </ContextIsolator>
       }

--- a/components/color-picker/ColorPickerPanel.tsx
+++ b/components/color-picker/ColorPickerPanel.tsx
@@ -37,6 +37,7 @@ const ColorPickerPanel: FC<ColorPickerPanelProps> = (props) => {
     gradientDragging,
     onGradientDragging,
     disabledFormat,
+    controls,
   } = props;
   const colorPickerPanelPrefixCls = `${prefixCls}-inner`;
 
@@ -60,6 +61,7 @@ const ColorPickerPanel: FC<ColorPickerPanelProps> = (props) => {
       gradientDragging,
       onGradientDragging,
       disabledFormat,
+      controls,
     }),
     [
       prefixCls,
@@ -79,6 +81,7 @@ const ColorPickerPanel: FC<ColorPickerPanelProps> = (props) => {
       gradientDragging,
       onGradientDragging,
       disabledFormat,
+      controls,
     ],
   );
 

--- a/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1501,6 +1501,1097 @@ exports[`renders components/color-picker/demo/controlled.tsx extend context corr
 
 exports[`renders components/color-picker/demo/controlled.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/color-picker/demo/controls.tsx extend context correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"
+>
+  <div
+    class="ant-space-item"
+  >
+    <h5
+      class="ant-typography css-var-test-id"
+    >
+      open controls
+    </h5>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      aria-describedby="test-id"
+      class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+    >
+      <div
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background: rgb(22, 119, 255);"
+        />
+      </div>
+    </div>
+    <div
+      class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-popover-css-var css-var-test-id css-var-test-id ant-color-picker css-var-test-id ant-color-picker-css-var ant-popover-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+    >
+      <div
+        class="ant-popover-arrow"
+        style="position: absolute;"
+      >
+        <span
+          class="ant-popover-arrow-content"
+        />
+      </div>
+      <div
+        class="ant-popover-container"
+        id="test-id"
+        role="tooltip"
+      >
+        <div
+          class="ant-popover-content"
+        >
+          <div
+            class="ant-color-picker-inner"
+          >
+            <div
+              class="ant-color-picker-inner-content"
+            >
+              <div
+                class="ant-color-picker-panel"
+              >
+                <div
+                  class="ant-color-picker-select"
+                >
+                  <div
+                    class="ant-color-picker-palette"
+                    style="position: relative;"
+                  >
+                    <div
+                      style="position: absolute; left: 91.37254901960785%; top: 0%; z-index: 1; transform: translate(-50%, -50%);"
+                    >
+                      <div
+                        class="ant-color-picker-handler"
+                        style="background-color: rgb(22, 119, 255);"
+                      />
+                    </div>
+                    <div
+                      class="ant-color-picker-saturation"
+                      style="background-color: rgb(0, 106, 255); background-image: linear-gradient(0deg, #000, transparent), linear-gradient(90deg, #fff, hsla(0, 0%, 100%, 0));"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-slider-container"
+                >
+                  <div
+                    class="ant-color-picker-slider-group"
+                  >
+                    <div
+                      class="ant-slider ant-color-picker-slider css-var-test-id ant-slider-horizontal"
+                    >
+                      <div
+                        class="ant-slider-rail ant-color-picker-slider-rail"
+                        style="background: linear-gradient(90deg, rgb(255, 0, 0) 0%, rgb(255, 255, 0) 17%, rgb(0, 255, 0) 33%, rgb(0, 255, 255) 50%, rgb(0, 0, 255) 67%, rgb(255, 0, 255) 83%, rgb(255, 0, 0) 100%);"
+                      />
+                      <div
+                        class="ant-slider-step"
+                      />
+                      <div
+                        aria-disabled="false"
+                        aria-orientation="horizontal"
+                        aria-valuemax="359"
+                        aria-valuemin="0"
+                        aria-valuenow="215"
+                        class="ant-slider-handle ant-slider-handle-1 ant-color-picker-slider-handle"
+                        role="slider"
+                        style="left: 59.888579387186624%; transform: translateX(-50%); background: rgb(0, 106, 255);"
+                        tabindex="0"
+                      />
+                    </div>
+                    <div
+                      class="ant-slider ant-color-picker-slider css-var-test-id ant-slider-horizontal"
+                    >
+                      <div
+                        class="ant-slider-rail ant-color-picker-slider-rail"
+                        style="background: linear-gradient(90deg, rgba(255, 0, 4, 0) 0%, rgb(22,119,255) 100%);"
+                      />
+                      <div
+                        class="ant-slider-step"
+                      />
+                      <div
+                        aria-disabled="false"
+                        aria-orientation="horizontal"
+                        aria-valuemax="100"
+                        aria-valuemin="0"
+                        aria-valuenow="100"
+                        class="ant-slider-handle ant-slider-handle-1 ant-color-picker-slider-handle"
+                        role="slider"
+                        style="left: 100%; transform: translateX(-50%); background: rgb(22, 119, 255);"
+                        tabindex="0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="ant-color-picker-color-block"
+                  >
+                    <div
+                      class="ant-color-picker-color-block-inner"
+                      style="background: rgb(22, 119, 255);"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ant-color-picker-input-container"
+              >
+                <div
+                  class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
+                >
+                  <div
+                    class="ant-select-content"
+                  >
+                    <div
+                      class="ant-select-content-value"
+                      style="visibility: visible;"
+                      title="HEX"
+                    >
+                      HEX
+                    </div>
+                    <input
+                      aria-autocomplete="list"
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      autocomplete="off"
+                      class="ant-select-input"
+                      id="test-id"
+                      readonly=""
+                      role="combobox"
+                      type="search"
+                      value=""
+                    />
+                  </div>
+                  <div
+                    class="ant-select-suffix"
+                  >
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </div>
+                <div
+                  class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomRight"
+                  style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1150; width: 68px;"
+                >
+                  <div>
+                    <div
+                      id="test-id_list"
+                      role="listbox"
+                      style="height: 0px; width: 0px; overflow: hidden;"
+                    >
+                      <div
+                        aria-label="HEX"
+                        aria-selected="true"
+                        id="test-id_list_0"
+                        role="option"
+                      >
+                        hex
+                      </div>
+                      <div
+                        aria-label="HSB"
+                        aria-selected="false"
+                        id="test-id_list_1"
+                        role="option"
+                      >
+                        hsb
+                      </div>
+                    </div>
+                    <div
+                      class="rc-virtual-list"
+                      style="position: relative;"
+                    >
+                      <div
+                        class="rc-virtual-list-holder"
+                        style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+                      >
+                        <div>
+                          <div
+                            class="rc-virtual-list-holder-inner"
+                            style="display: flex; flex-direction: column;"
+                          >
+                            <div
+                              class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                              title="HEX"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                HEX
+                              </div>
+                              <span
+                                aria-hidden="true"
+                                class="ant-select-item-option-state"
+                                style="user-select: none;"
+                                unselectable="on"
+                              />
+                            </div>
+                            <div
+                              class="ant-select-item ant-select-item-option"
+                              title="HSB"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                HSB
+                              </div>
+                              <span
+                                aria-hidden="true"
+                                class="ant-select-item-option-state"
+                                style="user-select: none;"
+                                unselectable="on"
+                              />
+                            </div>
+                            <div
+                              class="ant-select-item ant-select-item-option"
+                              title="RGB"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                RGB
+                              </div>
+                              <span
+                                aria-hidden="true"
+                                class="ant-select-item-option-state"
+                                style="user-select: none;"
+                                unselectable="on"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-input"
+                >
+                  <span
+                    class="ant-input-affix-wrapper ant-input-affix-wrapper-sm ant-input-outlined ant-color-picker-hex-input css-var-test-id ant-input-css-var"
+                  >
+                    <span
+                      class="ant-input-prefix"
+                    >
+                      #
+                    </span>
+                    <input
+                      class="ant-input ant-input-sm"
+                      type="text"
+                      value="1677ff"
+                    />
+                  </span>
+                </div>
+                <div
+                  class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-color-picker-steppers ant-color-picker-alpha-input ant-input-number-outlined ant-input-number-sm"
+                >
+                  <input
+                    aria-valuemax="100"
+                    aria-valuemin="0"
+                    aria-valuenow="100"
+                    autocomplete="off"
+                    class="ant-input-number-input"
+                    role="spinbutton"
+                    step="1"
+                    value="100%"
+                  />
+                  <div
+                    class="ant-input-number-actions"
+                  >
+                    <span
+                      aria-disabled="true"
+                      aria-label="Increase Value"
+                      class="ant-input-number-action ant-input-number-action-up ant-input-number-action-up-disabled"
+                      role="button"
+                      unselectable="on"
+                    >
+                      <span
+                        aria-label="up"
+                        class="anticon anticon-up"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          data-icon="up"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                    <span
+                      aria-disabled="false"
+                      aria-label="Decrease Value"
+                      class="ant-input-number-action ant-input-number-action-down"
+                      role="button"
+                      unselectable="on"
+                    >
+                      <span
+                        aria-label="down"
+                        class="anticon anticon-down"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          data-icon="down"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <h5
+      class="ant-typography css-var-test-id"
+    >
+      close controls
+    </h5>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      aria-describedby="test-id"
+      class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+    >
+      <div
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background: rgb(22, 119, 255);"
+        />
+      </div>
+    </div>
+    <div
+      class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-popover-css-var css-var-test-id css-var-test-id ant-color-picker css-var-test-id ant-color-picker-css-var ant-popover-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+    >
+      <div
+        class="ant-popover-arrow"
+        style="position: absolute;"
+      >
+        <span
+          class="ant-popover-arrow-content"
+        />
+      </div>
+      <div
+        class="ant-popover-container"
+        id="test-id"
+        role="tooltip"
+      >
+        <div
+          class="ant-popover-content"
+        >
+          <div
+            class="ant-color-picker-inner"
+          >
+            <div
+              class="ant-color-picker-inner-content"
+            >
+              <div
+                class="ant-color-picker-panel"
+              >
+                <div
+                  class="ant-color-picker-select"
+                >
+                  <div
+                    class="ant-color-picker-palette"
+                    style="position: relative;"
+                  >
+                    <div
+                      style="position: absolute; left: 91.37254901960785%; top: 0%; z-index: 1; transform: translate(-50%, -50%);"
+                    >
+                      <div
+                        class="ant-color-picker-handler"
+                        style="background-color: rgb(22, 119, 255);"
+                      />
+                    </div>
+                    <div
+                      class="ant-color-picker-saturation"
+                      style="background-color: rgb(0, 106, 255); background-image: linear-gradient(0deg, #000, transparent), linear-gradient(90deg, #fff, hsla(0, 0%, 100%, 0));"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-slider-container"
+                >
+                  <div
+                    class="ant-color-picker-slider-group"
+                  >
+                    <div
+                      class="ant-slider ant-color-picker-slider css-var-test-id ant-slider-horizontal"
+                    >
+                      <div
+                        class="ant-slider-rail ant-color-picker-slider-rail"
+                        style="background: linear-gradient(90deg, rgb(255, 0, 0) 0%, rgb(255, 255, 0) 17%, rgb(0, 255, 0) 33%, rgb(0, 255, 255) 50%, rgb(0, 0, 255) 67%, rgb(255, 0, 255) 83%, rgb(255, 0, 0) 100%);"
+                      />
+                      <div
+                        class="ant-slider-step"
+                      />
+                      <div
+                        aria-disabled="false"
+                        aria-orientation="horizontal"
+                        aria-valuemax="359"
+                        aria-valuemin="0"
+                        aria-valuenow="215"
+                        class="ant-slider-handle ant-slider-handle-1 ant-color-picker-slider-handle"
+                        role="slider"
+                        style="left: 59.888579387186624%; transform: translateX(-50%); background: rgb(0, 106, 255);"
+                        tabindex="0"
+                      />
+                    </div>
+                    <div
+                      class="ant-slider ant-color-picker-slider css-var-test-id ant-slider-horizontal"
+                    >
+                      <div
+                        class="ant-slider-rail ant-color-picker-slider-rail"
+                        style="background: linear-gradient(90deg, rgba(255, 0, 4, 0) 0%, rgb(22,119,255) 100%);"
+                      />
+                      <div
+                        class="ant-slider-step"
+                      />
+                      <div
+                        aria-disabled="false"
+                        aria-orientation="horizontal"
+                        aria-valuemax="100"
+                        aria-valuemin="0"
+                        aria-valuenow="100"
+                        class="ant-slider-handle ant-slider-handle-1 ant-color-picker-slider-handle"
+                        role="slider"
+                        style="left: 100%; transform: translateX(-50%); background: rgb(22, 119, 255);"
+                        tabindex="0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="ant-color-picker-color-block"
+                  >
+                    <div
+                      class="ant-color-picker-color-block-inner"
+                      style="background: rgb(22, 119, 255);"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ant-color-picker-input-container"
+              >
+                <div
+                  class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
+                >
+                  <div
+                    class="ant-select-content"
+                  >
+                    <div
+                      class="ant-select-content-value"
+                      style="visibility: visible;"
+                      title="HEX"
+                    >
+                      HEX
+                    </div>
+                    <input
+                      aria-autocomplete="list"
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      autocomplete="off"
+                      class="ant-select-input"
+                      id="test-id"
+                      readonly=""
+                      role="combobox"
+                      type="search"
+                      value=""
+                    />
+                  </div>
+                  <div
+                    class="ant-select-suffix"
+                  >
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </div>
+                <div
+                  class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomRight"
+                  style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1150; width: 68px;"
+                >
+                  <div>
+                    <div
+                      id="test-id_list"
+                      role="listbox"
+                      style="height: 0px; width: 0px; overflow: hidden;"
+                    >
+                      <div
+                        aria-label="HEX"
+                        aria-selected="true"
+                        id="test-id_list_0"
+                        role="option"
+                      >
+                        hex
+                      </div>
+                      <div
+                        aria-label="HSB"
+                        aria-selected="false"
+                        id="test-id_list_1"
+                        role="option"
+                      >
+                        hsb
+                      </div>
+                    </div>
+                    <div
+                      class="rc-virtual-list"
+                      style="position: relative;"
+                    >
+                      <div
+                        class="rc-virtual-list-holder"
+                        style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+                      >
+                        <div>
+                          <div
+                            class="rc-virtual-list-holder-inner"
+                            style="display: flex; flex-direction: column;"
+                          >
+                            <div
+                              class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                              title="HEX"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                HEX
+                              </div>
+                              <span
+                                aria-hidden="true"
+                                class="ant-select-item-option-state"
+                                style="user-select: none;"
+                                unselectable="on"
+                              />
+                            </div>
+                            <div
+                              class="ant-select-item ant-select-item-option"
+                              title="HSB"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                HSB
+                              </div>
+                              <span
+                                aria-hidden="true"
+                                class="ant-select-item-option-state"
+                                style="user-select: none;"
+                                unselectable="on"
+                              />
+                            </div>
+                            <div
+                              class="ant-select-item ant-select-item-option"
+                              title="RGB"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                RGB
+                              </div>
+                              <span
+                                aria-hidden="true"
+                                class="ant-select-item-option-state"
+                                style="user-select: none;"
+                                unselectable="on"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-input"
+                >
+                  <span
+                    class="ant-input-affix-wrapper ant-input-affix-wrapper-sm ant-input-outlined ant-color-picker-hex-input css-var-test-id ant-input-css-var"
+                  >
+                    <span
+                      class="ant-input-prefix"
+                    >
+                      #
+                    </span>
+                    <input
+                      class="ant-input ant-input-sm"
+                      type="text"
+                      value="1677ff"
+                    />
+                  </span>
+                </div>
+                <div
+                  class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-color-picker-steppers ant-color-picker-alpha-input ant-input-number-outlined ant-input-number-sm ant-input-number-without-controls"
+                >
+                  <input
+                    aria-valuemax="100"
+                    aria-valuemin="0"
+                    aria-valuenow="100"
+                    autocomplete="off"
+                    class="ant-input-number-input"
+                    role="spinbutton"
+                    step="1"
+                    value="100%"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <h5
+      class="ant-typography css-var-test-id"
+    >
+      customize controls
+    </h5>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      aria-describedby="test-id"
+      class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+    >
+      <div
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background: rgb(22, 119, 255);"
+        />
+      </div>
+    </div>
+    <div
+      class="ant-popover ant-zoom-big-appear ant-zoom-big-appear-prepare ant-zoom-big ant-popover-css-var css-var-test-id css-var-test-id ant-color-picker css-var-test-id ant-color-picker-css-var ant-popover-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+    >
+      <div
+        class="ant-popover-arrow"
+        style="position: absolute;"
+      >
+        <span
+          class="ant-popover-arrow-content"
+        />
+      </div>
+      <div
+        class="ant-popover-container"
+        id="test-id"
+        role="tooltip"
+      >
+        <div
+          class="ant-popover-content"
+        >
+          <div
+            class="ant-color-picker-inner"
+          >
+            <div
+              class="ant-color-picker-inner-content"
+            >
+              <div
+                class="ant-color-picker-panel"
+              >
+                <div
+                  class="ant-color-picker-select"
+                >
+                  <div
+                    class="ant-color-picker-palette"
+                    style="position: relative;"
+                  >
+                    <div
+                      style="position: absolute; left: 91.37254901960785%; top: 0%; z-index: 1; transform: translate(-50%, -50%);"
+                    >
+                      <div
+                        class="ant-color-picker-handler"
+                        style="background-color: rgb(22, 119, 255);"
+                      />
+                    </div>
+                    <div
+                      class="ant-color-picker-saturation"
+                      style="background-color: rgb(0, 106, 255); background-image: linear-gradient(0deg, #000, transparent), linear-gradient(90deg, #fff, hsla(0, 0%, 100%, 0));"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-slider-container"
+                >
+                  <div
+                    class="ant-color-picker-slider-group"
+                  >
+                    <div
+                      class="ant-slider ant-color-picker-slider css-var-test-id ant-slider-horizontal"
+                    >
+                      <div
+                        class="ant-slider-rail ant-color-picker-slider-rail"
+                        style="background: linear-gradient(90deg, rgb(255, 0, 0) 0%, rgb(255, 255, 0) 17%, rgb(0, 255, 0) 33%, rgb(0, 255, 255) 50%, rgb(0, 0, 255) 67%, rgb(255, 0, 255) 83%, rgb(255, 0, 0) 100%);"
+                      />
+                      <div
+                        class="ant-slider-step"
+                      />
+                      <div
+                        aria-disabled="false"
+                        aria-orientation="horizontal"
+                        aria-valuemax="359"
+                        aria-valuemin="0"
+                        aria-valuenow="215"
+                        class="ant-slider-handle ant-slider-handle-1 ant-color-picker-slider-handle"
+                        role="slider"
+                        style="left: 59.888579387186624%; transform: translateX(-50%); background: rgb(0, 106, 255);"
+                        tabindex="0"
+                      />
+                    </div>
+                    <div
+                      class="ant-slider ant-color-picker-slider css-var-test-id ant-slider-horizontal"
+                    >
+                      <div
+                        class="ant-slider-rail ant-color-picker-slider-rail"
+                        style="background: linear-gradient(90deg, rgba(255, 0, 4, 0) 0%, rgb(22,119,255) 100%);"
+                      />
+                      <div
+                        class="ant-slider-step"
+                      />
+                      <div
+                        aria-disabled="false"
+                        aria-orientation="horizontal"
+                        aria-valuemax="100"
+                        aria-valuemin="0"
+                        aria-valuenow="100"
+                        class="ant-slider-handle ant-slider-handle-1 ant-color-picker-slider-handle"
+                        role="slider"
+                        style="left: 100%; transform: translateX(-50%); background: rgb(22, 119, 255);"
+                        tabindex="0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="ant-color-picker-color-block"
+                  >
+                    <div
+                      class="ant-color-picker-color-block-inner"
+                      style="background: rgb(22, 119, 255);"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ant-color-picker-input-container"
+              >
+                <div
+                  class="ant-select ant-select-sm ant-select-borderless ant-color-picker-format-select css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
+                >
+                  <div
+                    class="ant-select-content"
+                  >
+                    <div
+                      class="ant-select-content-value"
+                      style="visibility: visible;"
+                      title="HEX"
+                    >
+                      HEX
+                    </div>
+                    <input
+                      aria-autocomplete="list"
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      autocomplete="off"
+                      class="ant-select-input"
+                      id="test-id"
+                      readonly=""
+                      role="combobox"
+                      type="search"
+                      value=""
+                    />
+                  </div>
+                  <div
+                    class="ant-select-suffix"
+                  >
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </div>
+                <div
+                  class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomRight"
+                  style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1150; width: 68px;"
+                >
+                  <div>
+                    <div
+                      id="test-id_list"
+                      role="listbox"
+                      style="height: 0px; width: 0px; overflow: hidden;"
+                    >
+                      <div
+                        aria-label="HEX"
+                        aria-selected="true"
+                        id="test-id_list_0"
+                        role="option"
+                      >
+                        hex
+                      </div>
+                      <div
+                        aria-label="HSB"
+                        aria-selected="false"
+                        id="test-id_list_1"
+                        role="option"
+                      >
+                        hsb
+                      </div>
+                    </div>
+                    <div
+                      class="rc-virtual-list"
+                      style="position: relative;"
+                    >
+                      <div
+                        class="rc-virtual-list-holder"
+                        style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+                      >
+                        <div>
+                          <div
+                            class="rc-virtual-list-holder-inner"
+                            style="display: flex; flex-direction: column;"
+                          >
+                            <div
+                              class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                              title="HEX"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                HEX
+                              </div>
+                              <span
+                                aria-hidden="true"
+                                class="ant-select-item-option-state"
+                                style="user-select: none;"
+                                unselectable="on"
+                              />
+                            </div>
+                            <div
+                              class="ant-select-item ant-select-item-option"
+                              title="HSB"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                HSB
+                              </div>
+                              <span
+                                aria-hidden="true"
+                                class="ant-select-item-option-state"
+                                style="user-select: none;"
+                                unselectable="on"
+                              />
+                            </div>
+                            <div
+                              class="ant-select-item ant-select-item-option"
+                              title="RGB"
+                            >
+                              <div
+                                class="ant-select-item-option-content"
+                              >
+                                RGB
+                              </div>
+                              <span
+                                aria-hidden="true"
+                                class="ant-select-item-option-state"
+                                style="user-select: none;"
+                                unselectable="on"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="ant-color-picker-input"
+                >
+                  <span
+                    class="ant-input-affix-wrapper ant-input-affix-wrapper-sm ant-input-outlined ant-color-picker-hex-input css-var-test-id ant-input-css-var"
+                  >
+                    <span
+                      class="ant-input-prefix"
+                    >
+                      #
+                    </span>
+                    <input
+                      class="ant-input ant-input-sm"
+                      type="text"
+                      value="1677ff"
+                    />
+                  </span>
+                </div>
+                <div
+                  class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-color-picker-steppers ant-color-picker-alpha-input ant-input-number-outlined ant-input-number-sm"
+                >
+                  <input
+                    aria-valuemax="100"
+                    aria-valuemin="0"
+                    aria-valuenow="100"
+                    autocomplete="off"
+                    class="ant-input-number-input"
+                    role="spinbutton"
+                    step="1"
+                    value="100%"
+                  />
+                  <div
+                    class="ant-input-number-actions"
+                  >
+                    <span
+                      aria-disabled="true"
+                      aria-label="Increase Value"
+                      class="ant-input-number-action ant-input-number-action-up ant-input-number-action-up-disabled"
+                      role="button"
+                      unselectable="on"
+                    >
+                      <span
+                        aria-label="caret-up"
+                        class="anticon anticon-caret-up"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          data-icon="caret-up"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="0 0 1024 1024"
+                          width="1em"
+                        >
+                          <path
+                            d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                    <span
+                      aria-disabled="false"
+                      aria-label="Decrease Value"
+                      class="ant-input-number-action ant-input-number-action-down"
+                      role="button"
+                      unselectable="on"
+                    >
+                      <span
+                        aria-label="caret-down"
+                        class="anticon anticon-caret-down"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          data-icon="caret-down"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="0 0 1024 1024"
+                          width="1em"
+                        >
+                          <path
+                            d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/color-picker/demo/controls.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/color-picker/demo/disabled.tsx extend context correctly 1`] = `
 Array [
   <div

--- a/components/color-picker/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo.test.tsx.snap
@@ -69,6 +69,88 @@ exports[`renders components/color-picker/demo/controlled.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/color-picker/demo/controls.tsx correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"
+>
+  <div
+    class="ant-space-item"
+  >
+    <h5
+      class="ant-typography css-var-test-id"
+    >
+      open controls
+    </h5>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+    >
+      <div
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background:rgb(22,119,255)"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <h5
+      class="ant-typography css-var-test-id"
+    >
+      close controls
+    </h5>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+    >
+      <div
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background:rgb(22,119,255)"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <h5
+      class="ant-typography css-var-test-id"
+    >
+      customize controls
+    </h5>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+    >
+      <div
+        class="ant-color-picker-color-block"
+      >
+        <div
+          class="ant-color-picker-color-block-inner"
+          style="background:rgb(22,119,255)"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/color-picker/demo/disabled.tsx correctly 1`] = `
 <div
   class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var ant-color-picker-trigger-disabled"

--- a/components/color-picker/__tests__/components.test.tsx
+++ b/components/color-picker/__tests__/components.test.tsx
@@ -46,9 +46,7 @@ describe('ColorPicker Components test', () => {
     fireEvent.change(container.querySelector('.test-hex-input input')!, {
       target: { value: 631515 },
     });
-    expect(container.querySelector('.test-hex-input input')?.getAttribute('value')).toBe(
-      '631515',
-    );
+    expect(container.querySelector('.test-hex-input input')?.getAttribute('value')).toBe('631515');
     expect(handleAlphaChange).toHaveBeenCalledTimes(1);
   });
 

--- a/components/color-picker/__tests__/gradient.test.tsx
+++ b/components/color-picker/__tests__/gradient.test.tsx
@@ -376,9 +376,7 @@ describe('ColorPicker.gradient', () => {
       document.querySelector('.ant-color-picker-presets .ant-color-picker-color-block-inner')!,
     );
     const color = onChange.mock.calls[0][0];
-    expect(color.toCssString()).toBe(
-      'linear-gradient(90deg, rgb(255,0,0) 0%, rgb(0,0,255) 100%)',
-    );
+    expect(color.toCssString()).toBe('linear-gradient(90deg, rgb(255,0,0) 0%, rgb(0,0,255) 100%)');
     expect(document.querySelector('.ant-color-picker-presets-color-checked')).toBeTruthy();
   });
 });

--- a/components/color-picker/components/ColorSteppers.tsx
+++ b/components/color-picker/components/ColorSteppers.tsx
@@ -1,9 +1,10 @@
 import type { FC } from 'react';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { clsx } from 'clsx';
 
 import type { InputNumberProps } from '../../input-number';
 import InputNumber from '../../input-number';
+import { PanelPickerContext } from '../context';
 
 interface ColorSteppersProps {
   prefixCls: string;
@@ -25,6 +26,8 @@ const ColorSteppers: FC<ColorSteppersProps> = ({
   className,
   formatter,
 }) => {
+  const { controls } = useContext(PanelPickerContext);
+
   const colorSteppersPrefixCls = `${prefixCls}-steppers`;
   const [internalValue, setInternalValue] = useState<number | undefined>(0);
 
@@ -33,6 +36,7 @@ const ColorSteppers: FC<ColorSteppersProps> = ({
   return (
     <InputNumber
       className={clsx(colorSteppersPrefixCls, className)}
+      controls={controls}
       min={min}
       max={max}
       value={stepValue}

--- a/components/color-picker/context.ts
+++ b/components/color-picker/context.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import type { GetProp } from '../_util/type';
+import type { InputNumberProps } from '../input-number';
 import type { AggregationColor } from './color';
 import type { ModeOptions } from './hooks/useModeColor';
 import type { ColorFormatType, ColorPickerProps, ModeType, PresetsItem } from './interface';
@@ -32,6 +33,8 @@ export interface PanelPickerContextProps {
 
   onClear?: () => void;
   disabledFormat?: boolean;
+
+  controls: InputNumberProps['controls'];
 }
 
 export interface PanelPresetsContextProps {

--- a/components/color-picker/demo/controls.md
+++ b/components/color-picker/demo/controls.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+设置`InputNumber`的`panelControls`，影响的是面板中 RGB、HSB 或 Alpha（透明度） 等`InputNumber`的表现
+
+## en-US
+
+Setting the `panelControls` prop of `InputNumber` affects the display of the stepper buttons for RGB, HSB, or Alpha (opacity) input fields within the panel.

--- a/components/color-picker/demo/controls.tsx
+++ b/components/color-picker/demo/controls.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { CaretDownOutlined, CaretUpOutlined } from '@ant-design/icons';
+import { ColorPicker, Space, Typography } from 'antd';
+
+const { Title } = Typography;
+
+const Demo = () => {
+  return (
+    <Space vertical>
+      <Title level={5}>open controls</Title>
+      <ColorPicker defaultValue="#1677ff" />
+      <Title level={5}>close controls</Title>
+      <ColorPicker panelControls={false} defaultValue="#1677ff" />
+      <Title level={5}>customize controls</Title>
+      <ColorPicker
+        panelControls={{ upIcon: <CaretUpOutlined />, downIcon: <CaretDownOutlined /> }}
+        defaultValue="#1677ff"
+      />
+    </Space>
+  );
+};
+
+export default Demo;

--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -20,6 +20,7 @@ Used when the user needs to make a customized color selection.
 <code src="./demo/base.tsx">Basic Usage</code>
 <code src="./demo/size.tsx">Trigger size</code>
 <code src="./demo/controlled.tsx">controlled mode</code>
+<code src="./demo/controls.tsx" version="6.6.0">controls</code>
 <code src="./demo/line-gradient.tsx" version="5.20.0">Line Gradient</code>
 <code src="./demo/text-render.tsx">Rendering Trigger Text</code>
 <code src="./demo/disabled.tsx">Disable</code>
@@ -47,6 +48,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | arrow | Configuration for popup arrow | `boolean \| { pointAtCenter: boolean }` | true |  | 6.3.0 |
 | children | Trigger of ColorPicker | React.ReactNode | - |  | × |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
+| panelControls | `InputNumber` Whether to show `+-` controls, or set custom arrow icons | boolean \| { upIcon?: React.ReactNode; downIcon?: React.ReactNode; } | - | 6.6.0 | × |
 | defaultValue | Default value of color | [ColorType](#colortype) | - |  | × |
 | defaultFormat | Default format of color | `rgb` \| `hex` \| `hsb` | `hex` | 5.9.0 | × |
 | disabled | Disable ColorPicker | boolean | - |  | × |

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -21,6 +21,7 @@ group:
 <code src="./demo/base.tsx">基本使用</code>
 <code src="./demo/size.tsx">触发器尺寸大小</code>
 <code src="./demo/controlled.tsx">受控模式</code>
+<code src="./demo/controls.tsx" version="6.6.0">controls</code>
 <code src="./demo/line-gradient.tsx" version="5.20.0">渐变色</code>
 <code src="./demo/text-render.tsx">渲染触发器文本</code>
 <code src="./demo/disabled.tsx">禁用</code>
@@ -48,6 +49,7 @@ group:
 | arrow | 配置弹出的箭头 | `boolean \| { pointAtCenter: boolean }` | true |  | 6.3.0 |
 | children | 颜色选择器的触发器 | React.ReactNode | - |  | × |
 | classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
+| panelControls | `InputNumber` 是否显示增减按钮，也可设置自定义箭头图标 | boolean \| { upIcon?: React.ReactNode; downIcon?: React.ReactNode; } | - | 6.6.0 | × |
 | defaultValue | 颜色默认的值 | [ColorType](#colortype) | - |  | × |
 | defaultFormat | 颜色格式默认的值 | `rgb` \| `hex` \| `hsb` | `hex` | 5.9.0 | × |
 | disabled | 禁用颜色选择器 | boolean | - |  | × |

--- a/components/color-picker/interface.ts
+++ b/components/color-picker/interface.ts
@@ -6,6 +6,7 @@ import type {
 
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import type { SizeType } from '../config-provider/SizeContext';
+import type { InputNumberProps } from '../input-number';
 import type { PopoverProps } from '../popover';
 import type { TooltipPlacement } from '../tooltip';
 import type { AggregationColor } from './color';
@@ -91,6 +92,7 @@ export type ColorPickerProps = Omit<
   value?: ColorValueType;
   defaultValue?: ColorValueType;
   children?: React.ReactNode;
+  panelControls?: InputNumberProps['controls'];
   open?: boolean;
   disabled?: boolean;
   placement?: TriggerPlacement;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature

### 🔗 Related Issues


### 💡 Background and Solution
<img width="330" height="317" alt="image" src="https://github.com/user-attachments/assets/25bfe6a1-87f5-4d58-ad9b-eed1b5425d6a" />
<img width="322" height="305" alt="image" src="https://github.com/user-attachments/assets/a4a7702d-a551-435b-8d8e-7cd55da4231c" />

如上图在使用中，`controls`会挡住输入框，其实有的时候不需要这个`controls`，现在没有参数可以把他去掉


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       support panelControls prop    |
| 🇨🇳 Chinese |     support panelControls prop      |
