### PR TITLE
feat: add inherit prop to ComponentsBlock for theme preview control

### DIFF
--- a/.dumi/pages/index/components/ThemePreview/ComponentsBlock.tsx
+++ b/.dumi/pages/index/components/ThemePreview/ComponentsBlock.tsx
@@ -95,21 +95,22 @@ interface ComponentsBlockProps {
   style?: React.CSSProperties;
   className?: string;
   containerClassName?: string;
+  inherit?: boolean;
 }
 
 const ComponentsBlock: React.FC<ComponentsBlockProps> = (props) => {
   const [locale] = useLocale(locales);
   const { styles } = useStyle();
-  const { config, style, className, containerClassName } = props;
+  const { config, style, className, containerClassName, inherit = false } = props;
 
   const { theme, ...restConfig } = config || {};
 
   const mergedTheme = React.useMemo(
     () => ({
       ...theme,
-      inherit: false,
+      inherit,
     }),
-    [theme],
+    [theme, inherit],
   );
 
   return (

--- a/.dumi/theme/common/ThemeSwitch/PromptDrawer.tsx
+++ b/.dumi/theme/common/ThemeSwitch/PromptDrawer.tsx
@@ -394,7 +394,7 @@ const PromptDrawer: React.FC<PromptDrawerProps> = ({ open, onClose, onThemeChang
                 overflow: 'auto',
               }}
             >
-              <ComponentsBlock style={{ padding: 16 }} className="prompt-drawer-preview" />
+              <ComponentsBlock style={{ padding: 16 }} className="prompt-drawer-preview" inherit />
             </div>
           </Flex>
         </Splitter.Panel>


### PR DESCRIPTION
Add an  property to ComponentsBlock component to control theme inheritance behavior, defaulting to false. Enable it in PromptDrawer to allow proper theme inheritance in the preview.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    -       |
| 🇨🇳 Chinese |     -      |
