### PR TITLE
feat(Flex): add childrenFlex prop to apply flex CSS to direct children

### DIFF
--- a/components/flex/__tests__/index.test.tsx
+++ b/components/flex/__tests__/index.test.tsx
@@ -106,6 +106,42 @@ describe('Flex', () => {
     });
   });
 
+  // ============================= childrenFlex =============================
+  describe('Props: childrenFlex', () => {
+    it('should add children-flex class and CSS variable', () => {
+      const { container } = render(
+        <Flex childrenFlex={1}>
+          <div>child1</div>
+          <div>child2</div>
+        </Flex>,
+      );
+      const flexEl = container.querySelector('.ant-flex');
+      expect(flexEl).toHaveClass('ant-flex-children-flex');
+      expect(flexEl).toHaveStyle({ '--ant-flex-children-flex': '1' });
+    });
+
+    it('should support string value', () => {
+      const { container } = render(
+        <Flex childrenFlex="1 0 auto">
+          <div>child1</div>
+          <div>child2</div>
+        </Flex>,
+      );
+      const flexEl = container.querySelector('.ant-flex');
+      expect(flexEl).toHaveClass('ant-flex-children-flex');
+      expect(flexEl).toHaveStyle({ '--ant-flex-children-flex': '1 0 auto' });
+    });
+
+    it('should not add class when childrenFlex is not set', () => {
+      const { container } = render(
+        <Flex>
+          <div>child1</div>
+        </Flex>,
+      );
+      expect(container.querySelector('.ant-flex')).not.toHaveClass('ant-flex-children-flex');
+    });
+  });
+
   // ============================= orientation =============================
   describe('orientation attribute', () => {
     it('vertical=true orientation=horizontal, result orientation=horizontal', () => {

--- a/components/flex/index.en-US.md
+++ b/components/flex/index.en-US.md
@@ -40,6 +40,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | justify | Sets the alignment of elements in the direction of the main axis | [justify-content](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) | normal |  |
 | align | Sets the alignment of elements in the direction of the cross axis | [align-items](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items) | normal |  |
 | flex | flex CSS shorthand properties | [flex](https://developer.mozilla.org/en-US/docs/Web/CSS/flex) | normal |  |
+| childrenFlex | Sets the flex CSS shorthand property for all direct children | [flex](https://developer.mozilla.org/en-US/docs/Web/CSS/flex) | - |  |
 | gap | Sets the gap between grids | `small` \| `medium` \| `large` \| string \| number | - |  |
 | component | custom element type | React.ComponentType | `div` |  |
 | orientation | direction of the flex | `horizontal` \| `vertical` | `horizontal` | - |

--- a/components/flex/index.tsx
+++ b/components/flex/index.tsx
@@ -19,6 +19,7 @@ const Flex = React.forwardRef<HTMLElement, React.PropsWithChildren<FlexProps>>((
     style,
     flex,
     gap,
+    childrenFlex,
     vertical,
     orientation,
     component: Component = 'div',
@@ -50,6 +51,7 @@ const Flex = React.forwardRef<HTMLElement, React.PropsWithChildren<FlexProps>>((
       [`${prefixCls}-rtl`]: ctxDirection === 'rtl',
       [`${prefixCls}-gap-${gap}`]: isPresetSize(gap),
       [`${prefixCls}-vertical`]: mergedVertical,
+      [`${prefixCls}-children-flex`]: isNonNullable(childrenFlex),
     },
   );
 
@@ -61,6 +63,10 @@ const Flex = React.forwardRef<HTMLElement, React.PropsWithChildren<FlexProps>>((
 
   if (isNonNullable(gap) && !isPresetSize(gap)) {
     mergedStyle.gap = gap;
+  }
+
+  if (isNonNullable(childrenFlex)) {
+    (mergedStyle as Record<string, unknown>)['--ant-flex-children-flex'] = childrenFlex;
   }
 
   return (

--- a/components/flex/index.tsx
+++ b/components/flex/index.tsx
@@ -66,7 +66,7 @@ const Flex = React.forwardRef<HTMLElement, React.PropsWithChildren<FlexProps>>((
   }
 
   if (isNonNullable(childrenFlex)) {
-    (mergedStyle as Record<string, unknown>)['--ant-flex-children-flex'] = childrenFlex;
+    mergedStyle['--ant-flex-children-flex'] = childrenFlex;
   }
 
   return (

--- a/components/flex/index.zh-CN.md
+++ b/components/flex/index.zh-CN.md
@@ -41,6 +41,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*8yArQ43EGccAAA
 | justify | 设置元素在主轴方向上的对齐方式 | [justify-content](https://developer.mozilla.org/zh-CN/docs/Web/CSS/justify-content) | normal |  |
 | align | 设置元素在交叉轴方向上的对齐方式 | [align-items](https://developer.mozilla.org/zh-CN/docs/Web/CSS/align-items) | normal |  |
 | flex | flex CSS 简写属性 | [flex](https://developer.mozilla.org/zh-CN/docs/Web/CSS/flex) | normal |  |
+| childrenFlex | 设置所有直接子元素的 flex CSS 简写属性 | [flex](https://developer.mozilla.org/zh-CN/docs/Web/CSS/flex) | - |  |
 | gap | 设置网格之间的间隙 | `small` \| `medium` \| `large` \| string \| number | - |  |
 | component | 自定义元素类型 | React.ComponentType | `div` |  |
 | orientation | 主轴的方向类型 | `horizontal` \| `vertical` | `horizontal` | - |

--- a/components/flex/interface.ts
+++ b/components/flex/interface.ts
@@ -13,6 +13,7 @@ export interface FlexProps<P = AnyObject> extends React.HTMLAttributes<HTMLEleme
   justify?: React.CSSProperties['justifyContent'];
   align?: React.CSSProperties['alignItems'];
   flex?: React.CSSProperties['flex'];
+  childrenFlex?: React.CSSProperties['flex'];
   gap?: LiteralUnion<SizeType, React.CSSProperties['gap']>;
   component?: CustomComponent<P>;
 }

--- a/components/flex/style/index.ts
+++ b/components/flex/style/index.ts
@@ -48,6 +48,9 @@ const genFlexStyle: GenerateStyle<FlexToken, CSSObject> = (token) => {
       '&:empty': {
         display: 'none',
       },
+      '&-children-flex > *': {
+        flex: 'var(--ant-flex-children-flex)',
+      },
     },
   };
 };


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close #56860

### 💡 Background and Solution

The Flex component's existing `flex` prop sets the flex CSS property on the container itself, which is only useful when the Flex component is nested inside another flex container. There was no way to uniformly apply a flex value to all direct children.

This PR adds a `childrenFlex` prop that applies the given flex CSS shorthand to all direct children of the Flex container using a CSS variable + child selector approach (`> *`), avoiding direct style injection on child elements (per maintainer feedback from zombieJ).

**API:**

```tsx
// All children will have flex: 1, occupying equal space
<Flex childrenFlex={1}>
  <Card>Card 1</Card>
  <Card>Card 2</Card>
  <Card>Card 3</Card>
</Flex>

// Supports full flex shorthand
<Flex childrenFlex="1 0 auto">
  <div>Item 1</div>
  <div>Item 2</div>
</Flex>
```

**Implementation:**
1. Added `childrenFlex` prop to `FlexProps` interface (type: `React.CSSProperties['flex']`)
2. When set, adds `ant-flex-children-flex` class and sets `--ant-flex-children-flex` CSS variable on the container
3. CSS rule `&-children-flex > * { flex: var(--ant-flex-children-flex) }` applies the value to all direct children
4. Added 3 unit tests covering numeric values, string values, and absence behavior

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🆕 Add `childrenFlex` prop to Flex component for applying flex CSS to all direct children. |
| 🇨🇳 Chinese | 🆕 为 Flex 组件新增 `childrenFlex` 属性，支持对所有直接子元素统一设置 flex CSS 简写属性。 |