### PR TITLE
fix: add drawer styles.content / classNames.content warning

### DIFF
--- a/components/drawer/Drawer.tsx
+++ b/components/drawer/Drawer.tsx
@@ -127,32 +127,6 @@ const Drawer: React.FC<DrawerProps> & {
       ? () => getPopupContainer(document.body)
       : customizeGetContainer;
 
-  // ========================== Warning ===========================
-  if (process.env.NODE_ENV !== 'production') {
-    const warning = devUseWarning('Drawer');
-    [
-      ['headerStyle', 'styles.header'],
-      ['bodyStyle', 'styles.body'],
-      ['footerStyle', 'styles.footer'],
-      ['contentWrapperStyle', 'styles.wrapper'],
-      ['maskStyle', 'styles.mask'],
-      ['drawerStyle', 'styles.section'],
-      ['destroyInactivePanel', 'destroyOnHidden'],
-      ['width', 'size'],
-      ['height', 'size'],
-    ].forEach(([deprecatedName, newName]) => {
-      warning.deprecated(!(deprecatedName in props), deprecatedName, newName);
-    });
-
-    if (getContainer !== undefined && props.style?.position === 'absolute') {
-      warning(
-        false,
-        'breaking',
-        '`style` is replaced by `rootStyle` in v5. Please check that `position: absolute` is necessary.',
-      );
-    }
-  }
-
   // ============================ Size ============================
   const drawerSize = React.useMemo<string | number | undefined>(() => {
     if (typeof size === 'number') {
@@ -230,6 +204,38 @@ const Drawer: React.FC<DrawerProps> & {
   >([contextClassNames, classNames], [contextStyles, styles], {
     props: mergedProps,
   });
+
+  // ========================== Warning ===========================
+  if (process.env.NODE_ENV !== 'production') {
+    const warning = devUseWarning('Drawer');
+    [
+      ['headerStyle', 'styles.header'],
+      ['bodyStyle', 'styles.body'],
+      ['footerStyle', 'styles.footer'],
+      ['contentWrapperStyle', 'styles.wrapper'],
+      ['maskStyle', 'styles.mask'],
+      ['drawerStyle', 'styles.section'],
+      ['destroyInactivePanel', 'destroyOnHidden'],
+      ['width', 'size'],
+      ['height', 'size'],
+    ].forEach(([deprecatedName, newName]) => {
+      warning.deprecated(!(deprecatedName in props), deprecatedName, newName);
+    });
+
+    if (getContainer !== undefined && props.style?.position === 'absolute') {
+      warning(
+        false,
+        'breaking',
+        '`style` is replaced by `rootStyle` in v5. Please check that `position: absolute` is necessary.',
+      );
+    }
+
+    warning.deprecated(
+      !(mergedClassNames?.content || mergedStyles?.content),
+      'classNames.content and styles.content',
+      'classNames.section and styles.section',
+    );
+  }
 
   const drawerClassName = clsx(
     {

--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -22,6 +22,10 @@ export type DrawerSemanticClassNames = {
   wrapper?: string;
   dragger?: string;
   close?: string;
+  /**
+   * @deprecated please use `classNames.section` instead.
+   */
+  content?: string;
 };
 
 export type DrawerSemanticStyles = {
@@ -36,6 +40,10 @@ export type DrawerSemanticStyles = {
   wrapper?: React.CSSProperties;
   dragger?: React.CSSProperties;
   close?: React.CSSProperties;
+  /**
+   * @deprecated please use `styles.section` instead.
+   */
+  content?: React.CSSProperties;
 };
 
 export type DrawerClassNamesType = SemanticClassNamesType<DrawerProps, DrawerSemanticClassNames>;

--- a/components/drawer/__tests__/semantic.test.tsx
+++ b/components/drawer/__tests__/semantic.test.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import { warning } from '@rc-component/util';
 
 import Drawer from '..';
 import type { DrawerProps } from '..';
 import { render } from '../../../tests/utils';
+
+const { resetWarned } = warning;
 
 describe('Drawer.Semantic', () => {
   it('should apply custom classnames & styles to Drawer', () => {
@@ -216,5 +219,25 @@ describe('Drawer.Semantic', () => {
     expect(bodyElement).toHaveStyle({ color: 'rgb(0, 255, 0)' });
     expect(footerElement).toHaveStyle({ color: 'rgb(255, 255, 0)' });
     expect(closeElement).toHaveStyle({ color: 'rgb(90, 0, 0)' });
+  });
+
+  it('warning with both deprecated classNames.content and styles.content props', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    resetWarned();
+
+    render(
+      <Drawer
+        open
+        classNames={{ content: 'custom-content' }}
+        styles={{ content: { color: 'red' } }}
+      >
+        Here is content of Drawer
+      </Drawer>,
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Warning: [antd: Drawer] `classNames.content and styles.content` is deprecated. Please use `classNames.section and styles.section` instead.',
+    );
+
+    errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION

### 🤔 This is a ...


- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close: #56035
https://github.com/ant-design/ant-design/issues/56035#issuecomment-3866330081
> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution
先前结构调整未增加 warning，会导致用户迁移困难。需要补充 warning。
<img width="2817" height="861" alt="image" src="https://github.com/user-attachments/assets/9c5650d1-a20f-4235-8579-9a3af269aba9" />

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     -      |
| 🇨🇳 Chinese |  -         |
