### PR TITLE
Revert "chore: revert "bump jsdom""

### DIFF
--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
     "jest-image-snapshot": "^6.5.1",
     "jest-puppeteer": "^11.0.0",
     "jquery": "^4.0.0",
-    "jsdom": "~28.0.0",
+    "jsdom": "~28.1.0",
     "jsonml-to-react-element": "^1.1.11",
     "jsonml.js": "^0.1.0",
     "lint-staged": "^16.2.7",

--- a/tests/setupAfterEnv.ts
+++ b/tests/setupAfterEnv.ts
@@ -1,7 +1,6 @@
 import '@testing-library/jest-dom';
 
 import { toHaveNoViolations } from 'jest-axe';
-import { JSDOM } from 'jsdom';
 import format, { plugins } from 'pretty-format';
 
 import { defaultConfig } from '../components/theme/internal';
@@ -29,7 +28,7 @@ function cleanup(node: HTMLElement) {
   const childList = Array.from(node.childNodes);
   node.innerHTML = '';
   childList.forEach((child) => {
-    if (!(child instanceof Text) || child.nodeType !== Node.TEXT_NODE) {
+    if (!(child instanceof Text)) {
       node.appendChild(cleanup(child as any));
     } else if (child.textContent) {
       node.appendChild(child);
@@ -91,9 +90,10 @@ expect.addSnapshotSerializer({
   // @ts-ignore
   print: ({ html }) => {
     // Create a temporary container to parse HTML
-    const { window } = new JSDOM(html);
+    const container = document.createElement('div');
+    container.innerHTML = html;
 
-    const children = Array.from(window.document.body.childNodes).filter(
+    const children = Array.from(container.childNodes).filter(
       // Ignore `link` node since React 18 or below not support this
       (node) => node.nodeName !== 'LINK',
     );


### PR DESCRIPTION
Reverts ant-design/ant-design#57028

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes: a minor `jsdom` patch bump and switching HTML parsing to use the existing Jest `document`, which may cause small snapshot differences but doesn’t affect runtime code.
> 
> **Overview**
> Bumps the dev dependency `jsdom` from `~28.0.0` to `~28.1.0`.
> 
> Updates `tests/setupAfterEnv.ts` to stop constructing `new JSDOM()` for demo snapshot serialization, instead parsing via a temporary `document` container, and slightly relaxes the `cleanup` text-node check used when normalizing snapshot HTML.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e73431ec5e8e604a51ee9200f216c996baf99858. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->