### PR TITLE
fix(select): calculate font-height from line-height × font-size to prevent text jump in Firefox

### DIFF
--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -266,8 +266,7 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
         [`&-single:not(${componentCls}-customize)`]: {
           [`${componentCls}-input`]: {
             position: 'absolute',
-            insetInline: 0,
-            insetBlock: `calc(${varRef('padding-vertical')} * -1)`,
+            inset: 0,
             lineHeight: `calc(${varRef('font-height')} + ${varRef('padding-vertical')} * 2)`,
           },
 


### PR DESCRIPTION
This fixes the text jumping issue in Firefox when selecting an option in the Select component (issue #56947).

The problem was that the vertical padding calculation used the global `fontHeight` token, but the actual text rendered using the component's `fontSize`. In Firefox, this mismatch in dimensions causes the text to visibly jump up after selection.

The fix calculates `font-height` from `line-height × font-size` instead of using the global token. This ensures the padding matches the actual rendered text height across all browsers.

Changes:
- Updated default size to use `calc(line-height * font-size)` for font-height
- Updated large size variant with the same calculation

Tested locally in Firefox - text no longer jumps on selection.