### PR TITLE
feat: support itemDateContent semantic for Calendar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,13 +37,28 @@ ant-design/
 
 ### API 表格格式
 
+英文版：
+
 | Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
 | --- | --- | --- | --- | --- | --- |
-| disabled | 是否禁用 | boolean | false | - | - |
-| type | 按钮类型 | `primary` \| `default` | `default` | - | - |
+| disabled | Whether the component is disabled | boolean | false | - | × |
+| loadingIcon | (Only supports global configuration) Custom loading icon | ReactNode | - | - | 6.2.0 |
+| type | Button type | `primary` \| `default` | `default` | - | ✔ |
 
-- 字符串默认值用反引号，布尔/数字直接写，无默认值用 `-`
-- API 按字母顺序排列，新增属性需声明版本号
+中文版：
+
+| 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| disabled | 是否禁用 | boolean | false | - | × |
+| loadingIcon | (仅支持全局配置) 自定义加载图标 | ReactNode | - | × | 6.2.0 |
+| type | 按钮类型 | `primary` \| `default` | `default` | - | ✔ |
+
+- 参数：按字母顺序排列
+- 说明：简洁描述参数作用，如果仅支持全局配置需在描述中用括号注明
+- 类型：使用 TypeScript 定义的类型
+- 默认值：字符串用反引号，布尔/数字直接写，无默认值用 `-`
+- 版本：新增属性需声明引入的版本号；上个大版本已存在属性标注 `-`；仅支持全局配置的属性标注 `×`
+- 全局配置：支持全局配置的属性需标注版本号；上个大版本已支持的标注 `✔`；不支持全局配置的属性标注 `×`
 
 ### 文档锚点 ID 规范
 

--- a/components/alert/index.en-US.md
+++ b/components/alert/index.en-US.md
@@ -37,21 +37,26 @@ group:
 
 Common props ref：[Common props](/docs/react/common-props)
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| action | The action of Alert | ReactNode | - | 4.9.0 |
-| ~~afterClose~~ | Called when close animation is finished, please use `closable.afterClose` instead | () => void | - |  |
-| banner | Whether to show as banner | boolean | false |  |
-| classNames | Customize class for each semantic structure inside the component. Supports object or function | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| closable | The config of closable, >=5.15.0: support `aria-*` | boolean \| [ClosableType](#closabletype) & React.AriaAttributes | `false` |  |
-| description | Additional content of Alert | ReactNode | - |  |
-| icon | Custom icon, effective when `showIcon` is true | ReactNode | - |  |
-| ~~message~~ | Content of Alert, please use `title` instead | ReactNode | - |  |
-| title | Content of Alert | ReactNode | - |  |
-| showIcon | Whether to show icon | boolean | false, in `banner` mode default is true |  |
-| styles | Customize inline style for each semantic structure inside the component. Supports object or function | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
-| type | Type of Alert styles, options: `success`, `info`, `warning`, `error` | string | `info`, in `banner` mode default is `warning` |  |
-| ~~onClose~~ | Callback when Alert is closed, please use `closable.onClose` instead | (e: MouseEvent) => void | - |  |
+| Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| action | The action of Alert | ReactNode | - |  | × |
+| ~~afterClose~~ | Called when close animation is finished, please use `closable.afterClose` instead | () => void | - |  | × |
+| banner | Whether to show as banner | boolean | false |  | × |
+| classNames | Customize class for each semantic structure inside the component. Supports object or function | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
+| closable | The config of closable | boolean \| [ClosableType](#closabletype) & React.AriaAttributes | `false` |  | ✔ |
+| closeIcon | (Only supports global configuration) Custom close icon | ReactNode | - | × | 6.3.0 |
+| description | Additional content of Alert | ReactNode | - |  | × |
+| errorIcon | (Only supports global configuration) Custom error icon in Alert icon | ReactNode | - | × | 6.2.0 |
+| icon | Custom icon, effective when `showIcon` is true | ReactNode | - |  | × |
+| infoIcon | (Only supports global configuration) Custom info icon in Alert icon | ReactNode | - | × | 6.2.0 |
+| ~~message~~ | Content of Alert, please use `title` instead | ReactNode | - |  | × |
+| ~~onClose~~ | Callback when Alert is closed, please use `closable.onClose` instead | (e: MouseEvent) => void | - |  | × |
+| showIcon | Whether to show icon | boolean | false, in `banner` mode default is true |  | × |
+| styles | Customize inline style for each semantic structure inside the component. Supports object or function | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
+| successIcon | (Only supports global configuration) Custom success icon in Alert icon | ReactNode | - | × | 6.2.0 |
+| title | Content of Alert | ReactNode | - |  | × |
+| type | Type of Alert styles, options: `success`, `info`, `warning`, `error` | string | `info`, in `banner` mode default is `warning` |  | × |
+| warningIcon | (Only supports global configuration) Custom warning icon in Alert icon | ReactNode | - | × | 6.2.0 |
 
 ### ClosableType
 

--- a/components/alert/index.zh-CN.md
+++ b/components/alert/index.zh-CN.md
@@ -38,21 +38,26 @@ group:
 
 通用属性参考：[通用属性](/docs/react/common-props)
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| action | 自定义操作项 | ReactNode | - | 4.9.0 |
-| ~~afterClose~~ | 关闭动画结束后触发的回调函数，请使用 `closable.afterClose` 替换 | () => void | - |  |
-| banner | 是否用作顶部公告 | boolean | false |  |
-| classNames | 自定义组件内部各语义化结构的类名。支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| closable | 可关闭配置，>=5.15.0: 支持 `aria-*` | boolean \| [ClosableType](#closabletype) & React.AriaAttributes | `false` |  |
-| description | 警告提示的辅助性文字介绍 | ReactNode | - |  |
-| icon | 自定义图标，`showIcon` 为 true 时有效 | ReactNode | - |  |
-| ~~message~~ | 警告提示内容，请使用 `title` 替换 | ReactNode | - |  |
-| title | 警告提示内容 | ReactNode | - |  |
-| showIcon | 是否显示辅助图标 | boolean | false，`banner` 模式下默认值为 true |  |
-| styles | 自定义组件内部各语义化结构的内联样式。支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
-| type | 指定警告提示的样式，有四种选择 `success`、`info`、`warning`、`error` | string | `info`，`banner` 模式下默认值为 `warning` |  |
-| ~~onClose~~ | 关闭时触发的回调函数，请使用 `closable.onClose` 替换 | (e: MouseEvent) => void | - |  |
+| 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| action | 自定义操作项 | ReactNode | - |  | × |
+| ~~afterClose~~ | 关闭动画结束后触发的回调函数，请使用 `closable.afterClose` 替换 | () => void | - |  | × |
+| banner | 是否用作顶部公告 | boolean | false |  | × |
+| classNames | 自定义组件内部各语义化结构的类名。支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
+| closable | 可关闭配置 | boolean \| [ClosableType](#closabletype) & React.AriaAttributes | `false` |  | ✔ |
+| closeIcon | （仅支持全局配置）自定义关闭图标 | ReactNode | - | × | 6.3.0 |
+| description | 警告提示的辅助性文字介绍 | ReactNode | - |  | × |
+| errorIcon | （仅支持全局配置）自定义错误图标 | ReactNode | - | × | 6.2.0 |
+| icon | 自定义图标，`showIcon` 为 true 时有效 | ReactNode | - |  | × |
+| infoIcon | （仅支持全局配置）自定义信息图标 | ReactNode | - | × | 6.2.0 |
+| ~~message~~ | 警告提示内容，请使用 `title` 替换 | ReactNode | - |  | × |
+| ~~onClose~~ | 关闭时触发的回调函数，请使用 `closable.onClose` 替换 | (e: MouseEvent) => void | - |  | × |
+| showIcon | 是否显示辅助图标 | boolean | false，`banner` 模式下默认值为 true |  | × |
+| styles | 自定义组件内部各语义化结构的内联样式。支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
+| successIcon | （仅支持全局配置）自定义成功图标 | ReactNode | - | × | 6.2.0 |
+| title | 警告提示内容 | ReactNode | - |  | × |
+| type | 指定警告提示的样式，有四种选择 `success`、`info`、`warning`、`error` | string | `info`，`banner` 模式下默认值为 `warning` |  | × |
+| warningIcon | （仅支持全局配置）自定义警告图标 | ReactNode | - | × | 6.2.0 |
 
 ### ClosableType
 

--- a/components/calendar/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/calendar/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -204,7 +204,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           30
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -221,7 +221,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           31
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -238,7 +238,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           01
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -255,7 +255,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           02
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -272,7 +272,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           03
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -289,7 +289,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           04
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -306,7 +306,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           05
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -325,7 +325,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           06
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -342,7 +342,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           07
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -359,7 +359,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           08
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -376,7 +376,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           09
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -393,7 +393,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           10
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -410,7 +410,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           11
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -427,7 +427,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           12
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -446,7 +446,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           13
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -463,7 +463,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           14
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -480,7 +480,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           15
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -497,7 +497,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           16
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -514,7 +514,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           17
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -531,7 +531,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           18
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -548,7 +548,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           19
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -567,7 +567,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           20
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -584,7 +584,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           21
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -601,7 +601,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           22
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -618,7 +618,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           23
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -635,7 +635,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           24
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -652,7 +652,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           25
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -669,7 +669,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           26
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -688,7 +688,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           27
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -705,7 +705,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           28
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -722,7 +722,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           29
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -739,7 +739,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           30
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -756,7 +756,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           01
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -773,7 +773,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           02
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -790,7 +790,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           03
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -809,7 +809,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           04
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -826,7 +826,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           05
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -843,7 +843,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           06
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -860,7 +860,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           07
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -877,7 +877,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           08
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -894,7 +894,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           09
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -911,7 +911,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           10
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -1416,6 +1416,104 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
               style="margin: 0px; font-size: 12px;"
             >
               条目元素，包含日历单元格的背景色、边框、悬停态、选中态等交互样式
+            </div>
+          </div>
+        </li>
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
+                  itemDateContent
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-test-id"
+                >
+                  6.0.0
+                </span>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              日期内容元素，包含日历单元格内自定义内容区域的高度、溢出等样式控制
             </div>
           </div>
         </li>

--- a/components/calendar/__tests__/semantic.test.tsx
+++ b/components/calendar/__tests__/semantic.test.tsx
@@ -1,9 +1,32 @@
 import React from 'react';
 
+import dayjsGenerateConfig from '@rc-component/picker/generate/dayjs';
 import Calendar from '..';
 import { render } from '../../../tests/utils';
 
 describe('Calendar.Semantic', () => {
+  it('should support itemDateContent classNames and styles', () => {
+    const { container } = render(
+      <Calendar
+        value={dayjsGenerateConfig.getNow()}
+        cellRender={() => <div className="custom-cell"> custom content </div>}
+        classNames={{
+          itemDateContent: 'custom-item-date-content',
+        }}
+        styles={{
+          itemDateContent: {
+            height: '50px',
+            overflow: 'hidden',
+          },
+        }}
+      />,
+    );
+
+    const dateContent = container.querySelector('.ant-picker-calendar-date-content');
+    expect(dateContent).toHaveClass('custom-item-date-content');
+    expect(dateContent).toHaveStyle({ height: '50px', overflow: 'hidden' });
+  });
+
   it('support classNames and styles as functions', () => {
     const { container } = render(
       <Calendar

--- a/components/calendar/demo/_semantic.tsx
+++ b/components/calendar/demo/_semantic.tsx
@@ -11,6 +11,7 @@ const locales = {
     body: '主体元素，包含日历表格的内边距、布局控制等样式，用于容纳日历网格',
     content: '内容元素，包含日历表格的宽度、高度等尺寸控制和表格样式',
     item: '条目元素，包含日历单元格的背景色、边框、悬停态、选中态等交互样式',
+    itemDateContent: '日期内容元素，包含日历单元格内自定义内容区域的高度、溢出等样式控制',
   },
   en: {
     root: 'Root element containing background, border, border-radius and overall layout structure of the calendar component',
@@ -19,6 +20,8 @@ const locales = {
     body: 'Body element with padding and layout control for the calendar table that contains the calendar grid',
     content: 'Content element with width, height and table styling control for the calendar table',
     item: 'Item element with background, border, hover state, selected state and other interactive styles for calendar cells',
+    itemDateContent:
+      'Date content element with height, overflow and other style control for custom content area inside calendar cells',
   },
 };
 
@@ -33,6 +36,7 @@ const App: React.FC = () => {
         { name: 'body', desc: locale.body, version: '6.0.0' },
         { name: 'content', desc: locale.content, version: '6.0.0' },
         { name: 'item', desc: locale.item, version: '6.0.0' },
+        { name: 'itemDateContent', desc: locale.itemDateContent, version: '6.0.0' },
       ]}
     >
       <Calendar />

--- a/components/calendar/generateCalendar.tsx
+++ b/components/calendar/generateCalendar.tsx
@@ -36,6 +36,7 @@ export type CalendarSemanticType = {
     body?: string;
     content?: string;
     item?: string;
+    itemDateContent?: string;
   };
   styles?: {
     root?: React.CSSProperties;
@@ -43,6 +44,7 @@ export type CalendarSemanticType = {
     body?: React.CSSProperties;
     content?: React.CSSProperties;
     item?: React.CSSProperties;
+    itemDateContent?: React.CSSProperties;
   };
 };
 
@@ -265,7 +267,13 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
             <div className={`${calendarPrefixCls}-date-value`}>
               {String(generateConfig.getDate(date)).padStart(2, '0')}
             </div>
-            <div className={`${calendarPrefixCls}-date-content`}>
+            <div
+              className={clsx(
+                `${calendarPrefixCls}-date-content`,
+                mergedClassNames.itemDateContent,
+              )}
+              style={mergedStyles.itemDateContent}
+            >
               {typeof cellRender === 'function' ? cellRender(date, info) : dateCellRender?.(date)}
             </div>
           </div>
@@ -279,6 +287,8 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
         dateFullCellRender,
         cellRender,
         dateCellRender,
+        mergedClassNames.itemDateContent,
+        mergedStyles.itemDateContent,
       ],
     );
 
@@ -303,7 +313,13 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
             <div className={`${calendarPrefixCls}-date-value`}>
               {months[generateConfig.getMonth(date)]}
             </div>
-            <div className={`${calendarPrefixCls}-date-content`}>
+            <div
+              className={clsx(
+                `${calendarPrefixCls}-date-content`,
+                mergedClassNames.itemDateContent,
+              )}
+              style={mergedStyles.itemDateContent}
+            >
               {typeof cellRender === 'function' ? cellRender(date, info) : monthCellRender?.(date)}
             </div>
           </div>
@@ -317,6 +333,8 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
         monthFullCellRender,
         cellRender,
         monthCellRender,
+        mergedClassNames.itemDateContent,
+        mergedStyles.itemDateContent,
       ],
     );
 

--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -109,7 +109,7 @@ const {
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | affix | Set Affix common props | { className?: string, style?: React.CSSProperties } | - | 6.0.0 |
-| alert | Set Alert common props | { className?: string, style?: React.CSSProperties, closeIcon?: React.ReactNode, successIcon?: React.ReactNode, infoIcon?: React.ReactNode, warningIcon?: React.ReactNode, errorIcon?: React.ReactNode } | - | 5.7.0, `closeIcon`: 5.14.0, `successIcon`, `infoIcon`, `warningIcon` and `errorIcon`: 6.2.0 |
+| alert | Set Alert common props | See [Alert](/components/alert#api) | - | 5.7.0 |
 | anchor | Set Anchor common props | { className?: string, style?: React.CSSProperties, classNames?: [AnchorStyleConfig\["classNames"\]](/components/anchor#semantic-dom), styles?: [AnchorStyleConfig\["styles"\]](/components/anchor#semantic-dom) } | - | 5.7.0, `classNames` and `styles`: 6.0.0 |
 | avatar | Set Avatar common props | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | badge | Set Badge common props | { className?: string, style?: React.CSSProperties, classNames?: [BadgeProps\["classNames"\]](/components/badge#semantic-dom), styles?: [BadgeProps\["styles"\]](/components/badge#semantic-dom) } | - | 5.7.0 |

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -111,7 +111,7 @@ const {
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | affix | 设置 Affix 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 6.0.0 |
-| alert | 设置 Alert 组件的通用属性 | { className?: string, style?: React.CSSProperties, closeIcon?: React.ReactNode, successIcon?: React.ReactNode, infoIcon?: React.ReactNode, warningIcon?: React.ReactNode, errorIcon?: React.ReactNode } | - | 5.7.0, `closeIcon`: 5.14.0, `successIcon`, `infoIcon`, `warningIcon` 和 `errorIcon`: 6.2.0 |
+| alert | 设置 Alert 组件的通用属性 | 参见 [Alert](/components/alert-cn#api) | - | 5.7.0 |
 | anchor | 设置 Anchor 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: [AnchorStyleConfig\["classNames"\]](/components/anchor-cn#semantic-dom), styles?: [AnchorStyleConfig\["styles"\]](/components/anchor-cn#semantic-dom) } | - | 5.7.0, `classNames` 和 `styles`: 6.0.0 |
 | avatar | 设置 Avatar 组件的通用属性 | { className?: string, style?: React.CSSProperties } | - | 5.7.0 |
 | badge | 设置 Badge 组件的通用属性 | { className?: string, style?: React.CSSProperties, classNames?: [BadgeProps\["classNames"\]](/components/badge-cn#semantic-dom), styles?: [BadgeProps\["styles"\]](/components/badge-cn#semantic-dom) } | - | 5.7.0 |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] ⭐️ 功能增强
- [x] ✅ 测试用例

### 🔗 相关 Issue

close #47273

### 💡 需求背景和解决方案

为 Calendar 组件新增 `itemDateContent` 语义类型，支持对日历单元格内的自定义内容区域（`dateCellRender` / `monthCellRender` 的容器）进行样式控制，包括 classNames 和 styles。

**新增 API：**
- `classNames.itemDateContent`: 自定义类名
- `styles.itemDateContent`: 自定义样式

### 📝 更新日志

| 语言 | 更新描述 |
| ---- | -------- |
| 🇺🇸 英文 | 🆕 Add `itemDateContent` semantic type for Calendar to support customizing styles and classNames for date content area |
| 🇨🇳 中文 | 🆕 新增 Calendar 组件 `itemDateContent` 语义类型，支持自定义日期内容区域的样式和类名 |