### PR TITLE
fix: TreeSelect's multi-line text will cause CheckBox compression. #5…

### DIFF
--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -280,6 +280,12 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
           .equal(),
       },
 
+      // >>> Checkbox
+      // https://github.com/ant-design/ant-design/issues/56957
+      [`${treeCls}-checkbox`]: {
+        flexShrink: 0,
+      },
+
       // >>> Switcher
       [`${treeCls}-switcher`]: {
         ...getSwitchStyle(prefixCls, token),


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ x] 🐞 Bug 修复

### 🔗 相关 Issue

fix #56957

### 💡 需求背景和解决方案

> 背景： 解决treeselect 的多行文本出现的时候会导致checkbox被挤压变形的问题
> 解决方案：给tree下的checkbox添加flex-shrink: 0

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |  Fix TreeSelect's multi-line text will cause `CheckBox `compression  |
| 🇨🇳 中文 |  修复 TreeSelect 在多行文本时 `CheckBox` 被压缩变形问题  |