### PR TITLE
feat(Tag): allow preset colors for CheckableTag (checkable mode)

### DIFF
--- a/components/tag/style/presetCmp.ts
+++ b/components/tag/style/presetCmp.ts
@@ -6,23 +6,44 @@ import { genPresetColor, genSubStyleComponent } from '../../theme/internal';
 // ============================== Preset ==============================
 const genPresetStyle = (token: TagToken) =>
   genPresetColor(token, (colorKey, { textColor, lightBorderColor, lightColor, darkColor }) => ({
-    [`${token.componentCls}${token.componentCls}-${colorKey}:not(${token.componentCls}-disabled)`]:
-      {
-        [`&${token.componentCls}-outlined`]: {
-          backgroundColor: lightColor,
-          borderColor: lightBorderColor,
+    [`${token.componentCls}${token.componentCls}-${colorKey}:not(${token.componentCls}-disabled)`]: {
+      [`&${token.componentCls}-outlined`]: {
+        backgroundColor: lightColor,
+        borderColor: lightBorderColor,
+        color: textColor,
+      },
+      [`&${token.componentCls}-solid`]: {
+        backgroundColor: darkColor,
+        borderColor: darkColor,
+        color: token.colorTextLightSolid,
+      },
+      [`&${token.componentCls}-filled`]: {
+        backgroundColor: lightColor,
+        color: textColor,
+      },
+
+      // CheckableTag preset color support
+      [`&${token.componentCls}-checkable`]: {
+        color: textColor,
+
+        [`&:not(${token.componentCls}-checkable-checked):hover`]: {
           color: textColor,
+          backgroundColor: lightColor,
         },
-        [`&${token.componentCls}-solid`]: {
-          backgroundColor: darkColor,
-          borderColor: darkColor,
+
+        [`&${token.componentCls}-checkable-checked`]: {
           color: token.colorTextLightSolid,
+          backgroundColor: darkColor,
+          '&:hover': {
+            backgroundColor: darkColor,
+          },
         },
-        [`&${token.componentCls}-filled`]: {
-          backgroundColor: lightColor,
-          color: textColor,
+
+        '&:active': {
+          backgroundColor: darkColor,
         },
       },
+    },
   }));
 
 // ============================== Export ==============================


### PR DESCRIPTION
Fixes ant-design/ant-design#11889.

Problem:
- Tag.CheckableTag (checkable mode) couldn't use preset colors (e.g. red/green) while normal Tag supports them.

Solution:
- Add `color` prop support to `CheckableTag` (leveraging existing `useColor` logic).
- Extend preset color styles to cover checkable state (hover/checked/active) so preset colors render correctly.

Notes:
- Keeps API surface minimal (adds `color` prop; aligns with Tag color behavior).
