### PR TITLE
docs: clarify PR body language guidance in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,10 +37,10 @@ ant-design/
 
 ### API 表格格式
 
-| Property | Description | Type | Default | Version |
-|---|---|---|---|---|
-| disabled | 是否禁用 | boolean | false | - |
-| type | 按钮类型 | `primary` \| `default` | `default` | - |
+| Property | Description | Type                   | Default   | Version |
+| -------- | ----------- | ---------------------- | --------- | ------- |
+| disabled | 是否禁用    | boolean                | false     | -       |
+| type     | 按钮类型    | `primary` \| `default` | `default` | -       |
 
 - 字符串默认值用反引号，布尔/数字直接写，无默认值用 `-`
 - API 按字母顺序排列，新增属性需声明版本号
@@ -65,7 +65,7 @@ ant-design/
 ### 标题与内容
 
 - PR 标题始终使用英文，格式：`类型: 简短描述`
-- PR 内容默认使用英文
+- PR 内容默认使用英文，可根据用户语言习惯决定使用中文或英文
 - 示例：`fix: fix button style issues in Safari browser`
 
 ### PR 模板（必须使用）
@@ -121,7 +121,7 @@ ant-design/
 #### 句式
 
 | 语言 | 格式 | 示例 |
-|---|---|---|
+| --- | --- | --- |
 | 中文 | `Emoji 动词 组件名 描述`（动词在前） | `🐞 修复 Button 在暗色主题下 \`color\` 的问题。` |
 | 英文 | `Emoji 动词 组件名 描述`（动词在前） | `🐞 Fix Button reversed \`hover\` colors in dark theme.` |
 
@@ -133,7 +133,7 @@ ant-design/
 ### Emoji 规范
 
 | Emoji  | 用途                   |
-|--------|------------------------|
+| ------ | ---------------------- |
 | 🐞     | 修复 Bug               |
 | 💄     | 样式更新或 token 更新  |
 | 🆕     | 新增特性 / 新增属性    |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- 无

### 💡 需求背景和解决方案

- 更新 `CLAUDE.md` 中的 PR 规范说明，明确 PR 标题保持英文，PR 正文默认使用英文，但可根据用户语言习惯决定使用中文或英文。
- 本次提交同时包含 Markdown 格式化带来的表格对齐调整，不涉及代码逻辑变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |
