### PR TITLE
fix: unify size className, add ConfigProvider size for Rate, support medium for Table

### DIFF
--- a/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1569,7 +1569,7 @@ Array [
         class="ant-card-head-wrapper"
       />
       <div
-        class="ant-tabs ant-tabs-top ant-tabs-middle ant-card-head-tabs css-var-test-id ant-tabs-css-var"
+        class="ant-tabs ant-tabs-top ant-card-head-tabs css-var-test-id ant-tabs-css-var"
       >
         <div
           aria-orientation="horizontal"

--- a/components/card/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.ts.snap
@@ -1501,7 +1501,7 @@ Array [
         class="ant-card-head-wrapper"
       />
       <div
-        class="ant-tabs ant-tabs-top ant-tabs-middle ant-card-head-tabs css-var-test-id ant-tabs-css-var"
+        class="ant-tabs ant-tabs-top ant-card-head-tabs css-var-test-id ant-tabs-css-var"
       >
         <div
           aria-orientation="horizontal"

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -5427,7 +5427,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize middle 
         </div>
       </div>
       <div
-        class="config-radio-group config-radio-group-outline config-radio-group-middle config-picker-calendar-mode-switch css-var-root config-radio-css-var"
+        class="config-radio-group config-radio-group-outline config-picker-calendar-mode-switch css-var-root config-radio-css-var"
         role="radiogroup"
       >
         <label
@@ -6294,7 +6294,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize middle 
         </div>
       </div>
       <div
-        class="config-radio-group config-radio-group-outline config-radio-group-middle config-picker-calendar-mode-switch css-var-root config-radio-css-var"
+        class="config-radio-group config-radio-group-outline config-picker-calendar-mode-switch css-var-root config-radio-css-var"
         role="radiogroup"
       >
         <label
@@ -12270,7 +12270,7 @@ exports[`ConfigProvider components DatePicker DatePicker configProvider componen
 exports[`ConfigProvider components DatePicker DatePicker configProvider componentSize middle 1`] = `
 <div>
   <div
-    class="config-picker config-picker-middle config-picker-outlined css-var-root config-picker-css-var"
+    class="config-picker config-picker-outlined css-var-root config-picker-css-var"
   >
     <div
       class="config-picker-input"
@@ -12572,7 +12572,7 @@ exports[`ConfigProvider components DatePicker MonthPicker configProvider compone
 exports[`ConfigProvider components DatePicker MonthPicker configProvider componentSize middle 1`] = `
 <div>
   <div
-    class="config-picker config-picker-middle config-picker-outlined css-var-root config-picker-css-var"
+    class="config-picker config-picker-outlined css-var-root config-picker-css-var"
   >
     <div
       class="config-picker-input"
@@ -13010,7 +13010,7 @@ exports[`ConfigProvider components DatePicker RangePicker configProvider compone
 exports[`ConfigProvider components DatePicker RangePicker configProvider componentSize middle 1`] = `
 <div>
   <div
-    class="config-picker config-picker-range config-picker-middle config-picker-outlined css-var-root config-picker-css-var"
+    class="config-picker config-picker-range config-picker-outlined css-var-root config-picker-css-var"
   >
     <div
       class="config-picker-input config-picker-input-start"
@@ -13492,7 +13492,7 @@ exports[`ConfigProvider components DatePicker WeekPicker configProvider componen
 exports[`ConfigProvider components DatePicker WeekPicker configProvider componentSize middle 1`] = `
 <div>
   <div
-    class="config-picker config-picker-middle config-picker-outlined css-var-root config-picker-css-var"
+    class="config-picker config-picker-outlined css-var-root config-picker-css-var"
   >
     <div
       class="config-picker-input"
@@ -15071,7 +15071,7 @@ exports[`ConfigProvider components Form configProvider componentSize large 1`] =
 
 exports[`ConfigProvider components Form configProvider componentSize middle 1`] = `
 <form
-  class="config-form config-form-horizontal config-form-middle css-var-root config-form-css-var"
+  class="config-form config-form-horizontal css-var-root config-form-css-var"
 >
   <div
     class="config-form-item css-var-root config-form-css-var config-form-item-with-help config-form-item-has-error config-form-item-horizontal"
@@ -21139,7 +21139,7 @@ exports[`ConfigProvider components Radio configProvider componentSize large 1`] 
 exports[`ConfigProvider components Radio configProvider componentSize middle 1`] = `
 <div>
   <div
-    class="config-radio-group config-radio-group-outline config-radio-group-middle css-var-root config-radio-css-var"
+    class="config-radio-group config-radio-group-outline css-var-root config-radio-css-var"
     role="radiogroup"
   >
     <label
@@ -21163,7 +21163,7 @@ exports[`ConfigProvider components Radio configProvider componentSize middle 1`]
     </label>
   </div>
   <div
-    class="config-radio-group config-radio-group-outline config-radio-group-middle css-var-root config-radio-css-var"
+    class="config-radio-group config-radio-group-outline css-var-root config-radio-css-var"
     role="radiogroup"
   >
     <label
@@ -21350,7 +21350,7 @@ exports[`ConfigProvider components Radio prefixCls 1`] = `
 
 exports[`ConfigProvider components Rate configProvider 1`] = `
 <ul
-  class="config-rate config-rate-middle css-var-root"
+  class="config-rate css-var-root"
   tabindex="0"
 >
   <li
@@ -21648,7 +21648,7 @@ exports[`ConfigProvider components Rate configProvider 1`] = `
 
 exports[`ConfigProvider components Rate configProvider componentDisabled 1`] = `
 <ul
-  class="config-rate config-rate-middle css-var-root config-rate-disabled"
+  class="config-rate css-var-root config-rate-disabled"
   tabindex="-1"
 >
   <li
@@ -21946,7 +21946,7 @@ exports[`ConfigProvider components Rate configProvider componentDisabled 1`] = `
 
 exports[`ConfigProvider components Rate configProvider componentSize large 1`] = `
 <ul
-  class="config-rate config-rate-middle css-var-root"
+  class="config-rate config-rate-large css-var-root"
   tabindex="0"
 >
   <li
@@ -22244,7 +22244,7 @@ exports[`ConfigProvider components Rate configProvider componentSize large 1`] =
 
 exports[`ConfigProvider components Rate configProvider componentSize middle 1`] = `
 <ul
-  class="config-rate config-rate-middle css-var-root"
+  class="config-rate css-var-root"
   tabindex="0"
 >
   <li
@@ -22542,7 +22542,7 @@ exports[`ConfigProvider components Rate configProvider componentSize middle 1`] 
 
 exports[`ConfigProvider components Rate configProvider componentSize small 1`] = `
 <ul
-  class="config-rate config-rate-middle css-var-root"
+  class="config-rate config-rate-small css-var-root"
   tabindex="0"
 >
   <li
@@ -22840,7 +22840,7 @@ exports[`ConfigProvider components Rate configProvider componentSize small 1`] =
 
 exports[`ConfigProvider components Rate normal 1`] = `
 <ul
-  class="ant-rate ant-rate-middle css-var-root"
+  class="ant-rate css-var-root"
   tabindex="0"
 >
   <li
@@ -23138,7 +23138,7 @@ exports[`ConfigProvider components Rate normal 1`] = `
 
 exports[`ConfigProvider components Rate prefixCls 1`] = `
 <ul
-  class="prefix-Rate prefix-Rate-middle css-var-root"
+  class="prefix-Rate css-var-root"
   tabindex="0"
 >
   <li
@@ -26066,7 +26066,7 @@ exports[`ConfigProvider components Table configProvider componentSize middle 1`]
       class="config-spin-container"
     >
       <div
-        class="config-table config-table-middle config-table-empty css-var-root config-table-css-var"
+        class="config-table config-table-medium config-table-empty css-var-root config-table-css-var"
       >
         <div
           class="config-table-container"
@@ -27546,7 +27546,7 @@ exports[`ConfigProvider components Tabs configProvider componentSize large 1`] =
 
 exports[`ConfigProvider components Tabs configProvider componentSize middle 1`] = `
 <div
-  class="config-tabs config-tabs-top config-tabs-middle css-var-root config-tabs-css-var"
+  class="config-tabs config-tabs-top css-var-root config-tabs-css-var"
 >
   <div
     aria-orientation="horizontal"
@@ -31191,7 +31191,7 @@ Array [
 exports[`ConfigProvider components TimePicker configProvider componentSize middle 1`] = `
 Array [
   <div
-    class="config-picker config-picker-middle config-picker-outlined css-var-root config-picker-css-var"
+    class="config-picker config-picker-outlined css-var-root config-picker-css-var"
   >
     <div
       class="config-picker-input"

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -16716,7 +16716,7 @@ exports[`ConfigProvider components List configProvider componentSize large 1`] =
   <div
     aria-busy="false"
     aria-live="polite"
-    class="config-spin css-var-root"
+    class="config-spin config-spin-lg css-var-root"
   >
     <div
       class="config-spin-container"
@@ -16824,7 +16824,7 @@ exports[`ConfigProvider components List configProvider componentSize small 1`] =
   <div
     aria-busy="false"
     aria-live="polite"
-    class="config-spin css-var-root"
+    class="config-spin config-spin-sm css-var-root"
   >
     <div
       class="config-spin-container"
@@ -24389,7 +24389,7 @@ exports[`ConfigProvider components Spin configProvider componentSize large 1`] =
 <div
   aria-busy="true"
   aria-live="polite"
-  class="config-spin config-spin-spinning config-spin-section css-var-root"
+  class="config-spin config-spin-lg config-spin-spinning config-spin-section css-var-root"
 >
   <span
     class="config-spin-dot-holder"
@@ -24447,7 +24447,7 @@ exports[`ConfigProvider components Spin configProvider componentSize small 1`] =
 <div
   aria-busy="true"
   aria-live="polite"
-  class="config-spin config-spin-spinning config-spin-section css-var-root"
+  class="config-spin config-spin-sm config-spin-spinning config-spin-section css-var-root"
 >
   <span
     class="config-spin-dot-holder"
@@ -25754,7 +25754,7 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
   <div
     aria-busy="false"
     aria-live="polite"
-    class="config-spin css-var-root"
+    class="config-spin config-spin-lg css-var-root"
   >
     <div
       class="config-spin-container"
@@ -26366,7 +26366,7 @@ exports[`ConfigProvider components Table configProvider componentSize small 1`] 
   <div
     aria-busy="false"
     aria-live="polite"
-    class="config-spin css-var-root"
+    class="config-spin config-spin-sm css-var-root"
   >
     <div
       class="config-spin-container"

--- a/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -63699,7 +63699,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
     class="ant-space-item"
   >
     <div
-      class="ant-picker ant-picker-middle ant-picker-outlined css-var-test-id ant-picker-css-var"
+      class="ant-picker ant-picker-outlined css-var-test-id ant-picker-css-var"
     >
       <div
         class="ant-picker-input"
@@ -64316,7 +64316,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
     class="ant-space-item"
   >
     <div
-      class="ant-picker ant-picker-middle ant-picker-outlined css-var-test-id ant-picker-css-var"
+      class="ant-picker ant-picker-outlined css-var-test-id ant-picker-css-var"
     >
       <div
         class="ant-picker-input"
@@ -64558,7 +64558,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
     class="ant-space-item"
   >
     <div
-      class="ant-picker ant-picker-range ant-picker-middle ant-picker-outlined css-var-test-id ant-picker-css-var"
+      class="ant-picker ant-picker-range ant-picker-outlined css-var-test-id ant-picker-css-var"
     >
       <div
         class="ant-picker-input ant-picker-input-start"
@@ -65758,7 +65758,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
     class="ant-space-item"
   >
     <div
-      class="ant-picker ant-picker-middle ant-picker-outlined css-var-test-id ant-picker-css-var"
+      class="ant-picker ant-picker-outlined css-var-test-id ant-picker-css-var"
     >
       <div
         class="ant-picker-input"

--- a/components/date-picker/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo.test.tsx.snap
@@ -6146,7 +6146,7 @@ exports[`renders components/date-picker/demo/size.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
-      class="ant-picker ant-picker-middle ant-picker-outlined css-var-test-id ant-picker-css-var"
+      class="ant-picker ant-picker-outlined css-var-test-id ant-picker-css-var"
     >
       <div
         class="ant-picker-input"
@@ -6188,7 +6188,7 @@ exports[`renders components/date-picker/demo/size.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
-      class="ant-picker ant-picker-middle ant-picker-outlined css-var-test-id ant-picker-css-var"
+      class="ant-picker ant-picker-outlined css-var-test-id ant-picker-css-var"
     >
       <div
         class="ant-picker-input"
@@ -6230,7 +6230,7 @@ exports[`renders components/date-picker/demo/size.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
-      class="ant-picker ant-picker-range ant-picker-middle ant-picker-outlined css-var-test-id ant-picker-css-var"
+      class="ant-picker ant-picker-range ant-picker-outlined css-var-test-id ant-picker-css-var"
     >
       <div
         class="ant-picker-input ant-picker-input-start"
@@ -6317,7 +6317,7 @@ exports[`renders components/date-picker/demo/size.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
-      class="ant-picker ant-picker-middle ant-picker-outlined css-var-test-id ant-picker-css-var"
+      class="ant-picker ant-picker-outlined css-var-test-id ant-picker-css-var"
     >
       <div
         class="ant-picker-input"

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -156,7 +156,8 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
           rootClassName={mergedRootClassName}
           className={clsx(
             {
-              [`${prefixCls}-${mergedSize}`]: mergedSize,
+              [`${prefixCls}-large`]: mergedSize === 'large',
+              [`${prefixCls}-small`]: mergedSize === 'small',
               [`${prefixCls}-${variant}`]: enableVariantCls,
             },
             getStatusClassNames(

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -43,8 +43,8 @@ import type {
   PickerProps,
   PickerPropsWithMultiple,
 } from './interface';
-import useSuffixIcon from './useSuffixIcon';
 import useComponents from './useComponents';
+import useSuffixIcon from './useSuffixIcon';
 
 const generatePicker = <DateType extends AnyObject = AnyObject>(
   generateConfig: GenerateConfig<DateType>,
@@ -222,7 +222,8 @@ const generatePicker = <DateType extends AnyObject = AnyObject>(
             rootClassName={mergedRootClassName}
             className={clsx(
               {
-                [`${prefixCls}-${mergedSize}`]: mergedSize,
+                [`${prefixCls}-large`]: mergedSize === 'large',
+                [`${prefixCls}-small`]: mergedSize === 'small',
                 [`${prefixCls}-${variant}`]: enableVariantCls,
               },
               getStatusClassNames(

--- a/components/divider/__tests__/index.test.tsx
+++ b/components/divider/__tests__/index.test.tsx
@@ -46,7 +46,7 @@ describe('Divider', () => {
 
   it('should apply the componentSize of ConfigProvider', () => {
     const { container, rerender } = render(
-      <ConfigProvider componentSize="middle">
+      <ConfigProvider componentSize="medium">
         <Divider />
       </ConfigProvider>,
     );
@@ -61,7 +61,7 @@ describe('Divider', () => {
   });
 
   it('support vertical size', () => {
-    const { container, rerender } = render(<Divider type="vertical" size="middle" />);
+    const { container, rerender } = render(<Divider type="vertical" size="medium" />);
     expect(container.querySelector<HTMLSpanElement>('.ant-divider-md')).toBeTruthy();
 
     rerender(<Divider type="vertical" size="small" />);

--- a/components/divider/demo/size.tsx
+++ b/components/divider/demo/size.tsx
@@ -12,7 +12,7 @@ const App: React.FC = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.
     </p>
-    <Divider size="middle" />
+    <Divider size="medium" />
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi ista
       probare, quae sunt a te dicta? Refert tamen, quo modo.

--- a/components/divider/index.en-US.md
+++ b/components/divider/index.en-US.md
@@ -44,7 +44,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | plain | Divider text show as plain style | boolean | true | 4.2.0 |
 | style | The style object of container | CSSProperties | - |  |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
-| size | The size of divider. Only valid for horizontal layout | `small` \| `middle` \| `large` | - | 5.25.0 |
+| size | The size of divider. Only valid for horizontal layout | `small` \| `medium` \| `large` | - | 5.25.0 |
 | titlePlacement | The position of title inside divider | `start` \| `end` \| `center` | `center` | - |
 | ~~type~~ | The direction type of divider | `horizontal` \| `vertical` | `horizontal` | - |
 | variant | Whether line is dashed, dotted or solid | `dashed` \| `dotted` \| `solid` | solid | 5.20.0 |

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -61,8 +61,6 @@ export interface DividerProps {
   styles?: DividerStylesType;
 }
 
-const sizeClassNameMap: Record<string, string> = { small: 'sm', middle: 'md' };
-
 const Divider: React.FC<DividerProps> = (props) => {
   const {
     getPrefixCls,
@@ -99,7 +97,6 @@ const Divider: React.FC<DividerProps> = (props) => {
   const [hashId, cssVarCls] = useStyle(prefixCls);
 
   const sizeFullName = useSize(customSize);
-  const sizeCls = sizeClassNameMap[sizeFullName];
 
   const hasChildren = !!children;
 
@@ -154,7 +151,8 @@ const Divider: React.FC<DividerProps> = (props) => {
       [`${prefixCls}-rtl`]: direction === 'rtl',
       [`${prefixCls}-no-default-orientation-margin-start`]: hasMarginStart,
       [`${prefixCls}-no-default-orientation-margin-end`]: hasMarginEnd,
-      [`${prefixCls}-${sizeCls}`]: !!sizeCls,
+      [`${prefixCls}-md`]: sizeFullName === 'medium' || sizeFullName === 'middle',
+      [`${prefixCls}-sm`]: sizeFullName === 'small',
       [railCls]: !children,
       [mergedClassNames.rail as string]: mergedClassNames.rail && !children,
     },

--- a/components/divider/index.zh-CN.md
+++ b/components/divider/index.zh-CN.md
@@ -45,7 +45,7 @@ group:
 | plain | 文字是否显示为普通正文样式 | boolean | false | 4.2.0 |
 | style | 分割线样式对象 | CSSProperties | - |  |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
-| size | 间距大小，仅对水平布局有效 | `small` \| `middle` \| `large` | - | 5.25.0 |
+| size | 间距大小，仅对水平布局有效 | `small` \| `medium` \| `large` | - | 5.25.0 |
 | titlePlacement | 分割线标题的位置 | `start` \| `end` \| `center` | `center` | - |
 | ~~type~~ | 水平还是垂直类型 | `horizontal` \| `vertical` | `horizontal` | - |
 | variant | 分割线是虚线、点线还是实线 | `dashed` \| `dotted` \| `solid` | solid | 5.20.0 |

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -176,7 +176,8 @@ const InternalForm: React.ForwardRefRenderFunction<FormRef, FormProps> = (props,
     {
       [`${prefixCls}-hide-required-mark`]: mergedRequiredMark === false, // todo: remove in next major version
       [`${prefixCls}-rtl`]: direction === 'rtl',
-      [`${prefixCls}-${mergedSize}`]: mergedSize,
+      [`${prefixCls}-large`]: mergedSize === 'large',
+      [`${prefixCls}-small`]: mergedSize === 'small',
     },
     cssVarCls,
     rootCls,

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5491,7 +5491,7 @@ Array [
               class="ant-form-item-control-input-content"
             >
               <ul
-                class="ant-rate ant-rate-middle css-var-test-id ant-rate-disabled"
+                class="ant-rate css-var-test-id ant-rate-disabled"
                 tabindex="-1"
               >
                 <li
@@ -12646,7 +12646,7 @@ exports[`renders components/form/demo/required-mark.tsx extend context correctly
 
 exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
 <form
-  class="ant-form ant-form-horizontal ant-form-default css-var-test-id ant-form-css-var"
+  class="ant-form ant-form-horizontal css-var-test-id ant-form-css-var"
   style="max-width: 600px;"
 >
   <div
@@ -12676,7 +12676,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
             class="ant-form-item-control-input-content"
           >
             <div
-              class="ant-radio-group ant-radio-group-outline ant-radio-group-default css-var-test-id ant-radio-css-var"
+              class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
               id="size"
               role="radiogroup"
             >
@@ -13234,7 +13234,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
             class="ant-form-item-control-input-content"
           >
             <div
-              class="ant-picker ant-picker-default ant-picker-outlined css-var-test-id ant-picker-css-var"
+              class="ant-picker ant-picker-outlined css-var-test-id ant-picker-css-var"
             >
               <div
                 class="ant-picker-input"
@@ -23781,7 +23781,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
             class="ant-form-item-control-input-content"
           >
             <ul
-              class="ant-rate ant-rate-middle css-var-test-id"
+              class="ant-rate css-var-test-id"
               id="validate_other_rate"
               tabindex="0"
             >

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2699,7 +2699,7 @@ Array [
               class="ant-form-item-control-input-content"
             >
               <ul
-                class="ant-rate ant-rate-middle css-var-test-id ant-rate-disabled"
+                class="ant-rate css-var-test-id ant-rate-disabled"
                 tabindex="-1"
               >
                 <li
@@ -8476,7 +8476,7 @@ exports[`renders components/form/demo/required-mark.tsx correctly 1`] = `
 
 exports[`renders components/form/demo/size.tsx correctly 1`] = `
 <form
-  class="ant-form ant-form-horizontal ant-form-default css-var-test-id ant-form-css-var"
+  class="ant-form ant-form-horizontal css-var-test-id ant-form-css-var"
   style="max-width:600px"
 >
   <div
@@ -8506,7 +8506,7 @@ exports[`renders components/form/demo/size.tsx correctly 1`] = `
             class="ant-form-item-control-input-content"
           >
             <div
-              class="ant-radio-group ant-radio-group-outline ant-radio-group-default css-var-test-id ant-radio-css-var"
+              class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
               id="size"
               role="radiogroup"
             >
@@ -8866,7 +8866,7 @@ exports[`renders components/form/demo/size.tsx correctly 1`] = `
             class="ant-form-item-control-input-content"
           >
             <div
-              class="ant-picker ant-picker-default ant-picker-outlined css-var-test-id ant-picker-css-var"
+              class="ant-picker ant-picker-outlined css-var-test-id ant-picker-css-var"
             >
               <div
                 class="ant-picker-input"
@@ -11121,7 +11121,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
             class="ant-form-item-control-input-content"
           >
             <ul
-              class="ant-rate ant-rate-middle css-var-test-id"
+              class="ant-rate css-var-test-id"
               id="validate_other_rate"
               tabindex="0"
             >

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -119,7 +119,8 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
     groupPrefixCls,
     `${groupPrefixCls}-${buttonStyle}`,
     {
-      [`${groupPrefixCls}-${mergedSize}`]: mergedSize,
+      [`${groupPrefixCls}-large`]: mergedSize === 'large',
+      [`${groupPrefixCls}-small`]: mergedSize === 'small',
       [`${groupPrefixCls}-rtl`]: direction === 'rtl',
       [`${groupPrefixCls}-block`]: block,
     },

--- a/components/rate/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/rate/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`renders components/rate/demo/basic.tsx extend context correctly 1`] = `
 <ul
-  class="ant-rate ant-rate-middle css-var-test-id"
+  class="ant-rate css-var-test-id"
   tabindex="0"
 >
   <li
@@ -305,7 +305,7 @@ exports[`renders components/rate/demo/character.tsx extend context correctly 1`]
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
 >
   <ul
-    class="ant-rate ant-rate-middle css-var-test-id"
+    class="ant-rate css-var-test-id"
     tabindex="0"
   >
     <li
@@ -600,7 +600,7 @@ exports[`renders components/rate/demo/character.tsx extend context correctly 1`]
     </li>
   </ul>
   <ul
-    class="ant-rate ant-rate-middle css-var-test-id"
+    class="ant-rate css-var-test-id"
     style="font-size: 36px;"
     tabindex="0"
   >
@@ -716,7 +716,7 @@ exports[`renders components/rate/demo/character.tsx extend context correctly 1`]
     </li>
   </ul>
   <ul
-    class="ant-rate ant-rate-middle css-var-test-id"
+    class="ant-rate css-var-test-id"
     tabindex="0"
   >
     <li
@@ -840,7 +840,7 @@ exports[`renders components/rate/demo/character-function.tsx extend context corr
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
 >
   <ul
-    class="ant-rate ant-rate-middle css-var-test-id"
+    class="ant-rate css-var-test-id"
     tabindex="0"
   >
     <li
@@ -955,7 +955,7 @@ exports[`renders components/rate/demo/character-function.tsx extend context corr
     </li>
   </ul>
   <ul
-    class="ant-rate ant-rate-middle css-var-test-id"
+    class="ant-rate css-var-test-id"
     tabindex="0"
   >
     <li
@@ -1262,7 +1262,7 @@ exports[`renders components/rate/demo/clear.tsx extend context correctly 1`] = `
     class="ant-flex css-var-test-id ant-flex-gap-middle"
   >
     <ul
-      class="ant-rate ant-rate-middle css-var-test-id"
+      class="ant-rate css-var-test-id"
       tabindex="0"
     >
       <li
@@ -1564,7 +1564,7 @@ exports[`renders components/rate/demo/clear.tsx extend context correctly 1`] = `
     class="ant-flex css-var-test-id ant-flex-gap-middle"
   >
     <ul
-      class="ant-rate ant-rate-middle css-var-test-id"
+      class="ant-rate css-var-test-id"
       tabindex="0"
     >
       <li
@@ -1869,7 +1869,7 @@ exports[`renders components/rate/demo/clear.tsx extend context correctly 2`] = `
 
 exports[`renders components/rate/demo/component-token.tsx extend context correctly 1`] = `
 <ul
-  class="ant-rate ant-rate-middle css-var-test-id"
+  class="ant-rate css-var-test-id"
   tabindex="0"
 >
   <li
@@ -2169,7 +2169,7 @@ exports[`renders components/rate/demo/component-token.tsx extend context correct
 
 exports[`renders components/rate/demo/disabled.tsx extend context correctly 1`] = `
 <ul
-  class="ant-rate ant-rate-middle css-var-test-id ant-rate-disabled"
+  class="ant-rate css-var-test-id ant-rate-disabled"
   tabindex="-1"
 >
   <li
@@ -2469,7 +2469,7 @@ exports[`renders components/rate/demo/disabled.tsx extend context correctly 2`] 
 
 exports[`renders components/rate/demo/half.tsx extend context correctly 1`] = `
 <ul
-  class="ant-rate ant-rate-middle css-var-test-id"
+  class="ant-rate css-var-test-id"
   tabindex="0"
 >
   <li
@@ -3068,7 +3068,7 @@ exports[`renders components/rate/demo/size.tsx extend context correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-rate ant-rate-middle css-var-test-id"
+    class="ant-rate css-var-test-id"
     tabindex="0"
   >
     <li
@@ -3667,7 +3667,7 @@ exports[`renders components/rate/demo/text.tsx extend context correctly 1`] = `
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
 >
   <ul
-    class="ant-rate ant-rate-middle css-var-test-id"
+    class="ant-rate css-var-test-id"
     tabindex="0"
   >
     <li

--- a/components/rate/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/rate/__tests__/__snapshots__/demo.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`renders components/rate/demo/basic.tsx correctly 1`] = `
 <ul
-  class="ant-rate ant-rate-middle css-var-test-id"
+  class="ant-rate css-var-test-id"
   tabindex="0"
 >
   <li
@@ -303,7 +303,7 @@ exports[`renders components/rate/demo/character.tsx correctly 1`] = `
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
 >
   <ul
-    class="ant-rate ant-rate-middle css-var-test-id"
+    class="ant-rate css-var-test-id"
     tabindex="0"
   >
     <li
@@ -598,7 +598,7 @@ exports[`renders components/rate/demo/character.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-rate ant-rate-middle css-var-test-id"
+    class="ant-rate css-var-test-id"
     style="font-size:36px"
     tabindex="0"
   >
@@ -714,7 +714,7 @@ exports[`renders components/rate/demo/character.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-rate ant-rate-middle css-var-test-id"
+    class="ant-rate css-var-test-id"
     tabindex="0"
   >
     <li
@@ -836,7 +836,7 @@ exports[`renders components/rate/demo/character-function.tsx correctly 1`] = `
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
 >
   <ul
-    class="ant-rate ant-rate-middle css-var-test-id"
+    class="ant-rate css-var-test-id"
     tabindex="0"
   >
     <li
@@ -951,7 +951,7 @@ exports[`renders components/rate/demo/character-function.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-rate ant-rate-middle css-var-test-id"
+    class="ant-rate css-var-test-id"
     tabindex="0"
   >
     <li
@@ -1256,7 +1256,7 @@ exports[`renders components/rate/demo/clear.tsx correctly 1`] = `
     class="ant-flex css-var-test-id ant-flex-gap-middle"
   >
     <ul
-      class="ant-rate ant-rate-middle css-var-test-id"
+      class="ant-rate css-var-test-id"
       tabindex="0"
     >
       <li
@@ -1558,7 +1558,7 @@ exports[`renders components/rate/demo/clear.tsx correctly 1`] = `
     class="ant-flex css-var-test-id ant-flex-gap-middle"
   >
     <ul
-      class="ant-rate ant-rate-middle css-var-test-id"
+      class="ant-rate css-var-test-id"
       tabindex="0"
     >
       <li
@@ -1861,7 +1861,7 @@ exports[`renders components/rate/demo/clear.tsx correctly 1`] = `
 
 exports[`renders components/rate/demo/component-token.tsx correctly 1`] = `
 <ul
-  class="ant-rate ant-rate-middle css-var-test-id"
+  class="ant-rate css-var-test-id"
   tabindex="0"
 >
   <li
@@ -2159,7 +2159,7 @@ exports[`renders components/rate/demo/component-token.tsx correctly 1`] = `
 
 exports[`renders components/rate/demo/disabled.tsx correctly 1`] = `
 <ul
-  class="ant-rate ant-rate-middle css-var-test-id ant-rate-disabled"
+  class="ant-rate css-var-test-id ant-rate-disabled"
   tabindex="-1"
 >
   <li
@@ -2457,7 +2457,7 @@ exports[`renders components/rate/demo/disabled.tsx correctly 1`] = `
 
 exports[`renders components/rate/demo/half.tsx correctly 1`] = `
 <ul
-  class="ant-rate ant-rate-middle css-var-test-id"
+  class="ant-rate css-var-test-id"
   tabindex="0"
 >
   <li
@@ -3054,7 +3054,7 @@ exports[`renders components/rate/demo/size.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-rate ant-rate-middle css-var-test-id"
+    class="ant-rate css-var-test-id"
     tabindex="0"
   >
     <li
@@ -3651,7 +3651,7 @@ exports[`renders components/rate/demo/text.tsx correctly 1`] = `
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
 >
   <ul
-    class="ant-rate ant-rate-middle css-var-test-id"
+    class="ant-rate css-var-test-id"
     tabindex="0"
   >
     <li

--- a/components/rate/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/rate/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Rate rtl render component should be rendered correctly in RTL direction 1`] = `
 <ul
-  class="ant-rate ant-rate-middle css-var-root ant-rate-rtl"
+  class="ant-rate css-var-root ant-rate-rtl"
   tabindex="0"
 >
   <li

--- a/components/rate/index.tsx
+++ b/components/rate/index.tsx
@@ -7,6 +7,8 @@ import { clsx } from 'clsx';
 
 import { useComponentConfig } from '../config-provider/context';
 import DisabledContext from '../config-provider/DisabledContext';
+import useSize from '../config-provider/hooks/useSize';
+import type { SizeType } from '../config-provider/SizeContext';
 import Tooltip from '../tooltip';
 import type { TooltipProps } from '../tooltip';
 import useStyle from './style';
@@ -18,7 +20,7 @@ const isTooltipProps = (item: TooltipProps | string): item is TooltipProps => {
 export interface RateProps extends RcRateProps {
   rootClassName?: string;
   tooltips?: (TooltipProps | string)[];
-  size?: 'small' | 'middle' | 'large';
+  size?: SizeType;
 }
 
 const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
@@ -30,7 +32,7 @@ const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
     tooltips,
     character = <StarFilled />,
     disabled: customDisabled,
-    size = 'middle',
+    size,
     ...rest
   } = props;
 
@@ -66,6 +68,9 @@ const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
   const disabled = React.useContext(DisabledContext);
   const mergedDisabled = customDisabled ?? disabled;
 
+  // ===================== Size =====================
+  const mergedSize = useSize((ctx) => size ?? ctx);
+
   return (
     <RcRate
       ref={ref}
@@ -73,14 +78,15 @@ const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
       characterRender={characterRender}
       disabled={mergedDisabled}
       {...rest}
-      className={clsx(
-        `${ratePrefixCls}-${size}`,
+      className={clsx({
+        [`${ratePrefixCls}-large`]: mergedSize === 'large',
+        [`${ratePrefixCls}-small`]: mergedSize === 'small',
         className,
         rootClassName,
         hashId,
         cssVarCls,
         contextClassName,
-      )}
+      })}
       style={mergedStyle}
       prefixCls={ratePrefixCls}
       direction={direction}

--- a/components/rate/index.tsx
+++ b/components/rate/index.tsx
@@ -78,15 +78,17 @@ const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
       characterRender={characterRender}
       disabled={mergedDisabled}
       {...rest}
-      className={clsx({
-        [`${ratePrefixCls}-large`]: mergedSize === 'large',
-        [`${ratePrefixCls}-small`]: mergedSize === 'small',
+      className={clsx(
+        {
+          [`${ratePrefixCls}-large`]: mergedSize === 'large',
+          [`${ratePrefixCls}-small`]: mergedSize === 'small',
+        },
         className,
         rootClassName,
         hashId,
         cssVarCls,
         contextClassName,
-      })}
+      )}
       style={mergedStyle}
       prefixCls={ratePrefixCls}
       direction={direction}

--- a/components/spin/index.en-US.md
+++ b/components/spin/index.en-US.md
@@ -38,7 +38,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | fullscreen | Display a backdrop with the `Spin` component | boolean | false | 5.11.0 |
 | indicator | React node of the spinning indicator | ReactNode | - |  |
 | percent | The progress percentage, when set to `auto`, it will be an indeterminate progress | number \| 'auto' | - | 5.18.0 |
-| size | The size of Spin, options: `small`, `default` and `large` | string | `default` |  |
+| size | The size of Spin, options: `small`, `medium` and `large` | string | `medium` |  |
 | spinning | Whether Spin is visible | boolean | true |  |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
 | ~~tip~~ | Customize description content when Spin has children. Deprecated, use `description` instead | ReactNode | - |  |

--- a/components/spin/index.tsx
+++ b/components/spin/index.tsx
@@ -6,13 +6,11 @@ import { useMergeSemantic } from '../_util/hooks';
 import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
+import useSize from '../config-provider/hooks/useSize';
+import type { SizeType } from '../config-provider/SizeContext';
 import Indicator from './Indicator';
 import useStyle from './style/index';
 import usePercent from './usePercent';
-
-const _SpinSizes = ['small', 'default', 'large'] as const;
-
-export type SpinSize = (typeof _SpinSizes)[number];
 
 export type SpinIndicator = React.ReactElement<HTMLElement>;
 
@@ -57,7 +55,10 @@ export interface SpinProps {
   /** Whether Spin is spinning */
   spinning?: boolean;
   style?: React.CSSProperties;
-  size?: SpinSize;
+  /**
+   * Note: `default` is deprecated and will be removed in v7, please use `medium` instead.
+   */
+  size?: SizeType | 'default';
   /** Customize description content when Spin has children */
   /** @deprecated Please use `description` instead */
   tip?: React.ReactNode;
@@ -95,7 +96,7 @@ const Spin: SpinType = (props) => {
     delay = 0,
     className,
     rootClassName,
-    size = 'default',
+    size,
     tip,
     description,
     wrapperClassName,
@@ -143,13 +144,21 @@ const Spin: SpinType = (props) => {
     setSpinning(false);
   }, [delay, customSpinning]);
 
+  // ======================= Size ======================
+  const mergedSize = useSize((ctx) => size ?? ctx);
+
+  if (process.env.NODE_ENV !== 'production') {
+    const warning = devUseWarning('Spin');
+    warning.deprecated(size !== 'default', 'size="default"', 'size="medium"');
+  }
+
   // ======================= Description ======================
   const mergedDescription = description ?? tip;
 
   // =============== Merged Props for Semantic ================
   const mergedProps: SpinProps = {
     ...props,
-    size,
+    size: mergedSize,
     spinning,
     tip: mergedDescription,
     description: mergedDescription,
@@ -225,8 +234,8 @@ const Spin: SpinType = (props) => {
       className={clsx(
         prefixCls,
         {
-          [`${prefixCls}-sm`]: size === 'small',
-          [`${prefixCls}-lg`]: size === 'large',
+          [`${prefixCls}-sm`]: mergedSize === 'small',
+          [`${prefixCls}-lg`]: mergedSize === 'large',
           [`${prefixCls}-spinning`]: spinning,
           [`${prefixCls}-rtl`]: direction === 'rtl',
           [`${prefixCls}-fullscreen`]: fullscreen,

--- a/components/spin/index.zh-CN.md
+++ b/components/spin/index.zh-CN.md
@@ -39,7 +39,7 @@ demo:
 | fullscreen | 显示带有 `Spin` 组件的背景 | boolean | false | 5.11.0 |
 | indicator | 加载指示符 | ReactNode | - |  |
 | percent | 展示进度，当设置 `percent="auto"` 时会预估一个永远不会停止的进度 | number \| 'auto' | - | 5.18.0 |
-| size | 组件大小，可选值为 `small` `default` `large` | string | `default` |  |
+| size | 组件大小，可选值为 `small` `medium` `large` | string | `medium` |  |
 | spinning | 是否为加载中状态 | boolean | true |  |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
 | ~~tip~~ | 当作为包裹元素时，可以自定义描述文案。已废弃，请使用 `description` | ReactNode | - |  |

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -601,7 +601,10 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     if (mergedPagination.size) {
       paginationSize = mergedPagination.size;
     } else {
-      paginationSize = mergedSize === 'small' || mergedSize === 'middle' ? 'small' : undefined;
+      paginationSize =
+        mergedSize === 'small' || mergedSize === 'middle' || mergedSize === 'medium'
+          ? 'small'
+          : undefined;
     }
 
     const renderPagination = (placement: 'start' | 'end' | 'center' = 'end') => (
@@ -703,6 +706,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
 
     switch (mergedSize) {
       case 'middle':
+      case 'medium':
         return paddingSM * 2 + fontHeight + lineWidth;
 
       case 'small':
@@ -734,7 +738,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
           prefixCls={prefixCls}
           className={clsx(
             {
-              [`${prefixCls}-middle`]: mergedSize === 'middle',
+              [`${prefixCls}-medium`]: mergedSize === 'medium' || mergedSize === 'middle',
               [`${prefixCls}-small`]: mergedSize === 'small',
               [`${prefixCls}-bordered`]: bordered,
               [`${prefixCls}-empty`]: rawData.length === 0,

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -13641,7 +13641,7 @@ exports[`renders components/table/demo/grouping-columns.tsx extend context corre
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-middle ant-table-bordered css-var-test-id ant-table-css-var ant-table-fix-start-shadow ant-table-fix-end-shadow ant-table-fixed-header ant-table-fixed-column ant-table-scroll-horizontal ant-table-has-fix-start ant-table-has-fix-end"
+        class="ant-table ant-table-medium ant-table-bordered css-var-test-id ant-table-css-var ant-table-fix-start-shadow ant-table-fix-end-shadow ant-table-fixed-header ant-table-fixed-column ant-table-scroll-horizontal ant-table-has-fix-start ant-table-has-fix-end"
       >
         <div
           class="ant-table-container"
@@ -20173,7 +20173,7 @@ Array [
         class="ant-spin-container"
       >
         <div
-          class="ant-table ant-table-middle css-var-test-id ant-table-css-var"
+          class="ant-table ant-table-medium css-var-test-id ant-table-css-var"
         >
           <div
             class="ant-table-container"
@@ -28732,7 +28732,7 @@ Array [
         class="ant-spin-container"
       >
         <div
-          class="ant-table ant-table-middle css-var-test-id ant-table-css-var"
+          class="ant-table ant-table-medium css-var-test-id ant-table-css-var"
         >
           <div
             class="ant-table-container"
@@ -29387,7 +29387,7 @@ exports[`renders components/table/demo/style-class.tsx extend context correctly 
         class="ant-spin-container"
       >
         <div
-          class="ant-table ant-table-middle css-var-test-id ant-table-css-var"
+          class="ant-table ant-table-medium css-var-test-id ant-table-css-var"
         >
           <div
             class="ant-table-title"

--- a/components/table/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`renders components/table/demo/_semantic.tsx correctly 1`] = `
             class="ant-spin-container"
           >
             <div
-              class="ant-table ant-table-middle ant-table-bordered css-var-test-id ant-table-css-var"
+              class="ant-table ant-table-medium ant-table-bordered css-var-test-id ant-table-css-var"
             >
               <div
                 class="ant-table-title semantic-mark-title"

--- a/components/table/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.ts.snap
@@ -14587,7 +14587,7 @@ exports[`renders components/table/demo/grouping-columns.tsx correctly 1`] = `
       class="ant-spin-container"
     >
       <div
-        class="ant-table ant-table-middle ant-table-bordered css-var-test-id ant-table-css-var ant-table-fix-start-shadow ant-table-fix-end-shadow ant-table-fixed-header ant-table-fixed-column ant-table-scroll-horizontal ant-table-has-fix-start ant-table-has-fix-end"
+        class="ant-table ant-table-medium ant-table-bordered css-var-test-id ant-table-css-var ant-table-fix-start-shadow ant-table-fix-end-shadow ant-table-fixed-header ant-table-fixed-column ant-table-scroll-horizontal ant-table-has-fix-start ant-table-has-fix-end"
       >
         <div
           class="ant-table-container"
@@ -18976,7 +18976,7 @@ Array [
         class="ant-spin-container"
       >
         <div
-          class="ant-table ant-table-middle css-var-test-id ant-table-css-var"
+          class="ant-table ant-table-medium css-var-test-id ant-table-css-var"
         >
           <div
             class="ant-table-container"
@@ -26297,7 +26297,7 @@ Array [
         class="ant-spin-container"
       >
         <div
-          class="ant-table ant-table-middle css-var-test-id ant-table-css-var"
+          class="ant-table ant-table-medium css-var-test-id ant-table-css-var"
         >
           <div
             class="ant-table-container"
@@ -28205,7 +28205,7 @@ exports[`renders components/table/demo/style-class.tsx correctly 1`] = `
         class="ant-spin-container"
       >
         <div
-          class="ant-table ant-table-middle css-var-test-id ant-table-css-var"
+          class="ant-table ant-table-medium css-var-test-id ant-table-css-var"
         >
           <div
             class="ant-table-title"

--- a/components/table/style/bordered.ts
+++ b/components/table/style/bordered.ts
@@ -18,7 +18,7 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
   const tableBorder = `${unit(lineWidth)} ${lineType} ${tableBorderColor}`;
 
   const getSizeBorderStyle = (
-    size: 'small' | 'middle',
+    size: 'small' | 'medium',
     paddingVertical: number,
     paddingHorizontal: number,
   ) => ({
@@ -135,7 +135,7 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
 
         // ============================ Size ============================
         ...getSizeBorderStyle(
-          'middle',
+          'medium',
           token.tablePaddingVerticalMiddle,
           token.tablePaddingHorizontalMiddle,
         ),

--- a/components/table/style/size.ts
+++ b/components/table/style/size.ts
@@ -7,7 +7,7 @@ import type { TableToken } from './index';
 const genSizeStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
   const { componentCls, tableExpandColumnWidth, calc } = token;
   const getSizeStyle = (
-    size: 'small' | 'middle',
+    size: 'small' | 'medium',
     paddingVertical: number,
     paddingHorizontal: number,
     fontSize: number,
@@ -56,7 +56,7 @@ const genSizeStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
   return {
     [`${componentCls}-wrapper`]: {
       ...getSizeStyle(
-        'middle',
+        'medium',
         token.tablePaddingVerticalMiddle,
         token.tablePaddingHorizontalMiddle,
         token.tableFontSizeMiddle,

--- a/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2161,7 +2161,7 @@ Array [
       </div>
     </div>
     <div
-      class="ant-tabs ant-tabs-top ant-tabs-middle ant-tabs-card css-var-test-id ant-tabs-css-var"
+      class="ant-tabs ant-tabs-top ant-tabs-card css-var-test-id ant-tabs-css-var"
     >
       <div
         aria-orientation="horizontal"

--- a/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
@@ -1809,7 +1809,7 @@ Array [
       </div>
     </div>
     <div
-      class="ant-tabs ant-tabs-top ant-tabs-middle ant-tabs-card css-var-test-id ant-tabs-css-var"
+      class="ant-tabs ant-tabs-top ant-tabs-card css-var-test-id ant-tabs-css-var"
     >
       <div
         aria-orientation="horizontal"

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -259,7 +259,8 @@ const InternalTabs = React.forwardRef<TabsRef, TabsProps>((props, ref) => {
       items={mergedItems}
       className={clsx(
         {
-          [`${prefixCls}-${size}`]: size,
+          [`${prefixCls}-large`]: size === 'large',
+          [`${prefixCls}-small`]: size === 'small',
           [`${prefixCls}-card`]: ['card', 'editable-card'].includes(type!),
           [`${prefixCls}-editable-card`]: type === 'editable-card',
           [`${prefixCls}-centered`]: centered,


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [x] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案

1. 统一了 size 的 classname 写法；
2. Rate 未接入全局 size（useSize）；
3. 修复了 Table 的 size `medium`不生效问题（仍保留了对 middle 的兼容）；
4. 调整了divider 的 size
5. Spin 接入了全局的useSize和调整枚举

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Unify size className; Rate uses ConfigProvider size; Table supports medium. |
| 🇨🇳 中文 | 统一 size className；Rate 支持全局 size；Table 支持 medium。 |
