### PR TITLE
Revert "site(a11y): apply prefers-reduced-motion handling for transitions"

### DIFF
--- a/.dumi/global.less
+++ b/.dumi/global.less
@@ -1,15 +1,6 @@
 // FIXME: workaround for avoid searchbar styles be extracted to async chunk
 @import 'dumi/theme-default/slots/SearchBar/index.less';
 
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation: none;
-    transition: none;
-  }
-}
-
 .demo-logo {
   width: 120px;
   min-width: 120px;


### PR DESCRIPTION
- Reverts ant-design/ant-design#56823

这个属性不能加在全局，会影响到一些依赖动画状态的组件，还是需要针对单个组件做，先回滚了