### PR TITLE
feat(Done): support rendering multiple values (#56744)

### DIFF
--- a/components/progress/Line.tsx
+++ b/components/progress/Line.tsx
@@ -168,7 +168,7 @@ const Line: React.FC<LineProps> = (props) => {
 
       return (
         <div
-          key={`${item.value}-${item.status}`}
+          key={`${item.value}-${item.status}-${item.accumulatedValue}`}
           className={clsx(
             trackCls,
             itemStatus === 'success' && `${trackCls}-success`,

--- a/components/progress/Steps.tsx
+++ b/components/progress/Steps.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { clsx } from 'clsx';
 
 import type { ProgressProps, ProgressSemanticClassNames, ProgressSemanticStyles } from './progress';
-import { getSize } from './utils';
+import { getSize, normalizePercent } from './utils';
 
 interface ProgressStepsProps extends Omit<ProgressProps, 'classNames' | 'styles'> {
   steps: number;
@@ -29,7 +29,8 @@ const Steps: React.FC<ProgressStepsProps> = (props) => {
     prefixCls,
     children,
   } = props;
-  const current = customRounding(steps * ((percent as number) / 100));
+  const normalizedPercent = normalizePercent(percent);
+  const current = customRounding(steps * (normalizedPercent / 100));
   const stepWidth = size === 'small' ? 2 : 14;
   const mergedSize = size ?? [stepWidth, strokeWidth];
   const [width, height] = getSize(mergedSize, 'step', { steps, strokeWidth });

--- a/components/progress/Steps.tsx
+++ b/components/progress/Steps.tsx
@@ -29,7 +29,7 @@ const Steps: React.FC<ProgressStepsProps> = (props) => {
     prefixCls,
     children,
   } = props;
-  const current = customRounding(steps * (percent / 100));
+  const current = customRounding(steps * ((percent as number) / 100));
   const stepWidth = size === 'small' ? 2 : 14;
   const mergedSize = size ?? [stepWidth, strokeWidth];
   const [width, height] = getSize(mergedSize, 'step', { steps, strokeWidth });

--- a/components/progress/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/progress/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3244,6 +3244,144 @@ exports[`renders components/progress/demo/linecap.tsx extend context correctly 1
 
 exports[`renders components/progress/demo/linecap.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/progress/demo/multi-value.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow="90"
+    class="ant-progress ant-progress-status-normal ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-show-info ant-progress-default css-var-test-id"
+    role="progressbar"
+  >
+    <div
+      class="ant-progress-body"
+      style="width: 100%;"
+    >
+      <div
+        class="ant-progress-rail"
+        style="height: 8px; position: relative;"
+      >
+        <div
+          class="ant-progress-track"
+          style="position: absolute; inset-inline-start: 0; width: 90%; height: 8px;"
+        />
+        <div
+          class="ant-progress-track"
+          style="position: absolute; inset-inline-start: 0; width: 70%; height: 8px;"
+        />
+        <div
+          class="ant-progress-track ant-progress-track-success"
+          style="position: absolute; inset-inline-start: 0; width: 40%; height: 8px;"
+        />
+      </div>
+      <span
+        class="ant-progress-indicator ant-progress-indicator-end ant-progress-indicator-outer"
+        title="90%"
+      >
+        90%
+      </span>
+    </div>
+  </div>
+  <div
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow="100"
+    class="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-show-info ant-progress-default css-var-test-id"
+    role="progressbar"
+  >
+    <div
+      class="ant-progress-body"
+      style="width: 100%;"
+    >
+      <div
+        class="ant-progress-rail"
+        style="height: 8px; position: relative;"
+      >
+        <div
+          class="ant-progress-track"
+          style="position: absolute; inset-inline-start: 0; width: 100%; height: 8px;"
+        />
+        <div
+          class="ant-progress-track"
+          style="position: absolute; inset-inline-start: 0; width: 80%; height: 8px;"
+        />
+        <div
+          class="ant-progress-track ant-progress-track-success"
+          style="position: absolute; inset-inline-start: 0; width: 30%; height: 8px;"
+        />
+      </div>
+      <span
+        class="ant-progress-indicator ant-progress-indicator-end ant-progress-indicator-outer"
+      >
+        <span
+          aria-label="check-circle"
+          class="anticon anticon-check-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="check-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow="85"
+    class="ant-progress ant-progress-status-normal ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-show-info ant-progress-default css-var-test-id"
+    role="progressbar"
+  >
+    <div
+      class="ant-progress-body"
+      style="width: 100%;"
+    >
+      <div
+        class="ant-progress-rail"
+        style="height: 8px; position: relative;"
+      >
+        <div
+          class="ant-progress-track"
+          style="position: absolute; inset-inline-start: 0; width: 85%; height: 8px; --progress-line-stroke-color: #d9d9d9; background: rgb(217, 217, 217);"
+        />
+        <div
+          class="ant-progress-track"
+          style="position: absolute; inset-inline-start: 0; width: 75%; height: 8px; --progress-line-stroke-color: #ff4d4f; background: rgb(255, 77, 79);"
+        />
+        <div
+          class="ant-progress-track"
+          style="position: absolute; inset-inline-start: 0; width: 60%; height: 8px; --progress-line-stroke-color: #1890ff; background: rgb(24, 144, 255);"
+        />
+        <div
+          class="ant-progress-track ant-progress-track-success"
+          style="position: absolute; inset-inline-start: 0; width: 25%; height: 8px; --progress-line-stroke-color: #52c41a; background: rgb(82, 196, 26);"
+        />
+      </div>
+      <span
+        class="ant-progress-indicator ant-progress-indicator-end ant-progress-indicator-outer"
+        title="85%"
+      >
+        85%
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/progress/demo/multi-value.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/progress/demo/segment.tsx extend context correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"

--- a/components/progress/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.ts.snap
@@ -3098,6 +3098,142 @@ exports[`renders components/progress/demo/linecap.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/progress/demo/multi-value.tsx correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow="90"
+    class="ant-progress ant-progress-status-normal ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-show-info ant-progress-default css-var-test-id"
+    role="progressbar"
+  >
+    <div
+      class="ant-progress-body"
+      style="width:100%"
+    >
+      <div
+        class="ant-progress-rail"
+        style="height:8px;position:relative"
+      >
+        <div
+          class="ant-progress-track"
+          style="position:absolute;inset-inline-start:0;width:90%;height:8px"
+        />
+        <div
+          class="ant-progress-track"
+          style="position:absolute;inset-inline-start:0;width:70%;height:8px"
+        />
+        <div
+          class="ant-progress-track ant-progress-track-success"
+          style="position:absolute;inset-inline-start:0;width:40%;height:8px"
+        />
+      </div>
+      <span
+        class="ant-progress-indicator ant-progress-indicator-end ant-progress-indicator-outer"
+        title="90%"
+      >
+        90%
+      </span>
+    </div>
+  </div>
+  <div
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow="100"
+    class="ant-progress ant-progress-status-success ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-show-info ant-progress-default css-var-test-id"
+    role="progressbar"
+  >
+    <div
+      class="ant-progress-body"
+      style="width:100%"
+    >
+      <div
+        class="ant-progress-rail"
+        style="height:8px;position:relative"
+      >
+        <div
+          class="ant-progress-track"
+          style="position:absolute;inset-inline-start:0;width:100%;height:8px"
+        />
+        <div
+          class="ant-progress-track"
+          style="position:absolute;inset-inline-start:0;width:80%;height:8px"
+        />
+        <div
+          class="ant-progress-track ant-progress-track-success"
+          style="position:absolute;inset-inline-start:0;width:30%;height:8px"
+        />
+      </div>
+      <span
+        class="ant-progress-indicator ant-progress-indicator-end ant-progress-indicator-outer"
+      >
+        <span
+          aria-label="check-circle"
+          class="anticon anticon-check-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="check-circle"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow="85"
+    class="ant-progress ant-progress-status-normal ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-show-info ant-progress-default css-var-test-id"
+    role="progressbar"
+  >
+    <div
+      class="ant-progress-body"
+      style="width:100%"
+    >
+      <div
+        class="ant-progress-rail"
+        style="height:8px;position:relative"
+      >
+        <div
+          class="ant-progress-track"
+          style="position:absolute;inset-inline-start:0;width:85%;height:8px;--progress-line-stroke-color:#d9d9d9;background:#d9d9d9"
+        />
+        <div
+          class="ant-progress-track"
+          style="position:absolute;inset-inline-start:0;width:75%;height:8px;--progress-line-stroke-color:#ff4d4f;background:#ff4d4f"
+        />
+        <div
+          class="ant-progress-track"
+          style="position:absolute;inset-inline-start:0;width:60%;height:8px;--progress-line-stroke-color:#1890ff;background:#1890ff"
+        />
+        <div
+          class="ant-progress-track ant-progress-track-success"
+          style="position:absolute;inset-inline-start:0;width:25%;height:8px;--progress-line-stroke-color:#52c41a;background:#52c41a"
+        />
+      </div>
+      <span
+        class="ant-progress-indicator ant-progress-indicator-end ant-progress-indicator-outer"
+        title="85%"
+      >
+        85%
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/progress/demo/segment.tsx correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"

--- a/components/progress/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.tsx.snap
@@ -902,6 +902,115 @@ exports[`Progress rtl render component should be rendered correctly in RTL direc
 </div>
 `;
 
+exports[`Progress should maintain backward compatibility with single number percent 1`] = `
+<div
+  aria-valuemax="100"
+  aria-valuemin="0"
+  aria-valuenow="50"
+  class="ant-progress ant-progress-status-normal ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-show-info ant-progress-default css-var-root"
+  role="progressbar"
+>
+  <div
+    class="ant-progress-body"
+    style="width: 100%;"
+  >
+    <div
+      class="ant-progress-rail"
+      style="height: 8px;"
+    >
+      <div
+        class="ant-progress-track"
+        style="width: 50%; height: 8px;"
+      />
+    </div>
+    <span
+      class="ant-progress-indicator ant-progress-indicator-end ant-progress-indicator-outer"
+      title="50%"
+    >
+      50%
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Progress should render multi-value progress 1`] = `
+<div
+  aria-valuemax="100"
+  aria-valuemin="0"
+  aria-valuenow="90"
+  class="ant-progress ant-progress-status-normal ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-show-info ant-progress-default css-var-root"
+  role="progressbar"
+>
+  <div
+    class="ant-progress-body"
+    style="width: 100%;"
+  >
+    <div
+      class="ant-progress-rail"
+      style="height: 8px; position: relative;"
+    >
+      <div
+        class="ant-progress-track"
+        style="position: absolute; inset-inline-start: 0; width: 90%; height: 8px;"
+      />
+      <div
+        class="ant-progress-track"
+        style="position: absolute; inset-inline-start: 0; width: 70%; height: 8px;"
+      />
+      <div
+        class="ant-progress-track ant-progress-track-success"
+        style="position: absolute; inset-inline-start: 0; width: 40%; height: 8px;"
+      />
+    </div>
+    <span
+      class="ant-progress-indicator ant-progress-indicator-end ant-progress-indicator-outer"
+      title="90%"
+    >
+      90%
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Progress should render multi-value progress with custom strokeColor 1`] = `
+<div
+  aria-valuemax="100"
+  aria-valuemin="0"
+  aria-valuenow="75"
+  class="ant-progress ant-progress-status-normal ant-progress-line ant-progress-line-align-end ant-progress-line-position-outer ant-progress-show-info ant-progress-default css-var-root"
+  role="progressbar"
+>
+  <div
+    class="ant-progress-body"
+    style="width: 100%;"
+  >
+    <div
+      class="ant-progress-rail"
+      style="height: 8px; position: relative;"
+    >
+      <div
+        class="ant-progress-track"
+        style="position: absolute; inset-inline-start: 0; width: 75%; height: 8px; --progress-line-stroke-color: #ff4d4f; background: rgb(255, 77, 79);"
+      />
+      <div
+        class="ant-progress-track"
+        style="position: absolute; inset-inline-start: 0; width: 60%; height: 8px; --progress-line-stroke-color: #1890ff; background: rgb(24, 144, 255);"
+      />
+      <div
+        class="ant-progress-track ant-progress-track-success"
+        style="position: absolute; inset-inline-start: 0; width: 25%; height: 8px; --progress-line-stroke-color: #52c41a; background: rgb(82, 196, 26);"
+      />
+    </div>
+    <span
+      class="ant-progress-indicator ant-progress-indicator-end ant-progress-indicator-outer"
+      title="75%"
+    >
+      75%
+    </span>
+  </div>
+</div>
+`;
+
 exports[`Progress should support steps 1`] = `
 <div
   aria-valuemax="100"

--- a/components/progress/__tests__/index.test.tsx
+++ b/components/progress/__tests__/index.test.tsx
@@ -449,4 +449,80 @@ describe('Progress', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('should render multi-value progress', () => {
+    const { container } = render(
+      <Progress
+        percent={[
+          { value: 40, status: 'success' },
+          { value: 30, status: 'active' },
+          { value: 20, status: 'exception' },
+        ]}
+      />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('should render multi-value progress with custom strokeColor', () => {
+    const { container } = render(
+      <Progress
+        percent={[
+          { value: 25, status: 'success', strokeColor: '#52c41a' },
+          { value: 35, status: 'active', strokeColor: '#1890ff' },
+          { value: 15, status: 'exception', strokeColor: '#ff4d4f' },
+        ]}
+      />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('should calculate total percent from multi-value array', () => {
+    const { container } = render(
+      <Progress
+        percent={[
+          { value: 30, status: 'success' },
+          { value: 50, status: 'active' },
+          { value: 20, status: 'normal' },
+        ]}
+        showInfo
+      />,
+    );
+    const indicator = container.querySelector('.ant-progress-indicator');
+    expect(indicator?.textContent).toBe('100%');
+  });
+
+  it('should maintain backward compatibility with single number percent', () => {
+    const { container } = render(<Progress percent={50} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('should warn when using multi-value with circle type', () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <Progress
+        type="circle"
+        percent={[
+          { value: 40, status: 'success' },
+          { value: 30, status: 'active' },
+        ]}
+      />,
+    );
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('should warn when using multi-value with dashboard type', () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <Progress
+        type="dashboard"
+        percent={[
+          { value: 40, status: 'success' },
+          { value: 30, status: 'active' },
+        ]}
+      />,
+    );
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
 });

--- a/components/progress/demo/multi-value.md
+++ b/components/progress/demo/multi-value.md
@@ -3,4 +3,10 @@ order: 0
 title: Multi-value Progress
 ---
 
-Progress with multiple segments, each with its own value and status.
+## zh-CN
+
+通过设置 `percent` 为数组，可以显示多个进度段，每个进度段可以有自己的值和状态。
+
+## en-US
+
+By setting `percent` as an array, you can display multiple progress segments, each with its own value and status.

--- a/components/progress/demo/multi-value.md
+++ b/components/progress/demo/multi-value.md
@@ -1,0 +1,6 @@
+---
+order: 0
+title: Multi-value Progress
+---
+
+Progress with multiple segments, each with its own value and status.

--- a/components/progress/demo/multi-value.tsx
+++ b/components/progress/demo/multi-value.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Flex, Progress } from 'antd';
+
+const App: React.FC = () => (
+  <Flex gap="middle" vertical>
+    <Progress
+      percent={[
+        { value: 40, status: 'success' },
+        { value: 30, status: 'active' },
+        { value: 20, status: 'exception' },
+      ]}
+    />
+    <Progress
+      percent={[
+        { value: 30, status: 'success' },
+        { value: 50, status: 'active' },
+        { value: 20, status: 'normal' },
+      ]}
+    />
+    <Progress
+      percent={[
+        { value: 25, status: 'success', strokeColor: '#52c41a' },
+        { value: 35, status: 'active', strokeColor: '#1890ff' },
+        { value: 15, status: 'exception', strokeColor: '#ff4d4f' },
+        { value: 10, status: 'normal', strokeColor: '#d9d9d9' },
+      ]}
+    />
+  </Flex>
+);
+
+export default App;

--- a/components/progress/demo/style-class.tsx
+++ b/components/progress/demo/style-class.tsx
@@ -10,7 +10,7 @@ const classNames: ProgressProps['classNames'] = {
 
 const stylesFn: ProgressProps['styles'] = (info) => {
   const percent = info?.props?.percent ?? 0;
-  const hue = 200 - (200 * percent) / 100;
+  const hue = 200 - (200 * (percent as number)) / 100;
   return {
     track: {
       backgroundImage: `

--- a/components/progress/demo/style-class.tsx
+++ b/components/progress/demo/style-class.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Flex, Progress } from 'antd';
 import type { ProgressProps } from 'antd';
+import { normalizePercent } from '../utils';
 
 const classNames: ProgressProps['classNames'] = {
   root: 'demo-progress-root',
@@ -10,7 +11,8 @@ const classNames: ProgressProps['classNames'] = {
 
 const stylesFn: ProgressProps['styles'] = (info) => {
   const percent = info?.props?.percent ?? 0;
-  const hue = 200 - (200 * (percent as number)) / 100;
+  const normalizedPercent = normalizePercent(percent);
+  const hue = 200 - (200 * normalizedPercent) / 100;
   return {
     track: {
       backgroundImage: `

--- a/components/progress/index.en-US.md
+++ b/components/progress/index.en-US.md
@@ -28,6 +28,7 @@ If it will take a long time to complete an operation, you can use `Progress` to 
 <code src="./demo/format.tsx">Custom text format</code>
 <code src="./demo/dashboard.tsx">Dashboard</code>
 <code src="./demo/segment.tsx">Progress bar with success segment</code>
+<code src="./demo/multi-value.tsx">Multi-value progress</code>
 <code src="./demo/linecap.tsx">Stroke Linecap</code>
 <code src="./demo/gradient-line.tsx">Custom line gradient</code>
 <code src="./demo/steps.tsx">Progress bar with steps</code>
@@ -46,7 +47,7 @@ Properties that shared by all types.
 | --- | --- | --- | --- | --- |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | format | The template function of the content | function(percent, successPercent) | (percent) => percent + `%` | - |
-| percent | To set the completion percentage | number | 0 | - |
+| percent | To set the completion percentage. When passing an array, each item represents a segment with `value` and optional `status` and `strokeColor` | number \| Array<{ value: number; status?: 'success' \| 'exception' \| 'active' \| 'normal'; strokeColor?: string }> | 0 | - |
 | railColor | The color of unfilled part | string | - | - |
 | showInfo | Whether to display the progress value and the status icon | boolean | true |
 | status | To set the status of the Progress, options: `success` `exception` `normal` `active`(line only) | string | - |

--- a/components/progress/index.tsx
+++ b/components/progress/index.tsx
@@ -6,6 +6,7 @@ export type {
   ProgressSemanticClassNames,
   ProgressSemanticName,
   ProgressSemanticStyles,
+  ProgressValueItem,
 } from './progress';
 
 export default Progress;

--- a/components/progress/index.zh-CN.md
+++ b/components/progress/index.zh-CN.md
@@ -29,6 +29,7 @@ demo:
 <code src="./demo/format.tsx">自定义文字格式</code>
 <code src="./demo/dashboard.tsx">仪表盘</code>
 <code src="./demo/segment.tsx">分段进度条</code>
+<code src="./demo/multi-value.tsx">多值进度条</code>
 <code src="./demo/linecap.tsx">边缘形状</code>
 <code src="./demo/gradient-line.tsx">自定义进度条渐变色</code>
 <code src="./demo/steps.tsx">步骤进度条</code>
@@ -47,7 +48,7 @@ demo:
 | --- | --- | --- | --- | --- |
 | classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | format | 内容的模板函数 | function(percent, successPercent) | (percent) => percent + `%` | - |
-| percent | 百分比 | number | 0 | - |
+| percent | 百分比。当传入数组时，每个元素代表一个分段，包含 `value` 以及可选的 `status` 和 `strokeColor` | number \| Array<{ value: number; status?: 'success' \| 'exception' \| 'active' \| 'normal'; strokeColor?: string }> | 0 | - |
 | railColor | 未完成的分段的颜色 | string | - | - |
 | showInfo | 是否显示进度数值或状态图标 | boolean | true | - |
 | status | 状态，可选：`success` `exception` `normal` `active`(仅限 line) | string | - | - |

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -144,7 +144,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>((props, ref) =>
   const percentNumber = React.useMemo<number>(() => {
     if (isMultiValue) {
       const total = percent.reduce((sum, item) => sum + validProgress(item.value), 0);
-      return Number.parseInt(total.toString(), 10);
+      return Number.parseInt(validProgress(total).toString(), 10);
     }
     const successPercent = getSuccessPercent(props);
     return Number.parseInt(

--- a/components/progress/utils.ts
+++ b/components/progress/utils.ts
@@ -23,7 +23,7 @@ export function getSuccessPercent({ success }: ProgressProps) {
 
 export const getPercentage = ({ percent, success }: ProgressProps) => {
   const realSuccessPercent = validProgress(getSuccessPercent({ success }));
-  return [realSuccessPercent, validProgress(validProgress(percent) - realSuccessPercent)];
+  return [realSuccessPercent, validProgress(validProgress(percent as number) - realSuccessPercent)];
 };
 
 export const getStrokeColor = ({

--- a/components/progress/utils.ts
+++ b/components/progress/utils.ts
@@ -21,9 +21,28 @@ export function getSuccessPercent({ success }: ProgressProps) {
   return percent;
 }
 
-export const getPercentage = ({ percent, success }: ProgressProps) => {
+/**
+ * Normalizes percent value to a number between 0-100.
+ * Handles both single number values and multi-value arrays (ProgressValueItem[]).
+ * For arrays, sums all values and clamps the result.
+ */
+export function normalizePercent(percent: ProgressProps['percent']): number {
+  if (Array.isArray(percent)) {
+    // For ProgressValueItem[], sum all values
+    if (percent.length > 0 && typeof percent[0] === 'object' && 'value' in percent[0]) {
+      const total = percent.reduce((sum, item) => sum + validProgress(item.value), 0);
+      return validProgress(total);
+    }
+    return 0;
+  }
+  const numPercent = Number(percent) || 0;
+  return validProgress(numPercent);
+}
+
+export const getPercentage = ({ percent, success }: ProgressProps): [number, number] => {
   const realSuccessPercent = validProgress(getSuccessPercent({ success }));
-  return [realSuccessPercent, validProgress(validProgress(percent as number) - realSuccessPercent)];
+  const normalizedPercent = normalizePercent(percent);
+  return [realSuccessPercent, validProgress(normalizedPercent - realSuccessPercent)];
 };
 
 export const getStrokeColor = ({


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Closes #56744

### 💡 Background and Solution

The current `Progress` component only supports a single value, which limits use cases such as segmented or stacked progress representations (e.g. completed, in-progress, failed).

This change adds support for rendering **multiple values** within a single `Progress` component while keeping the existing single-value API fully backward compatible.

No breaking changes are introduced. Existing usages of Progress with a single numeric value continue to work as before.

#### Example

```tsx
<Progress
  percent={[
    { value: 40, status: 'success' },
    { value: 30, status: 'active' },
    { value: 20, status: 'exception' },
  ]}
/>


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Progress component now supports rendering multiple values in a single progress bar. |
| 🇨🇳 Chinese | Progress 组件现已支持在单个进度条中渲染多个数值。 |

