### PR TITLE
feat(Input): add clear semantic segment for classNames and styles

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -35,6 +35,7 @@ export type InputSemanticType = {
     root?: string;
     prefix?: string;
     suffix?: string;
+    clear?: string;
     input?: string;
     count?: string;
   };
@@ -42,6 +43,7 @@ export type InputSemanticType = {
     root?: React.CSSProperties;
     prefix?: React.CSSProperties;
     suffix?: React.CSSProperties;
+    clear?: React.CSSProperties;
     input?: React.CSSProperties;
     count?: React.CSSProperties;
   };

--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -24,6 +24,7 @@ export type InputSearchSemanticType = {
     input?: string;
     prefix?: string;
     suffix?: string;
+    clear?: string;
     count?: string;
     button?: ButtonSemanticType['classNames'];
   };
@@ -32,6 +33,7 @@ export type InputSearchSemanticType = {
     input?: React.CSSProperties;
     prefix?: React.CSSProperties;
     suffix?: React.CSSProperties;
+    clear?: React.CSSProperties;
     count?: React.CSSProperties;
     button?: ButtonSemanticType['styles'];
   };

--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -31,11 +31,13 @@ export type TextAreaSemanticType = {
   classNames?: {
     root?: string;
     textarea?: string;
+    clear?: string;
     count?: string;
   };
   styles?: {
     root?: React.CSSProperties;
     textarea?: React.CSSProperties;
+    clear?: React.CSSProperties;
     count?: React.CSSProperties;
   };
 };

--- a/components/input/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`renders components/input/demo/_semantic_input.tsx correctly 1`] = `
       class="ant-col ant-col-16 acss-my3sst css-var-test-id"
     >
       <span
-        class="ant-input-affix-wrapper ant-input-outlined css-var-test-id ant-input-css-var semantic-mark-root"
+        class="ant-input-affix-wrapper ant-input-affix-wrapper-input-with-clear-btn ant-input-outlined css-var-test-id ant-input-css-var semantic-mark-root"
       >
         <span
           class="ant-input-prefix semantic-mark-prefix"
@@ -44,6 +44,32 @@ exports[`renders components/input/demo/_semantic_input.tsx correctly 1`] = `
         <span
           class="ant-input-suffix semantic-mark-suffix"
         >
+          <button
+            class="ant-input-clear-icon ant-input-clear-icon-has-suffix semantic-mark-clear"
+            tabindex="-1"
+            type="button"
+          >
+            <span
+              aria-label="close-circle"
+              class="anticon anticon-close-circle"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="close-circle"
+                fill="currentColor"
+                fill-rule="evenodd"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                />
+              </svg>
+            </span>
+          </button>
           <span
             class="ant-input-show-count-suffix ant-input-show-count-has-suffix semantic-mark-count"
           >
@@ -446,6 +472,99 @@ exports[`renders components/input/demo/_semantic_input.tsx correctly 1`] = `
               style="margin: 0px; font-size: 12px;"
             >
               后缀的包裹元素，包含后缀内容的布局和样式
+            </div>
+          </div>
+        </li>
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
+                  clear
+                </h5>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              清除按钮元素，包含清除内容按钮的布局、显隐和交互样式
             </div>
           </div>
         </li>
@@ -963,7 +1082,7 @@ exports[`renders components/input/demo/_semantic_password.tsx correctly 1`] = `
       class="ant-col ant-col-16 acss-my3sst css-var-test-id"
     >
       <span
-        class="ant-input-affix-wrapper ant-input-outlined ant-input-password css-var-test-id ant-input-css-var semantic-mark-root"
+        class="ant-input-affix-wrapper ant-input-affix-wrapper-input-with-clear-btn ant-input-outlined ant-input-password css-var-test-id ant-input-css-var semantic-mark-root"
       >
         <span
           class="ant-input-prefix semantic-mark-prefix"
@@ -996,6 +1115,32 @@ exports[`renders components/input/demo/_semantic_password.tsx correctly 1`] = `
         <span
           class="ant-input-suffix semantic-mark-suffix"
         >
+          <button
+            class="ant-input-clear-icon ant-input-clear-icon-has-suffix semantic-mark-clear"
+            tabindex="-1"
+            type="button"
+          >
+            <span
+              aria-label="close-circle"
+              class="anticon anticon-close-circle"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="close-circle"
+                fill="currentColor"
+                fill-rule="evenodd"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                />
+              </svg>
+            </span>
+          </button>
           <span
             class="ant-input-show-count-suffix ant-input-show-count-has-suffix semantic-mark-count"
           >
@@ -1440,6 +1585,99 @@ exports[`renders components/input/demo/_semantic_password.tsx correctly 1`] = `
                   class="ant-typography css-var-test-id"
                   style="margin: 0px;"
                 >
+                  clear
+                </h5>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              清除按钮元素
+            </div>
+          </div>
+        </li>
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
                   count
                 </h5>
               </div>
@@ -1537,7 +1775,7 @@ exports[`renders components/input/demo/_semantic_search.tsx correctly 1`] = `
         class="ant-space-compact ant-input-search css-var-test-id ant-input-search-with-button semantic-mark-root"
       >
         <span
-          class="ant-input-affix-wrapper ant-input-outlined css-var-test-id ant-input-css-var ant-input-compact-item ant-input-compact-first-item"
+          class="ant-input-affix-wrapper ant-input-affix-wrapper-input-with-clear-btn ant-input-outlined css-var-test-id ant-input-css-var ant-input-compact-item ant-input-compact-first-item"
         >
           <span
             class="ant-input-prefix semantic-mark-prefix"
@@ -1570,6 +1808,32 @@ exports[`renders components/input/demo/_semantic_search.tsx correctly 1`] = `
           <span
             class="ant-input-suffix semantic-mark-suffix"
           >
+            <button
+              class="ant-input-clear-icon ant-input-clear-icon-has-suffix semantic-mark-clear"
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                aria-label="close-circle"
+                class="anticon anticon-close-circle"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="close-circle"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                  />
+                </svg>
+              </span>
+            </button>
             <span
               class="ant-input-show-count-suffix ant-input-show-count-has-suffix semantic-mark-count"
             >
@@ -2025,6 +2289,99 @@ exports[`renders components/input/demo/_semantic_search.tsx correctly 1`] = `
                   class="ant-typography css-var-test-id"
                   style="margin: 0px;"
                 >
+                  clear
+                </h5>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              清除按钮元素
+            </div>
+          </div>
+        </li>
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
                   count
                 </h5>
               </div>
@@ -2398,7 +2755,7 @@ exports[`renders components/input/demo/_semantic_textarea.tsx correctly 1`] = `
       class="ant-col ant-col-16 acss-my3sst css-var-test-id"
     >
       <span
-        class="ant-input-affix-wrapper ant-input-textarea-affix-wrapper ant-input-textarea-show-count ant-input-outlined css-var-test-id ant-input-css-var semantic-mark-root"
+        class="ant-input-affix-wrapper ant-input-affix-wrapper-input-with-clear-btn ant-input-textarea-affix-wrapper ant-input-textarea-show-count ant-input-textarea-allow-clear ant-input-outlined css-var-test-id ant-input-css-var semantic-mark-root"
         data-count="17 / 100"
       >
         <textarea
@@ -2410,6 +2767,32 @@ exports[`renders components/input/demo/_semantic_textarea.tsx correctly 1`] = `
         <span
           class="ant-input-suffix"
         >
+          <button
+            class="ant-input-clear-icon ant-input-clear-icon-has-suffix semantic-mark-clear"
+            tabindex="-1"
+            type="button"
+          >
+            <span
+              aria-label="close-circle"
+              class="anticon anticon-close-circle"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="close-circle"
+                fill="currentColor"
+                fill-rule="evenodd"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                />
+              </svg>
+            </span>
+          </button>
           <span
             class="ant-input-data-count semantic-mark-count"
           >
@@ -2607,6 +2990,99 @@ exports[`renders components/input/demo/_semantic_textarea.tsx correctly 1`] = `
               style="margin: 0px; font-size: 12px;"
             >
               文本域元素，设置字体、行高、内边距、颜色、背景、边框、文本输入和多行文本展示样式
+            </div>
+          </div>
+        </li>
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
+                  clear
+                </h5>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              清除按钮元素，包含清除内容按钮的布局、显隐和交互样式
             </div>
           </div>
         </li>

--- a/components/input/__tests__/semantic.test.tsx
+++ b/components/input/__tests__/semantic.test.tsx
@@ -10,6 +10,7 @@ const testClassNames = {
   input: 'custom-input',
   textarea: 'custom-textarea',
   suffix: 'custom-suffix',
+  clear: 'custom-clear',
   count: 'custom-count',
   separator: 'custom-separator',
   button: {
@@ -25,6 +26,7 @@ const testStyles = {
   textarea: { color: 'rgb(0, 255, 0)' },
   prefix: { color: 'rgb(255, 255, 0)' },
   suffix: { color: 'rgb(128, 0, 128)' },
+  clear: { color: 'rgb(255, 20, 147)' },
   count: { color: 'rgb(255, 165, 0)' },
   separator: { color: 'rgb(255, 192, 203)' },
   button: {
@@ -39,6 +41,7 @@ describe('Input.Semantic', () => {
     const { container } = render(
       <Input
         value="123"
+        allowClear
         showCount
         prefix="prefix"
         suffix="suffix"
@@ -51,6 +54,7 @@ describe('Input.Semantic', () => {
     const input = container.querySelector('.ant-input');
     const prefix = container.querySelector('.ant-input-prefix');
     const suffix = container.querySelector('.ant-input-suffix');
+    const clear = container.querySelector('.custom-clear');
     const count = container.querySelector('.ant-input-show-count-suffix');
 
     expect(root).toHaveClass(testClassNames.root);
@@ -61,23 +65,28 @@ describe('Input.Semantic', () => {
     expect(prefix).toHaveStyle(testStyles.prefix);
     expect(suffix).toHaveClass(testClassNames.suffix);
     expect(suffix).toHaveStyle(testStyles.suffix);
+    expect(clear).toHaveClass(testClassNames.clear);
+    expect(clear).toHaveStyle(testStyles.clear);
     expect(count).toHaveClass(testClassNames.count);
     expect(count).toHaveStyle(testStyles.count);
   });
 
   it('textarea should support classNames and styles', () => {
     const { container } = render(
-      <Input.TextArea classNames={testClassNames} styles={testStyles} showCount />,
+      <Input.TextArea allowClear classNames={testClassNames} styles={testStyles} showCount />,
     );
 
     const root = container.querySelector('.ant-input-textarea-affix-wrapper');
     const textarea = container.querySelector('textarea');
+    const clear = container.querySelector('.custom-clear');
     const count = container.querySelector('.ant-input-data-count');
 
     expect(root).toHaveClass(testClassNames.root);
     expect(root).toHaveStyle(testStyles.root);
     expect(textarea).toHaveClass(testClassNames.textarea);
     expect(textarea).toHaveStyle(testStyles.textarea);
+    expect(clear).toHaveClass(testClassNames.clear);
+    expect(clear).toHaveStyle(testStyles.clear);
     expect(count).toHaveClass(testClassNames.count);
     expect(count).toHaveStyle(testStyles.count);
   });
@@ -86,6 +95,7 @@ describe('Input.Semantic', () => {
     const { container, getByText } = render(
       <Input.Search
         loading
+        allowClear
         enterButton="button text"
         classNames={testClassNames}
         styles={testStyles}
@@ -99,6 +109,7 @@ describe('Input.Semantic', () => {
     const input = container.querySelector('.ant-input');
     const prefix = container.querySelector('.ant-input-prefix');
     const suffix = container.querySelector('.ant-input-suffix');
+    const clear = container.querySelector('.custom-clear');
     const button = container.querySelector('.ant-btn');
     const buttonIcon = container.querySelector('.ant-btn-icon');
     const buttonContent = getByText('button text');
@@ -112,6 +123,8 @@ describe('Input.Semantic', () => {
     expect(prefix).toHaveStyle(testStyles.prefix);
     expect(suffix).toHaveClass(testClassNames.suffix);
     expect(suffix).toHaveStyle(testStyles.suffix);
+    expect(clear).toHaveClass(testClassNames.clear);
+    expect(clear).toHaveStyle(testStyles.clear);
     expect(button).toHaveClass(testClassNames.button.root);
     expect(button).toHaveStyle(testStyles.button.root);
     expect(buttonIcon).toHaveClass(testClassNames.button.icon);
@@ -125,6 +138,7 @@ describe('Input.Semantic', () => {
   it('password should support classNames and styles', () => {
     const { container } = render(
       <Input.Password
+        allowClear
         classNames={testClassNames}
         styles={testStyles}
         showCount
@@ -136,6 +150,7 @@ describe('Input.Semantic', () => {
     const input = container.querySelector('.ant-input');
     const prefix = container.querySelector('.ant-input-prefix');
     const suffix = container.querySelector('.ant-input-suffix');
+    const clear = container.querySelector('.custom-clear');
     const count = container.querySelector('.ant-input-show-count-suffix');
 
     expect(root).toHaveClass(testClassNames.root);
@@ -146,6 +161,8 @@ describe('Input.Semantic', () => {
     expect(prefix).toHaveStyle(testStyles.prefix);
     expect(suffix).toHaveClass(testClassNames.suffix);
     expect(suffix).toHaveStyle(testStyles.suffix);
+    expect(clear).toHaveClass(testClassNames.clear);
+    expect(clear).toHaveStyle(testStyles.clear);
     expect(count).toHaveClass(testClassNames.count);
     expect(count).toHaveStyle(testStyles.count);
   });

--- a/components/input/demo/_semantic_input.tsx
+++ b/components/input/demo/_semantic_input.tsx
@@ -11,6 +11,7 @@ const locales = {
     input: '输入框元素，包含输入框的核心交互样式和文本输入相关的样式',
     prefix: '前缀的包裹元素，包含前缀内容的布局和样式',
     suffix: '后缀的包裹元素，包含后缀内容的布局和样式',
+    clear: '清除按钮元素，包含清除内容按钮的布局、显隐和交互样式',
     count: '文字计数元素，包含字符计数显示的字体和颜色样式',
   },
   en: {
@@ -18,6 +19,8 @@ const locales = {
     input: 'Input element with core interactive styles and text input related styling',
     prefix: 'Prefix wrapper element with layout and styling for prefix content',
     suffix: 'Suffix wrapper element with layout and styling for suffix content',
+    clear:
+      'Clear button element with layout, visibility, and interaction styles for clearing content',
     count: 'Character count element with font and color styles for count display',
   },
 };
@@ -32,10 +35,12 @@ const App: React.FC = () => {
         { name: 'prefix', desc: locale.prefix },
         { name: 'input', desc: locale.input },
         { name: 'suffix', desc: locale.suffix },
+        { name: 'clear', desc: locale.clear },
         { name: 'count', desc: locale.count },
       ]}
     >
       <Input
+        allowClear
         showCount
         prefix={<UserOutlined />}
         suffix={<EditOutlined />}

--- a/components/input/demo/_semantic_password.tsx
+++ b/components/input/demo/_semantic_password.tsx
@@ -11,6 +11,7 @@ const locales = {
     input: '输入框元素',
     prefix: '前缀的包裹元素',
     suffix: '后缀的包裹元素',
+    clear: '清除按钮元素',
     count: '文字计数元素',
   },
   en: {
@@ -18,6 +19,7 @@ const locales = {
     input: 'input element',
     prefix: 'prefix element',
     suffix: 'suffix element',
+    clear: 'clear button element',
     count: 'count element',
   },
 };
@@ -32,10 +34,12 @@ const App: React.FC = () => {
         { name: 'prefix', desc: locale.prefix },
         { name: 'input', desc: locale.input },
         { name: 'suffix', desc: locale.suffix },
+        { name: 'clear', desc: locale.clear },
         { name: 'count', desc: locale.count },
       ]}
     >
       <Input.Password
+        allowClear
         showCount
         prefix={<UserOutlined />}
         suffix={<EditOutlined />}

--- a/components/input/demo/_semantic_search.tsx
+++ b/components/input/demo/_semantic_search.tsx
@@ -11,6 +11,7 @@ const locales = {
     input: '输入框元素',
     prefix: '前缀的包裹元素',
     suffix: '后缀的包裹元素',
+    clear: '清除按钮元素',
     count: '文字计数元素',
     'button.root': '按钮根元素',
     'button.icon': '按钮图标元素',
@@ -21,6 +22,7 @@ const locales = {
     input: 'input element',
     prefix: 'prefix element',
     suffix: 'suffix element',
+    clear: 'clear button element',
     count: 'count element',
     'button.root': 'button root element',
     'button.icon': 'button icon element',
@@ -38,6 +40,7 @@ const App: React.FC = () => {
         { name: 'prefix', desc: locale.prefix },
         { name: 'input', desc: locale.input },
         { name: 'suffix', desc: locale.suffix },
+        { name: 'clear', desc: locale.clear },
         { name: 'count', desc: locale.count },
         { name: 'button.root', desc: locale['button.root'] },
         { name: 'button.icon', desc: locale['button.icon'] },
@@ -46,6 +49,7 @@ const App: React.FC = () => {
     >
       <Input.Search
         loading
+        allowClear
         enterButton="Searching..."
         showCount
         prefix={<UserOutlined />}

--- a/components/input/demo/_semantic_textarea.tsx
+++ b/components/input/demo/_semantic_textarea.tsx
@@ -8,12 +8,15 @@ const locales = {
   cn: {
     root: '根元素，设置文本域包装器的样式、边框、圆角、过渡动画和状态控制',
     textarea: '文本域元素，设置字体、行高、内边距、颜色、背景、边框、文本输入和多行文本展示样式',
+    clear: '清除按钮元素，包含清除内容按钮的布局、显隐和交互样式',
     count: '文字计数元素，设置字符计数显示的位置、字体、颜色和数值统计样式',
   },
   en: {
     root: 'Root element with textarea wrapper styles, border, border radius, transition animation and state control',
     textarea:
       'Textarea element with font, line height, padding, color, background, border, text input and multi-line text display styles',
+    clear:
+      'Clear button element with layout, visibility, and interaction styles for clearing content',
     count:
       'Count element with character count display position, font, color and numeric statistics styles',
   },
@@ -27,10 +30,16 @@ const App: React.FC = () => {
       semantics={[
         { name: 'root', desc: locale.root },
         { name: 'textarea', desc: locale.textarea },
+        { name: 'clear', desc: locale.clear },
         { name: 'count', desc: locale.count },
       ]}
     >
-      <Input.TextArea defaultValue="Hello, Ant Design" rows={3} count={{ max: 100, show: true }} />
+      <Input.TextArea
+        allowClear
+        defaultValue="Hello, Ant Design"
+        rows={3}
+        count={{ max: 100, show: true }}
+      />
     </SemanticPreview>
   );
 };


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无（如需关联请在合并前补充）

### 💡 需求背景和解决方案

1. Input 系列已支持语义化 `classNames` / `styles`，但清除按钮缺少独立语义节点，无法与语义化文档里对「清除按钮」的说明对齐。
2. 为 `Input`、`Input.Search`、`Input.TextArea` 的语义类型增加 `clear` 字段，并在对应实现中接入，使清除按钮区域可通过 `classNames.clear` / `styles.clear` 定制。
3. 已更新语义化 demo 说明与单测；无视觉稿变更，一般无需截图。

rc-input相关调整：https://github.com/react-component/input/pull/162

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🆕 Add `clear` semantic segment to Input, Input.Search, and Input.TextArea `classNames` and `styles` for styling the clear button. |
| 🇨🇳 中文 | 🆕 为 Input、Input.Search、Input.TextArea 的语义化 `classNames` / `styles` 增加 `clear` 节点，用于定制清除按钮样式。 |
