### PR TITLE
fix: correct mismatched JSDoc parameter names in plugin files

### DIFF
--- a/.dumi/theme/plugins/raw-md.ts
+++ b/.dumi/theme/plugins/raw-md.ts
@@ -255,7 +255,7 @@ function antdCodeAppend(docFileAbs: string, src: string): string {
  *
  * @param md - 原始 markdown 内容
  * @param docFileAbs - 文档文件的绝对路径，用于解析相对路径和检测语言
- * @param enablePickLocaleBlock - 是否启用多语言块提取，可以是布尔值或函数，默认为 true
+ * @param codeAppend - 代码追加函数：在替换 <code src> 标签时，用于追加额外的内容（如 demo 描述信息）
  * @returns 替换后的 markdown 内容
  */
 function replaceCodeSrcToMarkdown(
@@ -556,7 +556,6 @@ function emitRawMd(api: IApi) {
  * 2. 在 HTML 文件导出阶段输出处理后的 raw markdown 文件
  *
  * @param api - Dumi API 实例
- * @param options - 插件配置选项
  */
 export default function rawMdPlugin(api: IApi) {
   // 注册配置键，允许用户在配置中使用 rawMd 键

--- a/.dumi/theme/plugins/semantic-md.ts
+++ b/.dumi/theme/plugins/semantic-md.ts
@@ -19,8 +19,8 @@ function extractSemantics(objContent: string): Record<string, string> {
 }
 
 /**
- * 从 _semantic*.tsx 文件中提取语义信息
- * @param semanticFile - _semantic*.tsx 文件的绝对路径
+ * 从 _semantic*.tsx 文件内容中提取语义信息
+ * @param content - _semantic*.tsx 文件的文件内容字符串
  * @returns 包含中文和英文语义描述的对象，失败返回 null
  */
 function extractLocaleInfoFromContent(content: string): {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [x] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案

> **问题描述：**
> 在 `.dumi/theme/plugins/raw-md.ts` 和 `.dumi/theme/plugins/semantic-md.ts` 文件中，部分函数的 JSDoc 注释参数名与实际函数签名不一致，导致文档不准确。

> **具体修改：**
> 1. **raw-md.ts**:
>    - `replaceCodeSrcToMarkdown` 函数：将注释中的 `@param enablePickLocaleBlock` 修正为 `@param codeAppend`，与实际参数名一致
>    - `rawMdPlugin` 函数：移除了不存在的 `@param options` 参数注释
> 
> 2. **semantic-md.ts**:
>    - `extractLocaleInfoFromContent` 函数：将注释中的 `@param semanticFile` 修正为 `@param content`，并更新描述为"文件内容字符串"，与实际参数类型一致

> **影响：**
> 此修改仅修正注释，不影响代码功能，但提高了代码文档的准确性和可维护性。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix mismatched JSDoc parameter names in plugin files |
| 🇨🇳 中文 | 修正插件文件中 JSDoc 注释参数名与函数签名不匹配的问题 |
