### PR TITLE
fix: Textarea ref miss nativeElement

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -67,6 +67,7 @@ export interface TextAreaRef {
   focus: (options?: InputFocusOptions) => void;
   blur: () => void;
   resizableTextArea?: RcTextAreaRef['resizableTextArea'];
+  nativeElement: HTMLElement | null;
 }
 
 const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
@@ -134,6 +135,7 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>((props, ref) => {
       triggerFocus(innerRef.current?.resizableTextArea?.textArea, option);
     },
     blur: () => innerRef.current?.blur(),
+    nativeElement: innerRef.current?.nativeElement || null,
   }));
 
   const prefixCls = getPrefixCls('input', customizePrefixCls);

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -12160,6 +12160,33 @@ Array [
       </span>
     </span>
   </span>,
+  <br />,
+  <textarea
+    aria-describedby="test-id"
+    class="ant-input ant-input-outlined css-var-test-id ant-input-css-var"
+    placeholder="TextArea wrapped in Tooltip for debugging"
+    style="margin-top: 16px;"
+  />,
+  <div
+    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-tooltip-placement-top"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+  >
+    <div
+      class="ant-tooltip-arrow"
+      style="position: absolute; bottom: 0px; left: 0px;"
+    >
+      <span
+        class="ant-tooltip-arrow-content"
+      />
+    </div>
+    <div
+      class="ant-tooltip-container"
+      id="test-id"
+      role="tooltip"
+    >
+      Debug TextArea with Tooltip
+    </div>
+  </div>,
 ]
 `;
 

--- a/components/input/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.tsx.snap
@@ -5477,6 +5477,12 @@ Array [
       </span>
     </span>
   </span>,
+  <br />,
+  <textarea
+    class="ant-input ant-input-outlined css-var-test-id ant-input-css-var"
+    placeholder="TextArea wrapped in Tooltip for debugging"
+    style="margin-top:16px"
+  />,
 ]
 `;
 

--- a/components/input/__tests__/textarea.test.tsx
+++ b/components/input/__tests__/textarea.test.tsx
@@ -605,4 +605,18 @@ describe('TextArea allowClear', () => {
     fireEvent.mouseUp(container.querySelector('textarea')!);
     expect(container.querySelector('.ant-input-mouse-active')).toBeFalsy();
   });
+
+  describe('ref.nativeElement should be the root div', () => {
+    it('basic', () => {
+      const ref = React.createRef<TextAreaRef>();
+      const { container } = render(<TextArea ref={ref} />);
+      expect(ref.current?.nativeElement).toBe(container.firstChild);
+    });
+
+    it('with showCount', () => {
+      const ref = React.createRef<TextAreaRef>();
+      const { container } = render(<TextArea ref={ref} showCount />);
+      expect(ref.current?.nativeElement).toBe(container.firstChild);
+    });
+  });
 });

--- a/components/input/demo/textarea-resize.tsx
+++ b/components/input/demo/textarea-resize.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
-import { Button, Input } from 'antd';
+import React, { useRef, useState } from 'react';
+import { Button, Input, Tooltip } from 'antd';
+import type { TextAreaRef } from 'antd/es/input/TextArea';
 
 const { TextArea } = Input;
 
@@ -8,6 +9,7 @@ const defaultValue =
 
 const App: React.FC = () => {
   const [autoResize, setAutoResize] = useState(false);
+  const textAreaRef = useRef<TextAreaRef>(null);
 
   return (
     <>
@@ -23,6 +25,15 @@ const App: React.FC = () => {
         }}
         showCount
       />
+      <br />
+      <Tooltip title="Debug TextArea with Tooltip">
+        <TextArea
+          ref={textAreaRef}
+          placeholder="TextArea wrapped in Tooltip for debugging"
+          style={{ marginTop: 16 }}
+          onFocus={() => console.log('nativeElement:', textAreaRef.current?.nativeElement)}
+        />
+      </Tooltip>
     </>
   );
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #56800

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Input.TextArea miss `ref.nativeElement` which makes Tooltip or Popover will not align on the correct position.       |
| 🇨🇳 Chinese |    修复 Input.TextArea 缺失 `ref.nativeElement` 导致 Tooltip 与 Popover 定位错误的问题。       |
