### PR TITLE
feat(locale): add Form.defaultValidateMessages to fi_FI, hu_HU, and lv_LV

### DIFF
--- a/components/locale/fi_FI.ts
+++ b/components/locale/fi_FI.ts
@@ -5,6 +5,8 @@ import Calendar from '../calendar/locale/fi_FI';
 import DatePicker from '../date-picker/locale/fi_FI';
 import TimePicker from '../time-picker/locale/fi_FI';
 
+const typeTemplate = '${label} ei ole kelvollinen ${type}';
+
 const localeValues: Locale = {
   locale: 'fi',
   Pagination,
@@ -60,6 +62,55 @@ const localeValues: Locale = {
     copy: 'Kopioi',
     copied: 'Kopioitu',
     expand: 'Näytä lisää',
+  },
+  Form: {
+    defaultValidateMessages: {
+      default: 'Kentän ${label} vahvistus epäonnistui',
+      required: 'Syötä ${label}',
+      enum: '${label} on oltava yksi seuraavista: [${enum}]',
+      whitespace: '${label} ei voi olla tyhjä',
+      date: {
+        format: '${label} päivämäärän muoto on virheellinen',
+        parse: '${label} ei voida muuntaa päivämääräksi',
+        invalid: '${label} on virheellinen päivämäärä',
+      },
+      types: {
+        string: typeTemplate,
+        method: typeTemplate,
+        array: typeTemplate,
+        object: typeTemplate,
+        number: typeTemplate,
+        date: typeTemplate,
+        boolean: typeTemplate,
+        integer: typeTemplate,
+        float: typeTemplate,
+        regexp: typeTemplate,
+        email: typeTemplate,
+        url: typeTemplate,
+        hex: typeTemplate,
+      },
+      string: {
+        len: '${label} täytyy olla täsmälleen ${len} merkkiä pitkä',
+        min: '${label} täytyy olla vähintään ${min} merkkiä pitkä',
+        max: '${label} saa olla enintään ${max} merkkiä pitkä',
+        range: '${label} täytyy olla ${min}–${max} merkkiä pitkä',
+      },
+      number: {
+        len: '${label} täytyy olla yhtä suuri kuin ${len}',
+        min: '${label} täytyy olla vähintään ${min}',
+        max: '${label} saa olla enintään ${max}',
+        range: '${label} täytyy olla välillä ${min}–${max}',
+      },
+      array: {
+        len: '${label} täytyy sisältää täsmälleen ${len} kohdetta',
+        min: '${label} täytyy sisältää vähintään ${min} kohdetta',
+        max: '${label} saa sisältää enintään ${max} kohdetta',
+        range: '${label} täytyy sisältää ${min}–${max} kohdetta',
+      },
+      pattern: {
+        mismatch: '${label} ei vastaa mallia ${pattern}',
+      },
+    },
   },
 };
 

--- a/components/locale/hu_HU.ts
+++ b/components/locale/hu_HU.ts
@@ -5,6 +5,8 @@ import Calendar from '../calendar/locale/hu_HU';
 import DatePicker from '../date-picker/locale/hu_HU';
 import TimePicker from '../time-picker/locale/hu_HU';
 
+const typeTemplate = '${label} nem érvényes ${type}';
+
 const localeValues: Locale = {
   locale: 'hu',
   Pagination,
@@ -51,6 +53,55 @@ const localeValues: Locale = {
     Next: 'Következő',
     Previous: 'Előző',
     Finish: 'Befejezés',
+  },
+  Form: {
+    defaultValidateMessages: {
+      default: '${label} mező érvényesítési hibája',
+      required: 'Kérjük töltse ki a(z) ${label} mezőt',
+      enum: '${label} az alábbiak egyike kell legyen: [${enum}]',
+      whitespace: '${label} nem lehet üres karakter',
+      date: {
+        format: '${label} dátum formátuma érvénytelen',
+        parse: '${label} nem konvertálható dátummá',
+        invalid: '${label} érvénytelen dátum',
+      },
+      types: {
+        string: typeTemplate,
+        method: typeTemplate,
+        array: typeTemplate,
+        object: typeTemplate,
+        number: typeTemplate,
+        date: typeTemplate,
+        boolean: typeTemplate,
+        integer: typeTemplate,
+        float: typeTemplate,
+        regexp: typeTemplate,
+        email: typeTemplate,
+        url: typeTemplate,
+        hex: typeTemplate,
+      },
+      string: {
+        len: '${label} pontosan ${len} karakter hosszú kell legyen',
+        min: '${label} legalább ${min} karakter hosszú kell legyen',
+        max: '${label} legfeljebb ${max} karakter hosszú lehet',
+        range: '${label} ${min}-${max} karakter hosszú kell legyen',
+      },
+      number: {
+        len: '${label} pontosan ${len} kell legyen',
+        min: '${label} legalább ${min} kell legyen',
+        max: '${label} legfeljebb ${max} lehet',
+        range: '${label} ${min}-${max} közé kell esnie',
+      },
+      array: {
+        len: '${label} pontosan ${len} elemet kell tartalmazzon',
+        min: '${label} legalább ${min} elemet kell tartalmazzon',
+        max: '${label} legfeljebb ${max} elemet tartalmazhat',
+        range: '${label} ${min}-${max} elemet kell tartalmazzon',
+      },
+      pattern: {
+        mismatch: '${label} nem egyezik meg a ${pattern} mintával',
+      },
+    },
   },
 };
 

--- a/components/locale/lv_LV.ts
+++ b/components/locale/lv_LV.ts
@@ -5,6 +5,8 @@ import Calendar from '../calendar/locale/lv_LV';
 import DatePicker from '../date-picker/locale/lv_LV';
 import TimePicker from '../time-picker/locale/lv_LV';
 
+const typeTemplate = '${label} nav derīgs ${type}';
+
 const localeValues: Locale = {
   locale: 'lv',
   Pagination,
@@ -50,6 +52,55 @@ const localeValues: Locale = {
   },
   Empty: {
     description: 'Nav datu',
+  },
+  Form: {
+    defaultValidateMessages: {
+      default: 'Lauka ${label} validācijas kļūda',
+      required: 'Lūdzu ievadiet ${label}',
+      enum: '${label} ir jābūt vienam no: [${enum}]',
+      whitespace: '${label} nevar būt tukša rakstzīme',
+      date: {
+        format: '${label} datuma formāts ir nederīgs',
+        parse: '${label} nav iespējams konvertēt par datumu',
+        invalid: '${label} ir nederīgs datums',
+      },
+      types: {
+        string: typeTemplate,
+        method: typeTemplate,
+        array: typeTemplate,
+        object: typeTemplate,
+        number: typeTemplate,
+        date: typeTemplate,
+        boolean: typeTemplate,
+        integer: typeTemplate,
+        float: typeTemplate,
+        regexp: typeTemplate,
+        email: typeTemplate,
+        url: typeTemplate,
+        hex: typeTemplate,
+      },
+      string: {
+        len: '${label} jābūt tieši ${len} rakstzīmju garam',
+        min: '${label} jābūt vismaz ${min} rakstzīmju garam',
+        max: '${label} drīkst būt ne vairāk kā ${max} rakstzīmes',
+        range: '${label} jābūt ${min}–${max} rakstzīmju garam',
+      },
+      number: {
+        len: '${label} jābūt vienādam ar ${len}',
+        min: '${label} jābūt vismaz ${min}',
+        max: '${label} drīkst būt ne vairāk kā ${max}',
+        range: '${label} jābūt starp ${min}–${max}',
+      },
+      array: {
+        len: '${label} jāsatur tieši ${len} elements(-i)',
+        min: '${label} jāsatur vismaz ${min} elements(-i)',
+        max: '${label} drīkst saturēt ne vairāk kā ${max} elementus',
+        range: '${label} jāsatur ${min}–${max} elementi',
+      },
+      pattern: {
+        mismatch: '${label} neatbilst šablonam ${pattern}',
+      },
+    },
   },
 };
 


### PR DESCRIPTION
## Summary

Closes part of #23369 — adds `Form.defaultValidateMessages` to three more locales.

## Changes

Added complete form validation message translations for:

| Locale | Language |
|--------|----------|
| `fi_FI` | Finnish (Suomi) |
| `hu_HU` | Hungarian (Magyar) |
| `lv_LV` | Latvian (Latviešu) |

### Coverage

All three locales now include translations for:
- `default` — generic field validation failure
- `required` — required field missing
- `enum` — value not in allowed list
- `whitespace` — blank-only value
- `date.format` / `date.parse` / `date.invalid`
- All `types.*` validators (string, number, boolean, date, etc.)
- `string` length rules (`len`, `min`, `max`, `range`)
- `number` range rules (`len`, `min`, `max`, `range`)
- `array` length rules (`len`, `min`, `max`, `range`)
- `pattern.mismatch`