### PR TITLE
fix: support CSP nonce in useToken and fix related test

### DIFF
--- a/components/button/demo/basic.tsx
+++ b/components/button/demo/basic.tsx
@@ -1,21 +1,14 @@
 import React from 'react';
-import { Button, ConfigProvider } from 'antd';
+import { Button, Flex } from 'antd';
 
 const App: React.FC = () => (
-  // <Flex gap="small" wrap>
-  //   <Button type="primary">Primary Button</Button>
-  //   <Button>Default Button</Button>
-  //   <Button type="dashed">Dashed Button</Button>
-  //   <Button type="text">Text Button</Button>
-  //   <Button type="link">Link Button</Button>
-  // </Flex>
-  <ConfigProvider
-    csp={{
-      nonce: 'bamboo',
-    }}
-  >
-    <Button />
-  </ConfigProvider>
+  <Flex gap="small" wrap>
+    <Button type="primary">Primary Button</Button>
+    <Button>Default Button</Button>
+    <Button type="dashed">Dashed Button</Button>
+    <Button type="text">Text Button</Button>
+    <Button type="link">Link Button</Button>
+  </Flex>
 );
 
 export default App;

--- a/components/button/demo/basic.tsx
+++ b/components/button/demo/basic.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
-import { Button, Flex } from 'antd';
+import { Button, ConfigProvider } from 'antd';
 
 const App: React.FC = () => (
-  <Flex gap="small" wrap>
-    <Button type="primary">Primary Button</Button>
-    <Button>Default Button</Button>
-    <Button type="dashed">Dashed Button</Button>
-    <Button type="text">Text Button</Button>
-    <Button type="link">Link Button</Button>
-  </Flex>
+  // <Flex gap="small" wrap>
+  //   <Button type="primary">Primary Button</Button>
+  //   <Button>Default Button</Button>
+  //   <Button type="dashed">Dashed Button</Button>
+  //   <Button type="text">Text Button</Button>
+  //   <Button type="link">Link Button</Button>
+  // </Flex>
+  <ConfigProvider
+    csp={{
+      nonce: 'bamboo',
+    }}
+  >
+    <Button />
+  </ConfigProvider>
 );
 
 export default App;

--- a/components/config-provider/__tests__/nonce.test.tsx
+++ b/components/config-provider/__tests__/nonce.test.tsx
@@ -65,8 +65,7 @@ describe('ConfigProvider.Icon', () => {
     expect(container.querySelector('#csp')?.innerHTML).toEqual('light');
   });
 
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('cssinjs should support nonce', () => {
+  it('cssinjs should support nonce', () => {
     render(
       <StyleProvider cache={createCache()}>
         <ConfigProvider csp={{ nonce: 'bamboo' }}>

--- a/components/theme/useToken.ts
+++ b/components/theme/useToken.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import type { Theme } from '@ant-design/cssinjs';
 import { useCacheToken } from '@ant-design/cssinjs';
 
+import { ConfigContext } from '../config-provider/context';
 import version from '../version';
 import type { DesignTokenProviderProps } from './context';
 import { defaultTheme, DesignTokenContext } from './context';
@@ -117,6 +118,8 @@ export default function useToken(): [
     zeroRuntime,
   } = React.useContext(DesignTokenContext);
 
+  const { csp } = React.useContext(ConfigContext);
+
   const cssVar = {
     prefix: ctxCssVar?.prefix ?? 'ant',
     key: ctxCssVar?.key ?? 'css-var-root',
@@ -139,6 +142,7 @@ export default function useToken(): [
         ignore,
         preserve,
       },
+      nonce: csp?.nonce,
     },
   );
 

--- a/package.json
+++ b/package.json
@@ -107,8 +107,8 @@
   },
   "dependencies": {
     "@ant-design/colors": "^8.0.1",
-    "@ant-design/cssinjs": "^2.1.0",
-    "@ant-design/cssinjs-utils": "^2.1.1",
+    "@ant-design/cssinjs": "^2.1.2",
+    "@ant-design/cssinjs-utils": "^2.1.2",
     "@ant-design/fast-color": "^3.0.1",
     "@ant-design/icons": "^6.1.0",
     "@ant-design/react-slick": "~2.0.0",


### PR DESCRIPTION
- Fix ConfigProvider nonce not being passed to useToken
- Update @ant-design/cssinjs to ^2.1.2 and @ant-design/cssinjs-utils to ^2.1.2
- Enable CSP nonce test that was previously skipped

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #57138

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fix ConfigProvider `csp` not take effect on all the dynamic style.       |
| 🇨🇳 Chinese |     修复 ConfigProvider 的 `csp` 配置没有对所有的动态 style 生效的问题。      |
