### PR TITLE
fix(transfer): handle non-string render results when rendering items

### DIFF
--- a/components/transfer/Section.tsx
+++ b/components/transfer/Section.tsx
@@ -41,14 +41,10 @@ function getTextFromRenderResult<RecordType extends KeyWiseTransferItem>(
   renderResult: RenderResult,
   item: RecordType,
 ): string {
-  if (typeof renderResult === 'string' || typeof renderResult === 'number') {
-    return String(renderResult);
-  }
-  if (typeof item.title === 'string' || typeof item.title === 'number') {
-    return String(item.title);
-  }
-  if (typeof item.key === 'string' || typeof item.key === 'number') {
-    return String(item.key);
+  for (const v of [renderResult, item.title, item.key]) {
+    if (typeof v === 'string' || typeof v === 'number') {
+      return String(v);
+    }
   }
   return '';
 }
@@ -200,16 +196,10 @@ const TransferSection = <RecordType extends KeyWiseTransferItem>(
   const renderItem = (item: RecordType): RenderedItem<RecordType> => {
     const renderResult = render(item);
     const isRenderResultPlain = isRenderResultPlainObject(renderResult);
-    let renderedEl: React.ReactNode;
-    let renderedText: string;
-
-    if (isRenderResultPlain) {
-      renderedEl = renderResult.label;
-      renderedText = renderResult.value;
-    } else {
-      renderedEl = renderResult;
-      renderedText = getTextFromRenderResult(renderResult, item);
-    }
+    const renderedEl = isRenderResultPlain ? renderResult.label : renderResult;
+    const renderedText = isRenderResultPlain
+      ? renderResult.value
+      : getTextFromRenderResult(renderResult, item);
 
     return {
       item,

--- a/components/transfer/Section.tsx
+++ b/components/transfer/Section.tsx
@@ -37,6 +37,22 @@ function getEnabledItemKeys<RecordType extends KeyWiseTransferItem>(items: Recor
   return items.filter((data) => !data.disabled).map((data) => data.key);
 }
 
+function getTextFromRenderResult<RecordType extends KeyWiseTransferItem>(
+  renderResult: RenderResult,
+  item: RecordType,
+): string {
+  if (typeof renderResult === 'string' || typeof renderResult === 'number') {
+    return String(renderResult);
+  }
+  if (typeof item.title === 'string' || typeof item.title === 'number') {
+    return String(item.title);
+  }
+  if (typeof item.key === 'string' || typeof item.key === 'number') {
+    return String(item.key);
+  }
+  return '';
+}
+
 const isValidIcon = (icon: React.ReactNode) => icon !== undefined;
 
 export interface RenderedItem<RecordType> {
@@ -192,16 +208,7 @@ const TransferSection = <RecordType extends KeyWiseTransferItem>(
       renderedText = renderResult.value;
     } else {
       renderedEl = renderResult;
-
-      if (typeof renderResult === 'string' || typeof renderResult === 'number') {
-        renderedText = String(renderResult);
-      } else if (typeof item.title === 'string' || typeof item.title === 'number') {
-        renderedText = String(item.title);
-      } else if (typeof item.key === 'string' || typeof item.key === 'number') {
-        renderedText = String(item.key);
-      } else {
-        renderedText = '';
-      }
+      renderedText = getTextFromRenderResult(renderResult, item);
     }
 
     return {

--- a/components/transfer/Section.tsx
+++ b/components/transfer/Section.tsx
@@ -184,10 +184,30 @@ const TransferSection = <RecordType extends KeyWiseTransferItem>(
   const renderItem = (item: RecordType): RenderedItem<RecordType> => {
     const renderResult = render(item);
     const isRenderResultPlain = isRenderResultPlainObject(renderResult);
+    let renderedEl: React.ReactNode;
+    let renderedText: string;
+
+    if (isRenderResultPlain) {
+      renderedEl = renderResult.label;
+      renderedText = renderResult.value;
+    } else {
+      renderedEl = renderResult;
+
+      if (typeof renderResult === 'string' || typeof renderResult === 'number') {
+        renderedText = String(renderResult);
+      } else if (typeof item.title === 'string' || typeof item.title === 'number') {
+        renderedText = String(item.title);
+      } else if (typeof item.key === 'string' || typeof item.key === 'number') {
+        renderedText = String(item.key);
+      } else {
+        renderedText = '';
+      }
+    }
+
     return {
       item,
-      renderedEl: isRenderResultPlain ? renderResult.label : renderResult,
-      renderedText: isRenderResultPlain ? renderResult.value : (renderResult as string),
+      renderedEl,
+      renderedText,
     };
   };
 

--- a/components/transfer/Section.tsx
+++ b/components/transfer/Section.tsx
@@ -398,7 +398,7 @@ const TransferSection = <RecordType extends KeyWiseTransferItem>(
               newCheckedKeysSet.add(key);
             }
           });
-          onItemSelectAll?.(Array.from(newCheckedKeysSet), 'replace');
+          onItemSelectAll?.([...newCheckedKeysSet], 'replace');
         },
       },
     ];

--- a/components/transfer/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/transfer/__tests__/__snapshots__/index.test.tsx.snap
@@ -339,6 +339,7 @@ exports[`Transfer should render correctly 1`] = `
       >
         <li
           class="ant-transfer-list-content-item ant-transfer-list-content-item-checked"
+          title="a"
         >
           <label
             class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-transfer-list-checkbox css-var-root ant-checkbox-css-var"
@@ -359,6 +360,7 @@ exports[`Transfer should render correctly 1`] = `
         </li>
         <li
           class="ant-transfer-list-content-item ant-transfer-list-content-item-disabled"
+          title="c"
         >
           <label
             class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox css-var-root ant-checkbox-css-var"
@@ -496,6 +498,7 @@ exports[`Transfer should render correctly 1`] = `
       >
         <li
           class="ant-transfer-list-content-item"
+          title="b"
         >
           <label
             class="ant-checkbox-wrapper ant-transfer-list-checkbox css-var-root ant-checkbox-css-var"
@@ -1077,6 +1080,7 @@ exports[`immutable data dataSource is frozen 1`] = `
       >
         <li
           class="ant-transfer-list-content-item"
+          title="title"
         >
           <label
             class="ant-checkbox-wrapper ant-transfer-list-checkbox css-var-root ant-checkbox-css-var"

--- a/components/transfer/__tests__/__snapshots__/section.test.tsx.snap
+++ b/components/transfer/__tests__/__snapshots__/section.test.tsx.snap
@@ -55,6 +55,7 @@ exports[`Transfer.List should render correctly 1`] = `
     >
       <li
         class="ant-transfer-list-content-item ant-transfer-list-content-item-checked"
+        title="a"
       >
         <label
           class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-transfer-list-checkbox css-var-root ant-checkbox-css-var"
@@ -75,6 +76,7 @@ exports[`Transfer.List should render correctly 1`] = `
       </li>
       <li
         class="ant-transfer-list-content-item"
+        title="b"
       >
         <label
           class="ant-checkbox-wrapper ant-transfer-list-checkbox css-var-root ant-checkbox-css-var"
@@ -94,6 +96,7 @@ exports[`Transfer.List should render correctly 1`] = `
       </li>
       <li
         class="ant-transfer-list-content-item ant-transfer-list-content-item-disabled"
+        title="c"
       >
         <label
           class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-transfer-list-checkbox css-var-root ant-checkbox-css-var"

--- a/components/transfer/__tests__/section.test.tsx
+++ b/components/transfer/__tests__/section.test.tsx
@@ -120,4 +120,25 @@ describe('Transfer.List', () => {
     fireEvent.click(container.querySelector('.custom-list-body')!);
     expect(onItemSelect).toHaveBeenCalledWith('a', false);
   });
+
+  it('should fallback to empty string text when render result is non-text', () => {
+    const handleFilter = jest.fn();
+    const { container } = render(
+      <Section
+        {...listCommonProps}
+        dataSource={[{ key: {} as unknown as React.Key } as KeyWiseTransferItem]}
+        showSearch
+        handleFilter={handleFilter}
+        handleClear={jest.fn()}
+        render={() => null}
+      />,
+    );
+
+    fireEvent.change(container.querySelector('.ant-transfer-list-search input')!, {
+      target: { value: 'x' },
+    });
+
+    expect(handleFilter).toHaveBeenCalled();
+    expect(container.querySelector('.ant-transfer-list-body-not-found')).toBeTruthy();
+  });
 });


### PR DESCRIPTION

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

__Background:__ When using the Transfer component with `showSearch` enabled and the `render` prop returning JSX elements, a JavaScript error occurs during search operations. The root cause is that the `renderItem` function incorrectly treats JSX elements as strings when extracting text for search filtering.

__Problem:__

- Transfer component crashes when `render` prop returns JSX and `showSearch` is enabled
- The original code forcefully casts JSX elements to strings in `renderItem` function
- This causes type errors and breaks the search functionality

__Solution:__

- Added proper type checking for render function return values

- Implemented `getTextFromReactElement` helper function to extract text content from React elements

- Enhanced `renderItem` function to handle different return types:

  - Plain objects (existing behavior)
  - String values (existing behavior)
  - React elements (new: extract text content)
  - Fallback to empty string for other types

[Minimal Reproducible Example](https://codesandbox.io/p/sandbox/ji-ben-yong-fa-antd-5-26-5-forked-pnvz69)

<img width="1034" height="434" alt="image" src="https://github.com/user-attachments/assets/08a13250-73d8-4f92-821a-fc9815ce4bc8" />

### 📝 Change Log

🇨🇳 Chinese
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English  |Enhanced transfer section rendering so JSX results are handled gracefully and we now fall back to item metadata for filter text.|
| 🇨🇳 Chinese |改进了穿梭框的渲染逻辑，兼容 JSX 返回值并在需要时回退到条目的元信息以保证过滤文本可用。|
