### PR TITLE
feat(Image): add placeholder.progress for loading state display

### DIFF
--- a/components/image/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/image/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -471,57 +471,236 @@ exports[`renders components/image/demo/nested.tsx extend context correctly 1`] =
 exports[`renders components/image/demo/nested.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/image/demo/placeholder.tsx extend context correctly 1`] = `
-<div
-  class="ant-space ant-space-horizontal ant-space-align-center css-var-test-id"
-  style="column-gap: 12px; row-gap: 12px;"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-space ant-space-horizontal ant-space-align-center css-var-test-id"
+    style="column-gap: 12px; row-gap: 12px;"
   >
     <div
-      class="ant-image css-var-test-id ant-image-css-var"
-      style="width: 200px;"
+      class="ant-space-item"
     >
-      <img
-        alt="basic image"
-        class="ant-image-img"
-        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?1479772800000"
-        width="200"
-      />
       <div
-        aria-hidden="true"
-        class="ant-image-placeholder"
+        class="ant-image css-var-test-id ant-image-css-var"
+        style="width: 200px;"
+      >
+        <img
+          alt="basic image"
+          class="ant-image-img"
+          src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?1479772800000"
+          width="200"
+        />
+        <div
+          aria-hidden="true"
+          class="ant-image-placeholder"
+        >
+          <div
+            class="ant-image css-var-test-id ant-image-css-var"
+            style="width: 200px;"
+          >
+            <img
+              alt="placeholder image"
+              class="ant-image-img"
+              src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?x-oss-process=image/blur,r_50,s_50/quality,q_1/resize,m_mfit,h_200,w_200"
+              width="200"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-image-cover ant-image-cover-center"
+        />
+      </div>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <div
+        class="ant-image ant-image-progress-wrapper css-var-test-id ant-image-css-var"
+        style="width: 200px; height: 200px;"
       >
         <div
-          class="ant-image css-var-test-id ant-image-css-var"
-          style="width: 200px;"
+          aria-busy="true"
+          class="ant-image-progress"
         >
-          <img
-            alt="placeholder image"
-            class="ant-image-img"
-            src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?x-oss-process=image/blur,r_50,s_50/quality,q_1/resize,m_mfit,h_200,w_200"
-            width="200"
+          <span
+            aria-live="polite"
+            role="status"
+            style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+          >
+            Loading
+          </span>
+          <div
+            class="ant-image-progress-ink-1"
+          />
+          <div
+            class="ant-image-progress-ink-2"
+          />
+          <div
+            class="ant-image-progress-ink-3"
+          />
+          <div
+            class="ant-image-progress-ink-4"
+          />
+          <div
+            class="ant-image-progress-ink-5"
+          />
+          <div
+            class="ant-image-progress-frosted"
           />
         </div>
       </div>
-      <div
-        class="ant-image-cover ant-image-cover-center"
-      />
     </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <button
-      class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
-      type="button"
+    <div
+      class="ant-space-item"
     >
-      <span>
-        Reload
-      </span>
-    </button>
-  </div>
-</div>
+      <div
+        class="ant-image ant-image-progress-wrapper css-var-test-id ant-image-css-var"
+        style="width: 200px; height: 200px;"
+      >
+        <div
+          aria-label="50%"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="50"
+          class="ant-image-progress"
+          role="progressbar"
+        >
+          <div
+            class="ant-image-progress-ink-1"
+          />
+          <div
+            class="ant-image-progress-ink-2"
+          />
+          <div
+            class="ant-image-progress-ink-3"
+          />
+          <div
+            class="ant-image-progress-ink-4"
+          />
+          <div
+            class="ant-image-progress-ink-5"
+          />
+          <div
+            class="ant-image-progress-frosted"
+          />
+          <div
+            class="ant-image-progress-content ant-image-progress-content-bar"
+          >
+            <div
+              class="ant-image-progress-bar"
+              style="width: 100%;"
+            >
+              <div
+                class="ant-image-progress-bar-inner"
+                style="width: 50%;"
+              />
+            </div>
+            <span
+              class="ant-image-progress-percent"
+            >
+              50%
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <div
+        class="ant-image ant-image-progress-wrapper css-var-test-id ant-image-css-var"
+        style="width: 200px; height: 200px;"
+      >
+        <div
+          aria-label="75%"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="75"
+          class="ant-image-progress"
+          role="progressbar"
+        >
+          <div
+            class="ant-image-progress-ink-1"
+          />
+          <div
+            class="ant-image-progress-ink-2"
+          />
+          <div
+            class="ant-image-progress-ink-3"
+          />
+          <div
+            class="ant-image-progress-ink-4"
+          />
+          <div
+            class="ant-image-progress-ink-5"
+          />
+          <div
+            class="ant-image-progress-frosted"
+          />
+          Generating 75%
+        </div>
+      </div>
+    </div>
+  </div>,
+  <button
+    class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    style="margin-top: 12px;"
+    type="button"
+  >
+    <span>
+      Reload Image
+    </span>
+  </button>,
+  <div
+    style="margin-top: 16px;"
+  >
+    <div>
+      <button
+        class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+        style="margin-bottom: 12px;"
+        type="button"
+      >
+        <span>
+          Generate
+        </span>
+      </button>
+      <div>
+        <div
+          class="ant-image ant-image-progress-wrapper css-var-test-id ant-image-css-var"
+          style="width: 200px; height: 200px; opacity: 0.6;"
+        >
+          <div
+            aria-label="0%"
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="0"
+            class="ant-image-progress"
+            role="progressbar"
+          >
+            <div
+              class="ant-image-progress-ink-1"
+            />
+            <div
+              class="ant-image-progress-ink-2"
+            />
+            <div
+              class="ant-image-progress-ink-3"
+            />
+            <div
+              class="ant-image-progress-ink-4"
+            />
+            <div
+              class="ant-image-progress-ink-5"
+            />
+            <div
+              class="ant-image-progress-frosted"
+            />
+            Generating 0%
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
 `;
 
 exports[`renders components/image/demo/placeholder.tsx extend context correctly 2`] = `[]`;

--- a/components/image/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/image/__tests__/__snapshots__/demo.test.ts.snap
@@ -456,57 +456,236 @@ exports[`renders components/image/demo/nested.tsx correctly 1`] = `
 `;
 
 exports[`renders components/image/demo/placeholder.tsx correctly 1`] = `
-<div
-  class="ant-space ant-space-horizontal ant-space-align-center css-var-test-id"
-  style="column-gap:12px;row-gap:12px"
->
+Array [
   <div
-    class="ant-space-item"
+    class="ant-space ant-space-horizontal ant-space-align-center css-var-test-id"
+    style="column-gap:12px;row-gap:12px"
   >
     <div
-      class="ant-image css-var-test-id ant-image-css-var"
-      style="width:200px"
+      class="ant-space-item"
     >
-      <img
-        alt="basic image"
-        class="ant-image-img"
-        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?1479772800000"
-        width="200"
-      />
       <div
-        aria-hidden="true"
-        class="ant-image-placeholder"
+        class="ant-image css-var-test-id ant-image-css-var"
+        style="width:200px"
+      >
+        <img
+          alt="basic image"
+          class="ant-image-img"
+          src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?1479772800000"
+          width="200"
+        />
+        <div
+          aria-hidden="true"
+          class="ant-image-placeholder"
+        >
+          <div
+            class="ant-image css-var-test-id ant-image-css-var"
+            style="width:200px"
+          >
+            <img
+              alt="placeholder image"
+              class="ant-image-img"
+              src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?x-oss-process=image/blur,r_50,s_50/quality,q_1/resize,m_mfit,h_200,w_200"
+              width="200"
+            />
+          </div>
+        </div>
+        <div
+          class="ant-image-cover ant-image-cover-center"
+        />
+      </div>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <div
+        class="ant-image ant-image-progress-wrapper css-var-test-id ant-image-css-var"
+        style="width:200px;height:200px"
       >
         <div
-          class="ant-image css-var-test-id ant-image-css-var"
-          style="width:200px"
+          aria-busy="true"
+          class="ant-image-progress"
         >
-          <img
-            alt="placeholder image"
-            class="ant-image-img"
-            src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?x-oss-process=image/blur,r_50,s_50/quality,q_1/resize,m_mfit,h_200,w_200"
-            width="200"
+          <span
+            aria-live="polite"
+            role="status"
+            style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0, 0, 0, 0);white-space:nowrap;border:0"
+          >
+            Loading
+          </span>
+          <div
+            class="ant-image-progress-ink-1"
+          />
+          <div
+            class="ant-image-progress-ink-2"
+          />
+          <div
+            class="ant-image-progress-ink-3"
+          />
+          <div
+            class="ant-image-progress-ink-4"
+          />
+          <div
+            class="ant-image-progress-ink-5"
+          />
+          <div
+            class="ant-image-progress-frosted"
           />
         </div>
       </div>
-      <div
-        class="ant-image-cover ant-image-cover-center"
-      />
     </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <button
-      class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
-      type="button"
+    <div
+      class="ant-space-item"
     >
-      <span>
-        Reload
-      </span>
-    </button>
-  </div>
-</div>
+      <div
+        class="ant-image ant-image-progress-wrapper css-var-test-id ant-image-css-var"
+        style="width:200px;height:200px"
+      >
+        <div
+          aria-label="50%"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="50"
+          class="ant-image-progress"
+          role="progressbar"
+        >
+          <div
+            class="ant-image-progress-ink-1"
+          />
+          <div
+            class="ant-image-progress-ink-2"
+          />
+          <div
+            class="ant-image-progress-ink-3"
+          />
+          <div
+            class="ant-image-progress-ink-4"
+          />
+          <div
+            class="ant-image-progress-ink-5"
+          />
+          <div
+            class="ant-image-progress-frosted"
+          />
+          <div
+            class="ant-image-progress-content ant-image-progress-content-bar"
+          >
+            <div
+              class="ant-image-progress-bar"
+              style="width:100%"
+            >
+              <div
+                class="ant-image-progress-bar-inner"
+                style="width:50%"
+              />
+            </div>
+            <span
+              class="ant-image-progress-percent"
+            >
+              50%
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <div
+        class="ant-image ant-image-progress-wrapper css-var-test-id ant-image-css-var"
+        style="width:200px;height:200px"
+      >
+        <div
+          aria-label="75%"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="75"
+          class="ant-image-progress"
+          role="progressbar"
+        >
+          <div
+            class="ant-image-progress-ink-1"
+          />
+          <div
+            class="ant-image-progress-ink-2"
+          />
+          <div
+            class="ant-image-progress-ink-3"
+          />
+          <div
+            class="ant-image-progress-ink-4"
+          />
+          <div
+            class="ant-image-progress-ink-5"
+          />
+          <div
+            class="ant-image-progress-frosted"
+          />
+          Generating 75%
+        </div>
+      </div>
+    </div>
+  </div>,
+  <button
+    class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+    style="margin-top:12px"
+    type="button"
+  >
+    <span>
+      Reload Image
+    </span>
+  </button>,
+  <div
+    style="margin-top:16px"
+  >
+    <div>
+      <button
+        class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+        style="margin-bottom:12px"
+        type="button"
+      >
+        <span>
+          Generate
+        </span>
+      </button>
+      <div>
+        <div
+          class="ant-image ant-image-progress-wrapper css-var-test-id ant-image-css-var"
+          style="width:200px;height:200px;opacity:0.6"
+        >
+          <div
+            aria-label="0%"
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="0"
+            class="ant-image-progress"
+            role="progressbar"
+          >
+            <div
+              class="ant-image-progress-ink-1"
+            />
+            <div
+              class="ant-image-progress-ink-2"
+            />
+            <div
+              class="ant-image-progress-ink-3"
+            />
+            <div
+              class="ant-image-progress-ink-4"
+            />
+            <div
+              class="ant-image-progress-ink-5"
+            />
+            <div
+              class="ant-image-progress-frosted"
+            />
+            Generating 0%
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
 `;
 
 exports[`renders components/image/demo/preview-group.tsx correctly 1`] = `

--- a/components/image/demo/placeholder.tsx
+++ b/components/image/demo/placeholder.tsx
@@ -1,33 +1,112 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button, Image, Space } from 'antd';
+
+const GeneratingProgress: React.FC = () => {
+  const [percent, setPercent] = useState(0);
+  const [status, setStatus] = useState<'idle' | 'generating' | 'complete'>('idle');
+
+  useEffect(() => {
+    if (status === 'generating' && percent < 100) {
+      const timer = setTimeout(() => {
+        setPercent((prev) => Math.min(prev + Math.random() * 8 + 2, 100));
+      }, 200);
+      return () => clearTimeout(timer);
+    } else if (status === 'generating' && percent >= 100) {
+      const timer = setTimeout(() => {
+        setStatus('complete');
+      }, 200);
+      return () => clearTimeout(timer);
+    }
+  }, [status, percent]);
+
+  const handleStart = () => {
+    setPercent(0);
+    setStatus('generating');
+  };
+
+  const imageNode =
+    status === 'complete' ? (
+      <Image
+        width={200}
+        height={200}
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+      />
+    ) : (
+      <Image
+        width={200}
+        height={200}
+        placeholder={{
+          progress: {
+            percent: Math.round(percent),
+            render: (_, p) => `Generating ${p}%`,
+          },
+        }}
+        style={{ opacity: status === 'idle' ? 0.6 : 1 }}
+      />
+    );
+
+  return (
+    <div>
+      <Button
+        type="primary"
+        onClick={handleStart}
+        disabled={status === 'generating'}
+        style={{ marginBottom: 12 }}
+      >
+        Generate
+      </Button>
+      <div>{imageNode}</div>
+    </div>
+  );
+};
 
 const App: React.FC = () => {
   const [random, setRandom] = useState<number>(() => Date.now());
 
   return (
-    <Space size={12}>
-      <Image
-        width={200}
-        alt="basic image"
-        src={`https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?${random}`}
-        placeholder={
-          <Image
-            preview={false}
-            alt="placeholder image"
-            src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?x-oss-process=image/blur,r_50,s_50/quality,q_1/resize,m_mfit,h_200,w_200"
-            width={200}
-          />
-        }
-      />
+    <>
+      <Space size={12}>
+        {/* 渐进式加载 */}
+        <Image
+          width={200}
+          alt="basic image"
+          src={`https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?${random}`}
+          placeholder={
+            <Image
+              preview={false}
+              alt="placeholder image"
+              src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?x-oss-process=image/blur,r_50,s_50/quality,q_1/resize,m_mfit,h_200,w_200"
+              width={200}
+            />
+          }
+        />
+        {/* 进度展示 */}
+        <Image width={200} height={200} placeholder={{ progress: true }} />
+        <Image width={200} height={200} placeholder={{ progress: { percent: 50 } }} />
+        <Image
+          width={200}
+          height={200}
+          placeholder={{
+            progress: {
+              percent: 75,
+              render: (_, p) => `Generating ${p}%`,
+            },
+          }}
+        />
+      </Space>
       <Button
         type="primary"
         onClick={() => {
           setRandom(Date.now());
         }}
+        style={{ marginTop: 12 }}
       >
-        Reload
+        Reload Image
       </Button>
-    </Space>
+      <div style={{ marginTop: 16 }}>
+        <GeneratingProgress />
+      </div>
+    </>
   );
 };
 

--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -46,7 +46,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | fallback | Fallback URL when load fails | string | - |  |
 | height | Image height | string \| number | - |  |
-| placeholder | Loading placeholder; if true, uses default placeholder | ReactNode | - |  |
+| placeholder | Loading placeholder, supports ReactNode or config object | [PlaceholderType](#placeholdertype) | - |  |
 | preview | Preview configuration; set to false to disable | boolean \| [PreviewType](#previewtype) | true |  |
 | src | Image URL | string | - |  |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
@@ -54,6 +54,20 @@ Common props ref：[Common props](/docs/react/common-props)
 | onError | Callback when loading error occurs | (event: Event) => void | - |  |
 
 Other Property ref [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes)
+
+### PlaceholderType
+
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| node | Custom placeholder content | ReactNode | - |  |
+| progress | Progress config, set to `true` to show gradient animation, set `{ percent: number }` to show progress, `render` for custom rendering | boolean \| [ImageProgressConfig](#imageprogressconfig) | - |  |
+
+### ImageProgressConfig
+
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| percent | Progress value | number | - |  |
+| render | Custom rendering, receives default progress UI and percentage | (progress: React.ReactNode, percent: number) => React.ReactNode | - |  |
 
 ### PreviewType
 

--- a/components/image/index.tsx
+++ b/components/image/index.tsx
@@ -48,11 +48,30 @@ export interface CompositionImage<P> extends React.FC<P> {
   PreviewGroup: typeof PreviewGroup;
 }
 
+export interface ImageProgressConfig {
+  percent?: number;
+  /** 自定义渲染，接收默认的进度 UI 和百分比 */
+  render?: (progress: React.ReactNode, percent: number) => React.ReactNode;
+}
+
+export interface PlaceholderConfig {
+  /** 自定义 placeholder 内容 */
+  node?: React.ReactNode;
+  /** 进度配置 */
+  progress?: boolean | ImageProgressConfig;
+}
+
+export type PlaceholderType = React.ReactNode | PlaceholderConfig;
+
 export type ImageSemanticType = {
   classNames?: {
     root?: string;
     image?: string;
     cover?: string;
+    placeholder?: {
+      progress?: string;
+      progressPercent?: string;
+    };
     popup?: {
       root?: string;
       mask?: string;
@@ -65,6 +84,10 @@ export type ImageSemanticType = {
     root?: React.CSSProperties;
     image?: React.CSSProperties;
     cover?: React.CSSProperties;
+    placeholder?: {
+      progress?: React.CSSProperties;
+      progressPercent?: React.CSSProperties;
+    };
     popup?: {
       root?: React.CSSProperties;
       mask?: React.CSSProperties;
@@ -77,12 +100,38 @@ export type ImageSemanticType = {
 
 export type ImageSemanticAllType = GenerateSemantic<ImageSemanticType, ImageProps>;
 
-export interface ImageProps extends Omit<RcImageProps, 'preview' | 'classNames' | 'styles'> {
+export interface ImageProps
+  extends Omit<RcImageProps, 'preview' | 'classNames' | 'styles' | 'placeholder'> {
   preview?: boolean | PreviewConfig;
   /** @deprecated Use `styles.root` instead */
   wrapperStyle?: React.CSSProperties;
   classNames?: ImageSemanticAllType['classNamesAndFn'];
   styles?: ImageSemanticAllType['stylesAndFn'];
+  placeholder?: PlaceholderType;
+}
+
+// ======================= Helper Functions =======================
+function isPlaceholderConfig(placeholder: any): placeholder is PlaceholderConfig {
+  return placeholder && typeof placeholder === 'object' && !React.isValidElement(placeholder);
+}
+
+function normalizePlaceholder(placeholder?: PlaceholderType): {
+  node: React.ReactNode;
+  progressConfig?: ImageProgressConfig;
+} {
+  if (!placeholder) return { node: undefined };
+  if (isPlaceholderConfig(placeholder)) {
+    return {
+      node: placeholder.node,
+      progressConfig:
+        typeof placeholder.progress === 'boolean'
+          ? placeholder.progress
+            ? {}
+            : undefined
+          : placeholder.progress,
+    };
+  }
+  return { node: placeholder };
 }
 
 const Image: CompositionImage<ImageProps> = (props) => {
@@ -96,6 +145,7 @@ const Image: CompositionImage<ImageProps> = (props) => {
     classNames,
     wrapperStyle,
     fallback,
+    placeholder,
     ...otherProps
   } = props;
 
@@ -181,7 +231,7 @@ const Image: CompositionImage<ImageProps> = (props) => {
     [mergedMask, prefixCls, blurClassName],
   );
 
-  const internalClassNames = React.useMemo(
+  const internalClassNames: any[] = React.useMemo(
     () => [contextClassNames, classNames, mergedLegacyClassNames, { popup: mergedPopupClassNames }],
     [contextClassNames, classNames, mergedLegacyClassNames, mergedPopupClassNames],
   );
@@ -194,12 +244,143 @@ const Image: CompositionImage<ImageProps> = (props) => {
     },
     {
       popup: { _default: 'root' },
+      placeholder: {},
     },
   );
 
   const mergedStyle: React.CSSProperties = { ...contextStyle, ...style };
   const mergedFallback: RcImageProps['fallback'] = fallback ?? contextFallback;
+
+  // ============================= Progress ==============================
+  const { node: placeholderNode, progressConfig } = normalizePlaceholder(placeholder);
+  const showProgressOverlay = progressConfig !== undefined;
+
+  const { percent, render: progressRender } = progressConfig || {};
+  const showProgressBar = true; // Always show progress bar by default when progress is active
+
+  // 判断是否有 percent（必须是有限数值）
+  const hasPercent = typeof percent === 'number' && Number.isFinite(percent);
+
+  // 计算 percent 数值（用于进度条宽度和 function 参数），约束在 0-100 之间
+  const percentValue = hasPercent ? Math.max(0, Math.min(100, Math.round(percent))) : 0;
+
+  // 渲染默认进度 UI
+  const renderDefaultProgressUI = () => {
+    if (!hasPercent) {
+      return null;
+    }
+
+    const placeholderClassNames = mergedClassNames?.placeholder as
+      | { progress?: string; progressPercent?: string }
+      | undefined;
+    const placeholderStyles = mergedStyles?.placeholder as
+      | { progress?: React.CSSProperties; progressPercent?: React.CSSProperties }
+      | undefined;
+
+    return (
+      <div
+        className={clsx(
+          `${prefixCls}-progress-content`,
+          showProgressBar && `${prefixCls}-progress-content-bar`,
+        )}
+      >
+        {showProgressBar && (
+          <div className={`${prefixCls}-progress-bar`} style={{ width: '100%' }}>
+            <div
+              className={`${prefixCls}-progress-bar-inner`}
+              style={{ width: `${percentValue}%` }}
+            />
+          </div>
+        )}
+        <span
+          className={clsx(`${prefixCls}-progress-percent`, placeholderClassNames?.progressPercent)}
+          style={placeholderStyles?.progressPercent}
+        >
+          {`${percentValue}%`}
+        </span>
+      </div>
+    );
+  };
+
   // ============================== Render ==============================
+  const { width, height, ...restOtherProps } = otherProps;
+
+  // When progress is active, render only progress layer with dimensions
+  if (showProgressOverlay) {
+    // 渲染进度内容
+    const defaultProgressUI = renderDefaultProgressUI();
+    const progressContent = progressRender
+      ? progressRender(defaultProgressUI, percentValue)
+      : defaultProgressUI;
+
+    const placeholderClassNames = mergedClassNames?.placeholder as
+      | { progress?: string; progressPercent?: string }
+      | undefined;
+    const placeholderStyles = mergedStyles?.placeholder as
+      | { progress?: React.CSSProperties; progressPercent?: React.CSSProperties }
+      | undefined;
+
+    return (
+      <div
+        className={clsx(
+          prefixCls,
+          `${prefixCls}-progress-wrapper`,
+          mergedRootClassName,
+          mergedClassName,
+        )}
+        style={{
+          width,
+          height,
+          ...mergedStyle,
+          ...mergedStyles?.root,
+        }}
+      >
+        {/* Main progress container with frosted glass */}
+        <div
+          className={clsx(`${prefixCls}-progress`, placeholderClassNames?.progress)}
+          style={placeholderStyles?.progress}
+          role={hasPercent ? 'progressbar' : undefined}
+          aria-valuemin={hasPercent ? 0 : undefined}
+          aria-valuemax={hasPercent ? 100 : undefined}
+          aria-valuenow={hasPercent ? percentValue : undefined}
+          aria-label={hasPercent ? `${percentValue}%` : undefined}
+          aria-busy={!hasPercent ? true : undefined}
+        >
+          {/* Visually hidden live region for non-percent loading state */}
+          {!hasPercent && (
+            <span
+              role="status"
+              aria-live="polite"
+              style={{
+                position: 'absolute',
+                width: 1,
+                height: 1,
+                padding: 0,
+                margin: -1,
+                overflow: 'hidden',
+                clip: 'rect(0, 0, 0, 0)',
+                whiteSpace: 'nowrap',
+                border: 0,
+              }}
+            >
+              Loading
+            </span>
+          )}
+          {/* Watercolor ink layers */}
+          <div className={`${prefixCls}-progress-ink-1`} />
+          <div className={`${prefixCls}-progress-ink-2`} />
+          <div className={`${prefixCls}-progress-ink-3`} />
+          <div className={`${prefixCls}-progress-ink-4`} />
+          <div className={`${prefixCls}-progress-ink-5`} />
+          {/* Frosted matte overlay */}
+          <div className={`${prefixCls}-progress-frosted`} />
+          {/* Progress content */}
+          {progressContent}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <RcImage
       prefixCls={prefixCls}
@@ -208,7 +389,10 @@ const Image: CompositionImage<ImageProps> = (props) => {
       className={mergedClassName}
       style={mergedStyle}
       fallback={mergedFallback}
-      {...otherProps}
+      placeholder={placeholderNode}
+      width={width}
+      height={height}
+      {...restOtherProps}
       classNames={mergedClassNames}
       styles={mergedStyles}
     />

--- a/components/image/index.zh-CN.md
+++ b/components/image/index.zh-CN.md
@@ -47,7 +47,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | fallback | 加载失败容错地址 | string | - |  |
 | height | 图像高度 | string \| number | - |  |
-| placeholder | 加载占位，为 `true` 时使用默认占位 | ReactNode | - |  |
+| placeholder | 加载占位，支持 ReactNode 或配置对象 | [PlaceholderType](#placeholdertype) | - |  |
 | preview | 预览参数，为 `false` 时禁用 | boolean \| [PreviewType](#previewtype) | true |  |
 | src | 图片地址 | string | - |  |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
@@ -55,6 +55,20 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | onError | 加载错误回调 | (event: Event) => void | - |  |
 
 其他属性见 [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes)
+
+### PlaceholderType
+
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| node | 自定义 placeholder 内容 | ReactNode | - |  |
+| progress | 进度配置，设置为 `true` 显示渐变动画，设置 `{ percent: number }` 显示进度，`render` 自定义渲染 | boolean \| [ImageProgressConfig](#imageprogressconfig) | - |  |
+
+### ImageProgressConfig
+
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| percent | 进度值 | number | - |  |
+| render | 自定义渲染，接收默认的进度 UI 和百分比 | (progress: React.ReactNode, percent: number) => React.ReactNode | - |  |
 
 ### PreviewType
 


### PR DESCRIPTION
## Summary

Add `placeholder.progress` support for Image component to display loading/progress state.

### New Features

- Support `placeholder.progress` for progress/configurable loading state
- Add `ImageProgressConfig` with `percent` and `render` props
- Add `PlaceholderConfig` interface with `node` and `progress` options
- Update semantic classNames to support `placeholder.progress` and `placeholder.progressPercent`

### Usage

```tsx
// With progress loading state
<Image
  width={200}
  height={200}
  placeholder={{
    progress: { percent: 50 }
  }}
/>

// Custom rendering
<Image
  width={200}
  height={200}
  placeholder={{
    progress: {
      percent: 75,
      render: (_, percent) => `Generating ${percent}%`
    }
  }}
/>

// Pure ReactNode (backward compatible)
<Image placeholder={<Spin />} />
```

## Test Plan

- [x] Run `npm run test components/image`
- [x] Update snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)