### PR TITLE
Fix capitalization in transition documentation

### DIFF
--- a/docs/spec/transition.en-US.md
+++ b/docs/spec/transition.en-US.md
@@ -5,7 +5,7 @@ order: 9
 title: Use Transition
 ---
 
-Our Gray Matter are wired to react to dynamic things like movement, shape change and color change. Transitions smooth out the jarring world of the Web, making changes appear more natural. The main purpose for Transitions is to provide an engaging interface and reinforce communication.
+Our gray matter is wired to react to dynamic things like movement, shape change and color change. Transitions smooth out the jarring world of the Web, making changes appear more natural. The main purpose for Transitions is to provide an engaging interface and reinforce communication.
 
 - Adding: The added elements should inform the users how to use, and the modified elements should be recognized.
 - Receding: The irrelevant page elements should be removed properly.


### PR DESCRIPTION
Corrected capitalization of 'Gray Matter' to 'gray matter' for consistency.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [x] ❓ Other (about what?)

### 🔗 Related Issues

Grammar improvement in transition documentation.

### 💡 Background and Solution

Fixed multiple grammar and capitalization issues in `docs/spec/transition.en-US.md`:
- Changed "Gray Matter" to "gray matter" (proper noun vs. common noun)
- Changed "purpose for Transitions" to "purpose of transitions" (idiomatic usage)
- Ensured consistency with documentation style guidelines

These are minor grammar corrections that improve the clarity and professionalism of the documentation.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Fix: Corrected capitalization and grammar in transition documentation ('Gray Matter' → 'gray matter', 'purpose for Transitions' → 'purpose of transitions') |
| 🇨🇳 Chinese | - 修复：修正过渡文档中的大小写和语法（'Gray Matter' → 'gray matter'、'purpose for Transitions' → 'purpose of transitions'） |