### PR TITLE
chore: add Cursor skills symlink

### DIFF
--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🛠 重构
- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无直接关联 issue，此改动用于为 AI 辅助开发补充 Cursor skills 软链，方便后续自动化协作。

### 💡 需求背景和解决方案

- 背景：当前仓库使用 `.claude/skills` 维护 AI 助手能力，但 Cursor 默认从 `.cursor/skills` 位置加载技能定义，需要一个链接打通两者。
- 方案：在仓库根目录新增 `.cursor/skills` 软链接，指向现有的 `../.claude/skills` 目录，使不同编辑器/助手可以共享同一套技能配置。
- 该改动不影响构建产物、Runtime 行为或组件 API，仅影响本地开发体验。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🛠 chore add symlink from `.cursor/skills` to `.claude/skills` to share AI assistant skills configuration in local development. |
| 🇨🇳 中文 | 🛠 chore 新增 `.cursor/skills` 指向 `.claude/skills` 的软链接，方便本地开发时在不同编辑器中共享 AI 助手技能配置。 |

Made with [Cursor](https://cursor.com)