### PR TITLE
site: make SemanticPreview semantic list scrollable

### DIFF
--- a/.dumi/theme/common/SemanticPreview.tsx
+++ b/.dumi/theme/common/SemanticPreview.tsx
@@ -36,7 +36,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     list-style: none;
     margin: 0;
     padding: 0;
-    overflow: scroll;
+    overflow: auto;
     max-height: 600px;
   `,
   listItem: css`

--- a/.dumi/theme/common/SemanticPreview.tsx
+++ b/.dumi/theme/common/SemanticPreview.tsx
@@ -36,7 +36,8 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     list-style: none;
     margin: 0;
     padding: 0;
-    overflow: hidden;
+    overflow: scroll;
+    max-height: 600px;
   `,
   listItem: css`
     cursor: pointer;

--- a/components/alert/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/alert/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`renders components/alert/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/anchor/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/anchor/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`renders components/anchor/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/auto-complete/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -144,7 +144,7 @@ exports[`renders components/auto-complete/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/badge/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/badge/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`renders components/badge/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"
@@ -306,7 +306,7 @@ exports[`renders components/badge/demo/_semantic_ribbon.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/breadcrumb/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`renders components/breadcrumb/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/button/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/button/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`renders components/button/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/calendar/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/calendar/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -927,7 +927,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/card/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/card/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`renders components/card/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"
@@ -914,7 +914,7 @@ exports[`renders components/card/demo/_semantic_meta.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/cascader/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/cascader/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -311,7 +311,7 @@ exports[`renders components/cascader/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/checkbox/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`renders components/checkbox/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/collapse/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/collapse/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`renders components/collapse/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/color-picker/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -300,7 +300,7 @@ exports[`renders components/color-picker/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/date-picker/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -1305,7 +1305,7 @@ exports[`renders components/date-picker/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/descriptions/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/descriptions/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`renders components/descriptions/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/divider/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/divider/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`renders components/divider/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/drawer/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`renders components/drawer/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/dropdown/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/dropdown/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -228,7 +228,7 @@ exports[`renders components/dropdown/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/empty/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/empty/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`renders components/empty/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/float-button/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/float-button/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`renders components/float-button/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"
@@ -498,7 +498,7 @@ exports[`renders components/float-button/demo/_semantic_group.tsx correctly 1`] 
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/form/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`renders components/form/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/image/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/image/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -315,7 +315,7 @@ exports[`renders components/image/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/input-number/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/input-number/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`renders components/input-number/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/input/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`renders components/input/demo/_semantic_input.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"
@@ -665,7 +665,7 @@ exports[`renders components/input/demo/_semantic_otp.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"
@@ -1050,7 +1050,7 @@ exports[`renders components/input/demo/_semantic_password.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"
@@ -1635,7 +1635,7 @@ exports[`renders components/input/demo/_semantic_search.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"
@@ -2422,7 +2422,7 @@ exports[`renders components/input/demo/_semantic_textarea.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/list/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -202,7 +202,7 @@ exports[`renders components/list/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/masonry/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/masonry/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`renders components/masonry/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/mentions/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/mentions/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`renders components/mentions/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/menu/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/menu/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -281,7 +281,7 @@ exports[`renders components/menu/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/message/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/message/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`renders components/message/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/modal/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/modal/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`renders components/modal/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/notification/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/notification/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`renders components/notification/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/pagination/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/pagination/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -138,7 +138,7 @@ exports[`renders components/pagination/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/popconfirm/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/popconfirm/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`renders components/popconfirm/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/popover/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/popover/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`renders components/popover/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/progress/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/progress/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -154,7 +154,7 @@ exports[`renders components/progress/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/qr-code/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`renders components/qr-code/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/radio/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`renders components/radio/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/result/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/result/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`renders components/result/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/segmented/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/segmented/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`renders components/segmented/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/select/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/select/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -292,7 +292,7 @@ exports[`renders components/select/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/skeleton/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`renders components/skeleton/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"
@@ -769,7 +769,7 @@ exports[`renders components/skeleton/demo/_semantic_element.tsx correctly 1`] = 
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/slider/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/slider/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`renders components/slider/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/space/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/space/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`renders components/space/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/spin/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/spin/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`renders components/spin/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/splitter/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/splitter/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`renders components/splitter/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/statistic/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/statistic/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`renders components/statistic/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/steps/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/steps/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -355,7 +355,7 @@ exports[`renders components/steps/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"
@@ -1648,7 +1648,7 @@ exports[`renders components/steps/demo/_semantic_items.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/switch/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/switch/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`renders components/switch/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/table/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -248,7 +248,7 @@ exports[`renders components/table/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/tabs/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -568,7 +568,7 @@ exports[`renders components/tabs/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/tag/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/tag/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`renders components/tag/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"
@@ -392,7 +392,7 @@ exports[`renders components/tag/demo/_semantic_group.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/time-picker/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/time-picker/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -1688,7 +1688,7 @@ exports[`renders components/time-picker/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/timeline/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/timeline/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`renders components/timeline/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"
@@ -1066,7 +1066,7 @@ exports[`renders components/timeline/demo/_semantic_items.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/tooltip/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`renders components/tooltip/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/tour/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/tour/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`renders components/tour/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/transfer/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/transfer/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -789,7 +789,7 @@ exports[`renders components/transfer/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/tree-select/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/tree-select/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -374,7 +374,7 @@ exports[`renders components/tree-select/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/tree/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/tree/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -226,7 +226,7 @@ exports[`renders components/tree/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"

--- a/components/upload/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/upload/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -290,7 +290,7 @@ exports[`renders components/upload/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-8 css-var-test-id"
     >
       <ul
-        class="acss-1ry21g5"
+        class="acss-11b5qta"
       >
         <li
           class="acss-1ehfz5v"


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

SemanticPreview 页面右侧的语义列表内容较多时会被截断，无法完整浏览。

本次调整将该列表改为可滚动，并限制最大高度，便于在预览较多语义项时继续查看和定位对应项。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | 无需更新日志 |
