### PR TITLE
chore: bump @rc-component/image to improve preview a11y and support movable classname

### DIFF
--- a/components/image/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/image/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2,8 +2,11 @@
 
 exports[`renders components/image/demo/basic.tsx extend context correctly 1`] = `
 <div
+  aria-label="basic"
   class="ant-image css-var-test-id ant-image-css-var"
+  role="button"
   style="width: 200px;"
+  tabindex="0"
 >
   <img
     alt="basic"
@@ -22,8 +25,11 @@ exports[`renders components/image/demo/basic.tsx extend context correctly 2`] = 
 exports[`renders components/image/demo/component-token.tsx extend context correctly 1`] = `
 Array [
   <div
+    aria-label="svg image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width: 150px;"
+    tabindex="0"
   >
     <img
       alt="svg image"
@@ -36,8 +42,11 @@ Array [
     />
   </div>,
   <div
+    aria-label="basic image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width: 150px;"
+    tabindex="0"
   >
     <img
       alt="basic image"
@@ -141,8 +150,11 @@ Array [
     </span>
   </button>,
   <div
+    aria-label="basic image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width: 200px;"
+    tabindex="0"
   >
     <img
       alt="basic image"
@@ -170,8 +182,11 @@ exports[`renders components/image/demo/coverPlacement.tsx extend context correct
     class="ant-space-item"
   >
     <div
+      aria-label="basic image"
       class="ant-image css-var-test-id ant-image-css-var"
+      role="button"
       style="width: 96px;"
+      tabindex="0"
     >
       <img
         alt="basic image"
@@ -221,8 +236,11 @@ exports[`renders components/image/demo/coverPlacement.tsx extend context correct
     class="ant-space-item"
   >
     <div
+      aria-label="image"
       class="ant-image css-var-test-id ant-image-css-var"
+      role="button"
       style="width: 96px;"
+      tabindex="0"
     >
       <img
         alt="image"
@@ -272,8 +290,11 @@ exports[`renders components/image/demo/coverPlacement.tsx extend context correct
     class="ant-space-item"
   >
     <div
+      aria-label="image"
       class="ant-image css-var-test-id ant-image-css-var"
+      role="button"
       style="width: 96px;"
+      tabindex="0"
     >
       <img
         alt="image"
@@ -326,8 +347,11 @@ exports[`renders components/image/demo/coverPlacement.tsx extend context correct
 
 exports[`renders components/image/demo/fallback.tsx extend context correctly 1`] = `
 <div
+  aria-label="basic image"
   class="ant-image css-var-test-id ant-image-css-var"
+  role="button"
   style="width: 200px; height: 200px;"
+  tabindex="0"
 >
   <img
     alt="basic image"
@@ -347,8 +371,11 @@ exports[`renders components/image/demo/fallback.tsx extend context correctly 2`]
 
 exports[`renders components/image/demo/imageRender.tsx extend context correctly 1`] = `
 <div
+  aria-label="basic image"
   class="ant-image css-var-test-id ant-image-css-var"
+  role="button"
   style="width: 200px;"
+  tabindex="0"
 >
   <img
     alt="basic image"
@@ -372,11 +399,14 @@ exports[`renders components/image/demo/mask.tsx extend context correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-label="blur preview"
       class="ant-image css-var-test-id ant-image-css-var"
+      role="button"
       style="width: 100px;"
+      tabindex="0"
     >
       <img
-        alt="blur"
+        alt="blur preview"
         class="ant-image-img"
         src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
         width="100"
@@ -400,11 +430,14 @@ exports[`renders components/image/demo/mask.tsx extend context correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-label="Dimmed mask preview"
       class="ant-image css-var-test-id ant-image-css-var"
+      role="button"
       style="width: 100px;"
+      tabindex="0"
     >
       <img
-        alt="Dimmed mask"
+        alt="Dimmed mask preview"
         class="ant-image-img"
         src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
         width="100"
@@ -428,11 +461,14 @@ exports[`renders components/image/demo/mask.tsx extend context correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-label="No mask preview"
       class="ant-image css-var-test-id ant-image-css-var"
+      role="button"
       style="width: 100px;"
+      tabindex="0"
     >
       <img
-        alt="No mask"
+        alt="No mask preview"
         class="ant-image-img"
         src="https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg"
         width="100"
@@ -479,8 +515,11 @@ exports[`renders components/image/demo/placeholder.tsx extend context correctly 
     class="ant-space-item"
   >
     <div
+      aria-label="basic image"
       class="ant-image css-var-test-id ant-image-css-var"
+      role="button"
       style="width: 200px;"
+      tabindex="0"
     >
       <img
         alt="basic image"
@@ -529,8 +568,11 @@ exports[`renders components/image/demo/placeholder.tsx extend context correctly 
 exports[`renders components/image/demo/preview-group.tsx extend context correctly 1`] = `
 Array [
   <div
+    aria-label="svg image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width: 200px;"
+    tabindex="0"
   >
     <img
       alt="svg image"
@@ -543,8 +585,11 @@ Array [
     />
   </div>,
   <div
+    aria-label="svg image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width: 200px;"
+    tabindex="0"
   >
     <img
       alt="svg image"
@@ -564,8 +609,11 @@ exports[`renders components/image/demo/preview-group.tsx extend context correctl
 exports[`renders components/image/demo/preview-group-top-progress.tsx extend context correctly 1`] = `
 Array [
   <div
+    aria-label="svg image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width: 150px;"
+    tabindex="0"
   >
     <img
       alt="svg image"
@@ -578,8 +626,11 @@ Array [
     />
   </div>,
   <div
+    aria-label="svg image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width: 150px;"
+    tabindex="0"
   >
     <img
       alt="svg image"
@@ -592,8 +643,11 @@ Array [
     />
   </div>,
   <div
+    aria-label="svg image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width: 150px;"
+    tabindex="0"
   >
     <img
       alt="svg image"
@@ -612,8 +666,11 @@ exports[`renders components/image/demo/preview-group-top-progress.tsx extend con
 
 exports[`renders components/image/demo/preview-group-visible.tsx extend context correctly 1`] = `
 <div
+  aria-label="webp image"
   class="ant-image css-var-test-id ant-image-css-var"
+  role="button"
   style="width: 200px;"
+  tabindex="0"
 >
   <img
     alt="webp image"
@@ -631,8 +688,11 @@ exports[`renders components/image/demo/preview-group-visible.tsx extend context 
 
 exports[`renders components/image/demo/preview-imgInfo.tsx extend context correctly 1`] = `
 <div
+  aria-label="test"
   class="ant-image css-var-test-id ant-image-css-var"
+  role="button"
   style="width: 200px; height: 200px;"
+  tabindex="0"
 >
   <img
     alt="test"
@@ -652,8 +712,11 @@ exports[`renders components/image/demo/preview-imgInfo.tsx extend context correc
 
 exports[`renders components/image/demo/preview-mask.tsx extend context correctly 1`] = `
 <div
+  aria-label="basic image"
   class="ant-image css-var-test-id ant-image-css-var"
+  role="button"
   style="width: 96px;"
+  tabindex="0"
 >
   <img
     alt="basic image"
@@ -704,8 +767,11 @@ exports[`renders components/image/demo/preview-mask.tsx extend context correctly
 
 exports[`renders components/image/demo/previewSrc.tsx extend context correctly 1`] = `
 <div
+  aria-label="basic image"
   class="ant-image css-var-test-id ant-image-css-var"
+  role="button"
   style="width: 200px;"
+  tabindex="0"
 >
   <img
     alt="basic image"
@@ -726,8 +792,11 @@ exports[`renders components/image/demo/style-class.tsx extend context correctly 
   class="ant-flex css-var-test-id ant-flex-gap-medium"
 >
   <div
+    aria-label="示例图片"
     class="ant-image css-var-test-id ant-image-css-var acss-1tjmp0k"
+    role="button"
     style="width: 160px;"
+    tabindex="0"
   >
     <img
       alt="示例图片"
@@ -741,8 +810,11 @@ exports[`renders components/image/demo/style-class.tsx extend context correctly 
     />
   </div>
   <div
+    aria-label="示例图片"
     class="ant-image css-var-test-id ant-image-css-var acss-1tjmp0k"
+    role="button"
     style="width: 160px; border: 2px solid rgb(165, 148, 249); border-radius: 8px; padding: 4px; transition: all 0.3s ease;"
+    tabindex="0"
   >
     <img
       alt="示例图片"
@@ -763,8 +835,11 @@ exports[`renders components/image/demo/style-class.tsx extend context correctly 
 exports[`renders components/image/demo/toolbarRender.tsx extend context correctly 1`] = `
 Array [
   <div
+    aria-label="image-0"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width: 200px;"
+    tabindex="0"
   >
     <img
       alt="image-0"
@@ -777,8 +852,11 @@ Array [
     />
   </div>,
   <div
+    aria-label="image-1"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width: 200px;"
+    tabindex="0"
   >
     <img
       alt="image-1"

--- a/components/image/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/image/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -20,7 +20,9 @@ exports[`renders components/image/demo/_semantic.tsx correctly 1`] = `
         >
           <div
             class="ant-image css-var-test-id ant-image-css-var semantic-mark-root"
+            role="button"
             style="width: 200px;"
+            tabindex="0"
           >
             <img
               class="ant-image-img semantic-mark-image"
@@ -36,8 +38,11 @@ exports[`renders components/image/demo/_semantic.tsx correctly 1`] = `
           style="flex: 1 1 0%; position: relative; min-height: 500px; width: 100%;"
         >
           <div
-            class="ant-image-preview css-var-test-id ant-image-css-var semantic-mark-popup-root"
+            aria-modal="true"
+            class="ant-image-preview css-var-test-id ant-image-css-var semantic-mark-popup-root ant-image-preview-movable"
+            role="dialog"
             style="position: absolute;"
+            tabindex="-1"
           >
             <div
               class="ant-image-preview-mask semantic-mark-popup-mask"
@@ -75,8 +80,9 @@ exports[`renders components/image/demo/_semantic.tsx correctly 1`] = `
                 </svg>
               </span>
             </button>
-            <div
+            <button
               class="ant-image-preview-switch ant-image-preview-switch-prev ant-image-preview-switch-disabled"
+              disabled=""
             >
               <span
                 aria-label="left"
@@ -97,9 +103,10 @@ exports[`renders components/image/demo/_semantic.tsx correctly 1`] = `
                   />
                 </svg>
               </span>
-            </div>
-            <div
+            </button>
+            <button
               class="ant-image-preview-switch ant-image-preview-switch-next"
+              type="button"
             >
               <span
                 aria-label="right"
@@ -120,7 +127,7 @@ exports[`renders components/image/demo/_semantic.tsx correctly 1`] = `
                   />
                 </svg>
               </span>
-            </div>
+            </button>
             <div
               class="ant-image-preview-footer semantic-mark-popup-footer"
             >
@@ -134,8 +141,10 @@ exports[`renders components/image/demo/_semantic.tsx correctly 1`] = `
               <div
                 class="ant-image-preview-actions semantic-mark-popup-actions"
               >
-                <div
+                <button
+                  aria-label="flipY"
                   class="ant-image-preview-actions-action ant-image-preview-actions-action-flipY"
+                  type="button"
                 >
                   <span
                     aria-label="swap"
@@ -157,9 +166,11 @@ exports[`renders components/image/demo/_semantic.tsx correctly 1`] = `
                       />
                     </svg>
                   </span>
-                </div>
-                <div
+                </button>
+                <button
+                  aria-label="flipX"
                   class="ant-image-preview-actions-action ant-image-preview-actions-action-flipX"
+                  type="button"
                 >
                   <span
                     aria-label="swap"
@@ -180,9 +191,11 @@ exports[`renders components/image/demo/_semantic.tsx correctly 1`] = `
                       />
                     </svg>
                   </span>
-                </div>
-                <div
+                </button>
+                <button
+                  aria-label="rotateLeft"
                   class="ant-image-preview-actions-action ant-image-preview-actions-action-rotateLeft"
+                  type="button"
                 >
                   <span
                     aria-label="rotate-left"
@@ -209,9 +222,11 @@ exports[`renders components/image/demo/_semantic.tsx correctly 1`] = `
                       />
                     </svg>
                   </span>
-                </div>
-                <div
+                </button>
+                <button
+                  aria-label="rotateRight"
                   class="ant-image-preview-actions-action ant-image-preview-actions-action-rotateRight"
+                  type="button"
                 >
                   <span
                     aria-label="rotate-right"
@@ -238,9 +253,12 @@ exports[`renders components/image/demo/_semantic.tsx correctly 1`] = `
                       />
                     </svg>
                   </span>
-                </div>
-                <div
+                </button>
+                <button
+                  aria-label="zoomOut"
                   class="ant-image-preview-actions-action ant-image-preview-actions-action-zoomOut ant-image-preview-actions-action-disabled"
+                  disabled=""
+                  type="button"
                 >
                   <span
                     aria-label="zoom-out"
@@ -261,9 +279,11 @@ exports[`renders components/image/demo/_semantic.tsx correctly 1`] = `
                       />
                     </svg>
                   </span>
-                </div>
-                <div
+                </button>
+                <button
+                  aria-label="zoomIn"
                   class="ant-image-preview-actions-action ant-image-preview-actions-action-zoomIn"
+                  type="button"
                 >
                   <span
                     aria-label="zoom-in"
@@ -284,7 +304,7 @@ exports[`renders components/image/demo/_semantic.tsx correctly 1`] = `
                       />
                     </svg>
                   </span>
-                </div>
+                </button>
               </div>
             </div>
           </div>

--- a/components/image/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/image/__tests__/__snapshots__/demo.test.ts.snap
@@ -2,8 +2,11 @@
 
 exports[`renders components/image/demo/basic.tsx correctly 1`] = `
 <div
+  aria-label="basic"
   class="ant-image css-var-test-id ant-image-css-var"
+  role="button"
   style="width:200px"
+  tabindex="0"
 >
   <img
     alt="basic"
@@ -20,8 +23,11 @@ exports[`renders components/image/demo/basic.tsx correctly 1`] = `
 exports[`renders components/image/demo/component-token.tsx correctly 1`] = `
 Array [
   <div
+    aria-label="svg image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width:150px"
+    tabindex="0"
   >
     <img
       alt="svg image"
@@ -34,8 +40,11 @@ Array [
     />
   </div>,
   <div
+    aria-label="basic image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width:150px"
+    tabindex="0"
   >
     <img
       alt="basic image"
@@ -138,8 +147,11 @@ Array [
     </span>
   </button>,
   <div
+    aria-label="basic image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width:200px"
+    tabindex="0"
   >
     <img
       alt="basic image"
@@ -165,8 +177,11 @@ exports[`renders components/image/demo/coverPlacement.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-label="basic image"
       class="ant-image css-var-test-id ant-image-css-var"
+      role="button"
       style="width:96px"
+      tabindex="0"
     >
       <img
         alt="basic image"
@@ -216,8 +231,11 @@ exports[`renders components/image/demo/coverPlacement.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-label="image"
       class="ant-image css-var-test-id ant-image-css-var"
+      role="button"
       style="width:96px"
+      tabindex="0"
     >
       <img
         alt="image"
@@ -267,8 +285,11 @@ exports[`renders components/image/demo/coverPlacement.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-label="image"
       class="ant-image css-var-test-id ant-image-css-var"
+      role="button"
       style="width:96px"
+      tabindex="0"
     >
       <img
         alt="image"
@@ -319,8 +340,11 @@ exports[`renders components/image/demo/coverPlacement.tsx correctly 1`] = `
 
 exports[`renders components/image/demo/fallback.tsx correctly 1`] = `
 <div
+  aria-label="basic image"
   class="ant-image css-var-test-id ant-image-css-var"
+  role="button"
   style="width:200px;height:200px"
+  tabindex="0"
 >
   <img
     alt="basic image"
@@ -338,8 +362,11 @@ exports[`renders components/image/demo/fallback.tsx correctly 1`] = `
 
 exports[`renders components/image/demo/imageRender.tsx correctly 1`] = `
 <div
+  aria-label="basic image"
   class="ant-image css-var-test-id ant-image-css-var"
+  role="button"
   style="width:200px"
+  tabindex="0"
 >
   <img
     alt="basic image"
@@ -361,11 +388,14 @@ exports[`renders components/image/demo/mask.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-label="blur preview"
       class="ant-image css-var-test-id ant-image-css-var"
+      role="button"
       style="width:100px"
+      tabindex="0"
     >
       <img
-        alt="blur"
+        alt="blur preview"
         class="ant-image-img"
         src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
         width="100"
@@ -389,11 +419,14 @@ exports[`renders components/image/demo/mask.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-label="Dimmed mask preview"
       class="ant-image css-var-test-id ant-image-css-var"
+      role="button"
       style="width:100px"
+      tabindex="0"
     >
       <img
-        alt="Dimmed mask"
+        alt="Dimmed mask preview"
         class="ant-image-img"
         src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
         width="100"
@@ -417,11 +450,14 @@ exports[`renders components/image/demo/mask.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-label="No mask preview"
       class="ant-image css-var-test-id ant-image-css-var"
+      role="button"
       style="width:100px"
+      tabindex="0"
     >
       <img
-        alt="No mask"
+        alt="No mask preview"
         class="ant-image-img"
         src="https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg"
         width="100"
@@ -464,8 +500,11 @@ exports[`renders components/image/demo/placeholder.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-label="basic image"
       class="ant-image css-var-test-id ant-image-css-var"
+      role="button"
       style="width:200px"
+      tabindex="0"
     >
       <img
         alt="basic image"
@@ -512,8 +551,11 @@ exports[`renders components/image/demo/placeholder.tsx correctly 1`] = `
 exports[`renders components/image/demo/preview-group.tsx correctly 1`] = `
 Array [
   <div
+    aria-label="svg image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width:200px"
+    tabindex="0"
   >
     <img
       alt="svg image"
@@ -526,8 +568,11 @@ Array [
     />
   </div>,
   <div
+    aria-label="svg image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width:200px"
+    tabindex="0"
   >
     <img
       alt="svg image"
@@ -545,8 +590,11 @@ Array [
 exports[`renders components/image/demo/preview-group-top-progress.tsx correctly 1`] = `
 Array [
   <div
+    aria-label="svg image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width:150px"
+    tabindex="0"
   >
     <img
       alt="svg image"
@@ -559,8 +607,11 @@ Array [
     />
   </div>,
   <div
+    aria-label="svg image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width:150px"
+    tabindex="0"
   >
     <img
       alt="svg image"
@@ -573,8 +624,11 @@ Array [
     />
   </div>,
   <div
+    aria-label="svg image"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width:150px"
+    tabindex="0"
   >
     <img
       alt="svg image"
@@ -591,8 +645,11 @@ Array [
 
 exports[`renders components/image/demo/preview-group-visible.tsx correctly 1`] = `
 <div
+  aria-label="webp image"
   class="ant-image css-var-test-id ant-image-css-var"
+  role="button"
   style="width:200px"
+  tabindex="0"
 >
   <img
     alt="webp image"
@@ -608,8 +665,11 @@ exports[`renders components/image/demo/preview-group-visible.tsx correctly 1`] =
 
 exports[`renders components/image/demo/preview-imgInfo.tsx correctly 1`] = `
 <div
+  aria-label="test"
   class="ant-image css-var-test-id ant-image-css-var"
+  role="button"
   style="width:200px;height:200px"
+  tabindex="0"
 >
   <img
     alt="test"
@@ -627,8 +687,11 @@ exports[`renders components/image/demo/preview-imgInfo.tsx correctly 1`] = `
 
 exports[`renders components/image/demo/preview-mask.tsx correctly 1`] = `
 <div
+  aria-label="basic image"
   class="ant-image css-var-test-id ant-image-css-var"
+  role="button"
   style="width:96px"
+  tabindex="0"
 >
   <img
     alt="basic image"
@@ -677,8 +740,11 @@ exports[`renders components/image/demo/preview-mask.tsx correctly 1`] = `
 
 exports[`renders components/image/demo/previewSrc.tsx correctly 1`] = `
 <div
+  aria-label="basic image"
   class="ant-image css-var-test-id ant-image-css-var"
+  role="button"
   style="width:200px"
+  tabindex="0"
 >
   <img
     alt="basic image"
@@ -697,8 +763,11 @@ exports[`renders components/image/demo/style-class.tsx correctly 1`] = `
   class="ant-flex css-var-test-id ant-flex-gap-medium"
 >
   <div
+    aria-label="示例图片"
     class="ant-image css-var-test-id ant-image-css-var acss-1tjmp0k"
+    role="button"
     style="width:160px"
+    tabindex="0"
   >
     <img
       alt="示例图片"
@@ -712,8 +781,11 @@ exports[`renders components/image/demo/style-class.tsx correctly 1`] = `
     />
   </div>
   <div
+    aria-label="示例图片"
     class="ant-image css-var-test-id ant-image-css-var acss-1tjmp0k"
+    role="button"
     style="width:160px;border:2px solid #A594F9;border-radius:8px;padding:4px;transition:all 0.3s ease"
+    tabindex="0"
   >
     <img
       alt="示例图片"
@@ -732,8 +804,11 @@ exports[`renders components/image/demo/style-class.tsx correctly 1`] = `
 exports[`renders components/image/demo/toolbarRender.tsx correctly 1`] = `
 Array [
   <div
+    aria-label="image-0"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width:200px"
+    tabindex="0"
   >
     <img
       alt="image-0"
@@ -746,8 +821,11 @@ Array [
     />
   </div>,
   <div
+    aria-label="image-1"
     class="ant-image css-var-test-id ant-image-css-var"
+    role="button"
     style="width:200px"
+    tabindex="0"
   >
     <img
       alt="image-1"

--- a/components/image/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/image/__tests__/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,10 @@ exports[`Image Default Group preview props 1`] = `
 <body>
   <div>
     <div
+      aria-label="test image"
       class="ant-image css-var-root ant-image-css-var"
+      role="button"
+      tabindex="0"
     >
       <img
         alt="test image"
@@ -18,7 +21,10 @@ exports[`Image Default Group preview props 1`] = `
   </div>
   <div>
     <div
-      class="ant-image-preview css-var-root ant-image-css-var ant-image-preview-fade-appear ant-image-preview-fade-appear-start ant-image-preview-fade"
+      aria-modal="true"
+      class="ant-image-preview css-var-root ant-image-css-var ant-image-preview-fade-appear ant-image-preview-fade-appear-start ant-image-preview-fade ant-image-preview-movable"
+      role="dialog"
+      tabindex="-1"
     >
       <div
         class="ant-image-preview-mask"
@@ -69,8 +75,10 @@ exports[`Image Default Group preview props 1`] = `
         <div
           class="ant-image-preview-actions"
         >
-          <div
+          <button
+            aria-label="flipY"
             class="ant-image-preview-actions-action ant-image-preview-actions-action-flipY"
+            type="button"
           >
             <span
               aria-label="swap"
@@ -92,9 +100,11 @@ exports[`Image Default Group preview props 1`] = `
                 />
               </svg>
             </span>
-          </div>
-          <div
+          </button>
+          <button
+            aria-label="flipX"
             class="ant-image-preview-actions-action ant-image-preview-actions-action-flipX"
+            type="button"
           >
             <span
               aria-label="swap"
@@ -115,9 +125,11 @@ exports[`Image Default Group preview props 1`] = `
                 />
               </svg>
             </span>
-          </div>
-          <div
+          </button>
+          <button
+            aria-label="rotateLeft"
             class="ant-image-preview-actions-action ant-image-preview-actions-action-rotateLeft"
+            type="button"
           >
             <span
               aria-label="rotate-left"
@@ -144,9 +156,11 @@ exports[`Image Default Group preview props 1`] = `
                 />
               </svg>
             </span>
-          </div>
-          <div
+          </button>
+          <button
+            aria-label="rotateRight"
             class="ant-image-preview-actions-action ant-image-preview-actions-action-rotateRight"
+            type="button"
           >
             <span
               aria-label="rotate-right"
@@ -173,9 +187,12 @@ exports[`Image Default Group preview props 1`] = `
                 />
               </svg>
             </span>
-          </div>
-          <div
+          </button>
+          <button
+            aria-label="zoomOut"
             class="ant-image-preview-actions-action ant-image-preview-actions-action-zoomOut ant-image-preview-actions-action-disabled"
+            disabled=""
+            type="button"
           >
             <span
               aria-label="zoom-out"
@@ -196,9 +213,11 @@ exports[`Image Default Group preview props 1`] = `
                 />
               </svg>
             </span>
-          </div>
-          <div
+          </button>
+          <button
+            aria-label="zoomIn"
             class="ant-image-preview-actions-action ant-image-preview-actions-action-zoomIn"
+            type="button"
           >
             <span
               aria-label="zoom-in"
@@ -219,7 +238,7 @@ exports[`Image Default Group preview props 1`] = `
                 />
               </svg>
             </span>
-          </div>
+          </button>
         </div>
       </div>
     </div>
@@ -230,6 +249,8 @@ exports[`Image Default Group preview props 1`] = `
 exports[`Image rtl render component should be rendered correctly in RTL direction 1`] = `
 <div
   class="ant-image css-var-root ant-image-css-var"
+  role="button"
+  tabindex="0"
 >
   <img
     class="ant-image-img"

--- a/components/image/__tests__/__snapshots__/semantic.test.tsx.snap
+++ b/components/image/__tests__/__snapshots__/semantic.test.tsx.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Image.Semantic should render with classNames and styles when passed as functions to PreviewGroup 1`] = `"<div class="ant-image css-var-root ant-image-css-var"><img class="ant-image-img" src="https://example.com/image.png"><div class="ant-image-cover ant-image-cover-center"></div></div>"`;
+exports[`Image.Semantic should render with classNames and styles when passed as functions to PreviewGroup 1`] = `"<div class="ant-image css-var-root ant-image-css-var" role="button" tabindex="0"><img class="ant-image-img" src="https://example.com/image.png"><div class="ant-image-cover ant-image-cover-center"></div></div>"`;
 
-exports[`Image.Semantic should render with custom classNames and styles when passed to PreviewGroup 1`] = `"<div class="ant-image css-var-root ant-image-css-var"><img class="ant-image-img" src="https://example.com/image.png"><div class="ant-image-cover ant-image-cover-center"></div></div>"`;
+exports[`Image.Semantic should render with custom classNames and styles when passed to PreviewGroup 1`] = `"<div class="ant-image css-var-root ant-image-css-var" role="button" tabindex="0"><img class="ant-image-img" src="https://example.com/image.png"><div class="ant-image-cover ant-image-cover-center"></div></div>"`;

--- a/components/image/demo/mask.tsx
+++ b/components/image/demo/mask.tsx
@@ -6,7 +6,7 @@ const App: React.FC = () => {
     <Space>
       <Image
         width={100}
-        alt="blur"
+        alt="blur preview"
         src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
         preview={{
           mask: { blur: true },
@@ -18,7 +18,7 @@ const App: React.FC = () => {
         }}
       />
       <Image
-        alt="Dimmed mask"
+        alt="Dimmed mask preview"
         width={100}
         src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
         preview={{
@@ -31,7 +31,7 @@ const App: React.FC = () => {
       />
       <Image
         width={100}
-        alt="No mask"
+        alt="No mask preview"
         src="https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg"
         preview={{
           mask: false,

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@rc-component/drawer": "~1.4.2",
     "@rc-component/dropdown": "~1.0.2",
     "@rc-component/form": "~1.8.0",
-    "@rc-component/image": "~1.7.1",
+    "@rc-component/image": "~1.8.0",
     "@rc-component/input": "~1.1.2",
     "@rc-component/input-number": "~1.6.2",
     "@rc-component/mentions": "~1.6.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues


### 💡 Background and Solution
关联PR：
https://github.com/react-component/image/pull/496
https://github.com/react-component/image/pull/497

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       chore: bump @rc-component/image to 1.8.0    |
| 🇨🇳 Chinese |     @rc-component/image 升级到 1.8.0      |
