### PR TITLE
docs: update MCP and CLI docs for antd mcp command

### DIFF
--- a/docs/react/cli.en-US.md
+++ b/docs/react/cli.en-US.md
@@ -72,6 +72,14 @@ antd migrate 4 5 --apply ./src      # Agent-ready migration prompt
 | `--lang en\|zh`                 | Output language                     | `en`        |
 | `--detail`                      | Include extended information        | `false`     |
 
+### MCP Server
+
+| Command    | Description                                                        |
+| ---------- | ------------------------------------------------------------------ |
+| `antd mcp` | Start an MCP server with 7 tools and 2 prompts for IDE integration |
+
+The `antd mcp` command launches a [Model Context Protocol](https://modelcontextprotocol.io/) server, allowing AI assistants to access Ant Design knowledge directly. See the [MCP Server](/docs/react/mcp-en-US) guide for full details and configuration.
+
 ## Usage with AI Tools
 
 The CLI ships with a built-in [skill file](https://github.com/ant-design/ant-design-cli/blob/main/skills/antd/SKILL.md) that teaches code agents when and how to use each command:

--- a/docs/react/cli.zh-CN.md
+++ b/docs/react/cli.zh-CN.md
@@ -72,6 +72,14 @@ antd migrate 4 5 --apply ./src      # 生成 Agent 迁移提示
 | `--lang en\|zh`                 | 输出语言                      | `en`     |
 | `--detail`                      | 包含扩展信息                  | `false`  |
 
+### MCP Server {#mcp-server}
+
+| 命令       | 说明                                                       |
+| ---------- | ---------------------------------------------------------- |
+| `antd mcp` | 启动 MCP 服务器，提供 7 个工具和 2 个提示词，支持 IDE 集成 |
+
+`antd mcp` 命令启动 [Model Context Protocol](https://modelcontextprotocol.io/) 服务器，让 AI 助手可以直接访问 Ant Design 知识。详细配置参见 [MCP Server](/docs/react/mcp-zh-CN) 指南。
+
 ## 在 AI 工具中的使用 {#usage-with-ai-tools}
 
 CLI 内置 [Skill 文件](https://github.com/ant-design/ant-design-cli/blob/main/skills/antd/SKILL.md)，指导 Code Agent 在正确的时机调用正确的命令：

--- a/docs/react/mcp.en-US.md
+++ b/docs/react/mcp.en-US.md
@@ -116,6 +116,6 @@ If your AI tool doesn't support MCP, you can use our [LLMs.txt](/docs/react/llms
 
 - [Model Context Protocol Documentation](https://modelcontextprotocol.io/)
 - [Ant Design CLI](/docs/react/cli-en-US)
-- [Ant Design LLMs.txt Guide](/docs/react/llms-en-US)
 - [@ant-design/cli on GitHub](https://github.com/ant-design/ant-design-cli)
+- [Ant Design LLMs.txt Guide](/docs/react/llms-en-US)
 - [@jzone-mcp/antd-components-mcp on npm](https://www.npmjs.com/package/@jzone-mcp/antd-components-mcp)

--- a/docs/react/mcp.en-US.md
+++ b/docs/react/mcp.en-US.md
@@ -13,9 +13,77 @@ This guide explains how to use Ant Design with AI tools through Model Context Pr
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open protocol that enables AI models to interact with external tools and data sources. Through MCP, AI assistants can access real-time documentation, code examples, and API references.
 
+## Official MCP Server
+
+Starting from [`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) v6.3.5, you can launch an official MCP server with the `antd mcp` command, providing 7 tools and 2 prompts for IDE integration.
+
+### Tools
+
+| Tool             | Description                                |
+| ---------------- | ------------------------------------------ |
+| `antd_list`      | Enumerate available components             |
+| `antd_info`      | Retrieve component property specifications |
+| `antd_doc`       | Fetch complete documentation               |
+| `antd_demo`      | Access runnable code examples              |
+| `antd_token`     | Query design token values                  |
+| `antd_semantic`  | Inspect DOM structure and styling hooks    |
+| `antd_changelog` | Analyze API changes across versions        |
+
+### Prompts
+
+| Prompt                | Description                                     |
+| --------------------- | ----------------------------------------------- |
+| `antd-expert`         | Positions the agent as an Ant Design specialist |
+| `antd-page-generator` | Assists with component-based page creation      |
+
+### Configuration
+
+Install the CLI globally and add the MCP server to your IDE configuration:
+
+```bash
+npm install -g @ant-design/cli
+```
+
+```json
+{
+  "mcpServers": {
+    "antd": {
+      "command": "antd",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+You can pin a specific antd version with additional args:
+
+```json
+{
+  "mcpServers": {
+    "antd": {
+      "command": "antd",
+      "args": ["mcp", "--version", "5.20.0"]
+    }
+  }
+}
+```
+
+## Usage with AI Tools
+
+| Tool | Description | Configuration |
+| --- | --- | --- |
+| **Cursor** | Add to `.cursor/mcp.json` or Settings → Features → MCP. [Documentation](https://docs.cursor.com/context/@-symbols/@-docs) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+| **Windsurf** | Add to `~/.codeium/windsurf/mcp_config.json`. [Documentation](https://docs.windsurf.com/windsurf/cascade/memories) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+| **Claude Code** | Add to `mcpServers` in Claude settings. [Documentation](https://docs.anthropic.com/en/docs/claude-code) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+| **Codex** | Add to `.codex/mcp.json`. [Documentation](https://github.com/openai/codex) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+| **Gemini CLI** | Add to MCP configuration. [Documentation](https://ai.google.dev/gemini-api/docs?hl=en) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+| **Trae** | Add to MCP settings. [Documentation](https://www.trae.ai/docs) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+| **Qoder** | Add to MCP configuration. [Documentation](https://docs.qoder.com/) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+| **Neovate Code** | Configure MCP in settings or describe task with prompt. [Documentation](https://github.com/neovateai/neovate-code) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+
 ## Community MCP Server
 
-Ant Design recommends the community-maintained MCP server: [`@jzone-mcp/antd-components-mcp`](https://www.npmjs.com/package/@jzone-mcp/antd-components-mcp)
+You can also use the community-maintained MCP server: [`@jzone-mcp/antd-components-mcp`](https://www.npmjs.com/package/@jzone-mcp/antd-components-mcp)
 
 This MCP server provides the following capabilities:
 
@@ -24,18 +92,18 @@ This MCP server provides the following capabilities:
 - **list-component-examples** - Get code examples for a component
 - **get-component-changelog** - Get the changelog for a component
 
-## Usage with AI Tools
+Configuration:
 
-| Tool | Description | Prompt |
-| --- | --- | --- |
-| **Cursor** | Add to `.cursor/mcp.json` or Settings → Features → MCP. [Documentation](https://docs.cursor.com/context/@-symbols/@-docs) | `Add Ant Design MCP server. Configuration: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
-| **Windsurf** | Add to `~/.codeium/windsurf/mcp_config.json`. [Documentation](https://docs.windsurf.com/windsurf/cascade/memories) | `Add Ant Design MCP server. Configuration: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
-| **Claude Code** | Add to `mcpServers` in Claude settings. [Documentation](https://docs.anthropic.com/en/docs/claude-code) | `Add Ant Design MCP server. Configuration: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
-| **Codex** | Add to `.codex/mcp.json`. [Documentation](https://github.com/openai/codex) | `Add Ant Design MCP server. Configuration: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
-| **Gemini CLI** | Add to MCP configuration. [Documentation](https://ai.google.dev/gemini-api/docs?hl=en) | `Add Ant Design MCP server. Configuration: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
-| **Trae** | Add to MCP settings. [Documentation](https://www.trae.ai/docs) | `Add Ant Design MCP server. Configuration: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
-| **Qoder** | Add to MCP configuration. [Documentation](https://docs.qoder.com/) | `Add Ant Design MCP server. Configuration: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
-| **Neovate Code** | Configure MCP in settings or describe task with prompt. [Documentation](https://github.com/neovateai/neovate-code) | `Add Ant Design MCP server. Configuration: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
+```json
+{
+  "mcpServers": {
+    "antd-components": {
+      "command": "npx",
+      "args": ["-y", "@jzone-mcp/antd-components-mcp"]
+    }
+  }
+}
+```
 
 ## Alternative: Using LLMs.txt
 
@@ -47,6 +115,7 @@ If your AI tool doesn't support MCP, you can use our [LLMs.txt](/docs/react/llms
 ## Learn More
 
 - [Model Context Protocol Documentation](https://modelcontextprotocol.io/)
+- [Ant Design CLI](/docs/react/cli-en-US)
 - [Ant Design LLMs.txt Guide](/docs/react/llms-en-US)
+- [@ant-design/cli on GitHub](https://github.com/ant-design/ant-design-cli)
 - [@jzone-mcp/antd-components-mcp on npm](https://www.npmjs.com/package/@jzone-mcp/antd-components-mcp)
-

--- a/docs/react/mcp.zh-CN.md
+++ b/docs/react/mcp.zh-CN.md
@@ -9,13 +9,81 @@ tag: New
 
 本指南介绍如何通过 Model Context Protocol (MCP) 在 AI 工具中使用 Ant Design。
 
-## 什么是 MCP？
+## 什么是 MCP？ {#what-is-mcp}
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) 是一个开放协议，使 AI 模型能够与外部工具和数据源进行交互。通过 MCP，AI 助手可以访问实时文档、代码示例和 API 参考资料。
 
-## 社区 MCP Server
+## 官方 MCP Server {#official-mcp-server}
 
-Ant Design 推荐使用社区维护的 MCP server：[`@jzone-mcp/antd-components-mcp`](https://www.npmjs.com/package/@jzone-mcp/antd-components-mcp)
+从 [`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) v6.3.5 起，你可以通过 `antd mcp` 命令启动官方 MCP 服务器，提供 7 个工具和 2 个提示词，支持 IDE 集成。
+
+### 工具 {#tools}
+
+| 工具             | 说明                    |
+| ---------------- | ----------------------- |
+| `antd_list`      | 列出可用组件            |
+| `antd_info`      | 获取组件属性规格        |
+| `antd_doc`       | 获取完整文档            |
+| `antd_demo`      | 获取可运行的代码示例    |
+| `antd_token`     | 查询 Design Token 值    |
+| `antd_semantic`  | 查看 DOM 结构和样式钩子 |
+| `antd_changelog` | 分析跨版本 API 变更     |
+
+### 提示词 {#prompts}
+
+| 提示词                | 说明                            |
+| --------------------- | ------------------------------- |
+| `antd-expert`         | 将 Agent 定位为 Ant Design 专家 |
+| `antd-page-generator` | 辅助基于组件的页面创建          |
+
+### 配置 {#configuration}
+
+全局安装 CLI 并将 MCP 服务器添加到 IDE 配置：
+
+```bash
+npm install -g @ant-design/cli
+```
+
+```json
+{
+  "mcpServers": {
+    "antd": {
+      "command": "antd",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+你可以通过额外参数指定 antd 版本：
+
+```json
+{
+  "mcpServers": {
+    "antd": {
+      "command": "antd",
+      "args": ["mcp", "--version", "5.20.0"]
+    }
+  }
+}
+```
+
+## 在 AI 工具中的使用 {#usage-with-ai-tools}
+
+| 工具 | 说明 | 配置 |
+| --- | --- | --- |
+| **Cursor** | 添加到 `.cursor/mcp.json` 或设置 → 功能 → MCP。[文档](https://docs.cursor.com/zh/context/@-symbols/@-docs) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+| **Windsurf** | 添加到 `~/.codeium/windsurf/mcp_config.json`。[文档](https://docs.windsurf.com/windsurf/cascade/memories) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+| **Claude Code** | 添加到 Claude 设置的 `mcpServers`。[文档](https://docs.anthropic.com/en/docs/claude-code) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+| **Codex** | 添加到 `.codex/mcp.json`。[文档](https://github.com/openai/codex) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+| **Gemini CLI** | 添加到 MCP 配置。[文档](https://ai.google.dev/gemini-api/docs?hl=zh-cn) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+| **Trae** | 添加到 MCP 设置。[文档](https://www.trae.ai/docs) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+| **Qoder** | 添加到 MCP 配置。[文档](https://docs.qoder.com/) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+| **Neovate Code** | 在设置中配置 MCP 或使用提示词描述任务。[文档](https://github.com/neovateai/neovate-code) | `{ "mcpServers": { "antd": { "command": "antd", "args": ["mcp"] } } }` |
+
+## 社区 MCP Server {#community-mcp-server}
+
+你也可以使用社区维护的 MCP server：[`@jzone-mcp/antd-components-mcp`](https://www.npmjs.com/package/@jzone-mcp/antd-components-mcp)
 
 该 MCP server 提供以下功能：
 
@@ -24,29 +92,30 @@ Ant Design 推荐使用社区维护的 MCP server：[`@jzone-mcp/antd-components
 - **list-component-examples** - 获取组件的代码示例
 - **get-component-changelog** - 获取组件的更新日志
 
-## 在 AI 工具中的使用
+配置：
 
-| 工具 | 说明 | 提示词 |
-| --- | --- | --- |
-| **Cursor** | 添加到 `.cursor/mcp.json` 或设置 → 功能 → MCP。[文档](https://docs.cursor.com/zh/context/@-symbols/@-docs) | `添加 Ant Design MCP 服务器。配置: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
-| **Windsurf** | 添加到 `~/.codeium/windsurf/mcp_config.json`。[文档](https://docs.windsurf.com/windsurf/cascade/memories) | `添加 Ant Design MCP 服务器。配置: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
-| **Claude Code** | 添加到 Claude 设置的 `mcpServers`。[文档](https://docs.anthropic.com/en/docs/claude-code) | `添加 Ant Design MCP 服务器。配置: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
-| **Codex** | 添加到 `.codex/mcp.json`。[文档](https://github.com/openai/codex) | `添加 Ant Design MCP 服务器。配置: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
-| **Gemini CLI** | 添加到 MCP 配置。[文档](https://ai.google.dev/gemini-api/docs?hl=zh-cn) | `添加 Ant Design MCP 服务器。配置: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
-| **Trae** | 添加到 MCP 设置。[文档](https://www.trae.ai/docs) | `添加 Ant Design MCP 服务器。配置: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
-| **Qoder** | 添加到 MCP 配置。[文档](https://docs.qoder.com/) | `添加 Ant Design MCP 服务器。配置: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
-| **Neovate Code** | 在设置中配置 MCP 或使用提示词描述任务。[文档](https://github.com/neovateai/neovate-code) | `添加 Ant Design MCP 服务器。配置: { "mcpServers": { "antd-components": { "command": "npx", "args": ["-y", "@jzone-mcp/antd-components-mcp"] } } }` |
+```json
+{
+  "mcpServers": {
+    "antd-components": {
+      "command": "npx",
+      "args": ["-y", "@jzone-mcp/antd-components-mcp"]
+    }
+  }
+}
+```
 
-## 备选方案：使用 LLMs.txt
+## 备选方案：使用 LLMs.txt {#alternative-llms-txt}
 
 如果您的 AI 工具不支持 MCP，可以使用我们的 [LLMs.txt](/docs/react/llms-zh-CN) 支持。我们提供：
 
 - [llms.txt](https://ant.design/llms.txt) - 所有组件的结构化概览
 - [llms-full.txt](https://ant.design/llms-full.txt) - 包含示例的完整文档
 
-## 了解更多
+## 了解更多 {#learn-more}
 
 - [Model Context Protocol 文档](https://modelcontextprotocol.io/)
+- [Ant Design CLI](/docs/react/cli-zh-CN)
 - [Ant Design LLMs.txt 指南](/docs/react/llms-zh-CN)
+- [@ant-design/cli GitHub 仓库](https://github.com/ant-design/ant-design-cli)
 - [@jzone-mcp/antd-components-mcp npm 地址](https://www.npmjs.com/package/@jzone-mcp/antd-components-mcp)
-

--- a/docs/react/mcp.zh-CN.md
+++ b/docs/react/mcp.zh-CN.md
@@ -116,6 +116,6 @@ npm install -g @ant-design/cli
 
 - [Model Context Protocol 文档](https://modelcontextprotocol.io/)
 - [Ant Design CLI](/docs/react/cli-zh-CN)
-- [Ant Design LLMs.txt 指南](/docs/react/llms-zh-CN)
 - [@ant-design/cli GitHub 仓库](https://github.com/ant-design/ant-design-cli)
+- [Ant Design LLMs.txt 指南](/docs/react/llms-zh-CN)
 - [@jzone-mcp/antd-components-mcp npm 地址](https://www.npmjs.com/package/@jzone-mcp/antd-components-mcp)


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/ant-design/ant-design-cli/releases/tag/v6.3.5-beta.0

### 💡 需求背景和解决方案

`@ant-design/cli` v6.3.5 新增了 `antd mcp` 命令，可以启动官方 MCP 服务器（7 个工具 + 2 个提示词），为 IDE 提供原生集成。

本次文档更新：

1. **MCP 文档**：新增"官方 MCP Server"章节，详细列出 7 个工具（`antd_list`、`antd_info`、`antd_doc`、`antd_demo`、`antd_token`、`antd_semantic`、`antd_changelog`）和 2 个提示词（`antd-expert`、`antd-page-generator`）的说明和配置方式；将各 AI 工具的配置统一更新为使用 `antd mcp`；原社区 MCP server 移至独立章节保留。
2. **CLI 文档**：在命令列表中新增 `antd mcp` 条目，并链接至 MCP 文档页面。

### 📝 更新日志

无需更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A      |
| 🇨🇳 中文 | N/A      |