### PR TITLE
Revert "chore: bump jsdom from 28.1.0 to 29.0.0 in the dev-dependencie"

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
     "jest-image-snapshot": "^6.5.1",
     "jest-puppeteer": "^11.0.0",
     "jquery": "^4.0.0",
-    "jsdom": "~29.0.0",
+    "jsdom": "~28.1.0",
     "jsonml-to-react-element": "^1.1.11",
     "jsonml.js": "^0.1.0",
     "lint-staged": "^16.2.7",


### PR DESCRIPTION
Reverts ant-design/ant-design#57311