### PR TITLE
site: refine ThemePreview styles for geek and glass themes

### DIFF
--- a/.dumi/pages/index/components/ThemePreview/ComponentsBlock.tsx
+++ b/.dumi/pages/index/components/ThemePreview/ComponentsBlock.tsx
@@ -158,10 +158,9 @@ const ComponentsBlock: React.FC<ComponentsBlockProps> = (props) => {
 
             {/* Filled variants */}
             <Flex gap="middle">
-              <DatePicker variant="filled" />
+              <DatePicker />
 
               <Select
-                variant="filled"
                 style={{ flex: 'auto' }}
                 mode="multiple"
                 maxTagCount="responsive"

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/geekTheme.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/geekTheme.ts
@@ -86,6 +86,7 @@ const useGeekTheme = () => {
           lineWidth: 2,
           colorPrimary: '#39ff14',
           colorText: '#39ff14',
+          colorInfo: '#39ff14',
           controlHeightSM: 26,
           controlHeight: 34,
         },
@@ -122,6 +123,11 @@ const useGeekTheme = () => {
         arrow: false,
       },
       select: {
+        classNames: {
+          root: styles.lightBorder,
+        },
+      },
+      datePicker: {
         classNames: {
           root: styles.lightBorder,
         },

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/glassTheme.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/glassTheme.ts
@@ -82,6 +82,11 @@ const useGlassTheme = () => {
           motionDurationMid: '0.1s',
           motionDurationFast: '0.05s',
         },
+        components: {
+          Segmented: {
+            itemSelectedBg: 'rgba(0,0,0,0.06)',
+          },
+        },
       },
       app: {
         className: styles.app,
@@ -109,6 +114,9 @@ const useGlassTheme = () => {
         className: clsx(styles.glassBox, styles.notBackdropFilter),
       },
       colorPicker: {
+        classNames: {
+          root: clsx(styles.glassBox, styles.notBackdropFilter),
+        },
         arrow: false,
       },
       dropdown: {
@@ -124,6 +132,24 @@ const useGlassTheme = () => {
           },
         },
       },
+      datePicker: {
+        classNames: {
+          root: clsx(styles.glassBox, styles.notBackdropFilter),
+          popup: {
+            container: styles.glassBox,
+          },
+        },
+      },
+      input: {
+        classNames: {
+          root: clsx(styles.glassBox, styles.notBackdropFilter),
+        },
+      },
+      inputNumber: {
+        classNames: {
+          root: clsx(styles.glassBox, styles.notBackdropFilter),
+        },
+      },
       popover: {
         classNames: {
           container: styles.glassBox,
@@ -133,6 +159,9 @@ const useGlassTheme = () => {
         classNames: {
           root: styles.switchRoot,
         },
+      },
+      segmented: {
+        className: clsx(styles.glassBox, styles.notBackdropFilter),
       },
       progress: {
         classNames: {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

优化站点首页 ThemePreview 中 geek 和 glass 两套预览主题的视觉表现，使相关控件样式与主题设定保持一致。

- 为 geek 主题补充 `colorInfo`，并给 DatePicker 增加边框样式类名。
- 为 glass 主题补充 Segmented、ColorPicker、DatePicker、Input、InputNumber 等控件的玻璃态样式。
- 调整 ThemePreview 示例中的 DatePicker 和 Select 展示方式，避免与主题样式表现冲突。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | 无需更新日志 |
