### PR TITLE
fix(Upload): show error message inline for touch screen accessibility (#57315)

### DIFF
--- a/components/upload/UploadList/ListItem.tsx
+++ b/components/upload/UploadList/ListItem.tsx
@@ -7,7 +7,7 @@ import { clsx } from 'clsx';
 
 import { ConfigContext } from '../../config-provider';
 import Progress from '../../progress';
-import Tooltip from '../../tooltip';
+
 import type {
   ItemRender,
   UploadFile,
@@ -245,10 +245,22 @@ const ListItem = React.forwardRef<HTMLDivElement, ListItemProps>(
     const { getPrefixCls } = React.useContext(ConfigContext);
     const rootPrefixCls = getPrefixCls();
 
-    const dom = (
+    const message =
+      file.response && typeof file.response === 'string'
+        ? file.response
+        : file.error?.statusText || file.error?.message || locale.uploadError;
+
+    // Show error message inline below the filename for better touch screen accessibility
+    const errorMessageNode =
+      mergedStatus === 'error' && message ? (
+        <span className={`${prefixCls}-list-item-error-message`}>{message}</span>
+      ) : null;
+
+    const item = (
       <div className={listItemClassName} style={styles?.item}>
         {icon}
         {fileName}
+        {errorMessageNode}
         {downloadOrDelete}
         {pictureCardActions}
         {showProgress && (
@@ -280,19 +292,6 @@ const ListItem = React.forwardRef<HTMLDivElement, ListItemProps>(
         )}
       </div>
     );
-
-    const message =
-      file.response && typeof file.response === 'string'
-        ? file.response
-        : file.error?.statusText || file.error?.message || locale.uploadError;
-    const item =
-      mergedStatus === 'error' ? (
-        <Tooltip title={message} getPopupContainer={(node) => node.parentNode as HTMLElement}>
-          {dom}
-        </Tooltip>
-      ) : (
-        dom
-      );
 
     return (
       <div className={clsx(`${prefixCls}-list-item-container`, className)} style={style} ref={ref}>

--- a/components/upload/style/list.ts
+++ b/components/upload/style/list.ts
@@ -104,6 +104,14 @@ const genListStyle: GenerateStyle<UploadToken, CSSObject> = (token) => {
               opacity: 1,
             },
           },
+
+          [`${itemCls}-error-message`]: {
+            flex: 'auto',
+            padding: `0 ${unit(token.paddingXS)}`,
+            fontSize,
+            lineHeight: 1.5,
+            color: token.colorError,
+          },
         },
 
         [`${componentCls}-list-item-container`]: {


### PR DESCRIPTION
## Fix: Upload error message inline display for touch screen accessibility

### Problem
Upload error messages were displayed using a `Tooltip` component, which is inaccessible on touch devices (iPad, mobile phones) since Tooltips require hover to display.

When a user taps on an errored file item on a touch device, it triggers file preview/download instead of showing the error message.

### Solution
Show error messages as inline text directly in the file list item, replacing the Tooltip approach:

- **Before**: Error message hidden inside Tooltip (requires hover)
- **After**: Error message displayed inline below filename (always visible)

### Changes
- `components/upload/UploadList/ListItem.tsx`: Removed Tooltip wrapper, added inline error message span below filename
- `components/upload/style/list.ts`: Added `.upload-list-item-error-message` CSS styling with proper error color and layout

### Testing
1. Trigger an upload error on a touch device (iPad/iPhone)
2. Observe that error message is now visible without any interaction
3. Tap the filename still works for preview (no regression)

Fixes #57315
