### PR TITLE
site: fix ThemePreview copy button in dark theme

### DIFF
--- a/.dumi/pages/index/components/ThemePreview/index.tsx
+++ b/.dumi/pages/index/components/ThemePreview/index.tsx
@@ -101,6 +101,13 @@ const useStyles = createStyles(({ css, cssVar }) => ({
     '&.visible': {
       opacity: 1,
     },
+
+    '&.dark': {
+      color: cssVar.colorTextLightSolid,
+      '&:hover': {
+        color: cssVar.colorTextLightSolid,
+      },
+    },
   }),
 
   // AI Generate Item
@@ -257,19 +264,13 @@ function ThemePreviewContent(props: ThemePreviewProps) {
                     <Button
                       className={clsx(
                         styles.copyButton,
-                        (hoveredName === previewTheme.name ||
-                          copiedName === previewTheme.name) &&
+                        (hoveredName === previewTheme.name || copiedName === previewTheme.name) &&
                           'visible',
+                        activeTheme?.bgImgDark && 'dark',
                       )}
                       type="text"
                       size="small"
-                      icon={
-                        copiedName === previewTheme.name ? (
-                          <CheckOutlined />
-                        ) : (
-                          <CopyOutlined />
-                        )
-                      }
+                      icon={copiedName === previewTheme.name ? <CheckOutlined /> : <CopyOutlined />}
                       onClick={(e) => handleCopyTheme(e, previewTheme.props, previewTheme.name)}
                       aria-label={locale.copyTheme}
                     />


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案

首页主题定制区块（ThemePreview）在暗色主题下，复制主题代码按钮的图标为深色，在深色背景上不显眼。

<img width="378" height="536" alt="image" src="https://github.com/user-attachments/assets/71ba9383-8d8c-46cb-9191-f61e4a9a2c3f" />

<img width="438" height="522" alt="image" src="https://github.com/user-attachments/assets/de49c94a-4264-4197-bacb-988fe95d5eef" />


### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | ThemePreview: improve copy button visibility and hover in dark theme. |
| 🇨🇳 中文 | ThemePreview：暗色主题下复制按钮可见性与 hover 反馈优化。 |
