### PR TITLE
fix(Watermark): guard undefined onRemove callback in hook

### DIFF
--- a/components/watermark/useWatermark.ts
+++ b/components/watermark/useWatermark.ts
@@ -30,7 +30,7 @@ function useWatermark(
   isWatermarkEle: (ele: Node, index?: number) => boolean,
 ] {
   const watermarkMapRef = React.useRef(new Map<HTMLElement, HTMLDivElement>());
-  const onRemoveEvent = useEvent(onRemove);
+  const onRemoveEvent = useEvent(onRemove ?? (() => {}));
 
   const appendWatermark = (base64Url: string, markWidth: number, container: HTMLElement) => {
     if (container) {

--- a/components/watermark/useWatermark.ts
+++ b/components/watermark/useWatermark.ts
@@ -15,6 +15,8 @@ const emphasizedStyle: React.CSSProperties = {
   visibility: 'visible !important',
 } as unknown as React.CSSProperties;
 
+const noop = (): void => {};
+
 export type AppendWatermark = (
   base64Url: string,
   markWidth: number,
@@ -30,7 +32,7 @@ function useWatermark(
   isWatermarkEle: (ele: Node, index?: number) => boolean,
 ] {
   const watermarkMapRef = React.useRef(new Map<HTMLElement, HTMLDivElement>());
-  const onRemoveEvent = useEvent(onRemove ?? (() => {}));
+  const onRemoveEvent = useEvent(onRemove ?? noop);
 
   const appendWatermark = (base64Url: string, markWidth: number, container: HTMLElement) => {
     if (container) {


### PR DESCRIPTION
### 🤔 这个变动的性质是？
  - [ ] 🆕 新特性提交
  - [x] 🐞 Bug 修复
  - [ ] 📝 站点、文档改进
  - [ ] 📽️ 演示代码改进
  - [ ] 💄 组件样式/交互改进
  - [ ] 🤖 TypeScript 定义更新
  - [ ] 📦 包体积优化
  - [ ] ⚡️ 性能优化
  - [ ] ⭐️ 功能增强
  - [ ] 🌐 国际化改进
  - [ ] 🛠 重构
  - [ ] 🎨 代码风格优化
  - [ ] ✅ 测试用例
  - [ ] 🔀 分支合并
  - [ ] ⏩ 工作流程
  - [ ] ⌨️ 无障碍改进
  - [ ] ❓ 其他改动（是关于什么的改动？）
  ### 🔗 相关 Issue
  N/A
  ### 💡 需求背景和解决方案
  Watermark 组件的 `useWatermark` 内部使用 `useEvent(onRemove)` 绑定移除回调，当未提供 `onRemove` 时会把
  `undefined` 传入，可能导致调用时抛出异常。
  本 PR 为 `useEvent` 提供一个空函数默认值：`onRemove ?? (() => {})`，保证在未传入回调时调用为
  no-op，不再报错。

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | 🐞 Fix Watermark TypeScript errors when `onRemove` is omitted. |
| 🇨🇳 中文 | 🐞 修复 Watermark 在未传入 `onRemove` 时的 TypeScript 报错。 |
