### PR TITLE
fix: normalize borderless Input and Select height mismatch

### DIFF
--- a/components/input/style/variants.ts
+++ b/components/input/style/variants.ts
@@ -177,10 +177,20 @@ export const genBorderlessStyle = (token: InputToken, extraStyles?: CSSObject): 
   return {
     '&-borderless': {
       background: 'transparent',
-      border: 'none',
+      borderWidth: token.lineWidth,
+      borderStyle: token.lineType,
+      borderColor: 'transparent',
+      boxShadow: 'none',
+
+      '&:hover': {
+        background: 'transparent',
+        borderColor: 'transparent',
+      },
 
       '&:focus, &:focus-within': {
         outline: 'none',
+        background: 'transparent',
+        borderColor: 'transparent',
       },
 
       // >>>>> Disabled


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] 💄 Component style improvement

### 🔗 Related Issues

close #56609

Also related to #55953

### 💡 Background and Solution

**Problem:**
Borderless `Input` and borderless `Select` render at different heights. For example, with default tokens, the borderless `Input` is 2px shorter than the borderless `Select`.

**Root cause:**
The borderless `Input` variant used `border: 'none'`, which completely removes the border and its space from the box model. Meanwhile, the borderless `Select` variant uses `borderColor: 'transparent'` with preserved border width (`--select-border-size: lineWidth`), keeping the total height equal to `controlHeight`.

Since `Input`'s `paddingBlock` is calculated as:
```
paddingBlock = (controlHeight - fontSize * lineHeight) / 2 - lineWidth
```
The padding already accounts for the border. So when `border: none` removes the border, the total height drops by `2 * lineWidth` (typically 2px).

**Solution:**
Replace `border: 'none'` with explicit `borderWidth: token.lineWidth`, `borderStyle: token.lineType`, and `borderColor: 'transparent'`. This preserves the border space in the box model (matching Select's approach) while keeping the border visually invisible.

This also fixes the same issue for all components sharing `genBorderlessStyle`: `InputNumber`, `Mentions`, and `DatePicker`.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: borderless Input, InputNumber, Mentions, and DatePicker now have consistent height with borderless Select |
| 🇨🇳 Chinese | 修复：无边框 Input、InputNumber、Mentions 和 DatePicker 现在与无边框 Select 高度一致 |