### PR TITLE
fix: fix Upload picture-card list overflow when items wrap to multiple lines

### DIFF
--- a/components/upload/style/picture.ts
+++ b/components/upload/style/picture.ts
@@ -141,6 +141,7 @@ const genPictureCardStyle: GenerateStyle<UploadToken> = (token) => {
       [`${listCls}${listCls}-picture-card, ${listCls}${listCls}-picture-circle`]: {
         display: 'flex',
         flexWrap: 'wrap',
+        minHeight: uploadPictureCardSize,
 
         '@supports not (gap: 1px)': {
           '& > *': {

--- a/components/upload/style/picture.ts
+++ b/components/upload/style/picture.ts
@@ -141,7 +141,6 @@ const genPictureCardStyle: GenerateStyle<UploadToken> = (token) => {
       [`${listCls}${listCls}-picture-card, ${listCls}${listCls}-picture-circle`]: {
         display: 'flex',
         flexWrap: 'wrap',
-        height: uploadPictureCardSize,
 
         '@supports not (gap: 1px)': {
           '& > *': {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

Related: #56864

### 💡 Background and Solution

The Upload component with `listType="picture-card"` has a fixed `height: uploadPicCardSize` on the list container (added in #56864), while also using `display: flex` with `flexWrap: wrap`. When the number of uploaded files exceeds one row, the wrapped items overflow the container and overlap with the content below (e.g., section titles and descriptions).

The fix replaces `height` with `min-height` on the list container. This preserves the original intent of #56864 (preventing the container from collapsing during animation) while allowing the container to grow naturally when items wrap to multiple lines.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Upload picture-card list overflow when items wrap to multiple lines. |
| 🇨🇳 Chinese | 🐞 Upload 修复照片墙模式下文件数量超过一行时列表溢出重叠的问题。 |
