### PR TITLE
fix(input): use colorBorderDisabled for disabled input border

### DIFF
--- a/components/input/style/variants.ts
+++ b/components/input/style/variants.ts
@@ -428,6 +428,7 @@ export const genUnderlinedStyle = (token: InputToken, extraStyles?: CSSObject): 
     // >>>>> Disabled
     [`&${token.componentCls}-disabled, &[disabled]`]: {
       color: token.colorTextDisabled,
+      borderColor: `transparent transparent ${token.colorBorderDisabled} transparent`,
       boxShadow: 'none',
       cursor: 'not-allowed',
       '&:hover': {

--- a/components/input/style/variants.ts
+++ b/components/input/style/variants.ts
@@ -22,7 +22,7 @@ export const genDisabledStyle: GenerateStyle<InputToken, CSSObject> = (token) =>
     cursor: 'not-allowed',
   },
 
-  '&:hover:not([disabled])': {
+  '&:hover': {
     ...genHoverStyle(
       mergeToken<InputToken>(token, {
         hoverBorderColor: token.colorBorderDisabled,

--- a/components/input/style/variants.ts
+++ b/components/input/style/variants.ts
@@ -13,7 +13,7 @@ export const genHoverStyle: GenerateStyle<InputToken, CSSObject> = (token) => ({
 export const genDisabledStyle: GenerateStyle<InputToken, CSSObject> = (token) => ({
   color: token.colorTextDisabled,
   backgroundColor: token.colorBgContainerDisabled,
-  borderColor: token.colorBorder,
+  borderColor: token.colorBorderDisabled,
   boxShadow: 'none',
   cursor: 'not-allowed',
   opacity: 1,
@@ -25,7 +25,7 @@ export const genDisabledStyle: GenerateStyle<InputToken, CSSObject> = (token) =>
   '&:hover:not([disabled])': {
     ...genHoverStyle(
       mergeToken<InputToken>(token, {
-        hoverBorderColor: token.colorBorder,
+        hoverBorderColor: token.colorBorderDisabled,
         hoverBg: token.colorBgContainerDisabled,
       }),
     ),
@@ -350,15 +350,15 @@ export const genFilledGroupStyle: GenerateStyle<InputToken, CSSObject> = (token)
         },
 
         '&-addon:first-child': {
-          borderInlineStart: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
-          borderTop: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
-          borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
+          borderInlineStart: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderDisabled}`,
+          borderTop: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderDisabled}`,
+          borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderDisabled}`,
         },
 
         '&-addon:last-child': {
-          borderInlineEnd: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
-          borderTop: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
-          borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
+          borderInlineEnd: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderDisabled}`,
+          borderTop: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderDisabled}`,
+          borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderDisabled}`,
         },
       },
     },
@@ -431,7 +431,7 @@ export const genUnderlinedStyle = (token: InputToken, extraStyles?: CSSObject): 
       boxShadow: 'none',
       cursor: 'not-allowed',
       '&:hover': {
-        borderColor: `transparent transparent ${token.colorBorder} transparent`,
+        borderColor: `transparent transparent ${token.colorBorderDisabled} transparent`,
       },
     },
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

close #56935

### 💡 Background and Solution

The disabled Input was using `colorBorder` instead of `colorBorderDisabled` for its border color. This means if someone customizes `colorBorderDisabled` through their theme, it wouldn't take effect on disabled inputs — even though components like Button and Select already use the correct token.

Fixed all the disabled border color references in `components/input/style/variants.ts`:
- `genDisabledStyle` — main disabled border + hover state
- Filled group disabled addon borders
- Underlined disabled hover border

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Input: use `colorBorderDisabled` token for disabled state border color. |
| 🇨🇳 Chinese | Input: 禁用状态下使用 `colorBorderDisabled` 作为边框颜色。 |