### PR TITLE
fix(site): prevent duplicate API requests for doc contributors

### DIFF
--- a/.dumi/theme/slots/Content/Contributors.tsx
+++ b/.dumi/theme/slots/Content/Contributors.tsx
@@ -3,6 +3,7 @@ import ContributorsList from '@qixian.cs/github-contributors-list';
 import { createStaticStyles } from 'antd-style';
 import { clsx } from 'clsx';
 import { useIntl } from 'dumi';
+import { SWRConfig } from 'swr';
 
 import SiteContext from '../SiteContext';
 import ContributorAvatar from './ContributorAvatar';
@@ -57,17 +58,26 @@ const Contributors: React.FC<ContributorsProps> = ({ filename }) => {
   return (
     <div className={clsx({ [styles.listMobile]: isMobile })}>
       <div className={styles.title}>{formatMessage({ id: 'app.content.contributors' })}</div>
-      <ContributorsList
-        cache
-        repo="ant-design"
-        owner="ant-design"
-        fileName={filename}
-        className={styles.list}
-        filter={(item) => !blockList.includes(item?.username?.toLowerCase() ?? '')}
-        renderItem={(item, loading) => (
-          <ContributorAvatar item={item} loading={loading} key={item?.url} />
-        )}
-      />
+      <SWRConfig
+        value={{
+          revalidateOnFocus: false,
+          revalidateOnReconnect: false,
+          revalidateOnMount: false,
+          revalidateIfStale: false,
+        }}
+      >
+        <ContributorsList
+          cache
+          repo="ant-design"
+          owner="ant-design"
+          fileName={filename}
+          className={styles.list}
+          filter={(item) => !blockList.includes(item?.username?.toLowerCase() ?? '')}
+          renderItem={(item, loading) => (
+            <ContributorAvatar item={item} loading={loading} key={item?.url} />
+          )}
+        />
+      </SWRConfig>
     </div>
   );
 };


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> N/A

### 💡 Background and Solution

The `cache` prop in `@qixian.cs/github-contributors-list` was not actually implemented in the library code, causing repeated API requests on every component mount. This PR wraps `ContributorsList` with `SWRConfig` to disable all revalidation behaviors:

- `revalidateOnFocus: false` - Don't re-request when window gains focus
- `revalidateOnReconnect: false` - Don't re-request when network reconnects
- `revalidateOnMount: false` - Don't re-request on mount if cached data exists
- `revalidateIfStale: false` - Don't re-request even if data is stale

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix duplicate API requests for doc contributors in site footer |
| 🇨🇳 Chinese | 修复站点页脚文档贡献者重复发起 API 请求的问题 |