### PR TITLE
fix: Update reference URL in font specification

### DIFF
--- a/docs/spec/font.en-US.md
+++ b/docs/spec/font.en-US.md
@@ -26,7 +26,7 @@ In order to implement a good font system, the first thing is to choose an approp
   'Noto Color Emoji';
 ```
 
-> References：https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/ and https://markdotto.com/blog/github-system-fonts/
+> References: https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/ and https://markdotto.com/blog/github-system-fonts/
 
 In addition, in many applications, numbers often need to be displayed vertically. We recommend setting the CSS property `font-variant-numeric` to `tabular-nums` to use [tabular figures](https://www.fonts.com/content/learning/fontology/level-3/numbers/proportional-vs-tabular-figures).
 

--- a/docs/spec/font.en-US.md
+++ b/docs/spec/font.en-US.md
@@ -26,7 +26,7 @@ In order to implement a good font system, the first thing is to choose an approp
   'Noto Color Emoji';
 ```
 
-> References：https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/ and http://markdotto.com/2018/02/07/github-system-fonts/
+> References：https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/ and https://markdotto.com/blog/github-system-fonts/
 
 In addition, in many applications, numbers often need to be displayed vertically. We recommend setting the CSS property `font-variant-numeric` to `tabular-nums` to use [tabular figures](https://www.fonts.com/content/learning/fontology/level-3/numbers/proportional-vs-tabular-figures).
 

--- a/docs/spec/font.zh-CN.md
+++ b/docs/spec/font.zh-CN.md
@@ -26,7 +26,7 @@ title: 字体
   'Noto Color Emoji';
 ```
 
-> 参考自 https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/ 和 http://markdotto.com/2018/02/07/github-system-fonts/
+> 参考自 https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/ 和 https://markdotto.com/blog/github-system-fonts/
 
 另外，在中后台系统中，数字经常需要进行纵向对比展示，我们推荐将数字的字体 [font-variant-numeric](https://www.fonts.com/content/learning/fontology/level-3/numbers/proportional-vs-tabular-figures) 设置为 `tabular-nums`，使其为等宽字体。
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 💡 Background and Solution

Update the URL: from https://markdotto.com/2018/02/07/github-system-fonts/ to https://markdotto.com/blog/github-system-fonts/

### 📝 Change Log
I do not see that the documentation changes are tracked in the Changelog https://ant.design/changelog 🤷🏼
