### PR TITLE
fix(Table): apply first-row radius when header is hidden

### DIFF
--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -222,6 +222,8 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     locale,
     showSorterTooltip = { target: 'full-header' },
     virtual,
+    title,
+    showHeader,
   } = props;
 
   const warning = devUseWarning('Table');
@@ -746,6 +748,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
                 [`${prefixCls}-small`]: mergedSize === 'small',
                 [`${prefixCls}-bordered`]: bordered,
                 [`${prefixCls}-empty`]: rawData.length === 0,
+                [`${prefixCls}-no-header`]: !title && showHeader === false,
               },
               cssVarCls,
               rootCls,

--- a/components/table/__tests__/Table.test.tsx
+++ b/components/table/__tests__/Table.test.tsx
@@ -637,6 +637,27 @@ describe('Table', () => {
     expect(container.querySelectorAll('.ant-table-cell-row-hover')).toHaveLength(0);
   });
 
+  it('should add no-header class only when header and title are absent', () => {
+    const columns = [{ title: 'Name', dataIndex: 'name' }];
+    const dataSource = [{ key: 1, name: 'Jack' }];
+    const { container, rerender } = render(
+      <Table showHeader={false} columns={columns} dataSource={dataSource} />,
+    );
+
+    expect(container.querySelector('.ant-table')).toHaveClass('ant-table-no-header');
+
+    rerender(
+      <Table
+        showHeader={false}
+        title={() => 'Title'}
+        columns={columns}
+        dataSource={dataSource}
+      />,
+    );
+
+    expect(container.querySelector('.ant-table')).not.toHaveClass('ant-table-no-header');
+  });
+
   it('rowSelection should support align', () => {
     const wrapper = render(
       <Table

--- a/components/table/__tests__/Table.test.tsx
+++ b/components/table/__tests__/Table.test.tsx
@@ -641,13 +641,18 @@ describe('Table', () => {
     const columns = [{ title: 'Name', dataIndex: 'name' }];
     const dataSource = [{ key: 1, name: 'Jack' }];
     const { container, rerender } = render(
-      <Table showHeader={false} columns={columns} dataSource={dataSource} />,
+      <Table bordered showHeader={false} columns={columns} dataSource={dataSource} />,
     );
 
     expect(container.querySelector('.ant-table')).toHaveClass('ant-table-no-header');
 
+    rerender(<Table bordered showHeader columns={columns} dataSource={dataSource} />);
+
+    expect(container.querySelector('.ant-table')).not.toHaveClass('ant-table-no-header');
+
     rerender(
       <Table
+        bordered
         showHeader={false}
         title={() => 'Title'}
         columns={columns}

--- a/components/table/style/radius.ts
+++ b/components/table/style/radius.ts
@@ -30,17 +30,16 @@ const genRadiusStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
           },
         },
 
-        [`&${componentCls}-bordered:not(:has(> ${componentCls}-title)):not(:has(${componentCls}-thead))`]:
-          {
-            [`> ${componentCls}-container`]: {
-              [`> ${componentCls}-content, > ${componentCls}-body`]: {
-                '> table > tbody > tr:first-child': {
-                  '> *:first-child': { borderStartStartRadius: tableRadius },
-                  '> *:last-child': { borderStartEndRadius: tableRadius },
-                },
+        [`&${componentCls}-bordered${componentCls}-no-header`]: {
+          [`> ${componentCls}-container`]: {
+            [`> ${componentCls}-content, > ${componentCls}-body`]: {
+              '> table > tbody > tr:first-child': {
+                '> *:first-child': { borderStartStartRadius: tableRadius },
+                '> *:last-child': { borderStartEndRadius: tableRadius },
               },
             },
           },
+        },
 
         '&-container': {
           borderStartStartRadius: tableRadius,

--- a/components/table/style/radius.ts
+++ b/components/table/style/radius.ts
@@ -30,6 +30,18 @@ const genRadiusStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
           },
         },
 
+        [`&${componentCls}-bordered:not(:has(> ${componentCls}-title)):not(:has(${componentCls}-thead))`]:
+          {
+            [`> ${componentCls}-container`]: {
+              [`> ${componentCls}-content, > ${componentCls}-body`]: {
+                '> table > tbody > tr:first-child': {
+                  '> *:first-child': { borderStartStartRadius: tableRadius },
+                  '> *:last-child': { borderStartEndRadius: tableRadius },
+                },
+              },
+            },
+          },
+
         '&-container': {
           borderStartStartRadius: tableRadius,
           borderStartEndRadius: tableRadius,


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- Close #46362

### 💡 Background and Solution

When Table uses `bordered` with `showHeader={false}`, no `thead` is rendered, so the existing header-cell radius styles do not cover the first body row. Its background and border can therefore overflow the Table's top corners, especially when the row is hovered.

This change applies the logical top corner radii to the first and last cells of the first body row when the bordered Table has neither a title nor a rendered header. It covers both the regular content container and the scroll body while preserving the existing square corners below a title.

There are no API changes.

#### Follow-up from review

Following [this compatibility review comment](https://github.com/ant-design/ant-design/pull/57035#discussion_r3792157429), the original `:has()` selector was replaced because Chrome 80–104 does not support `:has()` and would ignore the radius rule.

`InternalTable` now adds an explicit `.ant-table-no-header` state class only when `showHeader={false}` and no title is provided. The bordered radius styles use `.ant-table-bordered.ant-table-no-header`, providing the same behavior without relying on `:has()`. A regression test verifies that the state class is added without a header or title and omitted when a title is present.

#### Reproduction

The issue can be reproduced from the Table **Dynamic Settings** demo with the following configuration:

1. Enable **Bordered**.
2. Disable **Column Header** (`showHeader={false}`).
3. Disable **Title**.
4. Keep **Has Data** enabled.
5. Hover the first data row.
6. Toggle **Fixed Header** to verify both the regular and vertically scrollable layouts.

Equivalent props without vertical scrolling:

```tsx
<Table
  bordered
  showHeader={false}
  columns={columns}
  dataSource={dataSource}
/>
```

Equivalent props with vertical scrolling:

```tsx
<Table
  bordered
  showHeader={false}
  scroll={{ y: 240 }}
  columns={columns}
  dataSource={dataSource}
/>
```

Because `showHeader={false}` removes the `thead`, the first body row becomes the topmost visible row. The existing radius styles only target the first header row, so the first body row remains square. This is especially noticeable on hover because the row background extends into the Table's rounded top corners.

The DOM structure also differs depending on scrolling:

- Without `scroll.y`, the table is rendered inside `.ant-table-content`.
- With `scroll.y`, the table is rendered inside `.ant-table-body`.

The fix therefore covers both containers.

#### Title behavior

When `title` is not provided, the first body row is responsible for the Table's top corners and should receive the top-left and top-right radii.

When `title` is provided, `.ant-table-title` already owns the Table's top corners. In that case, the first body row must remain square so that it connects cleanly below the title.

The explicit state class is therefore added only when both the title and rendered header are absent.

Verification matrix:

| Title | `scroll.y` | Expected first body row |
| --- | --- | --- |
| No | No | Top corners are rounded |
| No | Yes | Top corners are rounded |
| Yes | No | Top corners remain square below the title |
| Yes | Yes | Top corners remain square below the title |

Verification:

- `npx eslint components/table/InternalTable.tsx components/table/style/radius.ts components/table/__tests__/Table.test.tsx`
- `npx tsc --noEmit --pretty false`
- `npm test -- components/table/__tests__/Table.test.tsx --runInBand` (33 tests and 5 snapshots passed)
- Manually verified with vertical scrolling enabled and disabled.
- Manually verified that tables with a title do not apply the body-row top radius.
- `npm run test:image -- components/table` was not run locally because the required Puppeteer Chrome binary is unavailable.

<!-- Attach the reproduction image or video before the fix here. -->

<!-- Attach the result image or video after the fix here. -->

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Table first-row corners when `bordered` is enabled and `showHeader` is `false`. |
| 🇨🇳 Chinese | 🐞 修复 Table 在启用 `bordered` 且 `showHeader` 为 `false` 时首行圆角异常的问题。 |