### PR TITLE
fix(Radio): keep radio same width in Group

### DIFF
--- a/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -430,6 +430,78 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
 
 exports[`renders components/radio/demo/component-token.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/radio/demo/debug-group-width.tsx extend context correctly 1`] = `
+<div
+  style="width: 280px; border: 1px solid rgb(238, 238, 238); padding: 16px;"
+>
+  <div
+    class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+    role="radiogroup"
+  >
+    <label
+      class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
+    >
+      <span
+        class="ant-radio ant-wave-target ant-radio-checked"
+      >
+        <input
+          checked=""
+          class="ant-radio-input"
+          name="test-id"
+          type="radio"
+          value="a"
+        />
+      </span>
+      <span
+        class="ant-radio-label"
+      >
+        Short
+      </span>
+    </label>
+    <label
+      class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+    >
+      <span
+        class="ant-radio ant-wave-target"
+      >
+        <input
+          class="ant-radio-input"
+          name="test-id"
+          type="radio"
+          value="b"
+        />
+      </span>
+      <span
+        class="ant-radio-label"
+      >
+        Long label that may wrap in narrow container
+      </span>
+    </label>
+    <label
+      class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+    >
+      <span
+        class="ant-radio ant-wave-target"
+      >
+        <input
+          class="ant-radio-input"
+          name="test-id"
+          type="radio"
+          value="c"
+        />
+      </span>
+      <span
+        class="ant-radio-label"
+      >
+        Medium
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`renders components/radio/demo/debug-group-width.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/radio/demo/debug-upload.tsx extend context correctly 1`] = `
 <div
   class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"

--- a/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
@@ -424,6 +424,76 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/radio/demo/debug-group-width.tsx correctly 1`] = `
+<div
+  style="width:280px;border:1px solid #eee;padding:16px"
+>
+  <div
+    class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+    role="radiogroup"
+  >
+    <label
+      class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
+    >
+      <span
+        class="ant-radio ant-wave-target ant-radio-checked"
+      >
+        <input
+          checked=""
+          class="ant-radio-input"
+          name="test-id"
+          type="radio"
+          value="a"
+        />
+      </span>
+      <span
+        class="ant-radio-label"
+      >
+        Short
+      </span>
+    </label>
+    <label
+      class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+    >
+      <span
+        class="ant-radio ant-wave-target"
+      >
+        <input
+          class="ant-radio-input"
+          name="test-id"
+          type="radio"
+          value="b"
+        />
+      </span>
+      <span
+        class="ant-radio-label"
+      >
+        Long label that may wrap in narrow container
+      </span>
+    </label>
+    <label
+      class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+    >
+      <span
+        class="ant-radio ant-wave-target"
+      >
+        <input
+          class="ant-radio-input"
+          name="test-id"
+          type="radio"
+          value="c"
+        />
+      </span>
+      <span
+        class="ant-radio-label"
+      >
+        Medium
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`renders components/radio/demo/debug-upload.tsx correctly 1`] = `
 <div
   class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"

--- a/components/radio/demo/debug-group-width.md
+++ b/components/radio/demo/debug-group-width.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+Group 内图标等宽：窄容器下长文案换行时，单选图标仍应对齐。
+
+## en-US
+
+Radios in Group same width: when label wraps in a narrow container, icons stay aligned.

--- a/components/radio/demo/debug-group-width.tsx
+++ b/components/radio/demo/debug-group-width.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Radio } from 'antd';
-import type { CheckboxGroupProps } from 'antd/es/checkbox';
+import type { RadioGroupProps } from 'antd/es/radio';
 
 const options: CheckboxGroupProps<string>['options'] = [
   { label: 'Short', value: 'a' },

--- a/components/radio/demo/debug-group-width.tsx
+++ b/components/radio/demo/debug-group-width.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Radio } from 'antd';
-import type { RadioGroupProps } from 'antd/es/radio';
 
-const options: CheckboxGroupProps<string>['options'] = [
+const options = [
   { label: 'Short', value: 'a' },
   { label: 'Long label that may wrap in narrow container', value: 'b' },
   { label: 'Medium', value: 'c' },

--- a/components/radio/demo/debug-group-width.tsx
+++ b/components/radio/demo/debug-group-width.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Radio } from 'antd';
+import type { CheckboxGroupProps } from 'antd/es/checkbox';
+
+const options: CheckboxGroupProps<string>['options'] = [
+  { label: 'Short', value: 'a' },
+  { label: 'Long label that may wrap in narrow container', value: 'b' },
+  { label: 'Medium', value: 'c' },
+];
+
+const App: React.FC = () => (
+  <div style={{ width: 280, border: '1px solid #eee', padding: 16 }}>
+    <Radio.Group options={options} defaultValue="a" />
+  </div>
+);
+
+export default App;

--- a/components/radio/index.en-US.md
+++ b/components/radio/index.en-US.md
@@ -52,6 +52,7 @@ return (
 <code src="./demo/radiobutton-solid.tsx">Solid radio button</code>
 <code src="./demo/style-class.tsx" version="6.0.0">Custom semantic dom styling</code>
 <code src="./demo/badge.tsx" debug>Badge style</code>
+<code src="./demo/debug-group-width.tsx" debug>Group same width</code>
 <code src="./demo/wireframe.tsx" debug>Wireframe</code>
 <code src="./demo/component-token.tsx" debug>Component Token</code>
 <code src="./demo/debug-upload.tsx" debug>Upload Debug</code>

--- a/components/radio/index.zh-CN.md
+++ b/components/radio/index.zh-CN.md
@@ -53,6 +53,7 @@ return (
 <code src="./demo/radiobutton-solid.tsx">填底的按钮样式</code>
 <code src="./demo/style-class.tsx" version="6.0.0">自定义语义结构的样式和类</code>
 <code src="./demo/badge.tsx" debug>测试 Badge 的样式</code>
+<code src="./demo/debug-group-width.tsx" debug>Group 内图标等宽</code>
 <code src="./demo/wireframe.tsx" debug>线框风格</code>
 <code src="./demo/component-token.tsx" debug>组件 Token</code>
 <code src="./demo/debug-upload.tsx" debug>Upload Debug</code>

--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -223,6 +223,7 @@ const getRadioBasicStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
         border: `${unit(lineWidth)} ${lineType} ${colorBorder}`,
         borderRadius: '50%',
         transition: `all ${motionDurationMid}`,
+        flex: 'none',
 
         // Dot
         '&:after': {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [ ] 🆕 新特性提交
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #57170

### 💡 需求背景和解决方案

1. **问题**：Radio.Group 中当某选项 label 较长或换行时，勾选方框宽度不一致，视觉上不对齐。
2. **方案**：在 `.ant-radio` 上增加 `flex: 'none'`，避免在 wrapper 的 inline-flex 布局中被伸缩，保证方框固定尺寸。
3. **演示**：新增 debug demo `debug-group-width`，用窄容器 + 长短不一 label 便于肉眼验证 Group 内勾选框等宽。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Radio in Group having inconsistent width when labels wrap or differ in length. |
| 🇨🇳 中文 | 修复 Radio.Group 在选项文案长短不一或换行时，勾选方框宽度不一致的问题。 |