### PR TITLE
fix(Cascader): optionRender usage for empty search results

### DIFF
--- a/components/cascader/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/cascader/__tests__/__snapshots__/index.test.tsx.snap
@@ -1288,6 +1288,38 @@ exports[`Cascader should highlight keyword and filter when search in Cascader 1`
 
 exports[`Cascader should highlight keyword and filter when search in Cascader with same field name of label and value 1`] = `"<div><div class="ant-cascader-menus"><ul class="ant-cascader-menu" role="menu"><li class="ant-cascader-menu-item" role="menuitemcheckbox" aria-checked="false" data-path-key="Zhejiang__RC_CASCADER_SPLIT__Hangzhou__RC_CASCADER_SPLIT__West Lake"><div class="ant-cascader-menu-item-content"><span class="ant-cascader-menu-item-keyword">Z</span>hejiang / Hang<span class="ant-cascader-menu-item-keyword">z</span>hou / West Lake</div></li><li class="ant-cascader-menu-item ant-cascader-menu-item-disabled" role="menuitemcheckbox" aria-checked="false" data-path-key="Zhejiang__RC_CASCADER_SPLIT__Hangzhou__RC_CASCADER_SPLIT__Xia Sha"><div class="ant-cascader-menu-item-content"><span class="ant-cascader-menu-item-keyword">Z</span>hejiang / Hang<span class="ant-cascader-menu-item-keyword">z</span>hou / Xia Sha</div></li></ul></div></div>"`;
 
+exports[`Cascader should render custom notFoundContent when search returns no results 1`] = `
+<div
+  class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-cascader-dropdown ant-select-css-var ant-cascader-css-var css-var-root ant-select-dropdown-empty ant-select-dropdown-placement-bottomLeft"
+  style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+>
+  <div>
+    <div
+      class="ant-cascader-menus ant-cascader-menu-empty"
+    >
+      <ul
+        class="ant-cascader-menu"
+        role="menu"
+      >
+        <li
+          aria-checked="false"
+          class="ant-cascader-menu-item ant-cascader-menu-item-disabled"
+          data-path-key="__EMPTY__"
+          role="menuitemcheckbox"
+          title="no data"
+        >
+          <div
+            class="ant-cascader-menu-item-content"
+          >
+            no data
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Cascader should render not found content 1`] = `
 <div
   class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-cascader-dropdown ant-select-css-var ant-cascader-css-var css-var-root ant-select-dropdown-empty ant-select-dropdown-placement-bottomLeft"

--- a/components/cascader/__tests__/index.test.tsx
+++ b/components/cascader/__tests__/index.test.tsx
@@ -207,6 +207,26 @@ describe('Cascader', () => {
     expect(getDropdown(container)).toMatchSnapshot();
   });
 
+  it('should render custom notFoundContent when search returns no results', () => {
+    const { container } = render(
+      <Cascader
+        options={options}
+        placeholder="Please select"
+        showSearch={{ filter }}
+        notFoundContent="no data"
+        optionRender={(option) => option?.label}
+      />,
+    );
+    fireEvent.change(container.querySelector('input')!, {
+      target: { value: '__notfoundkeyword__' },
+    });
+    const dropdown = getDropdown(container);
+    expect(dropdown).toBeTruthy();
+    const notFoundElement = dropdown?.querySelector('.ant-cascader-menu-item-content');
+    expect(notFoundElement?.textContent).toBe('no data');
+    expect(dropdown).toMatchSnapshot();
+  });
+
   it('should support to clear selection', () => {
     const { container } = render(
       <Cascader options={options} defaultValue={['zhejiang', 'hangzhou']} />,

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@ant-design/icons": "^6.1.0",
     "@ant-design/react-slick": "~2.0.0",
     "@babel/runtime": "^7.28.4",
-    "@rc-component/cascader": "~1.12.0",
+    "@rc-component/cascader": "~1.12.1",
     "@rc-component/checkbox": "~1.0.1",
     "@rc-component/collapse": "~1.2.0",
     "@rc-component/color-picker": "~3.1.0",


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
issue: [56724](https://github.com/ant-design/ant-design/issues/56724)

### 💡 Background and Solution
When both the optionRender and notFoundContent properties are set on the Cascader component, the search results are empty and notFoundContent does not take effect.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix notFoundContent not working |
| 🇨🇳 Chinese | 修复 notFoundContent 不生效 |
