### PR TITLE
fix: add trust verification for workflow_run and pull_request_target events

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: 🆕 Create new issue
     url: https://new-issue.ant.design
     about: The issue which is not created via https://new-issue.ant.design will be closed immediately.
   - name: 🆕 创建一个新 Issue
     url: https://new-issue.ant.design
-    about: ⚠️ 注意请不要使用上面的 Report a vulnerability（报告安全漏洞）来报告组件库的 bug 和特性请求，请点击右侧 Open 按钮。不是用 https://new-issue.ant.design 创建的 issue 会被机器人自动关闭。
+    about: 不是用 https://new-issue.ant.design 创建的 issue 会被机器人自动关闭。
+  - name: 🔐 Report a Security Vulnerability
+    url: https://github.com/ant-design/ant-design/security/advisories/new
+    about: Please report security vulnerabilities here. 请在此报告安全漏洞。

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,8 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: 🆕 Create new issue
     url: https://new-issue.ant.design
     about: The issue which is not created via https://new-issue.ant.design will be closed immediately.
   - name: 🆕 创建一个新 Issue
     url: https://new-issue.ant.design
-    about: 不是用 https://new-issue.ant.design 创建的 issue 会被机器人自动关闭。
-  - name: 🔐 Report a Security Vulnerability
-    url: https://github.com/ant-design/ant-design/security/advisories/new
-    about: Please report security vulnerabilities here. 请在此报告安全漏洞。
+    about: ⚠️ 注意请不要使用上面的 Report a vulnerability（报告安全漏洞）来报告组件库的 bug 和特性请求，请点击右侧 Open 按钮。不是用 https://new-issue.ant.design 创建的 issue 会被机器人自动关闭。

--- a/.github/workflows/discussion-open-check.yml
+++ b/.github/workflows/discussion-open-check.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read  # for visiky/dingtalk-release-notify to get latest release
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: send to dingtalk
         uses: visiky/dingtalk-release-notify@64fcb0373782b6c2f6d9b9ea3c68af80ca189585 # pin@main

--- a/.github/workflows/discussion-open-check.yml
+++ b/.github/workflows/discussion-open-check.yml
@@ -7,14 +7,19 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.discussion.number }}
+  cancel-in-progress: true
+
 jobs:
   discussion-create:
     permissions:
       contents: read  # for visiky/dingtalk-release-notify to get latest release
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
     steps:
       - name: send to dingtalk
-        uses: visiky/dingtalk-release-notify@main
+        uses: visiky/dingtalk-release-notify@64fcb0373782b6c2f6d9b9ea3c68af80ca189585 # pin@main
         with:
           DING_TALK_TOKEN: |
             ${{ secrets.DINGDING_BOT_TOKEN }}

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -9,12 +9,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   issue-labeled:
     permissions:
       issues: write  # for actions-cool/issues-helper to update issues
       pull-requests: write  # for actions-cool/issues-helper to update PRs
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     steps:
       - name: help wanted
         if: github.event.label.name == 'help wanted'

--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   issue-open-check:
     permissions:
@@ -14,6 +18,7 @@ jobs:
       issues: write  # for actions-cool/issues-helper to update issues
       pull-requests: write  # for actions-cool/issues-helper to update PRs
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     steps:
       - uses: actions-cool/check-user-permission@v2
         id: checkUser
@@ -94,7 +99,7 @@ jobs:
             Hello @${{ github.event.issue.user.login }}, v4 only support IE11 and above.
 
       - name: send to dingtalk
-        uses: visiky/dingtalk-release-notify@main
+        uses: visiky/dingtalk-release-notify@64fcb0373782b6c2f6d9b9ea3c68af80ca189585 # pin@main
         with:
           DING_TALK_TOKEN: |
             ${{ secrets.DINGDING_BOT_TOKEN }}

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -4,9 +4,14 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   build:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -27,8 +27,9 @@ jobs:
     steps:
       - name: get commit count
         id: get_commit_count
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           # Validate username format (GitHub usernames: alphanumeric and hyphens, max 39 chars)
           if ! [[ "$PR_AUTHOR" =~ ^[a-zA-Z0-9-]{1,39}$ ]]; then
             echo "Invalid username format, skipping"

--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -23,7 +23,7 @@ jobs:
     # Only run for merged PRs from the same repo (not from forks)
     if: github.event.pull_request.merged == true && github.repository == 'ant-design/ant-design' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: get commit count
         id: get_commit_count

--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -16,13 +16,20 @@ jobs:
     permissions:
       issues: write  # for actions-cool/maintain-one-comment to modify or create issue comments
       pull-requests: write  # for actions-cool/maintain-one-comment to modify or create PR comments
-    if: github.event.pull_request.merged == true && github.repository == 'ant-design/ant-design'
+    # Only run for merged PRs from the same repo (not from forks)
+    if: github.event.pull_request.merged == true && github.repository == 'ant-design/ant-design' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: get commit count
         id: get_commit_count
         run: |
-          PR_AUTHOR=$(echo "${{ github.event.pull_request.user.login }}")
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          # Validate username format (GitHub usernames: alphanumeric and hyphens, max 39 chars)
+          if ! [[ "$PR_AUTHOR" =~ ^[a-zA-Z0-9-]{1,39}$ ]]; then
+            echo "Invalid username format, skipping"
+            echo "COUNT=999" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           RESULT_DATA=$(curl -s "https://api.github.com/repos/${{ github.repository }}/commits?author=${PR_AUTHOR}&per_page=5")
           DATA_LENGTH=$(echo $RESULT_DATA | jq 'if type == "array" then length else 0 end')
           echo "COUNT=$DATA_LENGTH" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   comment:
     permissions:
@@ -19,6 +23,7 @@ jobs:
     # Only run for merged PRs from the same repo (not from forks)
     if: github.event.pull_request.merged == true && github.repository == 'ant-design/ant-design' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
     steps:
       - name: get commit count
         id: get_commit_count

--- a/.github/workflows/pr-open-check.yml
+++ b/.github/workflows/pr-open-check.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   refuse:
     permissions:

--- a/.github/workflows/pr-open-notify.yml
+++ b/.github/workflows/pr-open-notify.yml
@@ -7,11 +7,16 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   send-to-dingtalk:
     # Only run for PRs from the same repo (not from forks) to prevent potential injection
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
     steps:
       - name: send to dingtalk
         uses: visiky/dingtalk-release-notify@64fcb0373782b6c2f6d9b9ea3c68af80ca189585

--- a/.github/workflows/pr-open-notify.yml
+++ b/.github/workflows/pr-open-notify.yml
@@ -9,6 +9,8 @@ permissions:
 
 jobs:
   send-to-dingtalk:
+    # Only run for PRs from the same repo (not from forks) to prevent potential injection
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: send to dingtalk

--- a/.github/workflows/pr-open-notify.yml
+++ b/.github/workflows/pr-open-notify.yml
@@ -16,7 +16,7 @@ jobs:
     # Only run for PRs from the same repo (not from forks) to prevent potential injection
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: send to dingtalk
         uses: visiky/dingtalk-release-notify@64fcb0373782b6c2f6d9b9ea3c68af80ca189585

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -12,10 +12,29 @@ permissions:
   contents: read
 
 jobs:
+  check-trust:
+    name: Check if workflow run is trusted
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      trusted: ${{ steps.check.outputs.trusted }}
+    steps:
+      - name: Check trust
+        id: check
+        env:
+          REPO: ${{ github.event.workflow_run.repository.full_name }}
+          EVENT: ${{ github.event.workflow_run.event }}
+        run: |
+          if [[ "$REPO" == "ant-design/ant-design" && "$EVENT" == "pull_request" ]]; then
+            echo "trusted=true" >> $GITHUB_OUTPUT
+          else
+            echo "trusted=false" >> $GITHUB_OUTPUT
+          fi
+
   upstream-workflow-summary:
     name: upstream workflow summary
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    if: github.event.workflow_run.event == 'pull_request'
+    needs: [check-trust]
+    if: fromJSON(needs.check-trust.outputs.trusted)
     outputs:
       jobs: ${{ steps.prep-summary.outputs.result }}
       build-success: ${{ steps.prep-summary.outputs.build-success }}
@@ -58,8 +77,8 @@ jobs:
       issues: write # for actions-cool/maintain-one-comment to modify or create issue comments
       pull-requests: write # for actions-cool/maintain-one-comment to modify or create PR comments
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: upstream-workflow-summary
-    if: github.event.workflow_run.event == 'pull_request'
+    needs: [check-trust, upstream-workflow-summary]
+    if: fromJSON(needs.check-trust.outputs.trusted)
     steps:
       # We need get PR id first
       - name: download pr artifact

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -19,7 +19,7 @@ jobs:
   check-trust:
     name: Check if workflow run is trusted
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
+    timeout-minutes: 10
     outputs:
       trusted: ${{ steps.check.outputs.trusted }}
     steps:
@@ -38,7 +38,7 @@ jobs:
   upstream-workflow-summary:
     name: upstream workflow summary
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: [check-trust]
     if: fromJSON(needs.check-trust.outputs.trusted)
     outputs:
@@ -83,7 +83,7 @@ jobs:
       issues: write # for actions-cool/maintain-one-comment to modify or create issue comments
       pull-requests: write # for actions-cool/maintain-one-comment to modify or create PR comments
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: [check-trust, upstream-workflow-summary]
     if: fromJSON(needs.check-trust.outputs.trusted)
     steps:

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -11,10 +11,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
 jobs:
   check-trust:
     name: Check if workflow run is trusted
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
     outputs:
       trusted: ${{ steps.check.outputs.trusted }}
     steps:
@@ -33,6 +38,7 @@ jobs:
   upstream-workflow-summary:
     name: upstream workflow summary
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
     needs: [check-trust]
     if: fromJSON(needs.check-trust.outputs.trusted)
     outputs:
@@ -77,6 +83,7 @@ jobs:
       issues: write # for actions-cool/maintain-one-comment to modify or create issue comments
       pull-requests: write # for actions-cool/maintain-one-comment to modify or create PR comments
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     needs: [check-trust, upstream-workflow-summary]
     if: fromJSON(needs.check-trust.outputs.trusted)
     steps:

--- a/.github/workflows/release-dingtalk.yml
+++ b/.github/workflows/release-dingtalk.yml
@@ -23,7 +23,7 @@ jobs:
       contents: write  # for actions-cool/release-helper to create releases
     if: github.event.ref_type == 'tag'
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Send to Ant Design DingGroup
         uses: actions-cool/release-helper@v2

--- a/.github/workflows/release-dingtalk.yml
+++ b/.github/workflows/release-dingtalk.yml
@@ -13,12 +13,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.ref }}
+  cancel-in-progress: true
+
 jobs:
   release-helper:
     permissions:
       contents: write  # for actions-cool/release-helper to create releases
     if: github.event.ref_type == 'tag'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     steps:
       - name: Send to Ant Design DingGroup
         uses: actions-cool/release-helper@v2

--- a/.github/workflows/release-dingtalk.yml
+++ b/.github/workflows/release-dingtalk.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.ref }}
+  group: ${{ github.workflow }}-${{ github.event.ref_type }}-${{ github.event.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release-x.yml
+++ b/.github/workflows/release-x.yml
@@ -8,7 +8,7 @@ permissions: {}
 jobs:
   tweet:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
+    timeout-minutes: 10
     if: ${{ github.event.ref_type == 'tag' && !contains(github.event.ref, 'alpha') }}
     steps:
       - name: Tweet

--- a/.github/workflows/release-x.yml
+++ b/.github/workflows/release-x.yml
@@ -8,10 +8,11 @@ permissions: {}
 jobs:
   tweet:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
     if: ${{ github.event.ref_type == 'tag' && !contains(github.event.ref, 'alpha') }}
     steps:
       - name: Tweet
-        uses: nearform-actions/github-action-notify-twitter@master
+        uses: nearform-actions/github-action-notify-twitter@78c89f569aba92b378bcf69efbabfbc43cc6e564 # pin@master
         with:
           message: |
             🤖 Ant Design just released antd@${{ github.event.ref }} ✨🎊✨ Check out the full release note: https://github.com/ant-design/ant-design/releases/tag/${{ github.event.ref }}

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -8,18 +8,23 @@ permissions:
   issues: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   size:
     permissions:
       contents: read
       pull-requests: write
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v6
       - uses: utooland/setup-utoo@v1
       - name: size-limit
-        uses: ant-design/size-limit-action@master
+        uses: ant-design/size-limit-action@1cd308b2fb976363849b02434e706bbca8727aa1 # pin@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           package_manager: ut

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/visual-regression-diff-approver.yml
+++ b/.github/workflows/visual-regression-diff-approver.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   approval:
     permissions:
@@ -18,6 +22,7 @@ jobs:
     name: Check Virtual Regression Approval
     if: github.event.issue.pull_request != ''
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
     steps:
     # Check all the comments if contains `VISUAL_DIFF_SUCCESS` or `VISUAL_DIFF_FAILED`
     # Check if member of repo comment `Pass Visual Diff`

--- a/.github/workflows/visual-regression-diff-approver.yml
+++ b/.github/workflows/visual-regression-diff-approver.yml
@@ -22,7 +22,7 @@ jobs:
     name: Check Virtual Regression Approval
     if: github.event.issue.pull_request != ''
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
     # Check all the comments if contains `VISUAL_DIFF_SUCCESS` or `VISUAL_DIFF_FAILED`
     # Check if member of repo comment `Pass Visual Diff`

--- a/.github/workflows/visual-regression-diff-finish.yml
+++ b/.github/workflows/visual-regression-diff-finish.yml
@@ -19,7 +19,7 @@ jobs:
   check-trust:
     name: Check if workflow run is trusted
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
+    timeout-minutes: 10
     outputs:
       trusted: ${{ steps.check.outputs.trusted }}
     steps:
@@ -38,7 +38,7 @@ jobs:
   upstream-workflow-summary:
     name: upstream workflow summary
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: [check-trust]
     if: fromJSON(needs.check-trust.outputs.trusted)
     outputs:
@@ -89,7 +89,7 @@ jobs:
       pull-requests: write  # for actions-cool/maintain-one-comment to modify or create PR comments
       statuses: write
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 20
+    timeout-minutes: 30
     needs: [check-trust, upstream-workflow-summary]
     if: fromJSON(needs.check-trust.outputs.trusted)
     steps:

--- a/.github/workflows/visual-regression-diff-finish.yml
+++ b/.github/workflows/visual-regression-diff-finish.yml
@@ -11,10 +11,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
 jobs:
   check-trust:
     name: Check if workflow run is trusted
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
     outputs:
       trusted: ${{ steps.check.outputs.trusted }}
     steps:
@@ -33,6 +38,7 @@ jobs:
   upstream-workflow-summary:
     name: upstream workflow summary
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
     needs: [check-trust]
     if: fromJSON(needs.check-trust.outputs.trusted)
     outputs:
@@ -83,6 +89,7 @@ jobs:
       pull-requests: write  # for actions-cool/maintain-one-comment to modify or create PR comments
       statuses: write
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
     needs: [check-trust, upstream-workflow-summary]
     if: fromJSON(needs.check-trust.outputs.trusted)
     steps:

--- a/.github/workflows/visual-regression-diff-finish.yml
+++ b/.github/workflows/visual-regression-diff-finish.yml
@@ -12,9 +12,29 @@ permissions:
   contents: read
 
 jobs:
+  check-trust:
+    name: Check if workflow run is trusted
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      trusted: ${{ steps.check.outputs.trusted }}
+    steps:
+      - name: Check trust
+        id: check
+        env:
+          REPO: ${{ github.event.workflow_run.repository.full_name }}
+          EVENT: ${{ github.event.workflow_run.event }}
+        run: |
+          if [[ "$REPO" == "ant-design/ant-design" && "$EVENT" == "pull_request" ]]; then
+            echo "trusted=true" >> $GITHUB_OUTPUT
+          else
+            echo "trusted=false" >> $GITHUB_OUTPUT
+          fi
+
   upstream-workflow-summary:
     name: upstream workflow summary
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [check-trust]
+    if: fromJSON(needs.check-trust.outputs.trusted)
     outputs:
       jobs: ${{ steps.visual_diff_build_job_status.outputs.result }}
       upstream-job-link: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/job/${{ steps.visual_diff_build_job_status.outputs.job-id }}
@@ -63,7 +83,8 @@ jobs:
       pull-requests: write  # for actions-cool/maintain-one-comment to modify or create PR comments
       statuses: write
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [upstream-workflow-summary]
+    needs: [check-trust, upstream-workflow-summary]
+    if: fromJSON(needs.check-trust.outputs.trusted)
     steps:
       - uses: actions/checkout@v6
       - uses: utooland/setup-utoo@v1

--- a/.github/workflows/visual-regression-diff-start.yml
+++ b/.github/workflows/visual-regression-diff-start.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write  # for actions-cool/maintain-one-comment to modify or create PR comments
     name: start visual-regression diff
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: update status comment
         uses: actions-cool/maintain-one-comment@4b2dbf086015f892dcb5e8c1106f5fccd6c1476b

--- a/.github/workflows/visual-regression-diff-start.yml
+++ b/.github/workflows/visual-regression-diff-start.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   visual-regression-diff-start:
     permissions:
@@ -21,6 +25,7 @@ jobs:
       pull-requests: write  # for actions-cool/maintain-one-comment to modify or create PR comments
     name: start visual-regression diff
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
     steps:
       - name: update status comment
         uses: actions-cool/maintain-one-comment@4b2dbf086015f892dcb5e8c1106f5fccd6c1476b

--- a/.github/workflows/visual-regression-persist-finish.yml
+++ b/.github/workflows/visual-regression-persist-finish.yml
@@ -11,10 +11,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
 jobs:
   check-trust:
     name: Check if workflow run is trusted
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
     outputs:
       trusted: ${{ steps.check.outputs.trusted }}
     steps:
@@ -38,6 +43,7 @@ jobs:
   upstream-workflow-summary:
     name: upstream workflow summary
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
     outputs:
       jobs: ${{ steps.persist_start_job_status.outputs.result }}
       build-success: ${{ steps.persist_start_job_status.outputs.build-success }}
@@ -80,6 +86,7 @@ jobs:
     permissions:
       actions: read # for dawidd6/action-download-artifact to query and download artifacts
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
     needs: [check-trust, upstream-workflow-summary]
     if: fromJSON(needs.check-trust.outputs.trusted)
     steps:

--- a/.github/workflows/visual-regression-persist-finish.yml
+++ b/.github/workflows/visual-regression-persist-finish.yml
@@ -19,7 +19,7 @@ jobs:
   check-trust:
     name: Check if workflow run is trusted
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
+    timeout-minutes: 10
     outputs:
       trusted: ${{ steps.check.outputs.trusted }}
     steps:
@@ -43,7 +43,7 @@ jobs:
   upstream-workflow-summary:
     name: upstream workflow summary
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
+    timeout-minutes: 10
     outputs:
       jobs: ${{ steps.persist_start_job_status.outputs.result }}
       build-success: ${{ steps.persist_start_job_status.outputs.build-success }}
@@ -86,7 +86,7 @@ jobs:
     permissions:
       actions: read # for dawidd6/action-download-artifact to query and download artifacts
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 20
+    timeout-minutes: 30
     needs: [check-trust, upstream-workflow-summary]
     if: fromJSON(needs.check-trust.outputs.trusted)
     steps:

--- a/.github/workflows/visual-regression-persist-start.yml
+++ b/.github/workflows/visual-regression-persist-start.yml
@@ -12,10 +12,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-image:
     name: test image
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: utooland/setup-utoo@v1


### PR DESCRIPTION
## Summary
- Add `check-trust` job to `visual-regression-diff-finish.yml` and `preview-deploy.yml` to verify workflow_run triggers only from ant-design/ant-design repository
- Add fork check to `pr-open-notify.yml` to only process PRs from the same repository
- Add fork check and username validation to `pr-contributor-welcome.yml` to prevent potential injection attacks

This prevents attackers from triggering workflows via fork PRs and potentially accessing secrets or executing malicious code.

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Confirm fork PRs cannot trigger sensitive workflows
- [ ] Confirm normal PRs from ant-design/ant-design still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes execution conditions for multiple automation workflows; misconfigured trust checks or concurrency groups could skip expected notifications/deployments or cancel runs unexpectedly.
> 
> **Overview**
> **Hardens GitHub Actions workflows that run on `workflow_run` and `pull_request_target`** to reduce exposure to fork-based/injection attacks. Preview deploy and visual-regression “finish” workflows now gate execution behind a new `check-trust` job that only allows runs from the main repo and expected event types.
> 
> Several PR/issue/discussion notification workflows now add per-entity `concurrency` groups and job `timeout-minutes`, and actions previously referenced by `@main`/`@master` are pinned to specific commits. PR-triggered notifications/comments additionally add same-repo (non-fork) checks, and `pr-contributor-welcome` validates the PR author username before calling GitHub APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b5b56500ad03f3748fbfe3c927f919795e7b28e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->