### PR TITLE
fix: reset Image preview action button styles

### DIFF
--- a/components/image/__tests__/index.test.tsx
+++ b/components/image/__tests__/index.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 
 import Image from '..';
 import type { MaskType } from '../../_util/hooks';
@@ -46,23 +45,6 @@ describe('Image', () => {
     );
     expect(baseElement).toMatchSnapshot();
     expect(document.querySelector('.ant-image-preview')).toHaveClass('ant-image-preview-fade');
-  });
-
-  it('should not leak global button styles to preview actions', () => {
-    const cache = createCache();
-
-    render(
-      <StyleProvider cache={cache}>
-        <Image alt={alt} src={src} preview={{ open: true }} />
-      </StyleProvider>,
-    );
-
-    const styleText = extractStyle(cache, true);
-    expect(styleText).toContain('.ant-image-preview-actions-action');
-    expect(styleText).toContain('color:inherit;');
-    expect(styleText).toContain('background:transparent;');
-    expect(styleText).toContain('border:0;');
-    expect(styleText).toContain('font:inherit;');
   });
 
   it('Customize preview props', () => {

--- a/components/image/__tests__/index.test.tsx
+++ b/components/image/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 
 import Image from '..';
 import type { MaskType } from '../../_util/hooks';
@@ -45,6 +46,23 @@ describe('Image', () => {
     );
     expect(baseElement).toMatchSnapshot();
     expect(document.querySelector('.ant-image-preview')).toHaveClass('ant-image-preview-fade');
+  });
+
+  it('should not leak global button styles to preview actions', () => {
+    const cache = createCache();
+
+    render(
+      <StyleProvider cache={cache}>
+        <Image alt={alt} src={src} preview={{ open: true }} />
+      </StyleProvider>,
+    );
+
+    const styleText = extractStyle(cache, true);
+    expect(styleText).toContain('.ant-image-preview-actions-action');
+    expect(styleText).toContain('color:inherit;');
+    expect(styleText).toContain('background:transparent;');
+    expect(styleText).toContain('border:0;');
+    expect(styleText).toContain('font:inherit;');
   });
 
   it('Customize preview props', () => {

--- a/components/image/style/index.ts
+++ b/components/image/style/index.ts
@@ -242,6 +242,10 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken, CSSObject> = (token
         fontSize: previewOperationSize,
 
         '&-action': {
+          color: 'inherit',
+          background: 'transparent',
+          border: 0,
+          font: 'inherit',
           padding: paddingSM,
           cursor: 'pointer',
           transition: `all ${motionDurationSlow}`,


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix https://github.com/ant-design/ant-design/issues/57489

### 💡 需求背景和解决方案

`@rc-component/image` 将预览底部操作项改为原生 `button` 后，antd 的 Image 预览样式没有同步补上对应的 button reset，导致底部操作按钮可能被外部全局 `button` 样式污染。

这个 PR 在 `Image` preview actions 的样式中补充了最小 reset：
- `color: inherit`
- `background: transparent`
- `border: 0`
- `font: inherit`

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Image preview action buttons not resetting native button styles. |
| 🇨🇳 中文 | 🐞 修复 Image 预览底部操作按钮没有重置原生按钮样式的问题。 |
