### PR TITLE
fix: add exports field to package.json for Yarn PnP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,18 @@
   "module": "es/index.js",
   "unpkg": "dist/antd.min.js",
   "typings": "es/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "types": "./es/index.d.ts"
+    },
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
+    "./locale/*": "./locale/*",
+    "./dist/reset.css": "./dist/reset.css",
+    "./package.json": "./package.json"
+  },
   "files": [
     "BUG_VERSIONS.json",
     "dist",


### PR DESCRIPTION
## Summary

Add an `exports` field to `package.json` to enable proper subpath resolution in Yarn PnP (Plug'n'Play) environments.

### Problem

When consuming libraries that re-export antd components from subpaths (e.g., `antd/es/input/Search`), Yarn PnP fails to resolve these paths because antd does not declare them in the `exports` field of `package.json`. This is because Yarn PnP uses strict package resolution and requires explicit `exports` declarations for subpath imports.

### Solution

Added an `exports` field that:
- Maps the root entry point (`.`) to the existing `main`, `module`, and `typings` fields for both CJS (`require`) and ESM (`import`) consumers, along with TypeScript types
- Exposes `./es/*`, `./lib/*`, and `./locale/*` subpath patterns for deep imports
- Exposes `./dist/reset.css` for the commonly imported CSS reset file
- Exposes `./package.json` for tooling that reads it directly

This is fully backward-compatible — the existing `main`, `module`, and `typings` fields are preserved for bundlers and environments that do not support `exports`.

## Related Issues

Fixes #56858

## Type of Change

- [x] 🐛 Bug Fix (non-breaking change which fixes an issue)
- [ ] 🆕 New Feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ♻️ Code Refactor
- [ ] ⚡ Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔄 CI
- [ ] 🔧 Chore (other changes that don't modify src or test files)
- [ ] ⏩ Revert

## Testing

- [x] Verified the resulting `package.json` is valid JSON
- [x] The `exports` field values are consistent with the existing `main`, `module`, `typings`, and `files` fields
- [x] Subpath patterns match the directories declared in the `files` field (`es`, `lib`, `locale`, `dist`)
- [x] Backward-compatible: `main`, `module`, and `typings` fields are preserved for non-exports-aware resolvers