### PR TITLE
chore: fix changelog skill AGENTS.md references

### DIFF
--- a/.agents/skills/changelog-collect/SKILL.md
+++ b/.agents/skills/changelog-collect/SKILL.md
@@ -267,10 +267,10 @@ const componentNames = [
 
 **AGENTS.md 规范引用：**
 
-- [核心原则](./AGENTS.md#核心原则) - 有效性过滤规则
-- [格式与结构规范](./AGENTS.md#格式与结构规范) - 分组、描述、Emoji 规范
-- [Emoji 规范](./AGENTS.md#emoji-规范严格执行) - 根据 commit 类型自动标记
-- [输出示例参考](./AGENTS.md#输出示例参考) - 中英文格式参考
+- [核心原则](../../../AGENTS.md#核心原则) - 有效性过滤规则
+- [格式规范](../../../AGENTS.md#格式规范) - 分组、描述、Emoji 规范
+- [Emoji 规范](../../../AGENTS.md#emoji-规范) - 根据 commit 类型自动标记
+- [句式](../../../AGENTS.md#句式) - 中英文格式参考
 
 根据 AGENTS.md 的规范，对 `~changelog.md` 中的条目进行过滤、分组、格式检查，并在必要时进行交互式确认和修改。
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [x] ❓ 其他改动（Codex skill 文档维护）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

`changelog-collect` skill 中引用 `AGENTS.md` 的相对链接写成了从 skill 目录出发的错误路径，且部分锚点名与仓库中的实际标题不一致。

本次改动将这些引用更新为指向仓库根目录 `AGENTS.md` 的正确相对路径，并对齐到实际存在的章节锚点，保证 skill 在引用 changelog 规范时可以正确跳转和定位。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | 无需更新日志 |
