### PR TITLE
fix(Checkbox): keep checkbox same width in Group

### DIFF
--- a/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -264,6 +264,75 @@ exports[`renders components/checkbox/demo/debug-disable-popover.tsx extend conte
 
 exports[`renders components/checkbox/demo/debug-disable-popover.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/checkbox/demo/debug-group-width.tsx extend context correctly 1`] = `
+<div
+  style="width: 280px; border: 1px solid rgb(238, 238, 238); padding: 16px;"
+>
+  <div
+    class="ant-checkbox-group css-var-test-id ant-checkbox-css-var"
+    role="group"
+  >
+    <label
+      class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-group-item css-var-test-id ant-checkbox-css-var"
+    >
+      <span
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
+      >
+        <input
+          checked=""
+          class="ant-checkbox-input"
+          type="checkbox"
+          value="a"
+        />
+      </span>
+      <span
+        class="ant-checkbox-label"
+      >
+        Short
+      </span>
+    </label>
+    <label
+      class="ant-checkbox-wrapper ant-checkbox-group-item css-var-test-id ant-checkbox-css-var"
+    >
+      <span
+        class="ant-checkbox ant-wave-target"
+      >
+        <input
+          class="ant-checkbox-input"
+          type="checkbox"
+          value="b"
+        />
+      </span>
+      <span
+        class="ant-checkbox-label"
+      >
+        Long label that may wrap in narrow container
+      </span>
+    </label>
+    <label
+      class="ant-checkbox-wrapper ant-checkbox-group-item css-var-test-id ant-checkbox-css-var"
+    >
+      <span
+        class="ant-checkbox ant-wave-target"
+      >
+        <input
+          class="ant-checkbox-input"
+          type="checkbox"
+          value="c"
+        />
+      </span>
+      <span
+        class="ant-checkbox-label"
+      >
+        Medium
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`renders components/checkbox/demo/debug-group-width.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/checkbox/demo/debug-line.tsx extend context correctly 1`] = `
 <div>
   <div

--- a/components/checkbox/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.tsx.snap
@@ -229,6 +229,73 @@ exports[`renders components/checkbox/demo/debug-disable-popover.tsx correctly 1`
 </div>
 `;
 
+exports[`renders components/checkbox/demo/debug-group-width.tsx correctly 1`] = `
+<div
+  style="width:280px;border:1px solid #eee;padding:16px"
+>
+  <div
+    class="ant-checkbox-group css-var-test-id ant-checkbox-css-var"
+    role="group"
+  >
+    <label
+      class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-group-item css-var-test-id ant-checkbox-css-var"
+    >
+      <span
+        class="ant-checkbox ant-wave-target ant-checkbox-checked"
+      >
+        <input
+          checked=""
+          class="ant-checkbox-input"
+          type="checkbox"
+          value="a"
+        />
+      </span>
+      <span
+        class="ant-checkbox-label"
+      >
+        Short
+      </span>
+    </label>
+    <label
+      class="ant-checkbox-wrapper ant-checkbox-group-item css-var-test-id ant-checkbox-css-var"
+    >
+      <span
+        class="ant-checkbox ant-wave-target"
+      >
+        <input
+          class="ant-checkbox-input"
+          type="checkbox"
+          value="b"
+        />
+      </span>
+      <span
+        class="ant-checkbox-label"
+      >
+        Long label that may wrap in narrow container
+      </span>
+    </label>
+    <label
+      class="ant-checkbox-wrapper ant-checkbox-group-item css-var-test-id ant-checkbox-css-var"
+    >
+      <span
+        class="ant-checkbox ant-wave-target"
+      >
+        <input
+          class="ant-checkbox-input"
+          type="checkbox"
+          value="c"
+        />
+      </span>
+      <span
+        class="ant-checkbox-label"
+      >
+        Medium
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`renders components/checkbox/demo/debug-line.tsx correctly 1`] = `
 <div>
   <div

--- a/components/checkbox/demo/debug-group-width.md
+++ b/components/checkbox/demo/debug-group-width.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+Group 内勾选框等宽：窄容器下长文案换行时，方框仍应对齐。
+
+## en-US
+
+Checkboxes in Group same width: when label wraps in narrow container, boxes stay aligned.

--- a/components/checkbox/demo/debug-group-width.tsx
+++ b/components/checkbox/demo/debug-group-width.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Checkbox } from 'antd';
+import type { CheckboxOptionType } from 'antd';
+
+const options: CheckboxOptionType<string>[] = [
+  { label: 'Short', value: 'a' },
+  { label: 'Long label that may wrap in narrow container', value: 'b' },
+  { label: 'Medium', value: 'c' },
+];
+
+const App: React.FC = () => (
+  <div style={{ width: 280, border: '1px solid #eee', padding: 16 }}>
+    <Checkbox.Group options={options} defaultValue={['a']} />
+  </div>
+);
+
+export default App;

--- a/components/checkbox/index.en-US.md
+++ b/components/checkbox/index.en-US.md
@@ -26,6 +26,7 @@ demo:
 <code src="./demo/style-class.tsx" version="6.0.0">Custom semantic dom styling</code>
 <code src="./demo/debug-line.tsx" debug>Same line</code>
 <code src="./demo/debug-disable-popover.tsx" debug>Disabled to show Tooltip</code>
+<code src="./demo/debug-group-width.tsx" debug>Group same width</code>
 <code src="./demo/custom-line-width.tsx" debug>customize lineWidth</code>
 
 ## API

--- a/components/checkbox/index.zh-CN.md
+++ b/components/checkbox/index.zh-CN.md
@@ -27,6 +27,7 @@ demo:
 <code src="./demo/style-class.tsx" version="6.0.0">自定义语义结构的样式和类</code>
 <code src="./demo/debug-line.tsx" debug>同行布局</code>
 <code src="./demo/debug-disable-popover.tsx" debug>禁用下的 Tooltip</code>
+<code src="./demo/debug-group-width.tsx" debug>Group 内勾选框等宽</code>
 <code src="./demo/custom-line-width.tsx" debug>自定义 lineWidth</code>
 
 ## API

--- a/components/checkbox/style/index.ts
+++ b/components/checkbox/style/index.ts
@@ -100,6 +100,7 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
         borderRadius: token.borderRadiusSM,
         borderCollapse: 'separate',
         transition: `all ${token.motionDurationSlow}`,
+        flex: 'none',
         ...genNoMotionStyle(),
 
         // Checkmark


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [ ] 🆕 新特性提交
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #57140

### 💡 需求背景和解决方案

1. **问题**：Checkbox.Group 中当某选项 label 较长或换行时，勾选方框宽度不一致，视觉上不对齐。
2. **方案**：在 `.ant-checkbox` 上增加 `flex: 'none'`，避免在 wrapper 的 inline-flex 布局中被伸缩，保证方框固定尺寸。
3. **演示**：新增 debug demo `debug-group-width`，用窄容器 + 长短不一 label 便于肉眼验证 Group 内勾选框等宽。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Checkbox in Group having inconsistent width when labels wrap or differ in length. |
| 🇨🇳 中文 | 修复 Checkbox.Group 在选项文案长短不一或换行时，勾选方框宽度不一致的问题。 |