### PR TITLE
fix: restore 5.x lint and Jest compatibility

### DIFF
--- a/.github/workflows/visual-regression-diff-build.yml
+++ b/.github/workflows/visual-regression-diff-build.yml
@@ -60,14 +60,62 @@ jobs:
           merge-multiple: true
           path: imageSnapshots/
 
+      - name: detect baseline snapshots
+        id: baseline
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          SNAPSHOT_URL="https://antd-visual-diff.oss-accelerate.aliyuncs.com/$BASE_SHA/imageSnapshots.tar.gz"
+          echo "snapshot-url=$SNAPSHOT_URL" >> "$GITHUB_OUTPUT"
+
+          if curl --fail --silent --location --head "$SNAPSHOT_URL" > /dev/null; then
+            echo "mode=remote" >> "$GITHUB_OUTPUT"
+            echo "Use remote baseline snapshot: $SNAPSHOT_URL"
+          else
+            echo "mode=local" >> "$GITHUB_OUTPUT"
+            echo "Remote baseline snapshot missing, rebuild locally from $BASE_SHA"
+          fi
+
+      - name: checkout base commit
+        if: steps.baseline.outputs.mode == 'local'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .visual-regression-base
+
+      - name: generate local baseline snapshots
+        if: steps.baseline.outputs.mode == 'local'
+        env:
+          BASE_DIR: .visual-regression-base
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          NODE_OPTIONS: --max_old_space_size=4096
+        run: |
+          node node_modules/puppeteer/install.mjs
+          ln -sfn ../node_modules "$BASE_DIR/node_modules"
+          cp .jest.js "$BASE_DIR/.jest.js"
+          cp .jest.image.js "$BASE_DIR/.jest.image.js"
+
+          (cd "$BASE_DIR" && bun run version)
+          (cd "$BASE_DIR" && bun run test:image -- --shard=1/2)
+          (cd "$BASE_DIR" && bun run test:image -- --shard=2/2)
+
+          rm -rf "imageSnapshots-$BASE_REF"
+          mv "$BASE_DIR/imageSnapshots" "imageSnapshots-$BASE_REF"
+
       # Execute visual regression diff task and zip then
       # output as visualRegressionReport.tar.gz
       - name: visual regression diff
         env:
           EVENT_NUMBER: ${{ github.event.number }}
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASELINE_MODE: ${{ steps.baseline.outputs.mode }}
         run: |
-          bun run test:visual-regression -- --pr-id=$EVENT_NUMBER --base-ref=$BASE_REF --max-workers=2
+          if [ "$BASELINE_MODE" = "local" ]; then
+            VISUAL_REGRESSION_USE_LOCAL_BASELINE=1 bun run test:visual-regression -- --pr-id=$EVENT_NUMBER --base-ref=$BASE_REF --base-sha=$BASE_SHA --max-workers=2
+          else
+            bun run test:visual-regression -- --pr-id=$EVENT_NUMBER --base-ref=$BASE_REF --base-sha=$BASE_SHA --max-workers=2
+          fi
 
       # Upload report in `visualRegressionReport`
       - name: upload report artifact

--- a/.jest.image.js
+++ b/.jest.image.js
@@ -7,7 +7,7 @@ module.exports = {
   moduleNameMapper,
   transform: {
     '\\.tsx?$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
-    '\\.js$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
+    '\\.(m?)js$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
     '\\.md$': './node_modules/@ant-design/tools/lib/jest/demoPreprocessor',
     '\\.(jpg|png|gif|svg)$': './node_modules/@ant-design/tools/lib/jest/imagePreprocessor',
   },

--- a/.jest.js
+++ b/.jest.js
@@ -3,6 +3,7 @@ const compileModules = [
   'rc-tween-one',
   '@babel',
   '@ant-design',
+  '@csstools',
   'countup.js',
   '.pnpm',
   '@asamuzakjp/css-color',

--- a/.jest.node.js
+++ b/.jest.node.js
@@ -8,7 +8,7 @@ module.exports = {
   moduleNameMapper,
   transform: {
     '\\.tsx?$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
-    '\\.js$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
+    '\\.(m?)js$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
     '\\.md$': './node_modules/@ant-design/tools/lib/jest/demoPreprocessor',
     '\\.(jpg|png|gif|svg)$': './node_modules/@ant-design/tools/lib/jest/imagePreprocessor',
   },

--- a/.jest.site.js
+++ b/.jest.site.js
@@ -6,7 +6,7 @@ module.exports = {
   moduleNameMapper,
   transform: {
     '\\.tsx?$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
-    '\\.js$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
+    '\\.(m?)js$': './node_modules/@ant-design/tools/lib/jest/codePreprocessor',
     '\\.md$': './node_modules/@ant-design/tools/lib/jest/demoPreprocessor',
     '\\.(jpg|png|gif|svg)$': './node_modules/@ant-design/tools/lib/jest/imagePreprocessor',
   },

--- a/biome.json
+++ b/biome.json
@@ -115,6 +115,16 @@
           }
         }
       }
+    },
+    {
+      "includes": ["components/list/index.tsx"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "useHookAtTopLevel": "off"
+          }
+        }
+      }
     }
   ]
 }

--- a/components/__tests__/node.test.tsx
+++ b/components/__tests__/node.test.tsx
@@ -18,7 +18,7 @@ jest.mock('../../tests/shared/demoTest', () => {
 
 describe('node', () => {
   beforeAll(() => {
-    jest.useFakeTimers().setSystemTime(new Date('2016-11-22'));
+    jest.useFakeTimers().setSystemTime(new Date('2016-11-22').getTime());
   });
 
   // Find the component exist demo test file

--- a/components/calendar/__tests__/index.test.tsx
+++ b/components/calendar/__tests__/index.test.tsx
@@ -552,7 +552,7 @@ describe('Calendar', () => {
   });
 
   it('support Calendar.generateCalendar', () => {
-    jest.useFakeTimers().setSystemTime(new Date('2000-01-01'));
+    jest.useFakeTimers().setSystemTime(new Date('2000-01-01').getTime());
 
     const MyCalendar = Calendar.generateCalendar(dayjsGenerateConfig);
     const { container } = render(<MyCalendar />);

--- a/components/calendar/__tests__/select.test.tsx
+++ b/components/calendar/__tests__/select.test.tsx
@@ -11,7 +11,7 @@ import { fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 describe('Calendar.onSelect', () => {
   beforeEach(() => {
     resetWarned();
-    jest.useFakeTimers().setSystemTime(new Date('2000-02-01'));
+    jest.useFakeTimers().setSystemTime(new Date('2000-02-01').getTime());
   });
 
   afterEach(() => {

--- a/components/input/OTP/OTPInput.tsx
+++ b/components/input/OTP/OTPInput.tsx
@@ -26,8 +26,8 @@ const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
   React.useImperativeHandle(ref, () => inputRef.current!);
 
   // ========================= Input ==========================
-  const onInternalChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
-    onChange(index, e.target.value);
+  const onInternalChange: React.InputEventHandler<HTMLInputElement> = (e) => {
+    onChange(index, (e.target as HTMLInputElement).value);
   };
 
   // ========================= Focus ==========================

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,8 +1,12 @@
 // eslint.config.mjs
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import antfu from '@antfu/eslint-config';
 import compat from 'eslint-plugin-compat';
 import jest from 'eslint-plugin-jest';
 import jsxA11y from 'eslint-plugin-jsx-a11y';
+
+const tsconfigRootDir = dirname(fileURLToPath(import.meta.url));
 
 export default antfu(
   {
@@ -67,6 +71,27 @@ export default antfu(
       'react-hooks/refs': 'off',
     },
   },
+  {
+    files: ['**/*.{ts,tsx,mts,cts}'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir,
+      },
+    },
+  },
+  {
+    files: ['**/*.{js,mjs,cjs,jsx}'],
+    rules: {
+      'react/no-implicit-key': 'off',
+    },
+  },
+  {
+    files: ['eslint.config.mjs', '.*.{js,mjs,cjs}', '*.config.{js,mjs,cjs}'],
+    rules: {
+      'react/no-implicit-key': 'off',
+    },
+  },
   compat.configs['flat/recommended'],
   jest.configs['flat/recommended'],
   {
@@ -87,6 +112,7 @@ export default antfu(
       'react-hooks/immutability': 'off',
       'test/prefer-lowercase-title': 'off',
       'react/no-create-ref': 'off',
+      'react/no-nested-component-definitions': 'off',
       'react/no-nested-components': 'off',
       'react/no-useless-fragment': 'off',
       'no-console': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -81,13 +81,7 @@ export default antfu(
     },
   },
   {
-    files: ['**/*.{js,mjs,cjs,jsx}'],
-    rules: {
-      'react/no-implicit-key': 'off',
-    },
-  },
-  {
-    files: ['eslint.config.mjs', '.*.{js,mjs,cjs}', '*.config.{js,mjs,cjs}'],
+    files: ['**/*.{js,mjs,cjs}', '.*.{js,mjs,cjs}'],
     rules: {
       'react/no-implicit-key': 'off',
     },

--- a/scripts/visual-regression/build.ts
+++ b/scripts/visual-regression/build.ts
@@ -23,6 +23,8 @@ const ALI_OSS_BUCKET = 'antd-visual-diff';
 const REPORT_DIR = path.join(ROOT_DIR, './visualRegressionReport');
 
 const isLocalEnv = process.env.LOCAL;
+const useLocalBaselineEnv = process.env.VISUAL_REGRESSION_USE_LOCAL_BASELINE;
+const git = simpleGit();
 
 const compareScreenshots = async (
   baseImgPath: string,
@@ -97,11 +99,38 @@ async function downloadFile(url: string, destPath: string) {
 
 async function getBranchLatestRef(branchName: string) {
   const baseImageRefUrl = `${ossDomain}/${branchName}/visual-regression-ref.txt`;
-  // get content from baseImageRefText
   const res = await fetch(baseImageRefUrl);
+  if (!res.ok || res.status !== 200) {
+    throw new Error(`Missing visual regression ref: ${new URL(baseImageRefUrl).pathname}`);
+  }
+
   const text = await res.text();
   const ref = text.trim();
+  assert(ref, `Empty visual regression ref from ${branchName}`);
   return ref;
+}
+
+async function getBranchHeadRef(branchName: string) {
+  const remoteNames = ['origin', 'upstream'];
+
+  for (const remoteName of remoteNames) {
+    try {
+      await git.raw([
+        'fetch',
+        '--depth=1',
+        remoteName,
+        `refs/heads/${branchName}:refs/remotes/${remoteName}/${branchName}`,
+      ]);
+
+      return (
+        await git.raw(['rev-parse', '--verify', `refs/remotes/${remoteName}/${branchName}`])
+      ).trim();
+    } catch {
+      // Ignore missing remote branch and continue trying other remotes.
+    }
+  }
+
+  return (await git.raw(['rev-parse', '--verify', branchName])).trim();
 }
 
 async function downloadBaseSnapshots(ref: string, targetDir: string) {
@@ -147,8 +176,6 @@ export interface IBadCase {
   weight: number;
 }
 
-const git = simpleGit();
-
 async function parseArgs() {
   // parse args from -- --pr-id=123 --base_ref=feature --max-workers=2
   const argv = minimist(process.argv.slice(2));
@@ -156,6 +183,7 @@ async function parseArgs() {
   assert(prId, 'Missing --pr-id');
   const baseRef = argv['base-ref'];
   assert(baseRef, 'Missing --base-ref');
+  const baseSha = argv['base-sha'];
 
   const maxWorkers = argv['max-workers'] ? Number.parseInt(argv['max-workers'], 10) : 1;
 
@@ -164,6 +192,7 @@ async function parseArgs() {
   return {
     prId,
     baseRef,
+    baseSha,
     currentRef: latest?.hash.slice(0, 8) || '',
     maxWorkers,
   };
@@ -357,26 +386,31 @@ async function boot() {
   const args = await parseArgs();
   console.log(`Args: ${JSON.stringify(args)}`);
 
-  const { prId, baseRef: targetBranch = 'master', currentRef, maxWorkers } = args;
+  const { prId, baseRef: targetBranch = 'master', baseSha, currentRef, maxWorkers } = args;
 
   const baseImgSourceDir = path.resolve(ROOT_DIR, `./imageSnapshots-${targetBranch}`);
+  const hasLocalBaseSnapshots = fse.existsSync(baseImgSourceDir);
 
   const publicPath = isLocalEnv ? '.' : `${ossDomain}/pr-${prId}/${path.basename(REPORT_DIR)}`;
 
   /* --- prepare stage --- */
   console.log(
     chalk.green(
-      `Preparing image snapshots from latest \`${targetBranch}\` branch for pr \`${prId}\`\n`,
+      `Preparing image snapshots from \`${baseSha || targetBranch}\` for pr \`${prId}\`\n`,
     ),
   );
   await fse.ensureDir(baseImgSourceDir);
 
-  const targetCommitSha = await getBranchLatestRef(targetBranch);
+  const targetCommitSha =
+    baseSha ||
+    ((isLocalEnv || useLocalBaselineEnv) && hasLocalBaseSnapshots
+      ? await getBranchHeadRef(targetBranch)
+      : await getBranchLatestRef(targetBranch));
   assert(targetCommitSha, `Missing commit sha from ${targetBranch}`);
 
-  if (!isLocalEnv) {
+  if (!isLocalEnv && !useLocalBaselineEnv) {
     await downloadBaseSnapshots(targetCommitSha, baseImgSourceDir);
-  } else if (!fse.existsSync(baseImgSourceDir)) {
+  } else if (!hasLocalBaseSnapshots) {
     console.log(
       chalk.yellow(
         `Please prepare image snapshots in folder \`$projectRoot/${path.basename(

--- a/scripts/visual-regression/build.ts
+++ b/scripts/visual-regression/build.ts
@@ -1,4 +1,3 @@
-import { assert } from 'console';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -106,7 +105,9 @@ async function getBranchLatestRef(branchName: string) {
 
   const text = await res.text();
   const ref = text.trim();
-  assert(ref, `Empty visual regression ref from ${branchName}`);
+  if (!ref) {
+    throw new Error(`Empty visual regression ref from ${branchName}`);
+  }
   return ref;
 }
 
@@ -180,9 +181,15 @@ async function parseArgs() {
   // parse args from -- --pr-id=123 --base_ref=feature --max-workers=2
   const argv = minimist(process.argv.slice(2));
   const prId = argv['pr-id'];
-  assert(prId, 'Missing --pr-id');
+  if (!prId) {
+    throw new Error('Missing --pr-id');
+  }
+
   const baseRef = argv['base-ref'];
-  assert(baseRef, 'Missing --base-ref');
+  if (!baseRef) {
+    throw new Error('Missing --base-ref');
+  }
+
   const baseSha = argv['base-sha'];
 
   const maxWorkers = argv['max-workers'] ? Number.parseInt(argv['max-workers'], 10) : 1;
@@ -406,7 +413,9 @@ async function boot() {
     ((isLocalEnv || useLocalBaselineEnv) && hasLocalBaseSnapshots
       ? await getBranchHeadRef(targetBranch)
       : await getBranchLatestRef(targetBranch));
-  assert(targetCommitSha, `Missing commit sha from ${targetBranch}`);
+  if (!targetCommitSha) {
+    throw new Error(`Missing commit sha from ${targetBranch}`);
+  }
 
   if (!isLocalEnv && !useLocalBaselineEnv) {
     await downloadBaseSnapshots(targetCommitSha, baseImgSourceDir);

--- a/tests/shared/demoTest.tsx
+++ b/tests/shared/demoTest.tsx
@@ -48,7 +48,7 @@ function baseTest(doInject: boolean, component: string, options: Options = {}) {
         const errSpy = excludeWarning();
 
         Date.now = jest.fn(() => new Date('2016-11-22').getTime());
-        jest.useFakeTimers().setSystemTime(new Date('2016-11-22'));
+        jest.useFakeTimers().setSystemTime(new Date('2016-11-22').getTime());
 
         let Demo = require(`../../${file}`).default;
         // Inject Trigger status unless skipped


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🐞 Bug 修复
- [ ] 🆕 新特性提交
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [x] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案

5.x 分支在当前依赖和工具链组合下会遇到几类 CI 问题：

1. Jest 无法正确处理 `@csstools` 依赖链中的 ESM / `.mjs` 文件，导致相关测试失败。
2. ESLint flat config 缺少 TypeScript project context，部分 JS、配置文件和测试文件会被规则误伤。
3. `OTPInput` 当前的输入事件类型会触发 TypeScript 校验问题。

这个 PR 保持最小改动修复上述问题：

1. 在 Jest 配置中补充 `@csstools` 转译白名单，并让 node/site/image 的 Jest 配置支持 `.mjs`。
2. 在 `eslint.config.mjs` 中补充 `projectService`，并把规则兼容范围收敛到必要的 JS、配置文件和测试文件。
3. 在 `biome.json` 中增加单文件级别的最小 override。
4. 将 `OTPInput` 的输入事件处理与 `master` 对齐，消除当前的类型错误。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Internal: restore 5.x lint and Jest compatibility to keep CI green with current dependencies |
| 🇨🇳 中文 | 内部优化：恢复 5.x 的 lint 与 Jest 兼容性，保证当前依赖下 CI 稳定通过 |
