### PR TITLE
fix(radio): remove marginInlineEnd in Radio vertical mode

### DIFF
--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -182,6 +182,10 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
         marginInlineEnd: 0,
       },
 
+      [`${componentCls}-group-vertical &`]: {
+        marginInlineEnd: 0,
+      },
+
       // RTL
       [`&${componentCls}-wrapper-rtl`]: {
         direction: 'rtl',

--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -136,6 +136,10 @@ const getGroupRadioStyle: GenerateStyle<RadioToken> = (token) => {
         display: 'flex',
         flexDirection: 'column',
         rowGap: token.marginXS,
+
+        [`${componentCls}-wrapper`]: {
+          marginInlineEnd: 0,
+        },
       },
     },
   };
@@ -179,10 +183,6 @@ const getRadioBasicStyle: GenerateStyle<RadioToken> = (token) => {
       cursor: 'pointer',
 
       '&:last-child': {
-        marginInlineEnd: 0,
-      },
-
-      [`${componentCls}-group-vertical &`]: {
         marginInlineEnd: 0,
       },
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

- close #56904 
- close #56905

### 💡 Background and Solution

修复垂直模式下的右边距
<img width="810" height="376" alt="image" src="https://github.com/user-attachments/assets/4f3086b2-79e9-4efd-a079-2ae1a3c67a00" />
<img width="1421" height="353" alt="image" src="https://github.com/user-attachments/assets/1811e1c4-854c-4108-b97d-00312fe1145c" />



### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Radio: Fix extra right margin of radio items when Radio.Group is in vertical mode.         |
| 🇨🇳 Chinese |Radio：修复 Radio.Group 在垂直排列时单选项出现多余右边距的问题。 |