### PR TITLE
docs: correct size option values in API docs

### DIFF
--- a/components/auto-complete/demo/AutoComplete-and-Select.tsx
+++ b/components/auto-complete/demo/AutoComplete-and-Select.tsx
@@ -4,7 +4,7 @@ import { AutoComplete, Flex, Select } from 'antd';
 const AutoCompleteAndSelect = () => {
   return (
     <Flex vertical gap={16}>
-      {(['small', 'middle', 'large'] as const).map((size) => (
+      {(['small', 'medium', 'large'] as const).map((size) => (
         <Flex key={size}>
           <Select
             value="centered"

--- a/components/auto-complete/index.en-US.md
+++ b/components/auto-complete/index.en-US.md
@@ -65,7 +65,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | placeholder | The placeholder of input | string | - |  |
 | showSearch | search for configuration | true \| [Object](#showsearch) | true |  |
 | status | Set validation status | 'error' \| 'warning' | - | 4.19.0 |
-| size | The size of the input box | `large` \| `middle` \| `small` | - |  |
+| size | The size of the input box | `large` \| `medium` \| `small` | - |  |
 | value | Selected option | string | - |  |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
 | variant | Variants of input | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 |

--- a/components/auto-complete/index.zh-CN.md
+++ b/components/auto-complete/index.zh-CN.md
@@ -66,7 +66,7 @@ demo:
 | placeholder | 输入框提示 | string | - |  |
 | showSearch | 搜索配置 | true \| [Object](#showsearch) | true |  |
 | status | 设置校验状态 | 'error' \| 'warning' | - | 4.19.0 |
-| size | 控件大小 | `large` \| `middle` \| `small` | - |  |
+| size | 控件大小 | `large` \| `medium` \| `small` | - |  |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
 | value | 指定当前选中的条目 | string | - |  |
 | variant | 形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案

`size` 枚举已调整为 `large | medium | small`，部分组件 demo 和文档没完成更新。

目前已完成核对进展：

- affix ✅
- alert ✅
- anchor ✅
- app ✅
- auto-complete ✅
- avatar ✅

### 📝 更新日志

| 语言    | 更新描述                                        |
| ------- | ----------------------------------------------- |
| 🇺🇸 英文 | Correct `size` option values in docs and demos. |
| 🇨🇳 中文 | 修正文档和示例中 `size` 的可选值。              |
