### PR TITLE
feat: support itemContent semantic for Calendar

### DIFF
--- a/components/calendar/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/calendar/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -204,7 +204,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           30
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -221,7 +221,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           31
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -238,7 +238,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           01
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -255,7 +255,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           02
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -272,7 +272,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           03
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -289,7 +289,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           04
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -306,7 +306,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           05
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -325,7 +325,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           06
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -342,7 +342,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           07
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -359,7 +359,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           08
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -376,7 +376,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           09
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -393,7 +393,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           10
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -410,7 +410,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           11
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -427,7 +427,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           12
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -446,7 +446,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           13
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -463,7 +463,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           14
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -480,7 +480,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           15
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -497,7 +497,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           16
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -514,7 +514,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           17
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -531,7 +531,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           18
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -548,7 +548,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           19
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -567,7 +567,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           20
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -584,7 +584,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           21
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -601,7 +601,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           22
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -618,7 +618,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           23
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -635,7 +635,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           24
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -652,7 +652,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           25
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -669,7 +669,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           26
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -688,7 +688,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           27
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -705,7 +705,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           28
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -722,7 +722,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           29
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -739,7 +739,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           30
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -756,7 +756,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           01
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -773,7 +773,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           02
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -790,7 +790,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           03
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -809,7 +809,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           04
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -826,7 +826,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           05
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -843,7 +843,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           06
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -860,7 +860,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           07
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -877,7 +877,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           08
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -894,7 +894,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           09
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -911,7 +911,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           10
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
+                          class="ant-picker-calendar-date-content semantic-mark-itemContent"
                         />
                       </div>
                     </td>
@@ -1435,12 +1435,12 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                   class="ant-typography css-var-test-id"
                   style="margin: 0px;"
                 >
-                  itemDateContent
+                  itemContent
                 </h5>
                 <span
                   class="ant-tag ant-tag-filled ant-tag-blue css-var-test-id"
                 >
-                  6.0.0
+                  6.4.0
                 </span>
               </div>
               <div
@@ -1513,7 +1513,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
               class="ant-typography css-var-test-id"
               style="margin: 0px; font-size: 12px;"
             >
-              日期内容元素，包含日历单元格内自定义内容区域的高度、溢出等样式控制
+              条目内容元素，包含日历单元格内自定义内容区域的高度、溢出等样式控制
             </div>
           </div>
         </li>

--- a/components/calendar/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/calendar/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -204,7 +204,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           30
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -221,7 +221,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           31
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -238,7 +238,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           01
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -255,7 +255,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           02
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -272,7 +272,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           03
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -289,7 +289,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           04
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -306,7 +306,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           05
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -325,7 +325,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           06
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -342,7 +342,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           07
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -359,7 +359,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           08
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -376,7 +376,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           09
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -393,7 +393,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           10
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -410,7 +410,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           11
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -427,7 +427,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           12
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -446,7 +446,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           13
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -463,7 +463,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           14
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -480,7 +480,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           15
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -497,7 +497,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           16
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -514,7 +514,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           17
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -531,7 +531,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           18
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -548,7 +548,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           19
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -567,7 +567,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           20
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -584,7 +584,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           21
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -601,7 +601,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           22
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -618,7 +618,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           23
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -635,7 +635,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           24
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -652,7 +652,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           25
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -669,7 +669,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           26
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -688,7 +688,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           27
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -705,7 +705,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           28
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -722,7 +722,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           29
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -739,7 +739,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           30
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -756,7 +756,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           01
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -773,7 +773,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           02
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -790,7 +790,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           03
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -809,7 +809,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           04
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -826,7 +826,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           05
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -843,7 +843,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           06
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -860,7 +860,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           07
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -877,7 +877,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           08
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -894,7 +894,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           09
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -911,7 +911,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                           10
                         </div>
                         <div
-                          class="ant-picker-calendar-date-content"
+                          class="ant-picker-calendar-date-content semantic-mark-itemDateContent"
                         />
                       </div>
                     </td>
@@ -1416,6 +1416,104 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
               style="margin: 0px; font-size: 12px;"
             >
               条目元素，包含日历单元格的背景色、边框、悬停态、选中态等交互样式
+            </div>
+          </div>
+        </li>
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
+                  itemDateContent
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-test-id"
+                >
+                  6.0.0
+                </span>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              日期内容元素，包含日历单元格内自定义内容区域的高度、溢出等样式控制
             </div>
           </div>
         </li>

--- a/components/calendar/__tests__/semantic.test.tsx
+++ b/components/calendar/__tests__/semantic.test.tsx
@@ -1,9 +1,55 @@
 import React from 'react';
 
+import dayjsGenerateConfig from '@rc-component/picker/generate/dayjs';
 import Calendar from '..';
 import { render } from '../../../tests/utils';
 
 describe('Calendar.Semantic', () => {
+  it('should support itemDateContent classNames and styles', () => {
+    const { container } = render(
+      <Calendar
+        value={dayjsGenerateConfig.getNow()}
+        cellRender={() => <div className="custom-cell"> custom content </div>}
+        classNames={{
+          itemDateContent: 'custom-item-date-content',
+        }}
+        styles={{
+          itemDateContent: {
+            height: '50px',
+            overflow: 'hidden',
+          },
+        }}
+      />,
+    );
+
+    const dateContent = container.querySelector('.ant-picker-calendar-date-content');
+    expect(dateContent).toHaveClass('custom-item-date-content');
+    expect(dateContent).toHaveStyle({ height: '50px', overflow: 'hidden' });
+  });
+
+  it('should support itemDateContent classNames and styles in year mode', () => {
+    const { container } = render(
+      <Calendar
+        value={dayjsGenerateConfig.getNow()}
+        mode="year"
+        cellRender={() => <div className="custom-cell"> custom content </div>}
+        classNames={{
+          itemDateContent: 'custom-item-date-content-year',
+        }}
+        styles={{
+          itemDateContent: {
+            height: '80px',
+            overflow: 'auto',
+          },
+        }}
+      />,
+    );
+
+    const dateContent = container.querySelector('.ant-picker-calendar-date-content');
+    expect(dateContent).toHaveClass('custom-item-date-content-year');
+    expect(dateContent).toHaveStyle({ height: '80px', overflow: 'auto' });
+  });
+
   it('support classNames and styles as functions', () => {
     const { container } = render(
       <Calendar

--- a/components/calendar/__tests__/semantic.test.tsx
+++ b/components/calendar/__tests__/semantic.test.tsx
@@ -5,16 +5,16 @@ import Calendar from '..';
 import { render } from '../../../tests/utils';
 
 describe('Calendar.Semantic', () => {
-  it('should support itemDateContent classNames and styles', () => {
+  it('should support itemContent classNames and styles', () => {
     const { container } = render(
       <Calendar
         value={dayjsGenerateConfig.getNow()}
         cellRender={() => <div className="custom-cell"> custom content </div>}
         classNames={{
-          itemDateContent: 'custom-item-date-content',
+          itemContent: 'custom-item-content',
         }}
         styles={{
-          itemDateContent: {
+          itemContent: {
             height: '50px',
             overflow: 'hidden',
           },
@@ -23,21 +23,21 @@ describe('Calendar.Semantic', () => {
     );
 
     const dateContent = container.querySelector('.ant-picker-calendar-date-content');
-    expect(dateContent).toHaveClass('custom-item-date-content');
+    expect(dateContent).toHaveClass('custom-item-content');
     expect(dateContent).toHaveStyle({ height: '50px', overflow: 'hidden' });
   });
 
-  it('should support itemDateContent classNames and styles in year mode', () => {
+  it('should support itemContent classNames and styles in year mode', () => {
     const { container } = render(
       <Calendar
         value={dayjsGenerateConfig.getNow()}
         mode="year"
         cellRender={() => <div className="custom-cell"> custom content </div>}
         classNames={{
-          itemDateContent: 'custom-item-date-content-year',
+          itemContent: 'custom-item-content-year',
         }}
         styles={{
-          itemDateContent: {
+          itemContent: {
             height: '80px',
             overflow: 'auto',
           },
@@ -46,7 +46,7 @@ describe('Calendar.Semantic', () => {
     );
 
     const dateContent = container.querySelector('.ant-picker-calendar-date-content');
-    expect(dateContent).toHaveClass('custom-item-date-content-year');
+    expect(dateContent).toHaveClass('custom-item-content-year');
     expect(dateContent).toHaveStyle({ height: '80px', overflow: 'auto' });
   });
 

--- a/components/calendar/demo/_semantic.tsx
+++ b/components/calendar/demo/_semantic.tsx
@@ -36,7 +36,7 @@ const App: React.FC = () => {
         { name: 'body', desc: locale.body, version: '6.0.0' },
         { name: 'content', desc: locale.content, version: '6.0.0' },
         { name: 'item', desc: locale.item, version: '6.0.0' },
-        { name: 'itemDateContent', desc: locale.itemDateContent, version: '6.0.0' },
+        { name: 'itemDateContent', desc: locale.itemDateContent, version: '6.4.0' },
       ]}
     >
       <Calendar />

--- a/components/calendar/demo/_semantic.tsx
+++ b/components/calendar/demo/_semantic.tsx
@@ -11,6 +11,7 @@ const locales = {
     body: '主体元素，包含日历表格的内边距、布局控制等样式，用于容纳日历网格',
     content: '内容元素，包含日历表格的宽度、高度等尺寸控制和表格样式',
     item: '条目元素，包含日历单元格的背景色、边框、悬停态、选中态等交互样式',
+    itemDateContent: '日期内容元素，包含日历单元格内自定义内容区域的高度、溢出等样式控制',
   },
   en: {
     root: 'Root element containing background, border, border-radius and overall layout structure of the calendar component',
@@ -19,6 +20,8 @@ const locales = {
     body: 'Body element with padding and layout control for the calendar table that contains the calendar grid',
     content: 'Content element with width, height and table styling control for the calendar table',
     item: 'Item element with background, border, hover state, selected state and other interactive styles for calendar cells',
+    itemDateContent:
+      'Date content element with height, overflow and other style control for custom content area inside calendar cells',
   },
 };
 
@@ -33,6 +36,7 @@ const App: React.FC = () => {
         { name: 'body', desc: locale.body, version: '6.0.0' },
         { name: 'content', desc: locale.content, version: '6.0.0' },
         { name: 'item', desc: locale.item, version: '6.0.0' },
+        { name: 'itemDateContent', desc: locale.itemDateContent, version: '6.0.0' },
       ]}
     >
       <Calendar />

--- a/components/calendar/demo/_semantic.tsx
+++ b/components/calendar/demo/_semantic.tsx
@@ -11,7 +11,7 @@ const locales = {
     body: '主体元素，包含日历表格的内边距、布局控制等样式，用于容纳日历网格',
     content: '内容元素，包含日历表格的宽度、高度等尺寸控制和表格样式',
     item: '条目元素，包含日历单元格的背景色、边框、悬停态、选中态等交互样式',
-    itemDateContent: '日期内容元素，包含日历单元格内自定义内容区域的高度、溢出等样式控制',
+    itemContent: '条目内容元素，包含日历单元格内自定义内容区域的高度、溢出等样式控制',
   },
   en: {
     root: 'Root element containing background, border, border-radius and overall layout structure of the calendar component',
@@ -20,8 +20,8 @@ const locales = {
     body: 'Body element with padding and layout control for the calendar table that contains the calendar grid',
     content: 'Content element with width, height and table styling control for the calendar table',
     item: 'Item element with background, border, hover state, selected state and other interactive styles for calendar cells',
-    itemDateContent:
-      'Date content element with height, overflow and other style control for custom content area inside calendar cells',
+    itemContent:
+      'Item content element with height, overflow and other style control for custom content area inside calendar cells',
   },
 };
 
@@ -36,7 +36,7 @@ const App: React.FC = () => {
         { name: 'body', desc: locale.body, version: '6.0.0' },
         { name: 'content', desc: locale.content, version: '6.0.0' },
         { name: 'item', desc: locale.item, version: '6.0.0' },
-        { name: 'itemDateContent', desc: locale.itemDateContent, version: '6.4.0' },
+        { name: 'itemContent', desc: locale.itemContent, version: '6.4.0' },
       ]}
     >
       <Calendar />

--- a/components/calendar/generateCalendar.tsx
+++ b/components/calendar/generateCalendar.tsx
@@ -36,6 +36,7 @@ export type CalendarSemanticType = {
     body?: string;
     content?: string;
     item?: string;
+    itemDateContent?: string;
   };
   styles?: {
     root?: React.CSSProperties;
@@ -43,6 +44,7 @@ export type CalendarSemanticType = {
     body?: React.CSSProperties;
     content?: React.CSSProperties;
     item?: React.CSSProperties;
+    itemDateContent?: React.CSSProperties;
   };
 };
 
@@ -265,7 +267,13 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
             <div className={`${calendarPrefixCls}-date-value`}>
               {String(generateConfig.getDate(date)).padStart(2, '0')}
             </div>
-            <div className={`${calendarPrefixCls}-date-content`}>
+            <div
+              className={clsx(
+                `${calendarPrefixCls}-date-content`,
+                mergedClassNames.itemDateContent,
+              )}
+              style={mergedStyles.itemDateContent}
+            >
               {typeof cellRender === 'function' ? cellRender(date, info) : dateCellRender?.(date)}
             </div>
           </div>
@@ -279,6 +287,8 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
         dateFullCellRender,
         cellRender,
         dateCellRender,
+        mergedClassNames.itemDateContent,
+        mergedStyles.itemDateContent,
       ],
     );
 
@@ -303,7 +313,13 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
             <div className={`${calendarPrefixCls}-date-value`}>
               {months[generateConfig.getMonth(date)]}
             </div>
-            <div className={`${calendarPrefixCls}-date-content`}>
+            <div
+              className={clsx(
+                `${calendarPrefixCls}-date-content`,
+                mergedClassNames.itemDateContent,
+              )}
+              style={mergedStyles.itemDateContent}
+            >
               {typeof cellRender === 'function' ? cellRender(date, info) : monthCellRender?.(date)}
             </div>
           </div>
@@ -317,6 +333,8 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
         monthFullCellRender,
         cellRender,
         monthCellRender,
+        mergedClassNames.itemDateContent,
+        mergedStyles.itemDateContent,
       ],
     );
 

--- a/components/calendar/generateCalendar.tsx
+++ b/components/calendar/generateCalendar.tsx
@@ -36,7 +36,7 @@ export type CalendarSemanticType = {
     body?: string;
     content?: string;
     item?: string;
-    itemDateContent?: string;
+    itemContent?: string;
   };
   styles?: {
     root?: React.CSSProperties;
@@ -44,7 +44,7 @@ export type CalendarSemanticType = {
     body?: React.CSSProperties;
     content?: React.CSSProperties;
     item?: React.CSSProperties;
-    itemDateContent?: React.CSSProperties;
+    itemContent?: React.CSSProperties;
   };
 };
 
@@ -169,6 +169,9 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
         ] as const;
       }, [mergedClassNames, mergedStyles]);
 
+    const mergedItemContentClassName = mergedClassNames.itemContent;
+    const mergedItemContentStyle = mergedStyles.itemContent;
+
     const prefixCls = getPrefixCls('picker', customizePrefixCls);
     const calendarPrefixCls = `${prefixCls}-calendar`;
 
@@ -268,11 +271,8 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
               {String(generateConfig.getDate(date)).padStart(2, '0')}
             </div>
             <div
-              className={clsx(
-                `${calendarPrefixCls}-date-content`,
-                mergedClassNames.itemDateContent,
-              )}
-              style={mergedStyles.itemDateContent}
+              className={clsx(`${calendarPrefixCls}-date-content`, mergedItemContentClassName)}
+              style={mergedItemContentStyle}
             >
               {typeof cellRender === 'function' ? cellRender(date, info) : dateCellRender?.(date)}
             </div>
@@ -287,8 +287,8 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
         dateFullCellRender,
         cellRender,
         dateCellRender,
-        mergedClassNames.itemDateContent,
-        mergedStyles.itemDateContent,
+        mergedItemContentClassName,
+        mergedItemContentStyle,
       ],
     );
 
@@ -314,11 +314,8 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
               {months[generateConfig.getMonth(date)]}
             </div>
             <div
-              className={clsx(
-                `${calendarPrefixCls}-date-content`,
-                mergedClassNames.itemDateContent,
-              )}
-              style={mergedStyles.itemDateContent}
+              className={clsx(`${calendarPrefixCls}-date-content`, mergedItemContentClassName)}
+              style={mergedItemContentStyle}
             >
               {typeof cellRender === 'function' ? cellRender(date, info) : monthCellRender?.(date)}
             </div>
@@ -333,8 +330,8 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
         monthFullCellRender,
         cellRender,
         monthCellRender,
-        mergedClassNames.itemDateContent,
-        mergedStyles.itemDateContent,
+        mergedItemContentClassName,
+        mergedItemContentStyle,
       ],
     );
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

  - [x] ⭐️ 功能增强
  - [x] ✅ 测试用例

  ### 🔗 相关 Issue

  close #47273

  ### 💡 需求背景和解决方案

  为 Calendar 组件新增 `itemDateContent` 语义类型，支持对日历单元格内的自定义内容区域（`dateCellRender` / `monthCellRender` 的容器）进行样式控制，包括 classNames 和 styles。

  **新增 API：**
  - `classNames.itemDateContent`: 自定义类名
  - `styles.itemDateContent`: 自定义样式

  ### 📝 更新日志

  | 语言 | 更新描述 |
  | ---- | -------- |
  | 🇺🇸 英文 | 🆕 Add `itemDateContent` semantic type for Calendar to support customizing styles and classNames for date content area |
  | 🇨🇳 中文 | 🆕 新增 Calendar 组件 `itemDateContent` 语义类型，支持自定义日期内容区域的样式和类名 |

  ---