### PR TITLE
fix(List): legacy List design token not pass to content 

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -16614,7 +16614,7 @@ exports[`ConfigProvider components List configProvider 1`] = `
       class="config-spin-container"
     >
       <ul
-        class="config-list-items"
+        class="config-list-items config-list-container css-var-root"
       >
         <li
           class="config-list-item"
@@ -16668,7 +16668,7 @@ exports[`ConfigProvider components List configProvider componentDisabled 1`] = `
       class="config-spin-container"
     >
       <ul
-        class="config-list-items"
+        class="config-list-items config-list-container css-var-root"
       >
         <li
           class="config-list-item"
@@ -16722,7 +16722,7 @@ exports[`ConfigProvider components List configProvider componentSize large 1`] =
       class="config-spin-container"
     >
       <ul
-        class="config-list-items"
+        class="config-list-items config-list-container css-var-root"
       >
         <li
           class="config-list-item"
@@ -16776,7 +16776,7 @@ exports[`ConfigProvider components List configProvider componentSize middle 1`] 
       class="config-spin-container"
     >
       <ul
-        class="config-list-items"
+        class="config-list-items config-list-container css-var-root"
       >
         <li
           class="config-list-item"
@@ -16830,7 +16830,7 @@ exports[`ConfigProvider components List configProvider componentSize small 1`] =
       class="config-spin-container"
     >
       <ul
-        class="config-list-items"
+        class="config-list-items config-list-container css-var-root"
       >
         <li
           class="config-list-item"
@@ -16884,7 +16884,7 @@ exports[`ConfigProvider components List normal 1`] = `
       class="ant-spin-container"
     >
       <ul
-        class="ant-list-items"
+        class="ant-list-items ant-list-container css-var-root"
       >
         <li
           class="ant-list-item"
@@ -16938,7 +16938,7 @@ exports[`ConfigProvider components List prefixCls 1`] = `
       class="ant-spin-container"
     >
       <ul
-        class="prefix-List-items"
+        class="prefix-List-items prefix-List-container css-var-root"
       >
         <li
           class="prefix-List-item"

--- a/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
@@ -4643,7 +4643,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item"

--- a/components/drawer/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/drawer/__tests__/__snapshots__/demo.test.ts.snap
@@ -958,7 +958,7 @@ exports[`renders components/drawer/demo/user-profile.tsx correctly 1`] = `
       class="ant-spin-container"
     >
       <ul
-        class="ant-list-items"
+        class="ant-list-items ant-list-container css-var-test-id"
       >
         <li
           class="ant-list-item"

--- a/components/list/__tests__/__snapshots__/Item.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/Item.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`List Item Layout horizontal itemLayout List should accept extra node 1`
       class="ant-spin-container"
     >
       <ul
-        class="ant-list-items"
+        class="ant-list-items ant-list-container css-var-root"
       >
         <li
           class="ant-list-item"
@@ -72,7 +72,7 @@ exports[`List Item Layout rowKey could be function 1`] = `
       class="ant-spin-container"
     >
       <ul
-        class="ant-list-items"
+        class="ant-list-items ant-list-container css-var-root"
       >
         <li
           class="ant-list-item"
@@ -108,7 +108,7 @@ exports[`List Item Layout rowKey could be string 1`] = `
       class="ant-spin-container"
     >
       <ul
-        class="ant-list-items"
+        class="ant-list-items ant-list-container css-var-root"
       >
         <li
           class="ant-list-item"
@@ -144,7 +144,7 @@ exports[`List Item Layout should render in RTL direction 1`] = `
       class="ant-spin-container"
     >
       <ul
-        class="ant-list-items"
+        class="ant-list-items ant-list-container css-var-root"
       >
         <li
           class="ant-list-item"

--- a/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -13,7 +13,7 @@ exports[`renders components/list/demo/basic.tsx extend context correctly 1`] = `
       class="ant-spin-container"
     >
       <ul
-        class="ant-list-items"
+        class="ant-list-items ant-list-container css-var-test-id"
       >
         <li
           class="ant-list-item"
@@ -212,7 +212,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item ant-list-item-no-flex"
@@ -320,7 +320,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item"
@@ -393,7 +393,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item"
@@ -459,7 +459,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item"
@@ -641,7 +641,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item ant-list-item-no-flex"
@@ -1250,7 +1250,7 @@ exports[`renders components/list/demo/grid.tsx extend context correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-row css-var-test-id"
+        class="ant-row ant-list-container css-var-test-id css-var-test-id"
         style="margin-inline: -8px;"
       >
         <div
@@ -2157,7 +2157,7 @@ Array [
         class="ant-spin-container"
       >
         <div
-          class="ant-row css-var-test-id"
+          class="ant-row ant-list-container css-var-test-id css-var-test-id"
           style="margin-inline: -8px;"
         >
           <div
@@ -2386,7 +2386,7 @@ Array [
         class="ant-spin-container"
       >
         <div
-          class="ant-row css-var-test-id"
+          class="ant-row ant-list-container css-var-test-id css-var-test-id"
           style="margin-inline: -8px;"
         >
           <div
@@ -2615,7 +2615,7 @@ Array [
         class="ant-spin-container"
       >
         <div
-          class="ant-row css-var-test-id"
+          class="ant-row ant-list-container css-var-test-id css-var-test-id"
           style="margin-inline: -8px;"
         >
           <div
@@ -3193,7 +3193,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item"
@@ -3452,7 +3452,7 @@ exports[`renders components/list/demo/responsive.tsx extend context correctly 1`
       class="ant-spin-container"
     >
       <div
-        class="ant-row css-var-test-id"
+        class="ant-row ant-list-container css-var-test-id css-var-test-id"
         style="margin-inline: -8px;"
       >
         <div
@@ -3714,7 +3714,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item ant-list-item-no-flex"
@@ -3822,7 +3822,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item"
@@ -3895,7 +3895,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item"
@@ -3942,6 +3942,70 @@ exports[`renders components/list/demo/simple.tsx extend context correctly 2`] = 
 ]
 `;
 
+exports[`renders components/list/demo/spin-debug.tsx extend context correctly 1`] = `
+<div
+  class="ant-list ant-list-split css-var-test-id"
+>
+  <div
+    aria-busy="false"
+    aria-live="polite"
+    class="ant-spin css-var-test-id"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <ul
+        class="ant-list-items ant-list-container css-var-test-id"
+      >
+        <li
+          class="ant-list-item"
+        >
+          <div
+            class="ant-list-item-meta"
+          >
+            <div
+              class="ant-list-item-meta-avatar"
+            >
+              <span
+                class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
+              >
+                <img
+                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                />
+              </span>
+            </div>
+            <div
+              class="ant-list-item-meta-content"
+            >
+              <h4
+                class="ant-list-item-meta-title"
+              >
+                <a
+                  href="https://ant.design"
+                >
+                  Ant Design Title 1
+                </a>
+              </h4>
+              <div
+                class="ant-list-item-meta-description"
+              >
+                Ant Design, a design language for background applications, is refined by Ant UED Team
+              </div>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/list/demo/spin-debug.tsx extend context correctly 2`] = `
+[
+  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+]
+`;
+
 exports[`renders components/list/demo/vertical.tsx extend context correctly 1`] = `
 <div
   class="ant-list ant-list-vertical ant-list-lg ant-list-split ant-list-something-after-last-item css-var-test-id"
@@ -3955,7 +4019,7 @@ exports[`renders components/list/demo/vertical.tsx extend context correctly 1`] 
       class="ant-spin-container"
     >
       <ul
-        class="ant-list-items"
+        class="ant-list-items ant-list-container css-var-test-id"
       >
         <li
           class="ant-list-item"

--- a/components/list/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`renders components/list/demo/_semantic.tsx correctly 1`] = `
               class="ant-spin-container"
             >
               <ul
-                class="ant-list-items"
+                class="ant-list-items ant-list-container css-var-test-id"
               >
                 <li
                   class="ant-list-item"

--- a/components/list/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.ts.snap
@@ -13,7 +13,7 @@ exports[`renders components/list/demo/basic.tsx correctly 1`] = `
       class="ant-spin-container"
     >
       <ul
-        class="ant-list-items"
+        class="ant-list-items ant-list-container css-var-test-id"
       >
         <li
           class="ant-list-item"
@@ -206,7 +206,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item ant-list-item-no-flex"
@@ -319,7 +319,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item"
@@ -392,7 +392,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item"
@@ -458,7 +458,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item"
@@ -640,7 +640,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item ant-list-item-no-flex"
@@ -892,7 +892,7 @@ exports[`renders components/list/demo/drag-sorting.tsx correctly 1`] = `
       class="ant-spin-container"
     >
       <ul
-        class="ant-list-items"
+        class="ant-list-items ant-list-container css-var-test-id"
       >
         <li
           class="ant-list-item"
@@ -998,7 +998,7 @@ exports[`renders components/list/demo/drag-sorting-handler.tsx correctly 1`] = `
       class="ant-spin-container"
     >
       <ul
-        class="ant-list-items"
+        class="ant-list-items ant-list-container css-var-test-id"
       >
         <li
           class="ant-list-item ant-list-item-no-flex"
@@ -1234,7 +1234,7 @@ exports[`renders components/list/demo/grid.tsx correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-row css-var-test-id"
+        class="ant-row ant-list-container css-var-test-id css-var-test-id"
         style="margin-inline:-8px"
       >
         <div
@@ -1396,7 +1396,7 @@ exports[`renders components/list/demo/grid-drag-sorting.tsx correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-row css-var-test-id"
+        class="ant-row ant-list-container css-var-test-id css-var-test-id"
         style="margin-inline:-8px"
       >
         <div
@@ -1664,7 +1664,7 @@ exports[`renders components/list/demo/grid-drag-sorting-handler.tsx correctly 1`
       class="ant-spin-container"
     >
       <div
-        class="ant-row css-var-test-id"
+        class="ant-row ant-list-container css-var-test-id css-var-test-id"
         style="margin-inline:-8px"
       >
         <div
@@ -2101,7 +2101,7 @@ Array [
         class="ant-spin-container"
       >
         <div
-          class="ant-row css-var-test-id"
+          class="ant-row ant-list-container css-var-test-id css-var-test-id"
           style="margin-inline:-8px"
         >
           <div
@@ -2330,7 +2330,7 @@ Array [
         class="ant-spin-container"
       >
         <div
-          class="ant-row css-var-test-id"
+          class="ant-row ant-list-container css-var-test-id css-var-test-id"
           style="margin-inline:-8px"
         >
           <div
@@ -2559,7 +2559,7 @@ Array [
         class="ant-spin-container"
       >
         <div
-          class="ant-row css-var-test-id"
+          class="ant-row ant-list-container css-var-test-id css-var-test-id"
           style="margin-inline:-8px"
         >
           <div
@@ -3119,7 +3119,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item"
@@ -3372,7 +3372,7 @@ exports[`renders components/list/demo/responsive.tsx correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-row css-var-test-id"
+        class="ant-row ant-list-container css-var-test-id css-var-test-id"
         style="margin-inline:-8px"
       >
         <div>
@@ -3616,7 +3616,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item ant-list-item-no-flex"
@@ -3729,7 +3729,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item"
@@ -3802,7 +3802,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item"
@@ -3843,6 +3843,64 @@ Array [
 ]
 `;
 
+exports[`renders components/list/demo/spin-debug.tsx correctly 1`] = `
+<div
+  class="ant-list ant-list-split css-var-test-id"
+>
+  <div
+    aria-busy="false"
+    aria-live="polite"
+    class="ant-spin css-var-test-id"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <ul
+        class="ant-list-items ant-list-container css-var-test-id"
+      >
+        <li
+          class="ant-list-item"
+        >
+          <div
+            class="ant-list-item-meta"
+          >
+            <div
+              class="ant-list-item-meta-avatar"
+            >
+              <span
+                class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
+              >
+                <img
+                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                />
+              </span>
+            </div>
+            <div
+              class="ant-list-item-meta-content"
+            >
+              <h4
+                class="ant-list-item-meta-title"
+              >
+                <a
+                  href="https://ant.design"
+                >
+                  Ant Design Title 1
+                </a>
+              </h4>
+              <div
+                class="ant-list-item-meta-description"
+              >
+                Ant Design, a design language for background applications, is refined by Ant UED Team
+              </div>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/list/demo/vertical.tsx correctly 1`] = `
 <div
   class="ant-list ant-list-vertical ant-list-lg ant-list-split ant-list-something-after-last-item css-var-test-id"
@@ -3856,7 +3914,7 @@ exports[`renders components/list/demo/vertical.tsx correctly 1`] = `
       class="ant-spin-container"
     >
       <ul
-        class="ant-list-items"
+        class="ant-list-items ant-list-container css-var-test-id"
       >
         <li
           class="ant-list-item"

--- a/components/list/__tests__/__snapshots__/pagination.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/pagination.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`List.pagination renders pagination correctly 1`] = `
       class="ant-spin-container"
     >
       <ul
-        class="ant-list-items"
+        class="ant-list-items ant-list-container css-var-root"
       >
         <li
           class="ant-list-item ant-list-item-no-flex"

--- a/components/list/demo/basic.tsx
+++ b/components/list/demo/basic.tsx
@@ -16,6 +16,11 @@ const data = [
   },
 ];
 
+/**
+ * TODO: List 包裹的 Spin 子组件导致了 List 自身带的 css var 注入被 Spin 覆盖的问题，
+ * 需要在 components/list/index.tsx 给 Row or ul 添加一个 css var 注入，来解决这个问题
+ */
+
 const App: React.FC = () => (
   <ConfigProvider
     theme={{
@@ -29,7 +34,7 @@ const App: React.FC = () => (
     <List
       itemLayout="horizontal"
       dataSource={data}
-      loading
+      // loading
       renderItem={(item, index) => (
         <List.Item>
           <List.Item.Meta

--- a/components/list/demo/basic.tsx
+++ b/components/list/demo/basic.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Avatar, ConfigProvider, List } from 'antd';
+import { Avatar, List } from 'antd';
 
 const data = [
   {
@@ -17,30 +17,19 @@ const data = [
 ];
 
 const App: React.FC = () => (
-  <ConfigProvider
-    theme={{
-      components: {
-        List: {
-          colorText: 'red',
-        },
-      },
-    }}
-  >
-    <List
-      itemLayout="horizontal"
-      dataSource={data}
-      // loading
-      renderItem={(item, index) => (
-        <List.Item>
-          <List.Item.Meta
-            avatar={<Avatar src={`https://api.dicebear.com/7.x/miniavs/svg?seed=${index}`} />}
-            title={<a href="https://ant.design">{item.title}</a>}
-            description="Ant Design, a design language for background applications, is refined by Ant UED Team"
-          />
-        </List.Item>
-      )}
-    />
-  </ConfigProvider>
+  <List
+    itemLayout="horizontal"
+    dataSource={data}
+    renderItem={(item, index) => (
+      <List.Item>
+        <List.Item.Meta
+          avatar={<Avatar src={`https://api.dicebear.com/7.x/miniavs/svg?seed=${index}`} />}
+          title={<a href="https://ant.design">{item.title}</a>}
+          description="Ant Design, a design language for background applications, is refined by Ant UED Team"
+        />
+      </List.Item>
+    )}
+  />
 );
 
 export default App;

--- a/components/list/demo/basic.tsx
+++ b/components/list/demo/basic.tsx
@@ -16,11 +16,6 @@ const data = [
   },
 ];
 
-/**
- * TODO: List 包裹的 Spin 子组件导致了 List 自身带的 css var 注入被 Spin 覆盖的问题，
- * 需要在 components/list/index.tsx 给 Row or ul 添加一个 css var 注入，来解决这个问题
- */
-
 const App: React.FC = () => (
   <ConfigProvider
     theme={{

--- a/components/list/demo/basic.tsx
+++ b/components/list/demo/basic.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Avatar, List } from 'antd';
+import { Avatar, ConfigProvider, List } from 'antd';
 
 const data = [
   {
@@ -17,19 +17,30 @@ const data = [
 ];
 
 const App: React.FC = () => (
-  <List
-    itemLayout="horizontal"
-    dataSource={data}
-    renderItem={(item, index) => (
-      <List.Item>
-        <List.Item.Meta
-          avatar={<Avatar src={`https://api.dicebear.com/7.x/miniavs/svg?seed=${index}`} />}
-          title={<a href="https://ant.design">{item.title}</a>}
-          description="Ant Design, a design language for background applications, is refined by Ant UED Team"
-        />
-      </List.Item>
-    )}
-  />
+  <ConfigProvider
+    theme={{
+      components: {
+        List: {
+          colorText: 'red',
+        },
+      },
+    }}
+  >
+    <List
+      itemLayout="horizontal"
+      dataSource={data}
+      loading
+      renderItem={(item, index) => (
+        <List.Item>
+          <List.Item.Meta
+            avatar={<Avatar src={`https://api.dicebear.com/7.x/miniavs/svg?seed=${index}`} />}
+            title={<a href="https://ant.design">{item.title}</a>}
+            description="Ant Design, a design language for background applications, is refined by Ant UED Team"
+          />
+        </List.Item>
+      )}
+    />
+  </ConfigProvider>
 );
 
 export default App;

--- a/components/list/demo/spin-debug.md
+++ b/components/list/demo/spin-debug.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+Spin 加载状态下 List 组件样式调试示例。
+
+## en-US
+
+Debug example for List component styles in Spin loading state.

--- a/components/list/demo/spin-debug.tsx
+++ b/components/list/demo/spin-debug.tsx
@@ -5,15 +5,6 @@ const data = [
   {
     title: 'Ant Design Title 1',
   },
-  {
-    title: 'Ant Design Title 2',
-  },
-  {
-    title: 'Ant Design Title 3',
-  },
-  {
-    title: 'Ant Design Title 4',
-  },
 ];
 
 const App: React.FC = () => (
@@ -29,7 +20,6 @@ const App: React.FC = () => (
     <List
       itemLayout="horizontal"
       dataSource={data}
-      // loading
       renderItem={(item, index) => (
         <List.Item>
           <List.Item.Meta

--- a/components/list/demo/spin-debug.tsx
+++ b/components/list/demo/spin-debug.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Avatar, ConfigProvider, List } from 'antd';
+
+const data = [
+  {
+    title: 'Ant Design Title 1',
+  },
+  {
+    title: 'Ant Design Title 2',
+  },
+  {
+    title: 'Ant Design Title 3',
+  },
+  {
+    title: 'Ant Design Title 4',
+  },
+];
+
+const App: React.FC = () => (
+  <ConfigProvider
+    theme={{
+      components: {
+        List: {
+          colorText: 'red',
+        },
+      },
+    }}
+  >
+    <List
+      itemLayout="horizontal"
+      dataSource={data}
+      // loading
+      renderItem={(item, index) => (
+        <List.Item>
+          <List.Item.Meta
+            avatar={<Avatar src={`https://api.dicebear.com/7.x/miniavs/svg?seed=${index}`} />}
+            title={<a href="https://ant.design">{item.title}</a>}
+            description="Ant Design, a design language for background applications, is refined by Ant UED Team"
+          />
+        </List.Item>
+      )}
+    />
+  </ConfigProvider>
+);
+
+export default App;

--- a/components/list/index.en-US.md
+++ b/components/list/index.en-US.md
@@ -35,6 +35,7 @@ List component has been deprecated. Will be removed in the next major version.
 <code src="./demo/grid-drag-sorting-handler.tsx">Grid Drag sorting with handler</code>
 <code src="./demo/virtual-list.tsx">virtual list</code>
 <code src="./demo/component-token.tsx" debug>custom component token</code>
+<code src="./demo/spin-debug.tsx" debug>Spin loading debug</code>
 
 ## API
 

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -207,6 +207,8 @@ const InternalList = <T,>(props: ListProps<T>, ref: React.ForwardedRef<HTMLDivEl
     cssVarCls,
   );
 
+  const containerCls = `${prefixCls}-container`;
+
   const paginationProps = extendsObject(
     defaultPaginationProps,
     {
@@ -274,7 +276,7 @@ const InternalList = <T,>(props: ListProps<T>, ref: React.ForwardedRef<HTMLDivEl
   if (splitDataSource.length > 0) {
     const items = splitDataSource.map(renderInternalItem);
     childrenContent = grid ? (
-      <Row gutter={grid.gutter}>
+      <Row className={clsx(containerCls, cssVarCls)} gutter={grid.gutter}>
         {React.Children.map(items, (child) => (
           <div key={child?.key} style={colStyle}>
             {child}
@@ -282,7 +284,7 @@ const InternalList = <T,>(props: ListProps<T>, ref: React.ForwardedRef<HTMLDivEl
         ))}
       </Row>
     ) : (
-      <ul className={`${prefixCls}-items`}>{items}</ul>
+      <ul className={clsx(`${prefixCls}-items`, containerCls, cssVarCls)}>{items}</ul>
     );
   } else if (!children && !isLoading) {
     childrenContent = (

--- a/components/list/index.zh-CN.md
+++ b/components/list/index.zh-CN.md
@@ -36,6 +36,7 @@ List 组件已经进入废弃阶段，将于下个 major 版本移除。
 <code src="./demo/grid-drag-sorting-handler.tsx">栅格拖拽排序（拖拽手柄）</code>
 <code src="./demo/virtual-list.tsx">滚动加载无限长列表</code>
 <code src="./demo/component-token.tsx" debug>自定义组件 token</code>
+<code src="./demo/spin-debug.tsx" debug>Spin 加载状态调试</code>
 
 ## API
 

--- a/components/list/style/index.ts
+++ b/components/list/style/index.ts
@@ -454,4 +454,7 @@ export default genStyleHooks(
     return [genBaseStyle(listToken), genBorderedStyle(listToken), genResponsiveStyle(listToken)];
   },
   prepareComponentToken,
+  {
+    extraCssVarPrefixCls: ({ prefixCls }) => [`${prefixCls}-container`],
+  },
 );

--- a/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -725,7 +725,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item ant-list-item-no-flex"

--- a/components/skeleton/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo.test.tsx.snap
@@ -713,7 +713,7 @@ Array [
         class="ant-spin-container"
       >
         <ul
-          class="ant-list-items"
+          class="ant-list-items ant-list-container css-var-test-id"
         >
           <li
             class="ant-list-item ant-list-item-no-flex"

--- a/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1575,7 +1575,7 @@ exports[`renders components/steps/demo/inline.tsx extend context correctly 1`] =
       class="ant-spin-container"
     >
       <ul
-        class="ant-list-items"
+        class="ant-list-items ant-list-container css-var-test-id"
       >
         <li
           class="ant-list-item"

--- a/components/steps/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo.test.ts.snap
@@ -1453,7 +1453,7 @@ exports[`renders components/steps/demo/inline.tsx correctly 1`] = `
       class="ant-spin-container"
     >
       <ul
-        class="ant-list-items"
+        class="ant-list-items ant-list-container css-var-test-id"
       >
         <li
           class="ant-list-item"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   "dependencies": {
     "@ant-design/colors": "^8.0.1",
     "@ant-design/cssinjs": "^2.1.0",
-    "@ant-design/cssinjs-utils": "^2.1.0",
+    "@ant-design/cssinjs-utils": "^2.1.1",
     "@ant-design/fast-color": "^3.0.1",
     "@ant-design/icons": "^6.1.0",
     "@ant-design/react-slick": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -107,8 +107,8 @@
   },
   "dependencies": {
     "@ant-design/colors": "^8.0.1",
-    "@ant-design/cssinjs": "^2.0.3",
-    "@ant-design/cssinjs-utils": "^2.0.2",
+    "@ant-design/cssinjs": "^2.1.0",
+    "@ant-design/cssinjs-utils": "^2.1.0",
     "@ant-design/fast-color": "^3.0.1",
     "@ant-design/icons": "^6.1.0",
     "@ant-design/react-slick": "~2.0.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

resolve #56603

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix List color related tokens not taking effect.       |
| 🇨🇳 Chinese |     修复废弃组件 List 配置颜色相关 token 不生效的问题。       |
