### PR TITLE
fix(select): fix height mismatch in customize mode with sized custom input

### DIFF
--- a/components/select/style/select-input-customize.ts
+++ b/components/select/style/select-input-customize.ts
@@ -12,6 +12,7 @@ const genSelectInputCustomizeStyle: GenerateStyle<SelectToken, CSSObject> = (tok
       padding: 0,
       fontSize: 'inherit',
       lineHeight: 'inherit',
+      height: 'auto',
 
       [`${componentCls}-placeholder`]: {
         display: 'none',
@@ -20,6 +21,10 @@ const genSelectInputCustomizeStyle: GenerateStyle<SelectToken, CSSObject> = (tok
       [`${componentCls}-content`]: {
         margin: 0,
         padding: 0,
+
+        '&:before': {
+          display: 'none',
+        },
 
         '&-value': {
           display: 'none',

--- a/components/select/style/select-input-customize.ts
+++ b/components/select/style/select-input-customize.ts
@@ -22,7 +22,7 @@ const genSelectInputCustomizeStyle: GenerateStyle<SelectToken, CSSObject> = (tok
         margin: 0,
         padding: 0,
 
-        '&:before': {
+        '&::before': {
           display: 'none',
         },
 

--- a/components/select/style/select-input-customize.ts
+++ b/components/select/style/select-input-customize.ts
@@ -10,6 +10,8 @@ const genSelectInputCustomizeStyle: GenerateStyle<SelectToken, CSSObject> = (tok
     [`&${componentCls}-customize`]: {
       border: 0,
       padding: 0,
+      paddingBlock: 0,
+      paddingInline: 0,
       fontSize: 'inherit',
       lineHeight: 'inherit',
       height: 'auto',


### PR DESCRIPTION
When AutoComplete wraps a custom Input component with a size prop (e.g. Input.Search size="large"), the internal Select wrapper can cause height misalignment between parts of the custom input.

The customize mode strips border and padding but still inherits the Select default sizing constraints. The content::before pseudo-element (used as a height spacer in normal mode) is unnecessary in customize mode and can interfere with the custom input layout.

Changes:
- Add height: auto so the wrapper defers to the custom input height
- Hide content ::before spacer in customize mode

Closes #57065
Related: #52551