### PR TITLE
fix(upload): show list actions on touch devices

### DIFF
--- a/components/upload/style/list.ts
+++ b/components/upload/style/list.ts
@@ -46,6 +46,12 @@ const genListStyle: GenerateStyle<UploadToken, CSSObject> = (token) => {
               opacity: 0,
             },
 
+            '@media (hover: none), (pointer: coarse)': {
+              [actionCls]: {
+                opacity: 1,
+              },
+            },
+
             [iconCls]: {
               color: token.actionsColor,
               transition: `all ${motionDurationSlow}`,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- Fix [#57149](https://github.com/ant-design/ant-design/issues/57149)

### 💡 Background and Solution

- `Upload` list item actions (especially remove action) are mainly shown on hover.
- On touch devices (`hover: none` / coarse pointer), hover-only interaction makes remove action hard to discover and use.
- This PR updates Upload list styles to show list item actions by default on touch-oriented devices via:
  - `@media (hover: none), (pointer: coarse) { ... }`
- No API changes.
- Desktop behavior remains unchanged (hover interaction is preserved).

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 💄 Improve Upload touch-device usability by always showing list item actions on non-hover/coarse-pointer devices. |
| 🇨🇳 Chinese | 💄 优化 Upload 在触屏设备上的可用性，在不支持悬停或粗指针设备上默认显示列表操作按钮。 |
