### PR TITLE
fix(button): add theme-aware preset color hover/active tokens

### DIFF
--- a/.jest.image.js
+++ b/.jest.image.js
@@ -1,13 +1,11 @@
 const { moduleNameMapper, transformIgnorePatterns } = require('./.jest');
 
-// jest config for image snapshots
 module.exports = {
   setupFiles: ['./tests/setup.ts'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'md'],
   moduleNameMapper,
   transform: {
-    '\\.tsx?$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
-    '\\.js$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
+    '^.+\\.(ts|tsx|js|mjs)$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
     '\\.md$': './node_modules/@ant-design/tools/lib/jest/demoPreprocessor',
     '\\.(jpg|png|gif|svg)$': './node_modules/@ant-design/tools/lib/jest/imagePreprocessor',
   },

--- a/.jest.js
+++ b/.jest.js
@@ -63,7 +63,7 @@ module.exports = {
   ],
   transform: {
     '\\.tsx?$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
-    '\\.(m?)js$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
+    '\\.(m?)js(m)?$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
     '\\.md$': './node_modules/@ant-design/tools/lib/jest/demoPreprocessor',
     '\\.(jpg|png|gif|svg)$': './node_modules/@ant-design/tools/lib/jest/imagePreprocessor',
   },

--- a/.jest.js
+++ b/.jest.js
@@ -11,6 +11,7 @@ const compileModules = [
   'parse5',
   '@exodus',
   'jsdom',
+  '@csstools',
 ];
 
 // cnpm use `_` as prefix

--- a/.jest.node.js
+++ b/.jest.node.js
@@ -1,14 +1,12 @@
 const { moduleNameMapper, transformIgnorePatterns } = require('./.jest');
 
-// jest config for server render environment
 module.exports = {
   setupFiles: ['./tests/setup.ts'],
   setupFilesAfterEnv: ['./tests/setupAfterEnv.ts'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'md'],
   moduleNameMapper,
   transform: {
-    '\\.tsx?$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
-    '\\.js$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
+    '^.+\\.(ts|tsx|js|mjs)$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
     '\\.md$': './node_modules/@ant-design/tools/lib/jest/demoPreprocessor',
     '\\.(jpg|png|gif|svg)$': './node_modules/@ant-design/tools/lib/jest/imagePreprocessor',
   },

--- a/components/button/style/token.ts
+++ b/components/button/style/token.ts
@@ -4,9 +4,9 @@ import { unit } from '@ant-design/cssinjs';
 
 import { AggregationColor } from '../../color-picker/color';
 import { isBright } from '../../color-picker/components/ColorPresets';
+import { PresetColors } from '../../theme/interface';
 import type { FullToken, GenStyleFn, GetDefaultToken, PresetColorKey } from '../../theme/internal';
 import { getLineHeight, mergeToken } from '../../theme/internal';
-import { PresetColors } from '../../theme/interface';
 import getAlphaColor from '../../theme/util/getAlphaColor';
 
 /** Component only token. Which will handle additional calculation of alias token */
@@ -247,6 +247,10 @@ type ShadowColorMap = {
   [Key in `${PresetColorKey}ShadowColor`]: string;
 };
 
+type PresetColorHoverActiveMap = {
+  [Key in `${PresetColorKey}Hover` | `${PresetColorKey}Active`]: string;
+};
+
 type GroupToken = {
   /**
    * @desc 按钮组边框颜色
@@ -257,7 +261,11 @@ type GroupToken = {
   groupBorderColor: string;
 };
 
-export interface ButtonToken extends FullToken<'Button'>, ShadowColorMap, GroupToken {
+export interface ButtonToken
+  extends FullToken<'Button'>,
+    ShadowColorMap,
+    PresetColorHoverActiveMap,
+    GroupToken {
   /**
    * @desc 按钮横向内边距
    * @descEN Horizontal padding of button

--- a/components/button/style/variant.ts
+++ b/components/button/style/variant.ts
@@ -268,10 +268,10 @@ const genVariantStyle: GenerateStyle<ButtonToken> = (token) => {
       PresetColors.map((colorKey) => {
         const darkColor = token[`${colorKey}6`];
         const lightColor = token[`${colorKey}1`];
-        const hoverColor = token[`${colorKey}5`];
+        const hoverColor = token[`${colorKey}Hover`];
         const lightHoverColor = token[`${colorKey}2`];
         const lightActiveColor = token[`${colorKey}3`];
-        const activeColor = token[`${colorKey}7`];
+        const activeColor = token[`${colorKey}Active`];
 
         const shadowColor = token[`${colorKey}ShadowColor`];
 

--- a/components/theme/themes/dark/index.ts
+++ b/components/theme/themes/dark/index.ts
@@ -2,6 +2,7 @@ import { generate } from '@ant-design/colors';
 import type { DerivativeFunc } from '@ant-design/cssinjs';
 
 import type { MapToken, PresetColorType, SeedToken } from '../../interface';
+import { PresetColors } from '../../interface/presetColors';
 import defaultAlgorithm from '../default';
 import { defaultPresetColors } from '../seed';
 import genColorMapToken from '../shared/genColorMapToken';
@@ -29,6 +30,19 @@ const derivative: DerivativeFunc<SeedToken, MapToken> = (token, mapToken) => {
     generateNeutralColorPalettes,
   });
 
+  const presetColorHoverActiveTokens = PresetColors.reduce<Record<string, string>>(
+    (prev, colorKey) => {
+      const colorBase = token[colorKey as keyof PresetColorType];
+      if (colorBase) {
+        const colorPalette = generateColorPalettes(colorBase);
+        prev[`${colorKey}Hover`] = colorPalette[7];
+        prev[`${colorKey}Active`] = colorPalette[5];
+      }
+      return prev;
+    },
+    {},
+  );
+
   return {
     ...mergedMapToken,
 
@@ -37,6 +51,8 @@ const derivative: DerivativeFunc<SeedToken, MapToken> = (token, mapToken) => {
 
     // Colors
     ...colorMapToken,
+
+    ...presetColorHoverActiveTokens,
 
     // Customize selected item background color
     // https://github.com/ant-design/ant-design/issues/30524#issuecomment-871961867

--- a/components/theme/themes/shared/genColorMapToken.ts
+++ b/components/theme/themes/shared/genColorMapToken.ts
@@ -39,19 +39,12 @@ export default function genColorMapToken(
     .toHexString();
 
   const presetColorTokens: Record<string, string> = {};
-  const isDark = seed.colorBgBase === '#000';
-
   PresetColors.forEach((colorKey) => {
     const colorBase = seed[colorKey];
     if (colorBase) {
       const colorPalette = generateColorPalettes(colorBase);
-      if (isDark) {
-        presetColorTokens[`${colorKey}Hover`] = colorPalette[7];
-        presetColorTokens[`${colorKey}Active`] = colorPalette[5];
-      } else {
-        presetColorTokens[`${colorKey}Hover`] = colorPalette[5];
-        presetColorTokens[`${colorKey}Active`] = colorPalette[7];
-      }
+      presetColorTokens[`${colorKey}Hover`] = colorPalette[5];
+      presetColorTokens[`${colorKey}Active`] = colorPalette[7];
     }
   });
 

--- a/components/theme/themes/shared/genColorMapToken.ts
+++ b/components/theme/themes/shared/genColorMapToken.ts
@@ -1,6 +1,7 @@
 import { FastColor } from '@ant-design/fast-color';
 
 import type { ColorMapToken, SeedToken } from '../../interface';
+import { PresetColors } from '../../interface/presetColors';
 import type { GenerateColorMap, GenerateNeutralColorMap } from '../ColorMap';
 
 interface PaletteGenerators {
@@ -36,6 +37,23 @@ export default function genColorMapToken(
   const colorErrorBgFilledHover = new FastColor(errorColors[1])
     .mix(new FastColor(errorColors[3]), 50)
     .toHexString();
+
+  const presetColorTokens: Record<string, string> = {};
+  const isDark = seed.colorBgBase === '#000';
+
+  PresetColors.forEach((colorKey) => {
+    const colorBase = seed[colorKey];
+    if (colorBase) {
+      const colorPalette = generateColorPalettes(colorBase);
+      if (isDark) {
+        presetColorTokens[`${colorKey}Hover`] = colorPalette[7];
+        presetColorTokens[`${colorKey}Active`] = colorPalette[5];
+      } else {
+        presetColorTokens[`${colorKey}Hover`] = colorPalette[5];
+        presetColorTokens[`${colorKey}Active`] = colorPalette[7];
+      }
+    }
+  });
 
   return {
     ...neutralColors,
@@ -100,6 +118,8 @@ export default function genColorMapToken(
     colorLinkHover: linkColors[4],
     colorLink: linkColors[6],
     colorLinkActive: linkColors[7],
+
+    ...presetColorTokens,
 
     colorBgMask: new FastColor('#000').setA(0.45).toRgbString(),
     colorWhite: '#fff',

--- a/jest-mjs-transformer.js
+++ b/jest-mjs-transformer.js
@@ -1,0 +1,8 @@
+const babelJest = require('babel-jest');
+const { default: getBabelCommonConfig } = require('@ant-design/tools/lib/getBabelCommonConfig');
+
+const babelConfig = getBabelCommonConfig(false);
+const baseTransformer = babelJest.createTransformer(babelConfig);
+
+// Return the transformer directly, babel-jest handles this correctly
+module.exports = baseTransformer;

--- a/jest-mjs-transformer.js
+++ b/jest-mjs-transformer.js
@@ -1,8 +1,0 @@
-const babelJest = require('babel-jest');
-const { default: getBabelCommonConfig } = require('@ant-design/tools/lib/getBabelCommonConfig');
-
-const babelConfig = getBabelCommonConfig(false);
-const baseTransformer = babelJest.createTransformer(babelConfig);
-
-// Return the transformer directly, babel-jest handles this correctly
-module.exports = baseTransformer;


### PR DESCRIPTION
Add ${colorKey}Hover and ${colorKey}Active tokens that swap values based on dark/light mode for improved contrast and user experience.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #56656

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix Button with swapped `hover` and `active` colors for the `color` prop in dark theme.       |
| 🇨🇳 Chinese |     修复 Button 在暗色主题下 `color` 的 `hover` 与 `active` 状态颜色相反的问题。     |
