### PR TITLE
test: add page load wait logic for reliable image capture

### DIFF
--- a/tests/shared/imageTest.tsx
+++ b/tests/shared/imageTest.tsx
@@ -241,20 +241,19 @@ export default function imageTest(
         await page.setViewport({ width: 800, height: bodyHeight, ...sharedViewportConfig });
       }
 
-      await page.waitForFunction(
-        () =>
+      await page.waitForFunction(() =>
+        Promise.race([
+          // timeout 100ms
+          new Promise((resolve) => setTimeout(() => resolve(true), 100)),
+          // raf * 2
           new Promise((resolve) => {
-            const timeout = setTimeout(() => resolve(true), 100);
-            if (document.readyState === 'complete') {
-              clearTimeout(timeout);
-              resolve(true);
-            } else {
-              window.addEventListener('load', () => {
-                clearTimeout(timeout);
+            requestAnimationFrame(() => {
+              requestAnimationFrame(() => {
                 resolve(true);
               });
-            }
+            });
           }),
+        ]),
       );
 
       const image = await page.screenshot({ fullPage: !options.onlyViewport });

--- a/tests/shared/imageTest.tsx
+++ b/tests/shared/imageTest.tsx
@@ -240,6 +240,23 @@ export default function imageTest(
         );
         await page.setViewport({ width: 800, height: bodyHeight, ...sharedViewportConfig });
       }
+
+      await page.waitForFunction(
+        () =>
+          new Promise((resolve) => {
+            const timeout = setTimeout(() => resolve(true), 100);
+            if (document.readyState === 'complete') {
+              clearTimeout(timeout);
+              resolve(true);
+            } else {
+              window.addEventListener('load', () => {
+                clearTimeout(timeout);
+                resolve(true);
+              });
+            }
+          }),
+      );
+
       const image = await page.screenshot({ fullPage: !options.onlyViewport });
       await fse.writeFile(path.join(snapshotPath, `${identifier}${suffix}.png`), image);
       MockDate.reset();


### PR DESCRIPTION
Add waitForFunction with timeout-based load detection to ensure images are captured properly after page is fully loaded, improving test reliability across different loading conditions.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [x] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      -     |
| 🇨🇳 Chinese |     -      |
