### PR TITLE
Fix #56858: Missing exports field in package.json causes Yarn PnP resolu

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,18 @@
   "module": "es/index.js",
   "unpkg": "dist/antd.min.js",
   "typings": "es/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./es/index.d.ts",
+      "import": "./es/index.js",
+      "require": "./lib/index.js"
+    },
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
+    "./locale/*": "./locale/*",
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "files": [
     "BUG_VERSIONS.json",
     "dist",


### PR DESCRIPTION
Fixes #56858

## Summary
This PR fixes: Missing exports field in package.json causes Yarn PnP resolution failures for subpath imports

## Changes
```
package.json | 12 ++++++++++++
 1 file changed, 12 insertions(+)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: medium. Happy to make any adjustments!*