### PR TITLE
docs: release 6.3.4

### DIFF
--- a/.agents/skills/changelog-collect/SKILL.md
+++ b/.agents/skills/changelog-collect/SKILL.md
@@ -85,21 +85,35 @@ git log <from-tag>..<to-branch> --oneline
 
 解析每个 commit，提取 PR 编号（匹配 `#12345` 格式）。
 
-#### 1.5 获取每个 PR 的详情并实时写入
+#### 1.5 并行获取每个 PR 的详情
 
-对每个 PR 编号执行：
+**使用并行 subagent 同时获取所有 PR 详情，而不是顺序逐个请求。**
+
+将所有 PR 编号分批（每批最多 10 个），为每批 dispatch 一个 subagent，并行执行：
+
+```
+[主流程]
+  ├── subagent-1: gh pr view 56001 56002 56003 ... 56010
+  ├── subagent-2: gh pr view 56011 56012 56013 ... 56020
+  └── subagent-3: gh pr view 56021 56022 ...
+```
+
+每个 subagent 执行的命令：
 
 ```bash
-gh pr view <pr-number> --json title,body,author
+gh pr view <pr-number> --json title,body,author,number
 ```
 
 返回字段：
 
 - `title`: PR 标题
-- `body`: PR 描述（包含中英文 changelog）
+- `body`: PR 描述（可能包含中英文 changelog）
 - `author`: 提交者
+- `number`: PR 编号
 
-**每获取一个 PR 的详情后，立即追加写入 `~changelog.md`**（而不是等全部遍历完毕）。
+所有 subagent 返回后，汇总结果，再统一进行描述提取和写入。
+
+**每处理完一个 PR 后，立即追加写入 `~changelog.md`**。
 
 追加写入内容：
 
@@ -114,40 +128,9 @@ gh pr view <pr-number> --json title,body,author
 - Chinese: 修复 Select value 为空时高度不正确的问题
 ```
 
-追加写入方式（Bash）：
+##### 从 PR body 提取并校验中英文描述
 
-```bash
-cat >> ~changelog.md << 'EOF'
-
-## abc1234
-
-- PR: 56976
-- Committer: zombieJ
-- Commit: fix: Select height issue
-- Category: Select
-- English: Fix Select incorrect height when value is empty
-- Chinese: 修复 Select value 为空时高度不正确的问题
-EOF
-```
-
-或使用 Node.js：
-
-```javascript
-const content = `
-## ${hash}
-
-- PR: ${prNumber}
-- Committer: ${committer}
-- Commit: ${commitMessage}
-- Category: ${category}
-- English: ${english}
-- Chinese: ${chinese}
-`;
-
-fs.appendFileSync('~changelog.md', content, 'utf8');
-```
-
-##### 从 PR body 提取中英文描述
+**有限使用 PR body 中的 changelog，但必须校验合规性。**
 
 PR body 中提取 changelog 的模式：
 
@@ -174,7 +157,92 @@ Chinese:
 - 识别 `🇺🇸 English` 或 `English:` 标记后的 `- ` 行作为英文描述
 - 识别 `🇨🇳 Chinese` 或 `Chinese:` 标记后的 `- ` 行作为中文描述
 
-如果 PR body 中没有明确的中英文描述，则查询完整 commit 内容，自动生成。
+**提取后必须按照 antd changelog 规范进行校验，不合规则改写**（见下方"Changelog 合规校验"）。
+
+**如果 PR body 中没有 changelog 内容**，则根据 PR title、body 描述和 commit 信息自动生成符合规范的描述（见下方"无 changelog 时自动生成"）。
+
+##### 过滤规则：哪些 PR 不写入 changelog
+
+以下改动**不应出现**在 changelog 中（用户无感知）：
+
+- 纯内部重构（不影响 API 和行为）
+- 纯测试更新（新增/修改测试用例，无功能变更）
+- CI/工具链/依赖升级（与组件无关）
+- 文档/站点样式微调（不影响组件本身）
+- chore、build、ci 类型的 commit
+
+遇到上述类型，在 `~changelog.md` 中标记 `Skip: true`，最终写入时过滤掉。
+
+##### Changelog 合规校验
+
+对从 PR body 提取的描述，逐条检查以下规范，不符合的**必须改写**：
+
+| 规则 | 正确示例 | 错误示例 |
+| --- | --- | --- |
+| Emoji 必须在**行首** | `🐞 Fix Select height` | `Fix Select height 🐞` |
+| 必须以动作动词开头（Emoji 之后） | `🐞 修复 Select ...` / `🆕 新增 Button ...` | `Select 修复...` |
+| 正文必须包含**组件名** | `🐞 Fix Select height issue` | `🐞 Fix height issue` |
+| 组件名**不加反引号** | `Fix Select height` | `Fix \`Select\` height` |
+| **属性名/API 用反引号** | `Fix Select \`value\` prop` | `Fix Select value prop` |
+| 组件名后**不加冒号** | `🐞 Fix Select height` | `🐞 Fix Select: height` |
+| 中文与英文/数字之间保留空格 | `修复 Select 在暗色主题的问题` | `修复Select在暗色主题的问题` |
+| 每条只选一个 Emoji，不叠加 | `🐞 Fix Select ...` | `🐞🆕 Fix Select ...` |
+| 描述开发者影响，不描述实现细节 | `Fix Select height when empty` | `Remove minHeight CSS property` |
+
+**Emoji 规范**（完整版，从 CLAUDE.md 同步）：
+
+| Emoji  | 用途                   |
+| ------ | ---------------------- |
+| 🐞     | 修复 Bug               |
+| 💄     | 样式更新或 token 更新  |
+| 🆕     | 新增特性 / 新增属性    |
+| 🔥     | 极其值得关注的新增特性 |
+| 🇺🇸🇨🇳🇬🇧 | 国际化改动             |
+| 📖 📝  | 文档或网站改进         |
+| ✅     | 新增或更新测试用例     |
+| 🛎     | 更新警告/提示信息      |
+| ⌨️ ♿  | 可访问性增强           |
+| 🗑     | 废弃或移除             |
+| 🛠     | 重构或工具链优化       |
+| ⚡️     | 性能提升               |
+
+**commit 类型 → Emoji / 动词 映射**：
+
+| commit 前缀                | 中文动词   | 英文动词            | Emoji        |
+| -------------------------- | ---------- | ------------------- | ------------ |
+| `fix:` / `bug:`            | 修复       | Fix                 | 🐞           |
+| `feat:` / `feature:`       | 新增       | Add                 | 🆕           |
+| `style:` / `ui:`           | 优化       | Improve             | 💄           |
+| `refactor:`                | 重构       | Refactor            | 🛠           |
+| `perf:`                    | 提升性能   | Improve performance | ⚡️           |
+| `docs:`                    | 更新文档   | Update docs         | 📝           |
+| `i18n:` / `locale:`        | 更新国际化 | Update i18n         | 🇺🇸           |
+| `deprecate:`               | 废弃       | Deprecate           | 🗑           |
+| `chore:` / `test:` / `ci:` | —          | —                   | 跳过，不写入 |
+
+##### 无 changelog 时自动生成
+
+当 PR body 中没有 changelog 内容（无 English/Chinese 标记）时，根据以下信息生成：
+
+1. 优先使用 **PR title**（经过格式标准化，不能原文照抄）
+2. 参考 **PR body 的描述内容**（提取关键改动点，描述对开发者的影响）
+3. 如有必要，查看 `git show <hash>` 的 diff 内容辅助理解改动
+
+生成规则：
+
+- 根据 PR title 前缀或内容判断动作类型（fix/feat/style 等）
+- Emoji 置于**行首**，选择对应的 Emoji 和动词
+- 格式：`Emoji 动词 组件名 改动描述`（中英文各一条）
+- 描述"对开发者的影响"，而非"具体的实现细节"
+
+**示例**：
+
+```
+PR title: fix(Select): fix height issue when value is empty
+↓ 自动生成
+English: 🐞 Fix Select incorrect height when value is empty
+Chinese: 🐞 修复 Select value 为空时高度不正确的问题
+```
 
 ##### 识别组件 Category
 
@@ -265,22 +333,38 @@ const componentNames = [
 - Chinese: 修复 Select value 为空时高度不正确的问题
 ```
 
-**AGENTS.md 规范引用：**
+**CLAUDE.md 规范引用：**参考项目根目录 `CLAUDE.md` 中的 Changelog 规范（核心原则、格式规范、Emoji 规范、句式规范）。
 
-- [核心原则](../../../AGENTS.md#核心原则) - 有效性过滤规则
-- [格式规范](../../../AGENTS.md#格式规范) - 分组、描述、Emoji 规范
-- [Emoji 规范](../../../AGENTS.md#emoji-规范) - 根据 commit 类型自动标记
-- [句式](../../../AGENTS.md#句式) - 中英文格式参考
+根据规范，对 `~changelog.md` 中的条目进行过滤、分组、格式检查，并在必要时进行交互式确认和修改。
 
-根据 AGENTS.md 的规范，对 `~changelog.md` 中的条目进行过滤、分组、格式检查，并在必要时进行交互式确认和修改。
+#### 过滤规则
+
+- 跳过 `chore:`、`test:`、`ci:`、`build:` 类型的 commit
+- 跳过纯文档/站点改动（不影响组件 API 和行为的）
+- 跳过纯测试更新和工具链升级
+
+#### 分组逻辑
+
+- **同一组件有 2 条及以上改动时**，使用 `- 组件名` 作为分类标题，改动条目缩进列在其下
+- **单项改动**直接写单行条目，不需要标题
+
+**示例（多条）**：
+
+```markdown
+- Select
+  - 🐞 Fix Select incorrect height when value is empty. [#56976](https://github.com/ant-design/ant-design/pull/56976) [@zombieJ](https://github.com/zombieJ)
+  - 💄 Improve Select dropdown animation. [#56980](https://github.com/ant-design/ant-design/pull/56980) [@afc163](https://github.com/afc163)
+- 🐞 Fix Button style in Safari. [#56901](https://github.com/ant-design/ant-design/pull/56901) [@li](https://github.com/li)
+```
 
 #### 描述与署名补充规则
 
-- 描述必须以动作开头：中文优先使用 `修复`、`优化`、`新增`、`重构` 等动词开头；英文优先使用 `Fix`、`Improve`、`Add`、`Refactor` 开头。
-- 在“动作开头”的前提下，正文仍需包含组件名（例如：`修复 Select ...`、`Fix Select ...`）。
-- 每条 changelog 统一补充 PR 作者链接（如 `[@username](https://github.com/username)`），不再校验是否为团队成员。
+- Emoji 在行首，动词紧跟其后
+- 组件名不加反引号；属性名、API 名用反引号
+- 描述"对开发者的影响"，而非"具体实现细节"
+- 每条 changelog 统一补充 **PR 链接** 和 **PR 作者链接**，顺序为先 PR 后作者（如 `[#56976](https://github.com/ant-design/ant-design/pull/56976) [@username](https://github.com/username)`），不区分是否团队成员
 
-### 阶段三：写入文件
+### 阶段三：写入文件并校验
 
 在 `---` front matter 之后、第一个版本标题之前插入新内容：
 
@@ -290,6 +374,19 @@ const componentNames = [
 4. 写入文件
 
 同样流程处理 CHANGELOG.en-US.md
+
+**写入后必须运行 lint 校验**：
+
+```bash
+npm run lint:changelog
+```
+
+如果 lint 报错，根据错误信息修正对应的 changelog 条目，重新写入，直到 lint 通过。常见错误类型：
+
+- Emoji 格式不符
+- 中英文空格缺失
+- 组件名使用了反引号
+- 版本格式或日期格式不对
 
 ### 版本确认（可选）
 
@@ -329,18 +426,20 @@ const componentNames = [
    ↓
 4. 初始化 ~changelog.md 头部（写入版本信息）
    ↓
-5. git log 获取两个版本间的 commits
+5. git log 获取两个版本间的 commits，提取所有 PR 编号
    ↓
-6. 对每个 PR 执行 gh pr view 获取详情
+6. **并行 dispatch subagents** 批量获取 PR 详情（每批最多 10 个）
    ↓
-7. 从 PR body 提取中英文描述
+7. 汇总所有 PR 结果，逐条处理：
+   ├── 有 changelog → 提取 → **校验合规性** → 不合规则改写
+   └── 无 changelog → 根据 PR title/body/diff **自动生成**符合规范的描述
    ↓
 8. 识别组件 category
    ↓
-9. **实时追加写入** ~changelog.md（每获取一个 PR 就写入）
+9. 追加写入 ~changelog.md
    ↓
 10. 过滤无效 commit（交互确认）
-     ↓
+    ↓
 11. 分组处理（按组件名）
     ↓
 12. 检查描述规范性（交互确认）
@@ -353,7 +452,11 @@ const componentNames = [
     ↓
 16. 写入 CHANGELOG.zh-CN.md 和 CHANGELOG.en-US.md
     ↓
-17. 清理临时文件 ~changelog.md
+17. **运行 `npm run lint:changelog` 校验，有报错则修正并重新写入**
+    ↓
+18. 清理临时文件 ~changelog.md
+    ↓
+19. （可选）创建发布 PR，PR body 中直接包含完整的中英文 changelog 内容
 ```
 
 ## 所需命令
@@ -362,11 +465,12 @@ const componentNames = [
 
 - `git tag --list` - 获取版本标签
 - `git log <from>..<to> --oneline` - 获取版本间 commits
-- `gh pr view <pr-number> --json title,body,author` - 获取 PR 详情
-- `git show <hash>` - 查看 commit 详情
+- `gh pr view <pr-number> --json title,body,author,number` - 获取 PR 详情
+- `git show <hash>` - 查看 commit 详情（用于无 changelog 时辅助生成描述）
 - `npm version minor` - 升级次版本号（6.3.1 → 6.4.0）
 - `npm version patch` - 升级修订版本号（6.3.1 → 6.3.2）
-- `cat >> ~changelog.md` 或 Node.js fs.appendFileSync - 实时追加写入
+- `cat >> ~changelog.md` 或 Node.js fs.appendFileSync - 追加写入
+- `npm run lint:changelog` - 校验 changelog 格式（写入后必须运行）
 
 ## 注意事项
 
@@ -375,4 +479,5 @@ const componentNames = [
 - 保持中英文同步更新
 - 描述以动作开头，并保证正文包含组件名（如 `修复 Select ...`、`Fix Select ...`）
 - 统一添加 PR 作者链接（不区分是否团队成员）
-- PR body 中没有中英文描述时，使用 PR title 作为后备
+- PR body 有 changelog 时，以 PR body 为准，但必须校验并按 antd 规范改写不合规内容
+- PR body 无 changelog 时，根据 PR title/body/diff 自动生成，不能只用 PR title 原文照抄

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,23 @@ tag: vVERSION
 
 ---
 
+## 6.3.4
+
+`2026-03-24`
+
+- 🔥 Add [`@ant-design/cli`](https://www.npmjs.com/package/@ant-design/cli) official command-line tool for querying Ant Design component knowledge, analyzing project usage, and guiding migrations offline. [#57413](https://github.com/ant-design/ant-design/pull/57413) [@afc163](https://github.com/afc163)
+- 🐞 Fix Form.List losing sibling field values when using `onValuesChange`. [#57399](https://github.com/ant-design/ant-design/pull/57399) [@zombieJ](https://github.com/zombieJ)
+- 🐞 Fix missing `screenXXXLMin` in `useToken` causing incorrect antd.css to be generated. [#57372](https://github.com/ant-design/ant-design/pull/57372) [@sealye09](https://github.com/sealye09)
+- 🐞 Fix ConfigProvider component config typings to expose semantic `classNames` and `styles` for supported components. [#57396](https://github.com/ant-design/ant-design/pull/57396) [@QDyanbing](https://github.com/QDyanbing)
+- 🐞 Fix Image `fetchPriority` prop not being passed through to the `<img>` element. [#57392](https://github.com/ant-design/ant-design/pull/57392) [@aojunhao123](https://github.com/aojunhao123)
+- Menu
+  - 🐞 Fix Menu SubMenu parent item not applying custom hover color via ConfigProvider. [#57374](https://github.com/ant-design/ant-design/pull/57374) [@EmilyyyLiu](https://github.com/EmilyyyLiu)
+  - 🐞 Fix Menu collapsed icons appearing misaligned when customizing `collapsedIconSize`. [#57360](https://github.com/ant-design/ant-design/pull/57360) [@QDyanbing](https://github.com/QDyanbing)
+- 🐞 Fix Table controlled popover in column title being rendered twice when scroll is enabled. [#57342](https://github.com/ant-design/ant-design/pull/57342) [@QDyanbing](https://github.com/QDyanbing)
+- 🐞 Fix Transfer `render` prop returning JSX elements causing search to fail. [#57133](https://github.com/ant-design/ant-design/pull/57133) [@WustLCQ](https://github.com/WustLCQ)
+- 🐞 Fix Tree custom `switcherIcon` missing `switcher-line-icon` className when `showLine` is enabled. [#57303](https://github.com/ant-design/ant-design/pull/57303) [@QDyanbing](https://github.com/QDyanbing)
+- 🐞 Fix Watermark TypeScript errors when `onRemove` is omitted. [#57344](https://github.com/ant-design/ant-design/pull/57344) [@QDyanbing](https://github.com/QDyanbing)
+
 ## 6.3.3
 
 `2026-03-16`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,23 @@ tag: vVERSION
 
 ---
 
+## 6.3.4
+
+`2026-03-24`
+
+- 🔥 新增官方命令行工具 [`@ant-design/cli`](https://www.npmjs.com/package/@ant-design/cli)，支持离线查询 Ant Design 组件知识、分析项目用法及提供迁移指导。[#57413](https://github.com/ant-design/ant-design/pull/57413) [@afc163](https://github.com/afc163)
+- 🐞 修复 Form.List 在使用 `onValuesChange` 时丢失同级字段值的问题。[#57399](https://github.com/ant-design/ant-design/pull/57399) [@zombieJ](https://github.com/zombieJ)
+- 🐞 修复 `useToken` 缺少 `screenXXXLMin` 导致生成错误的 antd.css 的问题。[#57372](https://github.com/ant-design/ant-design/pull/57372) [@sealye09](https://github.com/sealye09)
+- 🐞 修复 ConfigProvider 组件配置的类型定义，为已支持的组件暴露语义化 `classNames` 和 `styles`。[#57396](https://github.com/ant-design/ant-design/pull/57396) [@QDyanbing](https://github.com/QDyanbing)
+- 🐞 修复 Image 组件 `fetchPriority` 属性未正确透传到 `<img>` 元素的问题。[#57392](https://github.com/ant-design/ant-design/pull/57392) [@aojunhao123](https://github.com/aojunhao123)
+- Menu
+  - 🐞 修复通过 ConfigProvider 自定义 Menu 的 `itemHoverColor` 时，SubMenu 父级菜单项 hover 状态颜色不生效的问题。[#57374](https://github.com/ant-design/ant-design/pull/57374) [@EmilyyyLiu](https://github.com/EmilyyyLiu)
+  - 🐞 修复 Menu 自定义 `collapsedIconSize` 后折叠图标看起来未居中的问题。[#57360](https://github.com/ant-design/ant-design/pull/57360) [@QDyanbing](https://github.com/QDyanbing)
+- 🐞 修复 Table 在开启滚动时列头中受控 Popover 被重复渲染的问题。[#57342](https://github.com/ant-design/ant-design/pull/57342) [@QDyanbing](https://github.com/QDyanbing)
+- 🐞 修复 Transfer `render` 属性返回 JSX 元素时搜索功能失效的问题。[#57133](https://github.com/ant-design/ant-design/pull/57133) [@WustLCQ](https://github.com/WustLCQ)
+- 🐞 修复 Tree 开启 `showLine` 时自定义 `switcherIcon` 缺少 `switcher-line-icon` 类名导致样式异常的问题。[#57303](https://github.com/ant-design/ant-design/pull/57303) [@QDyanbing](https://github.com/QDyanbing)
+- 🐞 修复 Watermark 在未传入 `onRemove` 时的 TypeScript 报错。[#57344](https://github.com/ant-design/ant-design/pull/57344) [@QDyanbing](https://github.com/QDyanbing)
+
 ## 6.3.3
 
 `2026-03-16`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "6.3.3",
+  "version": "6.3.4",
   "description": "An enterprise-class UI design language and React components implementation",
   "license": "MIT",
   "funding": {

--- a/scripts/generate-component-changelog.ts
+++ b/scripts/generate-component-changelog.ts
@@ -49,6 +49,7 @@ const miscKeys = [
   'antd',
   '@ant-design/cssinjs',
   '@ant-design/icons',
+  '@ant-design/cli',
   'rc-motion',
   '@rc-component/motion',
   ' IE ',


### PR DESCRIPTION
## 6.3.4

`2026-03-24`

- 🔥 Add [`@ant-design/cli`](https://www.npmjs.com/package/@ant-design/cli) official command-line tool for querying Ant Design component knowledge, analyzing project usage, and guiding migrations offline. [#57413](https://github.com/ant-design/ant-design/pull/57413) [@afc163](https://github.com/afc163)
- 🐞 Fix Form.List losing sibling field values when using `onValuesChange`. [#57399](https://github.com/ant-design/ant-design/pull/57399) [@zombieJ](https://github.com/zombieJ)
- 🐞 Fix missing `screenXXXLMin` in `useToken` causing incorrect antd.css to be generated. [#57372](https://github.com/ant-design/ant-design/pull/57372) [@sealye09](https://github.com/sealye09)
- 🐞 Fix ConfigProvider component config typings to expose semantic `classNames` and `styles` for supported components. [#57396](https://github.com/ant-design/ant-design/pull/57396) [@QDyanbing](https://github.com/QDyanbing)
- 🐞 Fix Image `fetchPriority` prop not being passed through to the `<img>` element. [#57392](https://github.com/ant-design/ant-design/pull/57392) [@aojunhao123](https://github.com/aojunhao123)
- Menu
  - 🐞 Fix Menu SubMenu parent item not applying custom hover color via ConfigProvider. [#57374](https://github.com/ant-design/ant-design/pull/57374) [@EmilyyyLiu](https://github.com/EmilyyyLiu)
  - 🐞 Fix Menu collapsed icons appearing misaligned when customizing `collapsedIconSize`. [#57360](https://github.com/ant-design/ant-design/pull/57360) [@QDyanbing](https://github.com/QDyanbing)
- 🐞 Fix Table controlled popover in column title being rendered twice when scroll is enabled. [#57342](https://github.com/ant-design/ant-design/pull/57342) [@QDyanbing](https://github.com/QDyanbing)
- 🐞 Fix Transfer `render` prop returning JSX elements causing search to fail. [#57133](https://github.com/ant-design/ant-design/pull/57133) [@WustLCQ](https://github.com/WustLCQ)
- 🐞 Fix Tree custom `switcherIcon` missing `switcher-line-icon` className when `showLine` is enabled. [#57303](https://github.com/ant-design/ant-design/pull/57303) [@QDyanbing](https://github.com/QDyanbing)
- 🐞 Fix Watermark TypeScript errors when `onRemove` is omitted. [#57344](https://github.com/ant-design/ant-design/pull/57344) [@QDyanbing](https://github.com/QDyanbing)

---

## 6.3.4

`2026-03-24`

- 🔥 新增官方命令行工具 [`@ant-design/cli`](https://www.npmjs.com/package/@ant-design/cli)，支持离线查询 Ant Design 组件知识、分析项目用法及提供迁移指导。[#57413](https://github.com/ant-design/ant-design/pull/57413) [@afc163](https://github.com/afc163)
- 🐞 修复 Form.List 在使用 `onValuesChange` 时丢失同级字段值的问题。[#57399](https://github.com/ant-design/ant-design/pull/57399) [@zombieJ](https://github.com/zombieJ)
- 🐞 修复 `useToken` 缺少 `screenXXXLMin` 导致生成错误的 antd.css 的问题。[#57372](https://github.com/ant-design/ant-design/pull/57372) [@sealye09](https://github.com/sealye09)
- 🐞 修复 ConfigProvider 组件配置的类型定义，为已支持的组件暴露语义化 `classNames` 和 `styles`。[#57396](https://github.com/ant-design/ant-design/pull/57396) [@QDyanbing](https://github.com/QDyanbing)
- 🐞 修复 Image 组件 `fetchPriority` 属性未正确透传到 `<img>` 元素的问题。[#57392](https://github.com/ant-design/ant-design/pull/57392) [@aojunhao123](https://github.com/aojunhao123)
- Menu
  - 🐞 修复通过 ConfigProvider 自定义 Menu 的 `itemHoverColor` 时，SubMenu 父级菜单项 hover 状态颜色不生效的问题。[#57374](https://github.com/ant-design/ant-design/pull/57374) [@EmilyyyLiu](https://github.com/EmilyyyLiu)
  - 🐞 修复 Menu 自定义 `collapsedIconSize` 后折叠图标看起来未居中的问题。[#57360](https://github.com/ant-design/ant-design/pull/57360) [@QDyanbing](https://github.com/QDyanbing)
- 🐞 修复 Table 在开启滚动时列头中受控 Popover 被重复渲染的问题。[#57342](https://github.com/ant-design/ant-design/pull/57342) [@QDyanbing](https://github.com/QDyanbing)
- 🐞 修复 Transfer `render` 属性返回 JSX 元素时搜索功能失效的问题。[#57133](https://github.com/ant-design/ant-design/pull/57133) [@WustLCQ](https://github.com/WustLCQ)
- 🐞 修复 Tree 开启 `showLine` 时自定义 `switcherIcon` 缺少 `switcher-line-icon` 类名导致样式异常的问题。[#57303](https://github.com/ant-design/ant-design/pull/57303) [@QDyanbing](https://github.com/QDyanbing)
- 🐞 修复 Watermark 在未传入 `onRemove` 时的 TypeScript 报错。[#57344](https://github.com/ant-design/ant-design/pull/57344) [@QDyanbing](https://github.com/QDyanbing)