### PR TITLE
fix: respect AutoComplete popupMatchSelectWidth={false}

### DIFF
--- a/components/auto-complete/AutoComplete.tsx
+++ b/components/auto-complete/AutoComplete.tsx
@@ -120,7 +120,7 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
 
   const mergedPopupRender = popupRender || dropdownRender;
   const mergedOnOpenChange = onOpenChange || onDropdownVisibleChange;
-  const mergedPopupMatchSelectWidth = popupMatchSelectWidth || dropdownMatchSelectWidth;
+  const mergedPopupMatchSelectWidth = popupMatchSelectWidth ?? dropdownMatchSelectWidth;
 
   // ============================= Input =============================
   let customizeInput: React.ReactElement | undefined;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #57427

### 💡 需求背景和解决方案

AutoComplete 在 6.3.3 和 6.3.4 中把 `popupMatchSelectWidth` 与兼容属性 `dropdownMatchSelectWidth` 通过 `||` 合并，导致显式传入 `false` 时被回退掉，下拉面板仍然会跟输入框保持同宽。

这个改动将合并逻辑改为 `??`，保留 `popupMatchSelectWidth={false}` 的显式配置，同时继续兼容旧属性的 fallback 逻辑，恢复该属性的预期行为。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix AutoComplete `popupMatchSelectWidth={false}` not taking effect. |
| 🇨🇳 中文 | 🐞 修复 AutoComplete `popupMatchSelectWidth={false}` 不生效的问题。 |
