### PR TITLE
fix: improve TreeSelect code

### DIFF
--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -378,14 +378,7 @@ const InternalTreeSelect: InternalTreeSelectRef = (props, ref) => {
   }
 
   // ==================== Render =====================
-  const selectProps = omit(restProps, [
-    'suffixIcon',
-    'removeIcon',
-    'clearIcon',
-    'itemIcon' as any,
-    'switcherIcon' as any,
-    'style',
-  ]);
+  const selectProps = omit(restProps, ['suffixIcon', 'removeIcon', 'clearIcon']);
 
   // ===================== Placement =====================
   const memoizedPlacement = React.useMemo<Placement>(() => {


### PR DESCRIPTION


### 🤔 This is a ...

- [ ] ❓ Other (about what?)

### 💡 Background and Solution
1. 这边要从 reset 中解构的部分，早就在上面 props 里面解构过了，已经不在 restProps 中了，不需要 omit了
<img width="701" height="661" alt="image" src="https://github.com/user-attachments/assets/eac13103-343a-4765-a731-69a3d96f1872" />

2. itemIcon 应该也是在 rc 中早早的废弃了，也不需要 omit 了

<img width="1526" height="595" alt="image" src="https://github.com/user-attachments/assets/2bd32cae-9594-40e3-80dc-2be417ad43cb" />

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        -   |
| 🇨🇳 Chinese |        -   |
