### PR TITLE
fix: fix TimePicker column cannot scroll on touch devices

### DIFF
--- a/components/date-picker/style/panel.ts
+++ b/components/date-picker/style/panel.ts
@@ -539,7 +539,7 @@ export const genPanelStyle: GenerateStyle<SharedPickerToken, CSSObject> = (token
           width: timeColumnWidth,
           margin: `${unit(paddingXXS)} 0`,
           padding: 0,
-          overflowY: 'hidden',
+          overflowY: 'auto',
           textAlign: 'start',
           listStyle: 'none',
           transition: `background-color ${motionDurationMid}`,
@@ -573,10 +573,6 @@ export const genPanelStyle: GenerateStyle<SharedPickerToken, CSSObject> = (token
 
           '&-active': {
             background: new FastColor(controlItemBgActive).setA(0.2).toHexString(),
-          },
-
-          '&:hover': {
-            overflowY: 'auto',
           },
 
           '> li': {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

fix #57300, fix #32011

### 💡 Background and Solution

**Root Cause:**

The time panel column CSS sets `overflow-y: hidden` by default and only switches to `overflow-y: auto` on `:hover`:

```css
/* Default */
overflow-y: hidden;

/* On hover */
&:hover {
  overflow-y: auto;
}
```

Touch devices do not support hover events, so `overflow-y` stays `hidden` forever, blocking touch-based scrolling entirely.

The reason users observe "scrolling works after tapping an item first" is the browser's **sticky hover** behavior — a tap briefly triggers the `:hover` pseudo-class and it persists, temporarily enabling `overflow-y: auto`.

**Fix:**

Simply set `overflow-y: auto` as the default value and remove the `:hover` override. The scrollbar is already styled to be thin and subtle via `::-webkit-scrollbar` and `scrollbar-width: thin`.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix TimePicker column cannot scroll directly on touch devices. |
| 🇨🇳 Chinese | 🐞 修复 TimePicker 在移动端（触摸设备）无法直接滚动时间列的问题。 |