### PR TITLE
chore(skills): improve create-pr skill trigger phrases

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -24,9 +24,9 @@ description: Create pull requests for ant-design using the repository's official
 - 总结当前分支改动用于提 PR
 - 用 `gh pr create` 为 `ant-design` 开 PR
 
-如果用户只输入很短的口语化指令，也应直接触发本 skill，不要因为信息太少而跳过，例如：`创建pr`、`创建 PR`、`开pr`、`开个pr`、`提pr`、`提个pr`、`帮我提个pr`、`发pr`、`写pr`、`准备pr`。
-
-英文里的简短说法也应直接触发，例如：`create pr`、`create a pr`、`open pr`、`open a pr`、`submit pr`、`send pr`、`draft pr`、`prepare pr`、`help me create a pr`、`open a pull request`。
+如果用户只输入很短的口语化指令，也应直接触发本 skill，不要因为信息太少而跳过。例如：
+- 中文：`创建pr`、`创建 PR`、`开pr`、`开个pr`、`提pr`、`提个pr`、`帮我提个pr`、`发pr`、`写pr`、`准备pr`。
+- 英文：`create pr`、`create a pr`、`open pr`、`open a pr`、`submit pr`、`send pr`、`draft pr`、`prepare pr`、`help me create a pr`、`open a pull request`。
 
 这类短句默认表示：先分析当前分支改动并整理待确认的 `base`、`title`、`body` 草稿，等用户确认后再真正创建 PR。
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -24,6 +24,12 @@ description: Create pull requests for ant-design using the repository's official
 - 总结当前分支改动用于提 PR
 - 用 `gh pr create` 为 `ant-design` 开 PR
 
+如果用户只输入很短的口语化指令，也应直接触发本 skill，不要因为信息太少而跳过，例如：`创建pr`、`创建 PR`、`开pr`、`开个pr`、`提pr`、`提个pr`、`帮我提个pr`、`发pr`、`写pr`、`准备pr`。
+
+英文里的简短说法也应直接触发，例如：`create pr`、`create a pr`、`open pr`、`open a pr`、`submit pr`、`send pr`、`draft pr`、`prepare pr`、`help me create a pr`、`open a pull request`。
+
+这类短句默认表示：先分析当前分支改动并整理待确认的 `base`、`title`、`body` 草稿，等用户确认后再真正创建 PR。
+
 ## 基本规则
 
 ### 一、必须以仓库模板为准


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [x] ❓ 其他改动（skill 维护：补充 create-pr 触发短句说明）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

补充 `create-pr` skill 的触发说明，增加口语化中英文短句示例（如 `创建pr`、`开pr`、`create pr`、`open a pr` 等），避免因用户输入过于简短而未能正确触发本 skill。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A      |
| 🇨🇳 中文 | N/A      |