### PR TITLE
refactor: remove duplicate initMotionCommonLeave function

### DIFF
--- a/components/style/motion/motion.ts
+++ b/components/style/motion/motion.ts
@@ -5,12 +5,6 @@ const initMotionCommon = (duration: string): CSSObject => ({
   animationFillMode: 'both',
 });
 
-// FIXME: origin less code seems same as initMotionCommon. Maybe we can safe remove
-const initMotionCommonLeave = (duration: string): CSSObject => ({
-  animationDuration: duration,
-  animationFillMode: 'both',
-});
-
 export const initMotion = (
   motionCls: string,
   inKeyframes: Keyframes,
@@ -30,7 +24,7 @@ export const initMotion = (
     },
 
     [`${sameLevelPrefix}${motionCls}-leave`]: {
-      ...initMotionCommonLeave(duration),
+      ...initMotionCommon(duration),
       animationPlayState: 'paused',
     },
 


### PR DESCRIPTION
`initMotionCommonLeave` was identical to `initMotionCommon` (as noted by the existing FIXME comment). Removed the duplicate and unified both enter and leave motion to use `initMotionCommon`.

### 🤔 This is a ...

- [x] 🛠 Refactoring

### 🔗 Related Issues

FIXME comment in `components/style/motion/motion.ts`

### 💡 Background and Solution

`initMotionCommonLeave` was identical to `initMotionCommon` (as noted by the existing FIXME comment). Removed the duplicate and unified both enter and leave motion to use `initMotionCommon`.

```diff
- // FIXME: origin less code seems same as initMotionCommon. Maybe we can safe remove
- const initMotionCommonLeave = (duration: string): CSSObject => ({
-   animationDuration: duration,
-   animationFillMode: 'both',
- });
```

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Remove duplicate `initMotionCommonLeave` function, reuse `initMotionCommon` for both enter and leave motion. |
| 🇨🇳 Chinese | 移除重复的 `initMotionCommonLeave` 函数，enter 和 leave 动画统一使用 `initMotionCommon`。 |
