### PR TITLE
type: add KeyboardEvent support to Modal onCancel type

### DIFF
--- a/components/config-provider/demo/direction.tsx
+++ b/components/config-provider/demo/direction.tsx
@@ -136,13 +136,11 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
     setModalOpen(true);
   };
 
-  const handleOk = (e: React.MouseEvent<HTMLElement>) => {
-    console.log(e);
+  const handleOk = () => {
     setModalOpen(false);
   };
 
-  const handleCancel = (e: React.MouseEvent<HTMLElement>) => {
-    console.log(e);
+  const handleCancel = () => {
     setModalOpen(false);
   };
 

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import Dialog from '@rc-component/dialog';
+import type { DialogProps } from '@rc-component/dialog';
 import { composeRef } from '@rc-component/util/lib/ref';
 import { clsx } from 'clsx';
 
@@ -123,7 +124,9 @@ const Modal: React.FC<ModalProps> = (props) => {
   const mergedFocusable = useFocusable(focusable, mergedMask, focusTriggerAfterClose);
 
   // ============================ Open ============================
-  const handleCancel = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleCancel = (
+    e: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLElement>,
+  ) => {
     if (confirmLoading) {
       return;
     }
@@ -261,7 +264,7 @@ const Modal: React.FC<ModalProps> = (props) => {
           footer={dialogFooter}
           visible={open}
           mousePosition={customizeMousePosition ?? mousePosition}
-          onClose={handleCancel as any}
+          onClose={handleCancel as DialogProps['onClose']}
           closable={mergedClosable}
           closeIcon={mergedCloseIcon}
           transitionName={getTransitionName(rootPrefixCls, 'zoom', props.transitionName)}

--- a/components/modal/__tests__/Modal.test.tsx
+++ b/components/modal/__tests__/Modal.test.tsx
@@ -64,6 +64,13 @@ describe('Modal', () => {
     expect(onCancel).toHaveBeenCalled();
   });
 
+  it('onCancel should be called when pressing ESC', () => {
+    const onCancel = jest.fn();
+    render(<Modal open onCancel={onCancel} />);
+    fireEvent.keyDown(document.querySelector('.ant-modal-wrap')!, { key: 'Escape', keyCode: 27 });
+    expect(onCancel).toHaveBeenCalled();
+  });
+
   it('onOk should be called', () => {
     const onOk = jest.fn();
     render(<Modal open onOk={onOk} />);

--- a/components/modal/__tests__/Modal.test.tsx
+++ b/components/modal/__tests__/Modal.test.tsx
@@ -277,7 +277,7 @@ describe('Modal', () => {
       useEffect(() => {
         setOpen(true);
       }, []);
-      const handleCancel = (event: React.MouseEvent<HTMLButtonElement>) => {
+      const handleCancel: ModalProps['onCancel'] = (event) => {
         setOpen(false);
         onCancel(event);
       };

--- a/components/modal/demo/button-props.tsx
+++ b/components/modal/demo/button-props.tsx
@@ -8,13 +8,11 @@ const App: React.FC = () => {
     setOpen(true);
   };
 
-  const handleOk = (e: React.MouseEvent<HTMLElement>) => {
-    console.log(e);
+  const handleOk = () => {
     setOpen(false);
   };
 
-  const handleCancel = (e: React.MouseEvent<HTMLElement>) => {
-    console.log(e);
+  const handleCancel = () => {
     setOpen(false);
   };
 

--- a/components/modal/demo/dark.tsx
+++ b/components/modal/demo/dark.tsx
@@ -340,13 +340,11 @@ const Demo: React.FC = () => {
     setOpen(true);
   };
 
-  const handleOk = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    console.log(e);
+  const handleOk = () => {
     setOpen(false);
   };
 
-  const handleCancel = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    console.log(e);
+  const handleCancel = () => {
     setOpen(false);
   };
 

--- a/components/modal/demo/modal-render.tsx
+++ b/components/modal/demo/modal-render.tsx
@@ -13,13 +13,11 @@ const App: React.FC = () => {
     setOpen(true);
   };
 
-  const handleOk = (e: React.MouseEvent<HTMLElement>) => {
-    console.log(e);
+  const handleOk = () => {
     setOpen(false);
   };
 
-  const handleCancel = (e: React.MouseEvent<HTMLElement>) => {
-    console.log(e);
+  const handleCancel = () => {
     setOpen(false);
   };
 

--- a/components/modal/interface.ts
+++ b/components/modal/interface.ts
@@ -77,8 +77,8 @@ export interface ModalProps extends ModalCommonProps {
   title?: React.ReactNode;
   /** Specify a function that will be called when a user clicks the OK button */
   onOk?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  /** Specify a function that will be called when a user clicks mask, close button on top right or Cancel button */
-  onCancel?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  /** Specify a function that will be called when a user clicks mask, close button on top right or Cancel button, or presses Esc key */
+  onCancel?: (e: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLElement>) => void;
   afterClose?: () => void;
   /** Callback when the animation ends when Modal is turned on and off */
   afterOpenChange?: (open: boolean) => void;

--- a/components/modal/shared.tsx
+++ b/components/modal/shared.tsx
@@ -20,7 +20,7 @@ export function renderCloseIcon(prefixCls: string, closeIcon?: React.ReactNode) 
 
 interface FooterProps {
   onOk?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
-  onCancel?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>;
+  onCancel?: ModalProps['onCancel'];
 }
 
 export const Footer: React.FC<


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- Fix [#56848](https://github.com/ant-design/ant-design/issues/56848)

### 💡 Background and Solution

The `onCancel` callback in `ModalProps` was typed as `(e: React.MouseEvent<HTMLButtonElement>) => void`, but pressing the Escape key triggers a `KeyboardEvent` via `@rc-component/dialog`'s `onClose` (typed as `(e: SyntheticEvent | KeyboardEvent) => any`). This caused a type mismatch — users handling keyboard events in the callback would get TypeScript errors.

**Changes:**

- **`components/modal/interface.ts`**: Update `onCancel` type to `(e: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLElement>) => void`
- **`components/modal/Modal.tsx`**: Update `handleCancel` parameter type to match; replace `as any` cast with `as DialogProps['onClose']`
- **`components/modal/shared.tsx`**: Align `FooterProps.onCancel` with `ModalProps['onCancel']`
- **Demos & tests**: Update explicit `MouseEvent` type annotations in demos and tests to align with the new signature

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🤖 Modal `onCancel` now correctly types the event parameter as `React.MouseEvent<HTMLButtonElement> \| React.KeyboardEvent<HTMLElement>` to support Escape key dismissal. |
| 🇨🇳 Chinese | 🤖 Modal `onCancel` 事件参数类型现在正确支持 `React.MouseEvent<HTMLButtonElement> \| React.KeyboardEvent<HTMLElement>`，以适配 Esc 键关闭场景。 |