### PR TITLE
docs: fix redundant characters in zh-CN blog and spec

### DIFF
--- a/docs/blog/notification-stack.zh-CN.md
+++ b/docs/blog/notification-stack.zh-CN.md
@@ -6,7 +6,7 @@ author: MadCcc
 
 ### 堆叠
 
-在 5.10.0 中，我们为 Notification 组件引入了一个新的特性，让原本会堆满屏幕的的醒目提醒堆叠到了一起，让原本紧张感满满的组件迎来了一丝灵动：
+在 5.10.0 中，我们为 Notification 组件引入了一个新的特性，让原本会堆满屏幕的醒目提醒堆叠到了一起，让原本紧张感满满的组件迎来了一丝灵动：
 
 ![Image](https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*ZAFSQ60WMVEAAAAAAAAAAAAADrJ8AQ/original)
 

--- a/docs/spec/detail-page.zh-CN.md
+++ b/docs/spec/detail-page.zh-CN.md
@@ -47,7 +47,7 @@ title: 详情页
 <img class="preview-img no-padding" src="https://gw.alipayobjects.com/mdn/rms_08e378/afts/img/A*tKooSqMRdTEAAAAAAAAAAABkARQnAQ">
 </ImagePreview>
 
-基础详情单页直接平铺所有需要展示信息，推荐使用这种详情展示方式。
+基础详情单页直接平铺所有需要展示的信息，推荐使用这种详情展示方式。
 
 #### [模板 -  基础详情](https://preview.pro.ant.design/profile/basic)
 

--- a/docs/spec/detail-page.zh-CN.md
+++ b/docs/spec/detail-page.zh-CN.md
@@ -47,7 +47,7 @@ title: 详情页
 <img class="preview-img no-padding" src="https://gw.alipayobjects.com/mdn/rms_08e378/afts/img/A*tKooSqMRdTEAAAAAAAAAAABkARQnAQ">
 </ImagePreview>
 
-基础详情单页直接平铺所有需要展示的的信息，推荐使用这种详情展示方式。
+基础详情单页直接平铺所有需要展示信息，推荐使用这种详情展示方式。
 
 #### [模板 -  基础详情](https://preview.pro.ant.design/profile/basic)
 
@@ -127,7 +127,7 @@ title: 详情页
 <img class="preview-img no-padding" src="https://gw.alipayobjects.com/mdn/rms_08e378/afts/img/A*3jPZSa8n2g4AAAAAAAAAAABkARQnAQ">
 </ImagePreview>
 
-根据各个信息之间的相关性，判断各个信息模块之间的亲密度。通常情况下，相关性强的内容尽量靠近，相关性弱的的内容尽量拉开层次。
+根据各个信息之间的相关性，判断各个信息模块之间的亲密度。通常情况下，相关性强的内容尽量靠近，相关性弱的内容尽量拉开层次。
 
 - 不通栏分割线：将相关内容分开；
 - 通栏分割线：将内容分成多个部分；


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无。

### 💡 需求背景和解决方案

修正中文文档中的赘字与笔误：博客 `notification-stack.zh-CN.md` 中「的的醒目」改为「的醒目」；规范页 `detail-page.zh-CN.md` 中「的的信息」「弱的的内容」等重复「的」已删除。仅文案修改，无 API/交互变更。

### 📝 更新日志

| 语言    | 更新描述     |
| ------- | ------------ |
| 🇺🇸 英文 | N/A          |
| 🇨🇳 中文 | 无需更新     |

Made with [Cursor](https://cursor.com)