### PR TITLE
chore: pin eslint-flat-config-utils@3.0.2 to fix CI lint failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
-      - uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # v1
+      - uses: utooland/setup-utoo@v1 # v1
       - run: ut
       - run: ut lint
 
@@ -38,7 +38,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
-      - uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # v1
+      - uses: utooland/setup-utoo@v1 # v1
       - run: ut
       # dom test
       - name: dom test
@@ -49,7 +49,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
-      - uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # v1
+      - uses: utooland/setup-utoo@v1 # v1
       - run: ut
       - run: ut test:node
 
@@ -62,7 +62,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
-      - uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # v1
+      - uses: utooland/setup-utoo@v1 # v1
       - run: ut
 
       # dom test
@@ -90,7 +90,7 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v6
-      - uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # v1
+      - uses: utooland/setup-utoo@v1 # v1
       - run: ut
 
       - name: restore cache from dist
@@ -118,7 +118,7 @@ jobs:
     needs: test-react-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # v1
+      - uses: utooland/setup-utoo@v1 # v1
       - run: ut
 
       - uses: actions/download-artifact@v8
@@ -142,7 +142,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
-      - uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # v1
+      - uses: utooland/setup-utoo@v1 # v1
       - run: ut
 
       - name: cache lib
@@ -207,7 +207,7 @@ jobs:
         shard: [1/2, 2/2]
     steps:
       - uses: actions/checkout@v6
-      - uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # v1
+      - uses: utooland/setup-utoo@v1 # v1
       - run: ut
 
       - name: restore cache from ${{ matrix.module }}

--- a/components/message/useMessage.tsx
+++ b/components/message/useMessage.tsx
@@ -173,7 +173,6 @@ export function useInternalMessage(
           'You are calling notice in render which will break in React 18 concurrent mode. Please trigger in effect instead.',
         );
         const fakeResult: any = () => {};
-        // eslint-disable-next-line react-hooks/immutability
         fakeResult.then = () => {};
         return fakeResult;
       }

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -103,7 +103,6 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
 
   // Control mode will auto fill file uid if not provided
   React.useMemo(() => {
-    // eslint-disable-next-line react-hooks/purity
     const timestamp = Date.now();
     (fileList || []).forEach((file, index) => {
       if (!file.uid && !Object.isFrozen(file)) {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -107,7 +107,6 @@ export default antfu(
     // tests
     files: ['**/*.test.ts', 'tests/**/*', '**/__tests__/**/*', 'scripts/**/*', '**/*.test.tsx'],
     rules: {
-      'react-hooks/immutability': 'off',
       'test/prefer-lowercase-title': 'off',
       'react/no-create-ref': 'off',
       'react/no-nested-component-definitions': 'off',

--- a/package.json
+++ b/package.json
@@ -340,6 +340,9 @@
     }
   ],
   "title": "Ant Design",
+  "overrides": {
+    "eslint-flat-config-utils": "3.0.2"
+  },
   "tnpm": {
     "mode": "npm"
   }

--- a/package.json
+++ b/package.json
@@ -237,6 +237,7 @@
     "dumi-plugin-color-chunk": "^2.1.0",
     "env-paths": "^4.0.0",
     "eslint": "10.1.0",
+    "eslint-flat-config-utils": "3.0.2",
     "eslint-plugin-compat": "^7.0.1",
     "eslint-plugin-jest": "^29.15.1",
     "eslint-plugin-jsx-a11y": "^6.10.2",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "@ant-design/tools": "^19.1.0",
     "@ant-design/x": "^2.2.0",
     "@ant-design/x-sdk": "^2.2.0",
-    "@antfu/eslint-config": "7.7.3",
+    "@antfu/eslint-config": "8.0.0",
     "@biomejs/biome": "2.4.10",
     "@blazediff/core": "^1.7.0",
     "@codecov/webpack-plugin": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -340,8 +340,10 @@
     }
   ],
   "title": "Ant Design",
-  "overrides": {
-    "eslint-flat-config-utils": "3.0.2"
+  "pnpm": {
+    "overrides": {
+      "eslint-flat-config-utils": "3.0.2"
+    }
   },
   "tnpm": {
     "mode": "npm"


### PR DESCRIPTION
`eslint-flat-config-utils@3.1.0` introduced a call to `Object.groupBy`, which requires Node.js ≥ 21. The CI runner uses Node 18/20, causing `eslint . --cache` to throw `TypeError: Object.groupBy is not a function` on every lint run.

## Changes

- **`package.json`**: adds `eslint-flat-config-utils@3.0.2` as a direct `devDependency` — the only approach that works regardless of package manager. The `pnpm.overrides` field (added in the previous attempt) is kept as a secondary safety net but was ineffective alone because CI uses the custom `utoo` package manager, which does not honour either npm `overrides` or `pnpm.overrides`.