### PR TITLE
fix: align Modal onCancel event type with Dialog onClose

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -123,7 +123,7 @@ const Modal: React.FC<ModalProps> = (props) => {
   const mergedFocusable = useFocusable(focusable, mergedMask, focusTriggerAfterClose);
 
   // ============================ Open ============================
-  const handleCancel = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleCancel: ModalProps['onCancel'] = (e) => {
     if (confirmLoading) {
       return;
     }

--- a/components/modal/__tests__/type.test.tsx
+++ b/components/modal/__tests__/type.test.tsx
@@ -28,4 +28,17 @@ describe('Modal.typescript', () => {
 
     expect(modal).toBeTruthy();
   });
+
+  it('Modal.onCancel should support keyboard event', () => {
+    const onCancel: React.ComponentProps<typeof Modal>['onCancel'] = (e) => {
+      if (e instanceof KeyboardEvent) {
+        const key = e.key;
+        expect(key).toBeTruthy();
+      }
+    };
+
+    const modal = <Modal onCancel={onCancel} />;
+
+    expect(modal).toBeTruthy();
+  });
 });

--- a/components/modal/interface.ts
+++ b/components/modal/interface.ts
@@ -78,7 +78,7 @@ export interface ModalProps extends ModalCommonProps {
   /** Specify a function that will be called when a user clicks the OK button */
   onOk?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   /** Specify a function that will be called when a user clicks mask, close button on top right or Cancel button */
-  onCancel?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onCancel?: DialogProps['onClose'];
   afterClose?: () => void;
   /** Callback when the animation ends when Modal is turned on and off */
   afterOpenChange?: (open: boolean) => void;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- Fix [#56848](https://github.com/ant-design/ant-design/issues/56848)

### 💡 Background and Solution

- `ModalProps['onCancel']` was typed as `React.MouseEvent<HTMLButtonElement>`, but `onCancel` can also be triggered by keyboard close behavior (for example, `Esc`).
- Updated `ModalProps['onCancel']` to reuse `DialogProps['onClose']` so Modal event typing matches underlying Dialog close behavior.
- Updated internal `handleCancel` typing to align with the new `onCancel` type.
- Added a TypeScript test to verify `Modal.onCancel` supports keyboard events.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🤖 Improve Modal `onCancel` typing to align with Dialog close event types, including keyboard-triggered cancel scenarios. |
| 🇨🇳 Chinese | 🤖 优化 Modal `onCancel` 类型定义，与 Dialog 关闭事件类型保持一致，支持键盘触发的取消场景。 |
