### PR TITLE
Refactor argument types in destroy and close functions

### DIFF
--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -79,8 +79,8 @@ export default function confirm(config: ModalFuncProps) {
   let currentConfig = { ...config, close, open: true } as any;
   let timeoutId: ReturnType<typeof setTimeout>;
 
-  function destroy(...args: any[]) {
-    const triggerCancel = args.some((param) => param?.triggerCancel);
+  function destroy(...args: unknown[]) {
+    const triggerCancel = args.some((param) => param && typeof param === 'object' && 'triggerCancel' in param && param.triggerCancel);
     if (triggerCancel) {
       config.onCancel?.(() => {}, ...args.slice(1));
     }
@@ -121,7 +121,7 @@ export default function confirm(config: ModalFuncProps) {
     });
   };
 
-  function close(...args: any[]) {
+  function close(...args: unknown[]) {
     currentConfig = {
       ...currentConfig,
       open: false,
@@ -129,8 +129,8 @@ export default function confirm(config: ModalFuncProps) {
         if (typeof config.afterClose === 'function') {
           config.afterClose();
         }
-        // @ts-ignore
-        destroy.apply(this, args);
+        // Fixed: Direct call instead of using apply with @ts-ignore
+        destroy(...args);
       },
     };
 


### PR DESCRIPTION
Refactor destroy and close functions to use unknown type for arguments and improve type safety.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Remove unsafe `@ts-ignore` in Modal confirm dialog by improving type safety. This addresses TypeScript suppression that was masking potential type issues.

### 💡 Background and Solution

**Problem:**
The `destroy` and `close` functions in `components/modal/confirm.tsx` were using `any[]` for the arguments parameter, and the `destroy.apply(this, args)` call required an unsafe `@ts-ignore` comment to suppress TypeScript errors.

**Solution:**
- Changed function signatures from `...args: any[]` to `...args: unknown[]` for better type safety
- Replaced `destroy.apply(this, args)` with direct function call `destroy(...args)` using the spread operator
- Added proper type guard for the `triggerCancel` check to safely handle the unknown type

This refactoring eliminates the need for the `@ts-ignore` directive while maintaining the same functionality and improving code quality.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - Fix: Remove unsafe `@ts-ignore` and improve type safety in Modal confirm by using `unknown` types and proper type guards instead of `any` |
| 🇨🇳 Chinese | - 修复：移除不安全的 `@ts-ignore` 注释，通过使用 `unknown` 类型和适当的类型守卫而不是 `any` 来改进 Modal confirm 的类型安全 |