### PR TITLE
fix: add transition for backdrop-filter on Image preview mask blur

### DIFF
--- a/components/image/style/index.ts
+++ b/components/image/style/index.ts
@@ -146,6 +146,8 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken, CSSObject> = (token
         inset: 0,
         position: 'absolute',
         background: colorBgMask,
+        backdropFilter: 'blur(0px)',
+        transition: `backdrop-filter ${motionDurationSlow}`,
         [`&${componentCls}-preview-mask-blur`]: {
           backdropFilter: 'blur(4px)',
         },


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] 💄 Component style improvement

### 🔗 Related Issues

close #55955

### 💡 Background and Solution

**Problem:** When opening the Image preview with `mask: { blur: true }`, the `backdrop-filter: blur(4px)` effect is applied instantly without any transition animation. This creates a jarring visual experience compared to the smooth fade animation of the mask's background opacity.

**Root Cause:** The preview mask element's `backdrop-filter` property was being toggled via the `.ant-image-preview-mask-blur` CSS class without any CSS transition defined for the `backdrop-filter` property. While the mask's opacity transitions smoothly via the parent preview's fade animation, `backdrop-filter` does not inherit this transition behavior and needs its own explicit transition.

**Solution:** 
- Add `backdropFilter: 'blur(0px)'` as the default state on the mask element, providing a transition origin
- Add `transition: backdrop-filter ${motionDurationSlow}` to the mask element so the blur effect transitions smoothly from `blur(0px)` to `blur(4px)` when the `.ant-image-preview-mask-blur` class is applied

This ensures the blur effect fades in smoothly alongside the mask's background opacity, creating a cohesive enter/leave animation.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Image preview mask blur transition not working. |
| 🇨🇳 Chinese | 🐞 修复 Image 预览遮罩模糊效果没有过渡动画的问题。 |