### PR TITLE
fix: apply custom hover color to SubMenu parent item

### DIFF
--- a/components/menu/style/theme.ts
+++ b/components/menu/style/theme.ts
@@ -90,6 +90,12 @@ const getThemeStyle = (token: MenuToken, themeSuffix: string): CSSInterpolation 
           },
         },
 
+      [`${componentCls}-submenu:not(${componentCls}-submenu-selected)`]: {
+        [`> ${componentCls}-submenu-title:hover`]: {
+          color: itemHoverColor,
+        },
+      },
+
       [`&:not(${componentCls}-horizontal)`]: {
         [`${componentCls}-item:not(${componentCls}-item-selected)`]: {
           '&:hover': {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

> fix https://github.com/ant-design/ant-design/issues/47873

### 💡 Background and Solution

当通过 ConfigProvider 自定义 Menu 的 `itemHoverColor` 时，SubMenu 的父级菜单项（submenu-title）在 hover 状态下没有应用自定义的字体颜色。

修复方法是在 `components/menu/style/theme.ts` 中为 SubMenu 的 hover 状态添加 `itemHoverColor` 样式支持：

```tsx
// SubMenu active (when hover on parent menu item)
[${componentCls}-submenu:not(${componentCls}-submenu-selected)] {
  [> ${componentCls}-submenu-title:hover] {
    color: itemHoverColor,
  },
},
```

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Menu SubMenu parent item not applying custom hover color via ConfigProvider. |
| 🇨🇳 Chinese | 🐞 修复通过 ConfigProvider 自定义 Menu 的 `itemHoverColor` 时，SubMenu 父级菜单项 hover 状态颜色不生效的问题。 |