### PR TITLE
chore: bump dayjs to 1.11.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "@rc-component/upload": "~1.1.0",
     "@rc-component/util": "^1.10.0",
     "clsx": "^2.1.1",
-    "dayjs": "^1.11.11",
+    "dayjs": "^1.11.20",
     "scroll-into-view-if-needed": "^3.1.0",
     "throttle-debounce": "^5.0.2"
   },


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature  
- [ ] 🐞 Bug fix  
- [ ] 📝 Site / documentation improvement  
- [ ] 📽️ Demo improvement  
- [ ] 💄 Component style improvement  
- [x] 🤖 TypeScript definition improvement  
- [ ] 📦 Bundle size optimization  
- [ ] ⚡️ Performance optimization  
- [ ] ⭐️ Feature enhancement  
- [ ] 🌐 Internationalization  
- [ ] 🛠 Refactoring  
- [ ] 🎨 Code style optimization  
- [ ] ✅ Test Case  
- [ ] 🔀 Branch merge  
- [ ] ⏩ Workflow  
- [ ] ⌨️ Accessibility improvement  
- [ ] ❓ Other (about what?)  

---

### 🔗 Related Issues

N/A

---

### 💡 Background and Solution

Currently, the project uses an older version of `dayjs`.

When a consumer project uses a newer version (e.g. `1.11.20`), TypeScript may report type incompatibility issues because multiple versions of `Dayjs` types are resolved, leading to mismatched types.

This PR updates `dayjs` to the latest version (`1.11.20`) to ensure compatibility with consumer projects and prevent duplicate type definitions.

This is a non-breaking change and aligns the dependency with the latest `dayjs` release.

---

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Bump `dayjs` version to `1.11.20` to avoid type incompatibility issues when multiple versions are installed in consumer projects. |
| 🇨🇳 Chinese | 将 `dayjs` 升级到 `1.11.20`，以避免在使用不同版本时出现类型不兼容问题。 |