### PR TITLE
demo(image): fix stacking context

### DIFF
--- a/components/image/demo/_semantic.tsx
+++ b/components/image/demo/_semantic.tsx
@@ -60,7 +60,6 @@ const Block: React.FC<Readonly<ImagePropsBlock>> = ({ classNames, ...restProps }
           width={200}
           src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
           classNames={{ ...classNames, cover: clsx(classNames?.cover, styles.cover) }}
-          preview={{ getContainer: () => holderRef.current! }}
           {...restProps}
         />
       </Flex>


### PR DESCRIPTION
css 层叠上下文导致的问题，把 preview 挂在 body 下即可解决

### Before
<img width="3024" height="1648" alt="image" src="https://github.com/user-attachments/assets/c987ccb3-efca-4f9c-b969-457b1ef9986e" />

### After

<img width="3024" height="1648" alt="image" src="https://github.com/user-attachments/assets/d54e5540-effe-4a37-a0fb-dc91387cc0fe" />
