### PR TITLE
fix(Tree): prevent scroll-to-top when context menu closes and tree regains focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@rc-component/textarea": "~1.2.0",
     "@rc-component/tooltip": "~1.4.0",
     "@rc-component/tour": "~2.4.0",
-    "@rc-component/tree": "~1.3.0",
+    "@rc-component/tree": "~1.3.1",
     "@rc-component/tree-select": "~1.9.0",
     "@rc-component/trigger": "^3.9.0",
     "@rc-component/upload": "~1.1.0",


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- ref https://github.com/react-component/tree/pull/1020

### 💡 需求背景和解决方案

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |      🐛 Fixed an issue where the page scrolls back to the top after triggering the right-click menu interaction on a Tree node.    |
| 🇨🇳 中文 |    - 🐛 修复 Tree 节点触发右键菜单交互后页面回滚到顶部的问题。      |

Made with [Cursor](https://cursor.com)