### PR TITLE
fix(Progress): prevent animation overflow when status is set to active

### DIFF
--- a/components/progress/style/index.ts
+++ b/components/progress/style/index.ts
@@ -147,6 +147,7 @@ const genLineStyle: GenerateStyle<ProgressToken> = (token) => {
         borderRadius: token.lineBorderRadius,
         position: 'relative',
         width: '100%',
+        overflow: 'hidden',
       },
 
       [`&${componentCls}-status-active`]: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close #56967

### 💡 Background and Solution

Fix animation overflow when `Progress` status is set to `"active"` by adding `overflow: hidden` to the rail class.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the animation overflowed when Progress's status was set to "active". |
| 🇨🇳 Chinese | 修复 Progress 组件在 `status="active"` 时动画溢出的问题。 |
