### PR TITLE
feat: add null type for menu item

### DIFF
--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -88,7 +88,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*Vn4XSqJFAxcAAA
 | icon     | 菜单图标                 | ReactNode | -      |        |
 | key      | item 的唯一标志          | string    | -      |        |
 | label    | 菜单项标题               | ReactNode | -      |        |
-| title    | 设置收缩时展示的悬浮标题 | string    | -      |        |
+| title    | 设置收缩时展示的悬浮标题 | string \| null | -      |        |
 
 #### SubMenuType
 

--- a/components/menu/interface.ts
+++ b/components/menu/interface.ts
@@ -12,7 +12,7 @@ export type DataAttributes = {
 export interface MenuItemType extends RcMenuItemType, DataAttributes {
   danger?: boolean;
   icon?: React.ReactNode;
-  title?: string;
+  title?: string | null;
 }
 
 export interface SubMenuType<T extends MenuItemType = MenuItemType>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🤖 TypeScript definition improvement

### 🔗 Related Issues

Resolves #56866

### 💡 Background and Solution

title指定为null可以不展示收缩状态下的tooltip，但是type目前只支持string和undefined

效果：https://codesandbox.io/p/devbox/cold-moon-gx2r7w?workspaceId=ws_VzQeogqhzmPjTB599QqiHw

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇨🇳 Chinese |     在MenuItemType里增加 title: null      |
