### PR TITLE
fix(Tree): prevent scrolling to top when clicking node

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@rc-component/textarea": "~1.1.2",
     "@rc-component/tooltip": "~1.4.0",
     "@rc-component/tour": "~2.3.0",
-    "@rc-component/tree": "~1.2.3",
+    "@rc-component/tree": "~1.2.4",
     "@rc-component/tree-select": "~1.8.0",
     "@rc-component/trigger": "^3.9.0",
     "@rc-component/upload": "~1.1.0",


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #57239

### 💡 需求背景和解决方案

Tree 组件在开启虚拟滚动（设置 `height`）时，当用户滚动到底部并点击节点（例如触发 Dropdown 右键菜单），树会自动滚回顶部。此问题在 6.3.1 版本出现，6.2.0 正常。

解决方案：升级 `@rc-component/tree` 从 `~1.2.3` 到 `~1.2.4`，该版本修复了上游虚拟滚动在点击节点时意外重置 scrollTop 的问题。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Tree scrolling to top when clicking node in scroll mode. |
| 🇨🇳 中文 | 修复 Tree 在滚动情况下点击节点会导致滚动回到顶部的问题。 |

Made with [Cursor](https://cursor.com)