### PR TITLE
fix: align ConfigProvider semantic style config typings

### DIFF
--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -353,6 +353,8 @@ export type SliderConfig = ComponentStyleConfig & Pick<SliderProps, 'styles' | '
 
 export type SkeletonConfig = ComponentStyleConfig & Pick<SkeletonProps, 'styles' | 'classNames'>;
 
+export type SplitterConfig = ComponentStyleConfig & Pick<SplitterProps, 'classNames' | 'styles'>;
+
 export type SegmentedConfig = ComponentStyleConfig & Pick<SegmentedProps, 'classNames' | 'styles'>;
 
 export type StepsConfig = ComponentStyleConfig & Pick<StepsProps, 'classNames' | 'styles'>;
@@ -430,7 +432,7 @@ export interface ConfigComponentProps {
   inputNumber?: InputNumberConfig;
   pagination?: PaginationConfig;
   space?: SpaceConfig;
-  splitter?: ComponentStyleConfig & Pick<SplitterProps, 'classNames' | 'styles'>;
+  splitter?: SplitterConfig;
   form?: FormConfig;
   select?: SelectConfig;
   alert?: AlertConfig;

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -17,9 +17,11 @@ import defaultSeedToken from '../theme/themes/seed';
 import UniqueProvider from '../tooltip/UniqueProvider';
 import type {
   AlertConfig,
+  AnchorStyleConfig,
   BadgeConfig,
   BreadcrumbConfig,
   ButtonConfig,
+  CalendarConfig,
   CardConfig,
   CardMetaConfig,
   CascaderConfig,
@@ -30,7 +32,9 @@ import type {
   ConfigConsumerProps,
   CSPConfig,
   DatePickerConfig,
+  DescriptionsConfig,
   DirectionType,
+  DividerConfig,
   DrawerConfig,
   DropdownConfig,
   EmptyConfig,
@@ -58,21 +62,29 @@ import type {
   QRcodeConfig,
   RadioConfig,
   RangePickerConfig,
+  ResultConfig,
   RibbonConfig,
+  SegmentedConfig,
   SelectConfig,
   SkeletonConfig,
+  SliderConfig,
   SpaceConfig,
   SpinConfig,
+  SplitterConfig,
+  StatisticConfig,
+  StepsConfig,
   SwitchStyleConfig,
   TableConfig,
   TabsConfig,
   TagConfig,
   TextAreaConfig,
   ThemeConfig,
+  TimelineConfig,
   TimePickerConfig,
   TooltipConfig,
   TourConfig,
   TransferConfig,
+  TreeConfig,
   TreeSelectConfig,
   UploadConfig,
   Variant,
@@ -200,7 +212,7 @@ export interface ConfigProviderProps {
    */
   direction?: DirectionType;
   space?: SpaceConfig;
-  splitter?: ComponentStyleConfig;
+  splitter?: SplitterConfig;
   /**
    * @descCN 设置 `false` 时关闭虚拟滚动。
    * @descEN Close the virtual scrolling when setting `false`.
@@ -215,37 +227,37 @@ export interface ConfigProviderProps {
   warning?: WarningContextProps;
   alert?: AlertConfig;
   affix?: ComponentStyleConfig;
-  anchor?: ComponentStyleConfig;
+  anchor?: AnchorStyleConfig;
   app?: ComponentStyleConfig;
   button?: ButtonConfig;
-  calendar?: ComponentStyleConfig;
+  calendar?: CalendarConfig;
   carousel?: ComponentStyleConfig;
   cascader?: CascaderConfig;
   treeSelect?: TreeSelectConfig;
   collapse?: CollapseConfig;
-  divider?: ComponentStyleConfig;
+  divider?: DividerConfig;
   drawer?: DrawerConfig;
   typography?: ComponentStyleConfig;
   skeleton?: SkeletonConfig;
   spin?: SpinConfig;
-  segmented?: ComponentStyleConfig;
-  statistic?: ComponentStyleConfig;
-  steps?: ComponentStyleConfig;
+  segmented?: SegmentedConfig;
+  statistic?: StatisticConfig;
+  steps?: StepsConfig;
   image?: ImageConfig;
   layout?: ComponentStyleConfig;
   list?: ListConfig;
   mentions?: MentionsConfig;
   modal?: ModalConfig;
   progress?: ProgressConfig;
-  result?: ComponentStyleConfig;
-  slider?: ComponentStyleConfig;
+  result?: ResultConfig;
+  slider?: SliderConfig;
   masonry?: MasonryConfig;
   breadcrumb?: BreadcrumbConfig;
   menu?: MenuConfig;
   floatButton?: FloatButtonConfig;
   floatButtonGroup?: FloatButtonGroupConfig;
   checkbox?: CheckboxConfig;
-  descriptions?: ComponentStyleConfig;
+  descriptions?: DescriptionsConfig;
   empty?: EmptyConfig;
   badge?: BadgeConfig;
   radio?: RadioConfig;
@@ -260,11 +272,11 @@ export interface ConfigProviderProps {
   card?: CardConfig;
   cardMeta?: CardMetaConfig;
   tabs?: TabsConfig;
-  timeline?: ComponentStyleConfig;
+  timeline?: TimelineConfig;
   timePicker?: TimePickerConfig;
   upload?: UploadConfig;
   notification?: NotificationConfig;
-  tree?: ComponentStyleConfig;
+  tree?: TreeConfig;
   colorPicker?: ColorPickerConfig;
   datePicker?: DatePickerConfig;
   rangePicker?: RangePickerConfig;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [x] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

ConfigProvider 的组件配置类型定义与部分组件实际支持的语义化样式能力不一致。

例如 `segmented` 实际已支持 `classNames` 和 `styles`，但对应的组件配置类型中没有正确暴露这些属性。

这次调整对齐了 ConfigProvider 中相关组件的类型声明，为文档和实现中已支持 `classNames`、`styles` 的组件正确暴露这些配置项。

涉及的组件包括：

- `splitter`
- `anchor`
- `calendar`
- `divider`
- `segmented`
- `statistic`
- `steps`
- `result`
- `slider`
- `descriptions`
- `timeline`
- `tree`

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix ConfigProvider component config typings to expose semantic `classNames` and `styles` for supported components. |
| 🇨🇳 中文 | 🐞 修复 ConfigProvider 组件配置的类型定义，为已支持的组件暴露语义化 `classNames` 和 `styles`。 |