### PR TITLE
fix(Input): normalize onChange event.target to real mounted element

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -226,7 +226,27 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     removePasswordTimeout();
-    onChange?.(e);
+    if (onChange) {
+      const realInput = inputRef.current?.input;
+      // @rc-component/input's resolveOnChange passes a cloneEvent()-created object
+      // whose target/currentTarget point to a detached DOM clone (not the mounted
+      // element). Third-party libraries such as react-number-format that use
+      // customInput perform DOM operations (e.g. document.contains, identity
+      // checks) against e.target and fail silently when it is detached.
+      //
+      // We normalise the event by re-pointing target/currentTarget to the real
+      // input. We deliberately do NOT clone nativeEvent to avoid breaking
+      // preventDefault() / stopPropagation() (Illegal invocation risk).
+      if (realInput && e.target !== realInput) {
+        return onChange(
+          Object.create(e, {
+            target: { value: realInput, enumerable: true, configurable: true },
+            currentTarget: { value: realInput, enumerable: true, configurable: true },
+          }) as React.ChangeEvent<HTMLInputElement>,
+        );
+      }
+      onChange(e);
+    }
   };
 
   const suffixNode = (hasFeedback || suffix) && (

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -237,15 +237,14 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       // We normalise the event by re-pointing target/currentTarget to the real
       // input. We deliberately do NOT clone nativeEvent to avoid breaking
       // preventDefault() / stopPropagation() (Illegal invocation risk).
-      if (realInput && e.target !== realInput) {
-        return onChange(
-          Object.create(e, {
-            target: { value: realInput, enumerable: true, configurable: true },
-            currentTarget: { value: realInput, enumerable: true, configurable: true },
-          }) as React.ChangeEvent<HTMLInputElement>,
-        );
-      }
-      onChange(e);
+      const normalizedEvent =
+        realInput && e.target !== realInput
+          ? (Object.create(e, {
+              target: { value: realInput, enumerable: true, configurable: true },
+              currentTarget: { value: realInput, enumerable: true, configurable: true },
+            }) as React.ChangeEvent<HTMLInputElement>)
+          : e;
+      onChange(normalizedEvent);
     }
   };
 

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -355,6 +355,29 @@ describe('Input allowClear', () => {
     expect(container.querySelector('input')?.value).toBe('');
   });
 
+  it('onChange event.target should be the real mounted input element', () => {
+    // Regression: @rc-component/input's cloneEvent creates a detached DOM clone
+    // as event.target, breaking libraries like react-number-format that check
+    // e.target identity or call document.contains(e.target).
+    // See: https://github.com/ant-design/ant-design/issues/46999
+    let receivedTarget: EventTarget | null = null;
+
+    const { container } = render(
+      <Input
+        onChange={(e) => {
+          receivedTarget = e.target;
+        }}
+      />,
+    );
+
+    const input = container.querySelector('input')!;
+    fireEvent.change(input, { target: { value: '123' } });
+
+    // The target must be the real mounted <input>, not a detached clone
+    expect(receivedTarget).toBe(input);
+    expect(document.contains(receivedTarget as Node)).toBe(true);
+  });
+
   it('should trigger event correctly on controlled mode', () => {
     let argumentEventObjectType;
     let argumentEventObjectValue;

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -355,17 +355,19 @@ describe('Input allowClear', () => {
     expect(container.querySelector('input')?.value).toBe('');
   });
 
-  it('onChange event.target should be the real mounted input element', () => {
+  it('onChange event.target and currentTarget should be the real mounted input element', () => {
     // Regression: @rc-component/input's cloneEvent creates a detached DOM clone
     // as event.target, breaking libraries like react-number-format that check
     // e.target identity or call document.contains(e.target).
     // See: https://github.com/ant-design/ant-design/issues/46999
     let receivedTarget: EventTarget | null = null;
+    let receivedCurrentTarget: EventTarget | null = null;
 
     const { container } = render(
       <Input
         onChange={(e) => {
           receivedTarget = e.target;
+          receivedCurrentTarget = e.currentTarget;
         }}
       />,
     );
@@ -373,8 +375,9 @@ describe('Input allowClear', () => {
     const input = container.querySelector('input')!;
     fireEvent.change(input, { target: { value: '123' } });
 
-    // The target must be the real mounted <input>, not a detached clone
+    // Both target and currentTarget must be the real mounted <input>, not a detached clone
     expect(receivedTarget).toBe(input);
+    expect(receivedCurrentTarget).toBe(input);
     expect(document.contains(receivedTarget as Node)).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

  Fixes #46999 — `Input` is incompatible with `react-number-format`'s `customInput` feature since v5.13.3.

  ## Root Cause

  `@rc-component/input`'s `resolveOnChange` calls `cloneEvent()` which does:

  ```ts
  const currentTarget = target.cloneNode(true); // detached clone
  const newEvent = Object.create(event, {
    target: { value: currentTarget },
    currentTarget: { value: currentTarget },
  });

  This means e.target in every onChange handler is a detached DOM node, not the mounted <input>. Libraries like
  react-number-format that use customInput call document.contains(e.target) and perform identity checks that fail
  silently against a detached clone, causing cursor jumps and broken input behaviour.

  Fix

  In handleChange, detect when e.target !== realInput and wrap the event in a thin Object.create override restoring
  target/currentTarget to the real element.

  Why not clone nativeEvent? PR #57032 tried that but reviewers noted it causes "Illegal invocation" because
  Object.create(nativeEvent) is not a real Event instance. This fix leaves nativeEvent untouched (inherited via
  prototype chain from the original synthetic event).

  Test

  Added unit test asserting e.target === container.querySelector('input') and document.contains(e.target) === true after
   fireEvent.change.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#46999: Antd Input: To use with react-number-format customInput feature.](https://oss.issuehunt.io/repos/34526884/issues/46999)
---
</details>
<!-- /Issuehunt content-->