### PR TITLE
fix(image): support fetchPriority prop passthrough

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@rc-component/drawer": "~1.4.2",
     "@rc-component/dropdown": "~1.0.2",
     "@rc-component/form": "~1.7.2",
-    "@rc-component/image": "~1.6.0",
+    "@rc-component/image": "~1.7.1",
     "@rc-component/input": "~1.1.2",
     "@rc-component/input-number": "~1.6.2",
     "@rc-component/mentions": "~1.6.0",


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

- https://github.com/react-component/image/pull/504

### 💡 Background and Solution

`fetchPriority` is a native `<img>` attribute that hints the browser about resource loading priority. Previously, it was not included in `@rc-component/image`'s prop whitelist, so it was applied to the wrapper `<div>` instead of the `<img>` element.

This PR upgrades `@rc-component/image` from `~1.6.0` to `~1.7.1` which includes the fix.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Image `fetchPriority` prop not being passed through to the `<img>` element. |
| 🇨🇳 Chinese | 🐞 修复 Image 组件 `fetchPriority` 属性未正确透传到 `<img>` 元素的问题。 |