### PR TITLE
fix(Tree): correct custom switcherIcon className when showLine is enabled

### DIFF
--- a/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -6369,7 +6369,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx extend context correctly
             >
               <span
                 aria-label="down"
-                class="anticon anticon-down ant-tree-switcher-icon"
+                class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
               >
                 <svg
@@ -6420,7 +6420,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx extend context correctly
             >
               <span
                 aria-label="down"
-                class="anticon anticon-down ant-tree-switcher-icon"
+                class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
               >
                 <svg
@@ -6582,7 +6582,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx extend context correctly
             >
               <span
                 aria-label="down"
-                class="anticon anticon-down ant-tree-switcher-icon"
+                class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
               >
                 <svg
@@ -6633,7 +6633,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx extend context correctly
             >
               <span
                 aria-label="down"
-                class="anticon anticon-down ant-tree-switcher-icon"
+                class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
               >
                 <svg

--- a/components/tree/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo.test.ts.snap
@@ -6247,7 +6247,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx correctly 1`] = `
             >
               <span
                 aria-label="down"
-                class="anticon anticon-down ant-tree-switcher-icon"
+                class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
               >
                 <svg
@@ -6298,7 +6298,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx correctly 1`] = `
             >
               <span
                 aria-label="down"
-                class="anticon anticon-down ant-tree-switcher-icon"
+                class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
               >
                 <svg
@@ -6460,7 +6460,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx correctly 1`] = `
             >
               <span
                 aria-label="down"
-                class="anticon anticon-down ant-tree-switcher-icon"
+                class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
               >
                 <svg
@@ -6511,7 +6511,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx correctly 1`] = `
             >
               <span
                 aria-label="down"
-                class="anticon anticon-down ant-tree-switcher-icon"
+                class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
               >
                 <svg

--- a/components/tree/__tests__/index.test.tsx
+++ b/components/tree/__tests__/index.test.tsx
@@ -140,6 +140,49 @@ describe('Tree', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
+  // https://github.com/ant-design/ant-design/issues/57301
+  it('custom switcherIcon should have switcher-line-icon className when showLine is enabled', () => {
+    const { container } = render(
+      <Tree showLine switcherIcon={<i className="custom-switcher" />} defaultExpandAll>
+        <TreeNode title="parent" key="0-0">
+          <TreeNode title="child" key="0-0-0" />
+        </TreeNode>
+      </Tree>,
+    );
+    const customIcon = container.querySelector('.custom-switcher');
+    expect(customIcon).toBeTruthy();
+    expect(customIcon).toHaveClass('ant-tree-switcher-line-icon');
+    expect(customIcon).not.toHaveClass('ant-tree-switcher-icon');
+  });
+
+  it('custom switcherIcon should have switcher-icon className when showLine is disabled', () => {
+    const { container } = render(
+      <Tree switcherIcon={<i className="custom-switcher" />} defaultExpandAll>
+        <TreeNode title="parent" key="0-0">
+          <TreeNode title="child" key="0-0-0" />
+        </TreeNode>
+      </Tree>,
+    );
+    const customIcon = container.querySelector('.custom-switcher');
+    expect(customIcon).toBeTruthy();
+    expect(customIcon).toHaveClass('ant-tree-switcher-icon');
+    expect(customIcon).not.toHaveClass('ant-tree-switcher-line-icon');
+  });
+
+  it('custom switcherIcon as render function should have switcher-line-icon className when showLine is enabled', () => {
+    const { container } = render(
+      <Tree showLine defaultExpandAll switcherIcon={() => <i className="custom-fn-switcher" />}>
+        <TreeNode title="parent" key="0-0">
+          <TreeNode title="child" key="0-0-0" />
+        </TreeNode>
+      </Tree>,
+    );
+    const customIcon = container.querySelector('.custom-fn-switcher');
+    expect(customIcon).toBeTruthy();
+    expect(customIcon).toHaveClass('ant-tree-switcher-line-icon');
+    expect(customIcon).not.toHaveClass('ant-tree-switcher-icon');
+  });
+
   it('switcherIcon in Tree could be render prop function', () => {
     const { container } = render(
       <Tree

--- a/components/tree/__tests__/index.test.tsx
+++ b/components/tree/__tests__/index.test.tsx
@@ -140,49 +140,6 @@ describe('Tree', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
-  // https://github.com/ant-design/ant-design/issues/57301
-  it('custom switcherIcon should have switcher-line-icon className when showLine is enabled', () => {
-    const { container } = render(
-      <Tree showLine switcherIcon={<i className="custom-switcher" />} defaultExpandAll>
-        <TreeNode title="parent" key="0-0">
-          <TreeNode title="child" key="0-0-0" />
-        </TreeNode>
-      </Tree>,
-    );
-    const customIcon = container.querySelector('.custom-switcher');
-    expect(customIcon).toBeTruthy();
-    expect(customIcon).toHaveClass('ant-tree-switcher-line-icon');
-    expect(customIcon).not.toHaveClass('ant-tree-switcher-icon');
-  });
-
-  it('custom switcherIcon should have switcher-icon className when showLine is disabled', () => {
-    const { container } = render(
-      <Tree switcherIcon={<i className="custom-switcher" />} defaultExpandAll>
-        <TreeNode title="parent" key="0-0">
-          <TreeNode title="child" key="0-0-0" />
-        </TreeNode>
-      </Tree>,
-    );
-    const customIcon = container.querySelector('.custom-switcher');
-    expect(customIcon).toBeTruthy();
-    expect(customIcon).toHaveClass('ant-tree-switcher-icon');
-    expect(customIcon).not.toHaveClass('ant-tree-switcher-line-icon');
-  });
-
-  it('custom switcherIcon as render function should have switcher-line-icon className when showLine is enabled', () => {
-    const { container } = render(
-      <Tree showLine defaultExpandAll switcherIcon={() => <i className="custom-fn-switcher" />}>
-        <TreeNode title="parent" key="0-0">
-          <TreeNode title="child" key="0-0-0" />
-        </TreeNode>
-      </Tree>,
-    );
-    const customIcon = container.querySelector('.custom-fn-switcher');
-    expect(customIcon).toBeTruthy();
-    expect(customIcon).toHaveClass('ant-tree-switcher-line-icon');
-    expect(customIcon).not.toHaveClass('ant-tree-switcher-icon');
-  });
-
   it('switcherIcon in Tree could be render prop function', () => {
     const { container } = render(
       <Tree

--- a/components/tree/utils/iconUtil.tsx
+++ b/components/tree/utils/iconUtil.tsx
@@ -65,7 +65,10 @@ const SwitcherIconCom: React.FC<SwitcherIconProps> = (props) => {
 
   if (React.isValidElement<{ className?: string }>(switcher)) {
     return cloneElement(switcher, {
-      className: clsx(switcher.props?.className, switcherCls),
+      className: clsx(
+        switcher.props?.className,
+        showLine ? `${prefixCls}-switcher-line-icon` : switcherCls,
+      ),
     });
   }
 


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #57301

### 💡 需求背景和解决方案

当 Tree 组件开启 `showLine` 并使用自定义 `switcherIcon` 时，自定义图标只会被注入 `ant-tree-switcher-icon` 类名，而不是 `ant-tree-switcher-line-icon`。这与内置图标的行为不一致，导致绑定在 `ant-tree-switcher-line-icon` 上的 `vertical-align` 样式丢失，展开收起按钮垂直居中异常。

修复方式：在 `iconUtil.tsx` 中，当 `showLine` 为 `true` 时，为自定义 `switcherIcon` 元素注入 `${prefixCls}-switcher-line-icon` 类名，与内置图标保持一致。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Tree custom `switcherIcon` missing `switcher-line-icon` className when `showLine` is enabled. |
| 🇨🇳 中文 | 🐞 Tree 修复开启 `showLine` 时自定义 `switcherIcon` 缺少 `switcher-line-icon` 类名导致样式异常的问题。 |

Made with [Cursor](https://cursor.com)