### PR TITLE
fix(tag): improve text contrast for custom color solid variant

### DIFF
--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -316,6 +316,26 @@ describe('Tag', () => {
     expect(tagElement).not.toBeNull();
   });
 
+  it('should have contrasting text color for custom solid variant', () => {
+    // Light background should have dark text
+    const { container: lightContainer } = render(
+      <Tag color="#ffffff" variant="solid">
+        light
+      </Tag>,
+    );
+    const lightTag = lightContainer.querySelector('.ant-tag');
+    expect(lightTag).toHaveStyle({ color: '#000' });
+
+    // Dark background should have light text
+    const { container: darkContainer } = render(
+      <Tag color="#000000" variant="solid">
+        dark
+      </Tag>,
+    );
+    const darkTag = darkContainer.querySelector('.ant-tag');
+    expect(darkTag).toHaveStyle({ color: '#fff' });
+  });
+
   it('legacy color inverse', () => {
     const { container } = render(<Tag color="green-inverse">tag</Tag>);
 

--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -352,6 +352,24 @@ describe('Tag', () => {
     );
     const semiLightTag = semiLightContainer.querySelector('.ant-tag');
     expect(semiLightTag).toHaveStyle({ color: '#000' });
+
+    // Bright yellow should have dark text
+    const { container: yellowContainer } = render(
+      <Tag color="#ffff00" variant="solid">
+        yellow
+      </Tag>,
+    );
+    const yellowTag = yellowContainer.querySelector('.ant-tag');
+    expect(yellowTag).toHaveStyle({ color: '#000' });
+
+    // Dark blue should have light text
+    const { container: blueContainer } = render(
+      <Tag color="#000080" variant="solid">
+        blue
+      </Tag>,
+    );
+    const blueTag = blueContainer.querySelector('.ant-tag');
+    expect(blueTag).toHaveStyle({ color: '#fff' });
   });
 
   it('legacy color inverse', () => {

--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -334,6 +334,24 @@ describe('Tag', () => {
     );
     const darkTag = darkContainer.querySelector('.ant-tag');
     expect(darkTag).toHaveStyle({ color: '#fff' });
+
+    // Semi-transparent dark color should have light text (opaque enough to be dark)
+    const { container: semiDarkContainer } = render(
+      <Tag color="rgba(0, 0, 0, 0.8)" variant="solid">
+        semi-dark
+      </Tag>,
+    );
+    const semiDarkTag = semiDarkContainer.querySelector('.ant-tag');
+    expect(semiDarkTag).toHaveStyle({ color: '#fff' });
+
+    // Semi-transparent light color should have dark text (opaque enough to be light)
+    const { container: semiLightContainer } = render(
+      <Tag color="rgba(255, 255, 255, 0.8)" variant="solid">
+        semi-light
+      </Tag>,
+    );
+    const semiLightTag = semiLightContainer.querySelector('.ant-tag');
+    expect(semiLightTag).toHaveStyle({ color: '#000' });
   });
 
   it('legacy color inverse', () => {

--- a/components/tag/hooks/useColor.ts
+++ b/components/tag/hooks/useColor.ts
@@ -3,6 +3,8 @@ import { FastColor } from '@ant-design/fast-color';
 
 import type { TagProps } from '..';
 import { isPresetColor, isPresetStatusColor } from '../../_util/colors';
+import { AggregationColor } from '../../color-picker/color';
+import { isBright } from '../../color-picker/components/ColorPresets';
 
 /**
  * Convert color related props to a unified object,
@@ -49,6 +51,9 @@ export default function useColor(
     if (!nextIsPreset && !nextIsStatus && nextColor) {
       if (nextVariant === 'solid') {
         tagStyle.backgroundColor = color;
+        // Calculate contrasting text color for custom solid tags
+        const textColor = isBright(new AggregationColor(nextColor), '#fff') ? '#000' : '#fff';
+        tagStyle.color = textColor;
       } else {
         const hsl = new FastColor(nextColor).toHsl();
         hsl.l = 0.95;

--- a/components/tag/hooks/useColor.ts
+++ b/components/tag/hooks/useColor.ts
@@ -50,7 +50,7 @@ export default function useColor(
 
     if (!nextIsPreset && !nextIsStatus && nextColor) {
       if (nextVariant === 'solid') {
-        tagStyle.backgroundColor = color;
+        tagStyle.backgroundColor = nextColor;
         // Calculate contrasting text color for custom solid tags.
         // For opaque colors, use standard luminance formula.
         // For semi-transparent colors, we assume a light background as fallback

--- a/components/tag/hooks/useColor.ts
+++ b/components/tag/hooks/useColor.ts
@@ -51,9 +51,20 @@ export default function useColor(
     if (!nextIsPreset && !nextIsStatus && nextColor) {
       if (nextVariant === 'solid') {
         tagStyle.backgroundColor = color;
-        // Calculate contrasting text color for custom solid tags
-        const textColor = isBright(new AggregationColor(nextColor), '#fff') ? '#000' : '#fff';
-        tagStyle.color = textColor;
+        // Calculate contrasting text color for custom solid tags.
+        // For opaque colors, use standard luminance formula.
+        // For semi-transparent colors, we assume a light background as fallback
+        // since we don't have access to theme context here.
+        // Note: Semi-transparent solid tags are an edge case - most solid tags use opaque colors.
+        const aggregatedColor = new AggregationColor(nextColor);
+        const { r, g, b, a } = aggregatedColor.toRgb();
+        // For opaque colors (alpha > 0.5), use luminance formula directly
+        // For semi-transparent colors, fall back to isBright with white background
+        const isLightColor =
+          a > 0.5
+            ? r * 0.299 + g * 0.587 + b * 0.114 > 192
+            : isBright(aggregatedColor, '#fff');
+        tagStyle.color = isLightColor ? '#000' : '#fff';
       } else {
         const hsl = new FastColor(nextColor).toHsl();
         hsl.l = 0.95;


### PR DESCRIPTION
## Summary
Fix poor text contrast in `Tag` component when using custom colors with `variant="solid"`, especially in dark mode.

## Problem
When using a custom color (e.g., `#66ccff`) with `variant="solid"`, the Tag component was setting the background color but not calculating a contrasting text color. This resulted in nearly illegible text, particularly in dark mode where the text and background could have very low contrast.

## Solution
Use the existing `isBright` utility function to determine whether the custom background color is light or dark, then set the text color to black (`#000`) for light backgrounds or white (`#fff`) for dark backgrounds.

## Changes
- `components/tag/hooks/useColor.ts`: Added text color calculation for custom solid variant tags
- `components/tag/__tests__/index.test.tsx`: Added test case to verify contrasting text colors

## Before/After
**Before:** Custom solid tags had no explicit text color, leading to poor contrast
**After:** Text color is automatically calculated based on background brightness

## Test Plan
- [x] Added unit test for light background (white bg → black text)
- [x] Added unit test for dark background (black bg → white text)
- [x] Verified existing tests still pass

Fixes #57029