### PR TITLE
feat(CheckableTag): support preset colors for checkable mode fixes #11889

### DIFF
--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -76,7 +76,7 @@ const CheckableTag = React.forwardRef<HTMLSpanElement, CheckableTagProps>((props
     {
       [`${prefixCls}-checkable-checked`]: checked,
       [`${prefixCls}-checkable-disabled`]: mergedDisabled,
-      [`${prefixCls}-${color}`]: isInternalColor && checked,
+      [`${prefixCls}-${color}`]: isInternalColor,
     },
     tag?.className,
     className,

--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { clsx } from 'clsx';
 
-import { isPresetColor, isPresetStatusColor, type PresetColorType, type PresetStatusColorType } from '../_util/colors';
+import { isPresetColor, isPresetStatusColor } from '../_util/colors';
+import type { PresetColorType, PresetStatusColorType } from '../_util/colors';
 import type { LiteralUnion } from '../_util/type';
 import { ConfigContext } from '../config-provider';
 import DisabledContext from '../config-provider/DisabledContext';

--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { clsx } from 'clsx';
 
+import { isPresetColor, isPresetStatusColor, type PresetColorType, type PresetStatusColorType } from '../_util/colors';
+import type { LiteralUnion } from '../_util/type';
 import { ConfigContext } from '../config-provider';
 import DisabledContext from '../config-provider/DisabledContext';
 import useStyle from './style';
@@ -23,6 +25,11 @@ export interface CheckableTagProps {
   onChange?: (checked: boolean) => void;
   onClick?: (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => void;
   disabled?: boolean;
+  /**
+   * Support preset colors for checkable mode
+   * @since 5.28.0
+   */
+  color?: LiteralUnion<PresetColorType | PresetStatusColorType>;
 }
 
 const CheckableTag = React.forwardRef<HTMLSpanElement, CheckableTagProps>((props, ref) => {
@@ -36,12 +43,18 @@ const CheckableTag = React.forwardRef<HTMLSpanElement, CheckableTagProps>((props
     onChange,
     onClick,
     disabled: customDisabled,
+    color,
     ...restProps
   } = props;
   const { getPrefixCls, tag } = React.useContext(ConfigContext);
 
   const disabled = React.useContext(DisabledContext);
   const mergedDisabled = customDisabled ?? disabled;
+
+  // Check if color is preset or status using shared utilities
+  const isPreset = isPresetColor(color);
+  const isStatus = isPresetStatusColor(color);
+  const isInternalColor = isPreset || isStatus;
 
   const handleClick = (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
     if (mergedDisabled) {
@@ -62,6 +75,7 @@ const CheckableTag = React.forwardRef<HTMLSpanElement, CheckableTagProps>((props
     {
       [`${prefixCls}-checkable-checked`]: checked,
       [`${prefixCls}-checkable-disabled`]: mergedDisabled,
+      [`${prefixCls}-${color}`]: isInternalColor && checked,
     },
     tag?.className,
     className,


### PR DESCRIPTION
## Summary

This PR adds support for preset colors in CheckableTag component, allowing users to use colored tags with checkable mode.

## Changes

- Added `color` prop to `CheckableTagProps` interface
- Added preset and status color detection logic
- Applied color class when checked and color is internal

## Usage

```tsx
import { Tag } from 'antd';

const MyComponent = () => {
  const [checked, setChecked] = useState(false);
  
  return (
    <Tag.CheckableTag
      checked={checked}
      onChange={setChecked}
      color="red"
    >
      Urgent
    </Tag.CheckableTag>
  );
};
```

fixes #11889