### PR TITLE
chore: merge duplicate debug demos 

### DIFF
--- a/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -968,30 +968,6 @@ exports[`renders components/button/demo/debug-color-variant.tsx extend context c
       </span>
     </button>
   </div>
-  <div
-    class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-small"
-  >
-    <button
-      class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text"
-      type="button"
-    >
-      <span>
-        type="text" (Default)
-      </span>
-    </button>
-  </div>
-  <div
-    class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-small"
-  >
-    <button
-      class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
-      type="button"
-    >
-      <span>
-        default button token
-      </span>
-    </button>
-  </div>
 </div>
 `;
 

--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -952,30 +952,6 @@ exports[`renders components/button/demo/debug-color-variant.tsx correctly 1`] = 
       </span>
     </button>
   </div>
-  <div
-    class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-small"
-  >
-    <button
-      class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text"
-      type="button"
-    >
-      <span>
-        type="text" (Default)
-      </span>
-    </button>
-  </div>
-  <div
-    class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-small"
-  >
-    <button
-      class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
-      type="button"
-    >
-      <span>
-        default button token
-      </span>
-    </button>
-  </div>
 </div>
 `;
 

--- a/components/button/demo/debug-color-variant.tsx
+++ b/components/button/demo/debug-color-variant.tsx
@@ -114,45 +114,6 @@ const App: React.FC = () => {
           <Button type="dashed">Dashed</Button>
         </ConfigProvider>
       </Flex>
-      <Flex gap="small" wrap>
-        <ConfigProvider
-          theme={{
-            components: {
-              Button: {
-                textTextColor: '#f60',
-                textTextHoverColor: '#722ed1',
-                textTextActiveColor: '#0f0',
-                textHoverBg: '#000',
-              },
-            },
-          }}
-        >
-          <Button type="text">type="text" (Default)</Button>
-        </ConfigProvider>
-      </Flex>
-      <Flex gap="small" wrap>
-        <ConfigProvider
-          theme={{
-            components: {
-              Button: {
-                textTextColor: '#f60',
-                textTextHoverColor: '#722ed1',
-                textTextActiveColor: '#0f0',
-                textHoverBg: '#000',
-
-                defaultColor: 'red',
-                defaultBorderColor: 'blue',
-                defaultHoverColor: 'yellow',
-                defaultHoverBorderColor: 'green',
-                defaultActiveColor: 'purple',
-                defaultActiveBorderColor: 'orange',
-              },
-            },
-          }}
-        >
-          <Button type="default">default button token</Button>
-        </ConfigProvider>
-      </Flex>
     </Flex>
   );
 };


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案

https://github.com/ant-design/ant-design/pull/56719
https://github.com/ant-design/ant-design/pull/56291
https://github.com/ant-design/ant-design/pull/56238

几个pr修复token问题的产生的debug demo合并到了 component-token的debug demo中

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |   merge duplicate debug demos        |
| 🇨🇳 中文 |     合并几个pr产生的几个重复的debug demo     |
