### PR TITLE
fix: align borderless Input and Select component heights

### DIFF
--- a/components/input/style/variants.ts
+++ b/components/input/style/variants.ts
@@ -178,6 +178,17 @@ export const genBorderlessStyle = (token: InputToken, extraStyles?: CSSObject): 
     '&-borderless': {
       background: 'transparent',
       border: 'none',
+      // Compensate for the removed border to maintain consistent height with other components
+      // (e.g. Select borderless) that keep a transparent border.
+      paddingBlock: token.calc(token.paddingBlock).add(token.lineWidth).equal(),
+
+      [`&${componentCls}-sm, &${componentCls}-affix-wrapper-sm`]: {
+        paddingBlock: token.calc(token.paddingBlockSM).add(token.lineWidth).equal(),
+      },
+
+      [`&${componentCls}-lg, &${componentCls}-affix-wrapper-lg`]: {
+        paddingBlock: token.calc(token.paddingBlockLG).add(token.lineWidth).equal(),
+      },
 
       '&:focus, &:focus-within': {
         outline: 'none',


### PR DESCRIPTION
## Summary

Fix inconsistent heights between borderless `Input` and `Select` components.

### Problem

When using `variant="borderless"`, the `Input` component is 2px shorter than the `Select` component:

- **Input borderless**: Sets `border: 'none'`, which removes the border entirely. Since `paddingBlock` is already calculated as `(controlHeight - fontHeight) / 2 - lineWidth`, the total height becomes `controlHeight - 2 * lineWidth` (e.g., 30px instead of 32px).
- **Select borderless**: Keeps the border but makes it transparent (`borderColor: transparent`), so it still occupies space. Total height remains `controlHeight` (32px).

### Fix

Compensate for the removed border by adding `lineWidth` back to the vertical padding (`paddingBlock`) of borderless Input. This ensures both components maintain a consistent height equal to `controlHeight` in borderless mode.

The fix covers all three sizes (default, small, large) and both bare input and affix-wrapper (input with prefix/suffix) variants.

## Related Issues

Fixes #56609

## Type of Change

- [x] 🐛 Bug Fix (non-breaking change which fixes an issue)

## Testing

- [x] The change aligns borderless Input height with borderless Select height
- [x] All three sizes (sm, default, lg) are handled
- [x] Affix-wrapper (Input with prefix/suffix) size variants are also compensated
- [x] InputNumber (which reuses `genBorderlessStyle`) also benefits from this fix