### PR TITLE
docs: add @ant-design/cli documentation and links

### DIFF
--- a/docs/react/cli.en-US.md
+++ b/docs/react/cli.en-US.md
@@ -1,0 +1,97 @@
+---
+group:
+  title: AI
+  order: 0.9
+order: 3
+title: CLI
+tag: New
+---
+
+This guide explains how to use `@ant-design/cli` to query Ant Design component knowledge, analyze project usage, and guide migrations from the command line.
+
+## What is Ant Design CLI?
+
+[`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) is an official command-line tool that brings Ant Design knowledge to your terminal. It ships all metadata locally — every prop, token, demo, and changelog entry for antd v4 / v5 / v6 — queryable in milliseconds, fully offline.
+
+## Highlights
+
+- **Fully offline** — All metadata ships with the package. No network calls, no latency, no API keys.
+- **Version-accurate** — 55+ per-minor snapshots across v4/v5/v6. Query the exact API surface of any version.
+- **Agent-optimized** — `--format json` on every command. Structured errors with codes and suggestions.
+- **Bilingual** — Every component name, description, and doc has both English and Chinese. Switch with `--lang zh`.
+- **Smart matching** — Typo `Buttn`? The CLI suggests `Button` using Levenshtein distance.
+
+## Install
+
+```bash
+npm install -g @ant-design/cli
+```
+
+## Quick Start
+
+```bash
+antd info Button                    # Component props, types, defaults
+antd demo Select basic              # Runnable demo source code
+antd token DatePicker               # Design Token values (v5+)
+antd semantic Table                 # classNames / styles structure
+antd changelog 4.24.0 5.0.0 Select  # API diff across versions
+antd doctor                         # Diagnose project issues
+antd lint ./src                     # Check deprecated APIs & best practices
+antd migrate 4 5 --apply ./src      # Agent-ready migration prompt
+```
+
+## Commands
+
+### Knowledge Query
+
+| Command | Description |
+| --- | --- |
+| `antd list` | List all components with bilingual names, categories, and `since` versions |
+| `antd info <Component>` | Props table with types, defaults, `since`, and deprecated status |
+| `antd doc <Component>` | Full markdown documentation for a component |
+| `antd demo <Component> [name]` | Runnable demo source code (TSX) |
+| `antd token [Component]` | Global or component-level Design Tokens |
+| `antd semantic <Component>` | Semantic `classNames` / `styles` structure with usage examples |
+| `antd changelog [v1] [v2] [component]` | Changelog entries, version ranges, or cross-version API diff |
+
+### Project Analysis
+
+| Command | Description |
+| --- | --- |
+| `antd doctor` | 10 diagnostic checks: React compat, duplicates, peer deps, SSR, babel plugins |
+| `antd usage [dir]` | Import stats, sub-component breakdown (`Form.Item`), non-component exports |
+| `antd lint [target]` | Deprecated APIs, accessibility gaps, performance issues, best practices |
+| `antd migrate <from> <to>` | Migration checklist with auto-fixable/manual split and `--apply` agent prompt |
+
+### Global Flags
+
+| Flag                            | Description                         | Default     |
+| ------------------------------- | ----------------------------------- | ----------- |
+| `--format json\|text\|markdown` | Output format                       | `text`      |
+| `--version <v>`                 | Target antd version (e.g. `5.20.0`) | auto-detect |
+| `--lang en\|zh`                 | Output language                     | `en`        |
+| `--detail`                      | Include extended information        | `false`     |
+
+## Usage with AI Tools
+
+The CLI ships with a built-in [skill file](https://github.com/ant-design/ant-design-cli/blob/main/skills/antd/SKILL.md) that teaches code agents when and how to use each command:
+
+```bash
+npx skills add ant-design/ant-design-cli
+```
+
+| Tool | Description |
+| --- | --- |
+| **Claude Code** | Install as agent skill or use `antd` commands directly in terminal. [Documentation](https://docs.anthropic.com/en/docs/claude-code) |
+| **Cursor** | Install skill, the agent will call CLI commands automatically. [Documentation](https://docs.cursor.com/context/@-symbols/@-docs) |
+| **Codex** | Install skill to enable agent access. [Documentation](https://github.com/openai/codex) |
+| **Gemini CLI** | Install skill for automatic command invocation. [Documentation](https://github.com/google-gemini/gemini-cli) |
+
+Works with any agent supporting the [skills](https://github.com/nicepkg/agent-skills) protocol.
+
+## Learn More
+
+- [@ant-design/cli on GitHub](https://github.com/ant-design/ant-design-cli)
+- [@ant-design/cli on npm](https://www.npmjs.com/package/@ant-design/cli)
+- [Ant Design LLMs.txt Guide](/docs/react/llms-en-US)
+- [Ant Design MCP Server](/docs/react/mcp-en-US)

--- a/docs/react/cli.zh-CN.md
+++ b/docs/react/cli.zh-CN.md
@@ -1,0 +1,97 @@
+---
+group:
+  title: AI
+  order: 0.9
+order: 3
+title: CLI
+tag: New
+---
+
+本指南介绍如何使用 `@ant-design/cli` 从命令行查询 Ant Design 组件知识、分析项目用量和指导版本迁移。
+
+## 什么是 Ant Design CLI？ {#what-is-ant-design-cli}
+
+[`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) 是官方命令行工具，将 Ant Design 知识带到你的终端。所有元数据随包安装 — antd v4 / v5 / v6 的每个 Prop、Token、Demo 和 Changelog 条目 — 毫秒级查询，完全离线。
+
+## 亮点 {#highlights}
+
+- **完全离线** — 所有元数据随包安装，无需网络请求，无延迟，无 API Key。
+- **版本精确** — 跨 v4/v5/v6 的 55+ 小版本快照，查询任意版本的精确 API。
+- **Agent 优化** — 所有命令支持 `--format json`，结构化错误码与修复建议。
+- **双语输出** — 每个组件名、描述和文档均有中英文，通过 `--lang zh` 切换。
+- **智能纠错** — 输入 `Buttn`？CLI 基于 Levenshtein 距离建议 `Button`。
+
+## 安装 {#install}
+
+```bash
+npm install -g @ant-design/cli
+```
+
+## 快速开始 {#quick-start}
+
+```bash
+antd info Button                    # 组件 Props、类型、默认值
+antd demo Select basic              # 可运行的 Demo 源码
+antd token DatePicker               # Design Token 值（v5+）
+antd semantic Table                 # classNames / styles 结构
+antd changelog 4.24.0 5.0.0 Select  # 跨版本 API 差异对比
+antd doctor                         # 诊断项目配置问题
+antd lint ./src                     # 检查废弃 API 和最佳实践
+antd migrate 4 5 --apply ./src      # 生成 Agent 迁移提示
+```
+
+## 命令 {#commands}
+
+### 知识查询 {#knowledge-query}
+
+| 命令                                   | 说明                                           |
+| -------------------------------------- | ---------------------------------------------- |
+| `antd list`                            | 列出所有组件，含双语名称、分类和引入版本       |
+| `antd info <Component>`                | Props 表格，含类型、默认值、引入版本和废弃状态 |
+| `antd doc <Component>`                 | 组件完整 Markdown 文档                         |
+| `antd demo <Component> [name]`         | 可运行的 Demo 源码（TSX）                      |
+| `antd token [Component]`               | 全局或组件级 Design Token                      |
+| `antd semantic <Component>`            | 语义化 `classNames` / `styles` 结构及用法示例  |
+| `antd changelog [v1] [v2] [component]` | Changelog 条目、版本范围或跨版本 API 对比      |
+
+### 项目分析 {#project-analysis}
+
+| 命令                       | 说明                                                              |
+| -------------------------- | ----------------------------------------------------------------- |
+| `antd doctor`              | 10 项诊断检查：React 兼容性、重复安装、peer 依赖、SSR、babel 插件 |
+| `antd usage [dir]`         | 导入统计、子组件分布（`Form.Item`）、非组件导出                   |
+| `antd lint [target]`       | 废弃 API、无障碍缺陷、性能问题、最佳实践                          |
+| `antd migrate <from> <to>` | 迁移清单，区分自动修复/手动处理，`--apply` 生成 Agent 提示        |
+
+### 全局参数 {#global-flags}
+
+| 参数                            | 说明                          | 默认值   |
+| ------------------------------- | ----------------------------- | -------- |
+| `--format json\|text\|markdown` | 输出格式                      | `text`   |
+| `--version <v>`                 | 目标 antd 版本（如 `5.20.0`） | 自动检测 |
+| `--lang en\|zh`                 | 输出语言                      | `en`     |
+| `--detail`                      | 包含扩展信息                  | `false`  |
+
+## 在 AI 工具中的使用 {#usage-with-ai-tools}
+
+CLI 内置 [Skill 文件](https://github.com/ant-design/ant-design-cli/blob/main/skills/antd/SKILL.md)，指导 Code Agent 在正确的时机调用正确的命令：
+
+```bash
+npx skills add ant-design/ant-design-cli
+```
+
+| 工具 | 说明 |
+| --- | --- |
+| **Claude Code** | 安装为 Agent Skill 或直接在终端使用 `antd` 命令。[文档](https://docs.anthropic.com/en/docs/claude-code) |
+| **Cursor** | 安装 Skill 后，Agent 会自动调用 CLI 命令。[文档](https://docs.cursor.com/zh/context/@-symbols/@-docs) |
+| **Codex** | 安装 Skill 以启用 Agent 访问。[文档](https://github.com/openai/codex) |
+| **Gemini CLI** | 安装 Skill 以启用自动命令调用。[文档](https://github.com/google-gemini/gemini-cli) |
+
+支持所有兼容 [skills](https://github.com/nicepkg/agent-skills) 协议的 Agent。
+
+## 了解更多 {#learn-more}
+
+- [@ant-design/cli GitHub 仓库](https://github.com/ant-design/ant-design-cli)
+- [@ant-design/cli npm 地址](https://www.npmjs.com/package/@ant-design/cli)
+- [Ant Design LLMs.txt 指南](/docs/react/llms-zh-CN)
+- [Ant Design MCP Server](/docs/react/mcp-zh-CN)

--- a/docs/react/introduce.en-US.md
+++ b/docs/react/introduce.en-US.md
@@ -101,6 +101,7 @@ export default App;
 - [Ant Design Mini](https://mini.ant.design)
 - [Ant Design Charts](https://charts.ant.design)
 - [Ant Design Web3](https://web3.ant.design)
+- [🤖 Ant Design CLI](https://github.com/ant-design/ant-design-cli)
 - [Landing Pages](https://landing.ant.design)
 - [Ant Motion](https://motion.ant.design)
 - [Scaffold Market](https://scaffold.ant.design)

--- a/docs/react/introduce.zh-CN.md
+++ b/docs/react/introduce.zh-CN.md
@@ -101,6 +101,7 @@ export default App;
 - [Ant Design Mini](https://mini.ant.design)
 - [Ant Design Charts](https://charts.ant.design)
 - [Ant Design Web3](https://web3.ant.design)
+- [🤖 Ant Design CLI](https://github.com/ant-design/ant-design-cli)
 - [动效](https://motion.ant.design)
 - [首页模板集](https://landing.ant.design)
 - [脚手架市场](https://scaffold.ant.design)

--- a/docs/react/recommendation.en-US.md
+++ b/docs/react/recommendation.en-US.md
@@ -45,6 +45,7 @@ title: Third-Party Libraries
 | Flow-based UI | [pro-flow](https://github.com/ant-design/pro-flow) [react-flow](https://github.com/wbkd/react-flow) [x6](https://github.com/antvis/x6) |
 | Phone Input | [react-phone-number-input](https://gitlab.com/catamphetamine/react-phone-number-input) [antd-phone-input](https://github.com/ArtyomVancyan/antd-phone-input/) |
 | AI Chat | [Ant Design X](https://github.com/ant-design/x) |
+| CLI Tool | [Ant Design CLI](https://github.com/ant-design/ant-design-cli) |
 | PDF | [react-pdf](https://github.com/diegomura/react-pdf) [@react-pdf/renderer](https://github.com/diegomura/react-pdf) |
 | React Gesture | [use-gesture](https://use-gesture.netlify.app) |
 

--- a/docs/react/recommendation.zh-CN.md
+++ b/docs/react/recommendation.zh-CN.md
@@ -47,6 +47,7 @@ title: 社区精选组件
 | Flow 流 | [pro-flow](https://github.com/ant-design/pro-flow) [react-flow](https://github.com/wbkd/react-flow) [x6](https://github.com/antvis/x6) |
 | 电话输入 | [react-phone-number-input](https://gitlab.com/catamphetamine/react-phone-number-input) [antd-phone-input](https://github.com/ArtyomVancyan/antd-phone-input/) |
 | AI 对话应用 | [Ant Design X](https://github.com/ant-design/x) |
+| 命令行工具 | [Ant Design CLI](https://github.com/ant-design/ant-design-cli) |
 | PDF | [react-pdf](https://github.com/diegomura/react-pdf) [@react-pdf/renderer](https://github.com/diegomura/react-pdf) |
 | React 手势库 | [use-gesture](https://use-gesture.netlify.app) |
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 📝 Site / documentation improvement

### 🔗 Related Issues

https://github.com/ant-design/ant-design-cli

### 💡 Background and Solution

[`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) is a new official CLI tool for querying antd component knowledge, analyzing project usage, and guiding migrations — fully offline. This PR adds documentation for it:

- **New CLI doc page** (en/zh): Added `docs/react/cli.en-US.md` and `docs/react/cli.zh-CN.md` under the AI group (alongside LLMs.txt and MCP Server), covering install, commands, global flags, and AI tool integration.
- **Introduction page** (en/zh): Added link in the Links section.
- **Recommendation page** (en/zh): Added "CLI Tool / 命令行工具" category.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 📝 Add `@ant-design/cli` documentation page and links to introduction and recommendation docs. |
| 🇨🇳 Chinese | 📝 新增 `@ant-design/cli` 文档页，并在介绍页和推荐页中添加链接。 |