### PR TITLE
feat(Message): add stack support

### DIFF
--- a/components/message/__tests__/hooks.test.tsx
+++ b/components/message/__tests__/hooks.test.tsx
@@ -391,4 +391,38 @@ describe('message.hooks', () => {
       expect(clearTimeout).toHaveBeenCalledTimes(1);
     });
   });
+
+  it('should support stack', () => {
+    const Demo = () => {
+      const [api, holder] = message.useMessage({ stack: { threshold: 3 } });
+
+      React.useEffect(() => {
+        api.info({ content: 'test1', duration: 0 });
+        api.info({ content: 'test2', duration: 0 });
+        api.info({ content: 'test3', duration: 0 });
+      }, []);
+
+      return holder;
+    };
+
+    render(<Demo />);
+
+    expect(document.querySelector('.ant-message-stack')).toBeTruthy();
+  });
+
+  it('should disable stack', () => {
+    const Demo = () => {
+      const [api, holder] = message.useMessage({ stack: false });
+
+      React.useEffect(() => {
+        api.info({ content: 'test', duration: 0 });
+      }, []);
+
+      return holder;
+    };
+
+    render(<Demo />);
+
+    expect(document.querySelector('.ant-message-stack')).toBeFalsy();
+  });
 });

--- a/components/message/demo/stack.md
+++ b/components/message/demo/stack.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+堆叠模式，超过阈值时会将消息折叠在一起。可以通过 `threshold` 来设置不会被折叠的最大数量。
+
+## en-US
+
+Stack mode, messages will be stacked together when exceeding the threshold. You can set the maximum number that will not be stacked by `threshold`.

--- a/components/message/demo/stack.tsx
+++ b/components/message/demo/stack.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Button, Divider, InputNumber, message, Space, Switch } from 'antd';
+
+const App: React.FC = () => {
+  const [enabled, setEnabled] = React.useState(true);
+  const [threshold, setThreshold] = React.useState(3);
+  const [messageApi, contextHolder] = message.useMessage({
+    stack: enabled
+      ? {
+          threshold,
+        }
+      : false,
+  });
+
+  const openMessage = () => {
+    messageApi.open({
+      type: 'success',
+      content: 'This is a success message',
+      duration: 0,
+    });
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <div>
+        <Space size="large">
+          <Space style={{ width: '100%' }}>
+            <span>Enabled: </span>
+            <Switch checked={enabled} onChange={(v) => setEnabled(v)} />
+          </Space>
+          <Space style={{ width: '100%' }}>
+            <span>Threshold: </span>
+            <InputNumber
+              disabled={!enabled}
+              value={threshold}
+              step={1}
+              min={1}
+              max={10}
+              onChange={(v) => setThreshold(v || 0)}
+            />
+          </Space>
+        </Space>
+        <Divider />
+        <Button type="primary" onClick={openMessage}>
+          Open the message
+        </Button>
+      </div>
+    </>
+  );
+};
+
+export default App;

--- a/components/message/index.en-US.md
+++ b/components/message/index.en-US.md
@@ -26,6 +26,7 @@ demo:
 <code src="./demo/custom-style.tsx">Customized style</code>
 <code src="./demo/style-class.tsx" version="6.0.0">Custom semantic dom styling</code>
 <code src="./demo/update.tsx">Update Message Content</code>
+<code src="./demo/stack.tsx">Stack</code>
 <code src="./demo/info.tsx">Static method (deprecated)</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>
 <code src="./demo/component-token.tsx" debug>Component Token</code>
@@ -112,6 +113,7 @@ message.config({
 | maxCount | Max message show, drop oldest if exceed limit | number | - |  |
 | prefixCls | The prefix className of message node | string | `ant-message` | 4.5.0 |
 | rtl | Whether to enable RTL mode | boolean | false |  |
+| stack | Stack messages when exceeding threshold | boolean \| { threshold?: number } | `{ threshold: 3 }` |  |
 | top | Distance from top | string \| number | 8 |  |
 
 ## Semantic DOM

--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -53,10 +53,10 @@ let taskQueue: Task[] = [];
 let defaultGlobalConfig: ConfigOptions = {};
 
 function getGlobalContext() {
-  const { getContainer, duration, rtl, maxCount, top } = defaultGlobalConfig;
+  const { getContainer, duration, rtl, maxCount, top, stack } = defaultGlobalConfig;
   const mergedContainer = getContainer?.() || document.body;
 
-  return { getContainer: () => mergedContainer, duration, rtl, maxCount, top };
+  return { getContainer: () => mergedContainer, duration, rtl, maxCount, top, stack };
 }
 
 interface GlobalHolderRef {

--- a/components/message/index.zh-CN.md
+++ b/components/message/index.zh-CN.md
@@ -27,6 +27,7 @@ demo:
 <code src="./demo/custom-style.tsx">自定义样式</code>
 <code src="./demo/style-class.tsx" version="6.0.0">自定义语义结构的样式和类</code>
 <code src="./demo/update.tsx">更新消息内容</code>
+<code src="./demo/stack.tsx">堆叠</code>
 <code src="./demo/info.tsx">静态方法（不推荐）</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>
 <code src="./demo/component-token.tsx" debug>组件 Token</code>
@@ -112,6 +113,7 @@ message.config({
 | maxCount | 最大显示数，超过限制时，最早的消息会被自动关闭 | number | - |  |
 | prefixCls | 消息节点的 className 前缀 | string | `ant-message` | 4.5.0 |
 | rtl | 是否开启 RTL 模式 | boolean | false |  |
+| stack | 堆叠模式，超出阈值时会将消息折叠 | boolean \| { threshold?: number } | `{ threshold: 3 }` |  |
 | top | 消息距离顶部的位置 | string \| number | 8 |  |
 
 ## Semantic DOM

--- a/components/message/interface.ts
+++ b/components/message/interface.ts
@@ -35,6 +35,11 @@ export interface ConfigOptions {
    * @descEN keep the timer running or not on hover
    */
   pauseOnHover?: boolean;
+  /**
+   * @descCN 堆叠模式，超出阈值时会将消息折叠
+   * @descEN Stack mode, messages will be stacked when exceeding the threshold
+   */
+  stack?: boolean | { threshold?: number };
   classNames?: ArgsClassNamesType;
   styles?: ArgsStylesType;
 }

--- a/components/message/style/index.ts
+++ b/components/message/style/index.ts
@@ -6,6 +6,7 @@ import { CONTAINER_MAX_OFFSET } from '../../_util/hooks';
 import { resetComponent } from '../../style';
 import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genStyleHooks, mergeToken } from '../../theme/internal';
+import genStackStyle from './stack';
 
 /** Component only token. Which will handle additional calculation of alias token */
 export interface ComponentToken {
@@ -31,13 +32,18 @@ export interface ComponentToken {
  * @desc Message 组件的 Token
  * @descEN Token for Message component
  */
-interface MessageToken extends FullToken<'Message'> {
+export interface MessageToken extends FullToken<'Message'> {
   // Custom token here
   /**
    * @desc 提示框高度
    * @descEN Height of Message
    */
   height: number;
+  /**
+   * @desc 提示框堆叠层数
+   * @descEN Stack layer of Message
+   */
+  messageStackLayer: number;
 }
 
 const genMessageStyle: GenerateStyle<MessageToken> = (token) => {
@@ -210,8 +216,11 @@ export default genStyleHooks(
   'Message',
   (token) => {
     // Gen-style functions here
-    const combinedToken = mergeToken<MessageToken>(token, { height: 150 });
-    return genMessageStyle(combinedToken);
+    const combinedToken = mergeToken<MessageToken>(token, {
+      height: 150,
+      messageStackLayer: 3,
+    });
+    return [genMessageStyle(combinedToken), genStackStyle(combinedToken)];
   },
   prepareComponentToken,
 );

--- a/components/message/style/stack.ts
+++ b/components/message/style/stack.ts
@@ -1,0 +1,89 @@
+import type { CSSObject } from '@ant-design/cssinjs';
+
+import type { MessageToken } from '.';
+import type { GenerateStyle } from '../../theme/internal';
+
+const genStackChildrenStyle: GenerateStyle<MessageToken, CSSObject> = (token) => {
+  const childrenStyle: CSSObject = {};
+  for (let i = 1; i < token.messageStackLayer; i++) {
+    childrenStyle[`&:nth-last-child(${i + 1})`] = {
+      overflow: 'hidden',
+
+      [`& > ${token.componentCls}-notice`]: {
+        opacity: 0,
+        transition: `opacity ${token.motionDurationMid}`,
+      },
+    };
+  }
+
+  return {
+    [`&:not(:nth-last-child(-n+${token.messageStackLayer}))`]: {
+      opacity: 0,
+      overflow: 'hidden',
+      color: 'transparent',
+      pointerEvents: 'none',
+    },
+    ...childrenStyle,
+  };
+};
+
+const genStackedNoticeStyle: GenerateStyle<MessageToken, CSSObject> = (token) => {
+  const childrenStyle: CSSObject = {};
+  for (let i = 1; i < token.messageStackLayer; i++) {
+    childrenStyle[`&:nth-last-child(${i + 1})`] = {
+      background: token.colorBgBlur,
+      backdropFilter: 'blur(10px)',
+      '-webkit-backdrop-filter': 'blur(10px)',
+    };
+  }
+  return childrenStyle;
+};
+
+const genStackStyle: GenerateStyle<MessageToken, CSSObject> = (token) => {
+  const { componentCls } = token;
+  return {
+    [`${componentCls}-stack`]: {
+      [`& > ${componentCls}-notice-wrapper`]: {
+        transition: `transform ${token.motionDurationSlow}, backdrop-filter 0s`,
+        willChange: 'transform, opacity',
+        position: 'absolute',
+        top: 0,
+        left: { value: 0, _skip_check_: true },
+
+        ...genStackChildrenStyle(token),
+      },
+    },
+    [`${componentCls}-stack:not(${componentCls}-stack-expanded)`]: {
+      [`& > ${componentCls}-notice-wrapper`]: {
+        ...genStackedNoticeStyle(token),
+      },
+    },
+    [`${componentCls}-stack${componentCls}-stack-expanded`]: {
+      [`& > ${componentCls}-notice-wrapper`]: {
+        '&:not(:nth-last-child(-n + 1))': {
+          opacity: 1,
+          overflow: 'unset',
+          color: 'inherit',
+          pointerEvents: 'auto',
+
+          [`& > ${token.componentCls}-notice`]: {
+            opacity: 1,
+          },
+        },
+
+        '&:after': {
+          content: '""',
+          position: 'absolute',
+          height: token.margin,
+          width: '100%',
+          insetInline: 0,
+          bottom: token.calc(token.margin).mul(-1).equal(),
+          background: 'transparent',
+          pointerEvents: 'auto',
+        },
+      },
+    },
+  };
+};
+
+export default genStackStyle;

--- a/components/message/useMessage.tsx
+++ b/components/message/useMessage.tsx
@@ -21,6 +21,7 @@ import { ConfigContext } from '../config-provider';
 import { useComponentConfig } from '../config-provider/context';
 import type { MessageConfig } from '../config-provider/context';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
+import { useToken } from '../theme/internal';
 import type {
   ArgsClassNamesType,
   ArgsProps,
@@ -87,9 +88,11 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     transitionName,
     onAllRemoved,
     pauseOnHover = true,
+    stack,
   } = props;
   const { getPrefixCls, direction, getPopupContainer } = useComponentConfig('message');
   const { message } = React.useContext(ConfigContext);
+  const [, token] = useToken();
 
   const prefixCls = staticPrefixCls || getPrefixCls('message');
 
@@ -129,6 +132,14 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     onAllRemoved,
     renderNotifications,
     pauseOnHover,
+    stack:
+      stack === false
+        ? false
+        : {
+            threshold: typeof stack === 'object' ? stack?.threshold : undefined,
+            offset: 8,
+            gap: token.margin,
+          },
   });
 
   // ================================ Ref ================================


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature

### 🔗 Related Issues

close #57323

### 💡 Background and Solution

The Notification component already supports a `stack` prop that collapses notifications when they exceed a threshold. This PR brings the same capability to the Message component.

**Changes:**
- Added `stack` prop to `ConfigOptions` interface (`boolean | { threshold?: number }`)
- Updated `useMessage` hook to pass `stack` configuration to the underlying `@rc-component/notification`
- Created `style/stack.ts` with stack-specific styles (collapse animation, backdrop blur, opacity transitions)
- Updated `style/index.ts` with `messageStackLayer` token
- Updated static API (`index.tsx`) to pass `stack` through global config
- Added demo and test cases
- Updated both English and Chinese documentation

**API:**
```tsx
const [messageApi, contextHolder] = message.useMessage({
  stack: { threshold: 3 }, // or true / false
});
```

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Message supports `stack` prop to collapse messages when exceeding threshold. |
| 🇨🇳 Chinese | Message 新增 `stack` 属性，支持消息超出阈值时折叠显示。 |