### PR TITLE
ci: reopen pr-open-notify

### DIFF
--- a/.github/workflows/pr-open-notify.yml
+++ b/.github/workflows/pr-open-notify.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   send-to-dingtalk:
+    if: github.repository == 'ant-design/ant-design'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:

--- a/.github/workflows/pr-open-notify.yml
+++ b/.github/workflows/pr-open-notify.yml
@@ -13,8 +13,6 @@ concurrency:
 
 jobs:
   send-to-dingtalk:
-    # Only run for PRs from the same repo (not from forks) to prevent potential injection
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:


### PR DESCRIPTION


### 🤔 This is a ...

- [ ] ❓ Other (about what?)

### 🔗 Related Issues
https://github.com/ant-design/ant-design/pull/57094/changes#diff-e8f9193d55faa0f8f922aee65e82af911c5ed1b666b8d033f2ed9223702d172dR17
### 💡 Background and Solution
感觉还是打开钉钉通知比较好，issue 也是有群通知的，而且其实pr量并没有那么大，应该不会造成太大的噪音污染。

打开群通知，方便社区同学及时帮忙 Review 一些外部同学提交的容易处理的 PR。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       -    |
| 🇨🇳 Chinese |        -   |
