### PR TITLE
fix(Typography): lower link selector specificity

### DIFF
--- a/components/drawer/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`renders components/drawer/demo/_semantic.tsx correctly 1`] = `
               class="ant-drawer-footer semantic-mark-footer"
             >
               <a
-                class="ant-typography css-var-test-id"
+                class="ant-typography ant-typography-link css-var-test-id"
               >
                 Footer
               </a>

--- a/components/dropdown/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/dropdown/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -7118,7 +7118,7 @@ exports[`renders components/dropdown/demo/render-panel.tsx extend context correc
 exports[`renders components/dropdown/demo/selectable.tsx extend context correctly 1`] = `
 Array [
   <a
-    class="ant-typography ant-dropdown-trigger css-var-test-id"
+    class="ant-typography ant-typography-link ant-dropdown-trigger css-var-test-id"
   >
     <div
       class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"

--- a/components/dropdown/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/dropdown/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1262,7 +1262,7 @@ exports[`renders components/dropdown/demo/render-panel.tsx correctly 1`] = `
 
 exports[`renders components/dropdown/demo/selectable.tsx correctly 1`] = `
 <a
-  class="ant-typography ant-dropdown-trigger css-var-test-id"
+  class="ant-typography ant-typography-link ant-dropdown-trigger css-var-test-id"
 >
   <div
     class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"

--- a/components/modal/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/modal/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1052,7 +1052,7 @@ exports[`renders components/modal/demo/render-panel.tsx extend context correctly
           class="ant-typography css-var-test-id"
         >
           <a
-            class="ant-typography css-var-test-id"
+            class="ant-typography ant-typography-link css-var-test-id"
             href="https://github.com/ant-design/ant-design/pull/44318"
           >
             Feature #44318

--- a/components/modal/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/modal/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1014,7 +1014,7 @@ exports[`renders components/modal/demo/render-panel.tsx correctly 1`] = `
           class="ant-typography css-var-test-id"
         >
           <a
-            class="ant-typography css-var-test-id"
+            class="ant-typography ant-typography-link css-var-test-id"
             href="https://github.com/ant-design/ant-design/pull/44318"
           >
             Feature #44318

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -16413,7 +16413,7 @@ exports[`renders components/space/demo/separator.tsx extend context correctly 1`
     class="ant-space-item"
   >
     <a
-      class="ant-typography css-var-test-id"
+      class="ant-typography ant-typography-link css-var-test-id"
     >
       Link
     </a>
@@ -16430,7 +16430,7 @@ exports[`renders components/space/demo/separator.tsx extend context correctly 1`
     class="ant-space-item"
   >
     <a
-      class="ant-typography css-var-test-id"
+      class="ant-typography ant-typography-link css-var-test-id"
     >
       Link
     </a>
@@ -16447,7 +16447,7 @@ exports[`renders components/space/demo/separator.tsx extend context correctly 1`
     class="ant-space-item"
   >
     <a
-      class="ant-typography css-var-test-id"
+      class="ant-typography ant-typography-link css-var-test-id"
     >
       Link
     </a>

--- a/components/space/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.tsx.snap
@@ -4275,7 +4275,7 @@ exports[`renders components/space/demo/separator.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <a
-      class="ant-typography css-var-test-id"
+      class="ant-typography ant-typography-link css-var-test-id"
     >
       Link
     </a>
@@ -4292,7 +4292,7 @@ exports[`renders components/space/demo/separator.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <a
-      class="ant-typography css-var-test-id"
+      class="ant-typography ant-typography-link css-var-test-id"
     >
       Link
     </a>
@@ -4309,7 +4309,7 @@ exports[`renders components/space/demo/separator.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <a
-      class="ant-typography css-var-test-id"
+      class="ant-typography ant-typography-link css-var-test-id"
     >
       Link
     </a>

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -8550,7 +8550,7 @@ exports[`renders components/table/demo/edit-row.tsx extend context correctly 1`]
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -8579,7 +8579,7 @@ exports[`renders components/table/demo/edit-row.tsx extend context correctly 1`]
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -8608,7 +8608,7 @@ exports[`renders components/table/demo/edit-row.tsx extend context correctly 1`]
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -8637,7 +8637,7 @@ exports[`renders components/table/demo/edit-row.tsx extend context correctly 1`]
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -8666,7 +8666,7 @@ exports[`renders components/table/demo/edit-row.tsx extend context correctly 1`]
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -8695,7 +8695,7 @@ exports[`renders components/table/demo/edit-row.tsx extend context correctly 1`]
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -8724,7 +8724,7 @@ exports[`renders components/table/demo/edit-row.tsx extend context correctly 1`]
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -8753,7 +8753,7 @@ exports[`renders components/table/demo/edit-row.tsx extend context correctly 1`]
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -8782,7 +8782,7 @@ exports[`renders components/table/demo/edit-row.tsx extend context correctly 1`]
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -8811,7 +8811,7 @@ exports[`renders components/table/demo/edit-row.tsx extend context correctly 1`]
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>

--- a/components/table/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.ts.snap
@@ -7504,7 +7504,7 @@ exports[`renders components/table/demo/edit-row.tsx correctly 1`] = `
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -7533,7 +7533,7 @@ exports[`renders components/table/demo/edit-row.tsx correctly 1`] = `
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -7562,7 +7562,7 @@ exports[`renders components/table/demo/edit-row.tsx correctly 1`] = `
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -7591,7 +7591,7 @@ exports[`renders components/table/demo/edit-row.tsx correctly 1`] = `
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -7620,7 +7620,7 @@ exports[`renders components/table/demo/edit-row.tsx correctly 1`] = `
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -7649,7 +7649,7 @@ exports[`renders components/table/demo/edit-row.tsx correctly 1`] = `
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -7678,7 +7678,7 @@ exports[`renders components/table/demo/edit-row.tsx correctly 1`] = `
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -7707,7 +7707,7 @@ exports[`renders components/table/demo/edit-row.tsx correctly 1`] = `
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -7736,7 +7736,7 @@ exports[`renders components/table/demo/edit-row.tsx correctly 1`] = `
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>
@@ -7765,7 +7765,7 @@ exports[`renders components/table/demo/edit-row.tsx correctly 1`] = `
                     class="ant-table-cell"
                   >
                     <a
-                      class="ant-typography css-var-test-id"
+                      class="ant-typography ant-typography-link css-var-test-id"
                     >
                       Edit
                     </a>

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -440,6 +440,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
                 [`${prefixCls}-ellipsis`]: enableEllipsis,
                 [`${prefixCls}-ellipsis-single-line`]: cssTextOverflow,
                 [`${prefixCls}-ellipsis-multiple-line`]: cssLineClamp,
+                [`${prefixCls}-link`]: component === 'a',
               },
               className,
             )}

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -59,7 +59,7 @@ exports[`renders components/typography/demo/basic.tsx extend context correctly 1
     <ul>
       <li>
         <a
-          class="ant-typography css-var-test-id"
+          class="ant-typography ant-typography-link css-var-test-id"
           href="/docs/spec/proximity"
         >
           Principles
@@ -67,7 +67,7 @@ exports[`renders components/typography/demo/basic.tsx extend context correctly 1
       </li>
       <li>
         <a
-          class="ant-typography css-var-test-id"
+          class="ant-typography ant-typography-link css-var-test-id"
           href="/docs/spec/overview"
         >
           Patterns
@@ -75,7 +75,7 @@ exports[`renders components/typography/demo/basic.tsx extend context correctly 1
       </li>
       <li>
         <a
-          class="ant-typography css-var-test-id"
+          class="ant-typography ant-typography-link css-var-test-id"
           href="/docs/resources"
         >
           Resource Download
@@ -163,7 +163,7 @@ exports[`renders components/typography/demo/basic.tsx extend context correctly 1
     <ul>
       <li>
         <a
-          class="ant-typography css-var-test-id"
+          class="ant-typography ant-typography-link css-var-test-id"
           href="/docs/spec/proximity-cn"
         >
           设计原则
@@ -171,7 +171,7 @@ exports[`renders components/typography/demo/basic.tsx extend context correctly 1
       </li>
       <li>
         <a
-          class="ant-typography css-var-test-id"
+          class="ant-typography ant-typography-link css-var-test-id"
           href="/docs/spec/overview-cn"
         >
           设计模式
@@ -179,7 +179,7 @@ exports[`renders components/typography/demo/basic.tsx extend context correctly 1
       </li>
       <li>
         <a
-          class="ant-typography css-var-test-id"
+          class="ant-typography ant-typography-link css-var-test-id"
           href="/docs/resources-cn"
         >
           设计资源
@@ -272,7 +272,7 @@ Array [
       <ul>
         <li>
           <a
-            class="ant-typography css-var-test-id"
+            class="ant-typography ant-typography-link css-var-test-id"
             href="/docs/spec/proximity"
           >
             Principles
@@ -280,7 +280,7 @@ Array [
         </li>
         <li>
           <a
-            class="ant-typography css-var-test-id"
+            class="ant-typography ant-typography-link css-var-test-id"
             href="/docs/spec/overview"
           >
             Patterns
@@ -288,7 +288,7 @@ Array [
         </li>
         <li>
           <a
-            class="ant-typography css-var-test-id"
+            class="ant-typography ant-typography-link css-var-test-id"
             href="/docs/resources"
           >
             Resource Download
@@ -371,7 +371,7 @@ Array [
       <ul>
         <li>
           <a
-            class="ant-typography css-var-test-id"
+            class="ant-typography ant-typography-link css-var-test-id"
             href="/docs/spec/proximity-cn"
           >
             设计原则
@@ -379,7 +379,7 @@ Array [
         </li>
         <li>
           <a
-            class="ant-typography css-var-test-id"
+            class="ant-typography ant-typography-link css-var-test-id"
             href="/docs/spec/overview-cn"
           >
             设计模式
@@ -387,7 +387,7 @@ Array [
         </li>
         <li>
           <a
-            class="ant-typography css-var-test-id"
+            class="ant-typography ant-typography-link css-var-test-id"
             href="/docs/resources-cn"
           >
             设计资源
@@ -2233,6 +2233,47 @@ exports[`renders components/typography/demo/ellipsis-middle.tsx extend context c
 
 exports[`renders components/typography/demo/ellipsis-middle.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/typography/demo/link-danger-debug.tsx extend context correctly 1`] = `
+<article
+  class="ant-typography css-var-test-id"
+>
+  <span
+    class="ant-typography css-var-test-id"
+  >
+    Typography.Link 的 type="danger" 颜色应为 error 文本色。
+  </span>
+  <br />
+  <a
+    class="ant-typography ant-typography-danger ant-typography-link css-var-test-id"
+    href="https://ant.design"
+  >
+    Danger Link
+  </a>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-rail"
+    role="separator"
+  />
+  <span
+    class="ant-typography css-var-test-id"
+  >
+    Button 以 a 标签渲染时，不应被 Typography 链接样式影响。
+  </span>
+  <br />
+  <a
+    aria-disabled="false"
+    class="ant-btn css-var-test-id ant-btn-link ant-btn-color-link ant-btn-variant-link"
+    href="https://ant.design"
+    tabindex="0"
+  >
+    <span>
+      Button Link
+    </span>
+  </a>
+</article>
+`;
+
+exports[`renders components/typography/demo/link-danger-debug.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/typography/demo/paragraph-debug.tsx extend context correctly 1`] = `
 Array [
   <h1
@@ -2635,7 +2676,7 @@ exports[`renders components/typography/demo/text.tsx extend context correctly 1`
     class="ant-space-item"
   >
     <a
-      class="ant-typography css-var-test-id"
+      class="ant-typography ant-typography-link css-var-test-id"
       href="https://ant.design"
       rel="noopener noreferrer"
       target="_blank"

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1586,6 +1586,45 @@ exports[`renders components/typography/demo/ellipsis-middle.tsx correctly 1`] = 
 </span>
 `;
 
+exports[`renders components/typography/demo/link-danger-debug.tsx correctly 1`] = `
+<article
+  class="ant-typography css-var-test-id"
+>
+  <span
+    class="ant-typography css-var-test-id"
+  >
+    Typography.Link 的 type="danger" 颜色应为 error 文本色。
+  </span>
+  <br />
+  <a
+    class="ant-typography ant-typography-danger css-var-test-id"
+    href="https://ant.design"
+  >
+    Danger Link
+  </a>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-rail"
+    role="separator"
+  />
+  <span
+    class="ant-typography css-var-test-id"
+  >
+    Button 以 a 标签渲染时，不应被 Typography 链接样式影响。
+  </span>
+  <br />
+  <a
+    aria-disabled="false"
+    class="ant-btn css-var-test-id ant-btn-link ant-btn-color-link ant-btn-variant-link"
+    href="https://ant.design"
+    tabindex="0"
+  >
+    <span>
+      Button Link
+    </span>
+  </a>
+</article>
+`;
+
 exports[`renders components/typography/demo/paragraph-debug.tsx correctly 1`] = `
 Array [
   <h1

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`renders components/typography/demo/basic.tsx correctly 1`] = `
     <ul>
       <li>
         <a
-          class="ant-typography css-var-test-id"
+          class="ant-typography ant-typography-link css-var-test-id"
           href="/docs/spec/proximity"
         >
           Principles
@@ -68,7 +68,7 @@ exports[`renders components/typography/demo/basic.tsx correctly 1`] = `
       </li>
       <li>
         <a
-          class="ant-typography css-var-test-id"
+          class="ant-typography ant-typography-link css-var-test-id"
           href="/docs/spec/overview"
         >
           Patterns
@@ -76,7 +76,7 @@ exports[`renders components/typography/demo/basic.tsx correctly 1`] = `
       </li>
       <li>
         <a
-          class="ant-typography css-var-test-id"
+          class="ant-typography ant-typography-link css-var-test-id"
           href="/docs/resources"
         >
           Resource Download
@@ -164,7 +164,7 @@ exports[`renders components/typography/demo/basic.tsx correctly 1`] = `
     <ul>
       <li>
         <a
-          class="ant-typography css-var-test-id"
+          class="ant-typography ant-typography-link css-var-test-id"
           href="/docs/spec/proximity-cn"
         >
           设计原则
@@ -172,7 +172,7 @@ exports[`renders components/typography/demo/basic.tsx correctly 1`] = `
       </li>
       <li>
         <a
-          class="ant-typography css-var-test-id"
+          class="ant-typography ant-typography-link css-var-test-id"
           href="/docs/spec/overview-cn"
         >
           设计模式
@@ -180,7 +180,7 @@ exports[`renders components/typography/demo/basic.tsx correctly 1`] = `
       </li>
       <li>
         <a
-          class="ant-typography css-var-test-id"
+          class="ant-typography ant-typography-link css-var-test-id"
           href="/docs/resources-cn"
         >
           设计资源
@@ -272,7 +272,7 @@ Array [
       <ul>
         <li>
           <a
-            class="ant-typography css-var-test-id"
+            class="ant-typography ant-typography-link css-var-test-id"
             href="/docs/spec/proximity"
           >
             Principles
@@ -280,7 +280,7 @@ Array [
         </li>
         <li>
           <a
-            class="ant-typography css-var-test-id"
+            class="ant-typography ant-typography-link css-var-test-id"
             href="/docs/spec/overview"
           >
             Patterns
@@ -288,7 +288,7 @@ Array [
         </li>
         <li>
           <a
-            class="ant-typography css-var-test-id"
+            class="ant-typography ant-typography-link css-var-test-id"
             href="/docs/resources"
           >
             Resource Download
@@ -371,7 +371,7 @@ Array [
       <ul>
         <li>
           <a
-            class="ant-typography css-var-test-id"
+            class="ant-typography ant-typography-link css-var-test-id"
             href="/docs/spec/proximity-cn"
           >
             设计原则
@@ -379,7 +379,7 @@ Array [
         </li>
         <li>
           <a
-            class="ant-typography css-var-test-id"
+            class="ant-typography ant-typography-link css-var-test-id"
             href="/docs/spec/overview-cn"
           >
             设计模式
@@ -387,7 +387,7 @@ Array [
         </li>
         <li>
           <a
-            class="ant-typography css-var-test-id"
+            class="ant-typography ant-typography-link css-var-test-id"
             href="/docs/resources-cn"
           >
             设计资源
@@ -1597,7 +1597,7 @@ exports[`renders components/typography/demo/link-danger-debug.tsx correctly 1`] 
   </span>
   <br />
   <a
-    class="ant-typography ant-typography-danger css-var-test-id"
+    class="ant-typography ant-typography-danger ant-typography-link css-var-test-id"
     href="https://ant.design"
   >
     Danger Link
@@ -2003,7 +2003,7 @@ exports[`renders components/typography/demo/text.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <a
-      class="ant-typography css-var-test-id"
+      class="ant-typography ant-typography-link css-var-test-id"
       href="https://ant.design"
       rel="noopener noreferrer"
       target="_blank"

--- a/components/typography/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/index.test.tsx.snap
@@ -20,6 +20,6 @@ exports[`Typography rtl render component should be rendered correctly in RTL dir
 
 exports[`Typography rtl render component should be rendered correctly in RTL direction 4`] = `
 <a
-  class="ant-typography ant-typography-rtl css-var-root"
+  class="ant-typography ant-typography-rtl ant-typography-link css-var-root"
 />
 `;

--- a/components/typography/demo/link-danger-debug.md
+++ b/components/typography/demo/link-danger-debug.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+Typography.Link 的 danger 颜色与 Button Link 的样式隔离。
+
+## en-US
+
+Typography.Link danger color and isolation from Button link styles.

--- a/components/typography/demo/link-danger-debug.tsx
+++ b/components/typography/demo/link-danger-debug.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Button, Divider, Typography } from 'antd';
+
+const { Text, Link } = Typography;
+
+const App: React.FC = () => (
+  <Typography>
+    <Text>Typography.Link 的 type="danger" 颜色应为 error 文本色。</Text>
+    <br />
+    <Link href="https://ant.design" type="danger">
+      Danger Link
+    </Link>
+    <Divider />
+    <Text>Button 以 a 标签渲染时，不应被 Typography 链接样式影响。</Text>
+    <br />
+    <Button type="link" href="https://ant.design">
+      Button Link
+    </Button>
+  </Typography>
+);
+
+export default App;

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -27,6 +27,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 <code src="./demo/ellipsis-debug.tsx" debug>Ellipsis Debug</code>
 <code src="./demo/suffix.tsx">suffix</code>
 <code src="./demo/componentToken-debug.tsx" debug>Component Token</code>
+<code src="./demo/link-danger-debug.tsx" debug>Link danger Debug</code>
 
 ## API
 

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -28,6 +28,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 <code src="./demo/ellipsis-debug.tsx" debug>省略号 Debug</code>
 <code src="./demo/suffix.tsx">后缀</code>
 <code src="./demo/componentToken-debug.tsx" debug>组件 Token</code>
+<code src="./demo/link-danger-debug.tsx" debug>Link danger Debug</code>
 
 ## API
 

--- a/components/typography/style/index.ts
+++ b/components/typography/style/index.ts
@@ -36,22 +36,34 @@ const genTypographyStyle: GenerateStyle<TypographyToken> = (token) => {
       lineHeight: token.lineHeight,
       [`&${componentCls}-secondary`]: {
         color: token.colorTextDescription,
+        [`&${componentCls}-link`]: {
+          color: token.colorTextDescription,
+        },
       },
 
       [`&${componentCls}-success`]: {
         color: token.colorSuccessText,
+        [`&${componentCls}-link`]: {
+          color: token.colorSuccessText,
+        },
       },
 
       [`&${componentCls}-warning`]: {
         color: token.colorWarningText,
+        [`&${componentCls}-link`]: {
+          color: token.colorWarningText,
+        },
       },
 
       [`&${componentCls}-danger`]: {
         color: token.colorErrorText,
-        'a&:active, a&:focus': {
+        [`&${componentCls}-link`]: {
+          color: token.colorErrorText,
+        },
+        [`&${componentCls}-link:active, &${componentCls}-link:focus`]: {
           color: token.colorErrorTextActive,
         },
-        'a&:hover': {
+        [`&${componentCls}-link:hover`]: {
           color: token.colorErrorTextHover,
         },
       },

--- a/components/typography/style/index.ts
+++ b/components/typography/style/index.ts
@@ -34,32 +34,20 @@ const genTypographyStyle: GenerateStyle<TypographyToken> = (token) => {
       color: token.colorText,
       wordBreak: 'break-word',
       lineHeight: token.lineHeight,
-      [`&${componentCls}-secondary`]: {
+      [`&${componentCls}-secondary, &${componentCls}-link${componentCls}-secondary`]: {
         color: token.colorTextDescription,
-        [`&${componentCls}-link`]: {
-          color: token.colorTextDescription,
-        },
       },
 
-      [`&${componentCls}-success`]: {
+      [`&${componentCls}-success, &${componentCls}-link${componentCls}-success`]: {
         color: token.colorSuccessText,
-        [`&${componentCls}-link`]: {
-          color: token.colorSuccessText,
-        },
       },
 
-      [`&${componentCls}-warning`]: {
+      [`&${componentCls}-warning, &${componentCls}-link${componentCls}-warning`]: {
         color: token.colorWarningText,
-        [`&${componentCls}-link`]: {
-          color: token.colorWarningText,
-        },
       },
 
-      [`&${componentCls}-danger`]: {
+      [`&${componentCls}-danger, &${componentCls}-link${componentCls}-danger`]: {
         color: token.colorErrorText,
-        [`&${componentCls}-link`]: {
-          color: token.colorErrorText,
-        },
         [`&${componentCls}-link:active, &${componentCls}-link:focus`]: {
           color: token.colorErrorTextActive,
         },

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -60,7 +60,7 @@ export const getLinkStyles: GenerateStyle<TypographyToken, CSSObject> = (token) 
   return {
     // fix issue: https://github.com/ant-design/ant-design/issues/56606
     // exclude ant-btn to avoid style conflicts with Button component when it renders as <a></a> tag (variant='link' with href)
-    [`a&:not(${btnCls}), a:not(${btnCls})`]: {
+    [`a&:not(:where(${btnCls})), a:not(:where(${btnCls}))`]: {
       ...operationUnit(token),
 
       [`&[disabled], &${componentCls}-disabled`]: {

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -54,14 +54,13 @@ export const getTitleStyles: GenerateStyle<TypographyToken, CSSObject> = (token)
 };
 
 export const getLinkStyles: GenerateStyle<TypographyToken, CSSObject> = (token) => {
-  const { componentCls, antCls } = token;
-  const btnCls = `${antCls}-btn`;
+  const { componentCls } = token;
+  const linkCls = `${componentCls}-link`;
 
   return {
-    // fix issue: https://github.com/ant-design/ant-design/issues/56606
-    // exclude ant-btn to avoid style conflicts with Button component when it renders as <a></a> tag (variant='link' with href)
-    [`a&:not(:where(${btnCls})), a:not(:where(${btnCls}))`]: {
+    [`&${linkCls}`]: {
       ...operationUnit(token),
+      userSelect: 'text',
 
       [`&[disabled], &${componentCls}-disabled`]: {
         color: token.colorTextDisabled,


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- fix #56757

### 💡 需求背景和解决方案

- `Typography.Link` 在 `type="danger"` 时颜色被链接样式覆盖，表现为仍是主题色。
- 调整 `Typography` 链接样式的选择器权重，避免压过 `type` 的颜色类。
- 新增 debug demo 覆盖两个场景：`Link type="danger"` 颜色、`Button` 以 `<a>` 渲染时样式隔离。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix `Typography.Link` danger color being overridden by link styles. |
| 🇨🇳 中文 | 修复 `Typography.Link` 的 danger 颜色被链接样式覆盖的问题。 |