### PR TITLE
fix(Tag): improve solid variant text contrast in dark theme

### DIFF
--- a/components/date-picker/generatePicker/useSuffixIcon.tsx
+++ b/components/date-picker/generatePicker/useSuffixIcon.tsx
@@ -18,10 +18,10 @@ const useSuffixIcon = ({ picker, hasFeedback, feedbackIcon, suffixIcon }: UseSuf
   }
   if (suffixIcon === true || suffixIcon === undefined) {
     return (
-      <>
+      <span aria-hidden="true">
         {picker === TIME ? <ClockCircleOutlined /> : <CalendarOutlined />}
         {hasFeedback && feedbackIcon}
-      </>
+      </span>
     );
   }
 

--- a/components/date-picker/generatePicker/useSuffixIcon.tsx
+++ b/components/date-picker/generatePicker/useSuffixIcon.tsx
@@ -18,10 +18,10 @@ const useSuffixIcon = ({ picker, hasFeedback, feedbackIcon, suffixIcon }: UseSuf
   }
   if (suffixIcon === true || suffixIcon === undefined) {
     return (
-      <span aria-hidden="true">
+      <>
         {picker === TIME ? <ClockCircleOutlined /> : <CalendarOutlined />}
         {hasFeedback && feedbackIcon}
-      </span>
+      </>
     );
   }
 

--- a/components/tag/style/index.ts
+++ b/components/tag/style/index.ts
@@ -220,9 +220,9 @@ export const prepareToken = (token: Parameters<GenStyleFn<'Tag'>>[0]) => {
 };
 
 export const prepareComponentToken: GetDefaultToken<'Tag'> = (token) => {
-  const solidTextColor = isBright(new AggregationColor(token.colorBgSolid), '#fff')
-    ? '#000'
-    : '#fff';
+  const solidTextColor = isBright(new AggregationColor(token.colorBgSolid), token.colorBgContainer)
+    ? token.colorTextSolid
+    : token.colorTextLightSolid;
 
   return {
     defaultBg: new FastColor(token.colorFillTertiary)


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other

### 🔗 Related Issues

fix #57029

### 💡 Background and Solution

The `Tag` component with `variant="solid"` had hardcoded text colors (#000/#fff) that did not account for the background brightness in dark theme, leading to poor contrast. This PR replaces the hardcoded values with a dynamic check using the theme's `colorTextSolid` and `colorTextLightSolid` tokens against the container background brightness.\n
### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve Tag solid variant text contrast in dark theme. |
| 🇨🇳 Chinese | 优化 Tag 组件 solid 变体在昗色主题下的文本对比度。 |