### PR TITLE
fix: correct Cascader menu item ellipsis styles

### DIFF
--- a/components/cascader/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/cascader/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1291,64 +1291,21 @@ exports[`renders components/cascader/demo/disabled-option.tsx extend context cor
 
 exports[`renders components/cascader/demo/ellipsis-debug.tsx extend context correctly 1`] = `
 <div
-  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-flex-start ant-flex-gap-middle"
 >
   <div
-    class="ant-select ant-cascader ant-select-outlined ant-select-css-var ant-cascader-css-var css-var-test-id ant-select-single ant-select-show-arrow ant-select-open"
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
   >
-    <div
-      class="ant-select-content"
+    <span
+      class="ant-typography css-var-test-id"
     >
-      <div
-        class="ant-select-placeholder"
-        style="visibility: visible;"
-      >
-        Constrained width for ellipsis
-      </div>
-      <input
-        aria-autocomplete="list"
-        aria-controls="test-id_list"
-        aria-expanded="true"
-        aria-haspopup="listbox"
-        aria-owns="test-id_list"
-        autocomplete="off"
-        class="ant-select-input"
-        id="test-id"
-        readonly=""
-        role="combobox"
-        type="search"
-        value=""
-      />
-    </div>
+      <strong>
+        Constrained item width
+      </strong>
+    </span>
     <div
-      class="ant-select-suffix"
+      class="ant-cascader-panel css-var-test-id ant-cascader-css-var"
     >
-      <span
-        aria-label="down"
-        class="anticon anticon-down"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="down"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-          />
-        </svg>
-      </span>
-    </div>
-  </div>
-  <div
-    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-cascader-dropdown ant-select-css-var ant-cascader-css-var css-var-test-id ant-select-dropdown-placement-bottomLeft"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; min-width: auto;"
-  >
-    <div>
       <div
         class="ant-cascader-menus"
       >
@@ -1363,7 +1320,6 @@ exports[`renders components/cascader/demo/ellipsis-debug.tsx extend context corr
             data-path-key="zhejiang"
             data-title="Zhejiang"
             role="menuitemcheckbox"
-            style="width: 160px;"
             title="ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang"
           >
             <div
@@ -1402,7 +1358,6 @@ exports[`renders components/cascader/demo/ellipsis-debug.tsx extend context corr
             data-path-key="jiangsu"
             data-title="Jiangsu"
             role="menuitemcheckbox"
-            style="width: 160px;"
             title="JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu"
           >
             <div
@@ -1439,61 +1394,18 @@ exports[`renders components/cascader/demo/ellipsis-debug.tsx extend context corr
     </div>
   </div>
   <div
-    class="ant-select ant-cascader ant-select-outlined ant-select-css-var ant-cascader-css-var css-var-test-id ant-select-single ant-select-show-arrow ant-select-open"
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
   >
-    <div
-      class="ant-select-content"
+    <span
+      class="ant-typography css-var-test-id"
     >
-      <div
-        class="ant-select-placeholder"
-        style="visibility: visible;"
-      >
-        Default width for comparison
-      </div>
-      <input
-        aria-autocomplete="list"
-        aria-controls="test-id_list"
-        aria-expanded="true"
-        aria-haspopup="listbox"
-        aria-owns="test-id_list"
-        autocomplete="off"
-        class="ant-select-input"
-        id="test-id"
-        readonly=""
-        role="combobox"
-        type="search"
-        value=""
-      />
-    </div>
+      <strong>
+        Default item width
+      </strong>
+    </span>
     <div
-      class="ant-select-suffix"
+      class="ant-cascader-panel css-var-test-id ant-cascader-css-var"
     >
-      <span
-        aria-label="down"
-        class="anticon anticon-down"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="down"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
-        >
-          <path
-            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-          />
-        </svg>
-      </span>
-    </div>
-  </div>
-  <div
-    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-cascader-dropdown ant-select-css-var ant-cascader-css-var css-var-test-id ant-select-dropdown-placement-bottomLeft"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; min-width: auto;"
-  >
-    <div>
       <div
         class="ant-cascader-menus"
       >

--- a/components/cascader/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/cascader/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1289,6 +1289,303 @@ Array [
 
 exports[`renders components/cascader/demo/disabled-option.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/cascader/demo/ellipsis-debug.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+>
+  <div
+    class="ant-select ant-cascader ant-select-outlined ant-select-css-var ant-cascader-css-var css-var-test-id ant-select-single ant-select-show-arrow ant-select-open"
+  >
+    <div
+      class="ant-select-content"
+    >
+      <div
+        class="ant-select-placeholder"
+        style="visibility: visible;"
+      >
+        Constrained width for ellipsis
+      </div>
+      <input
+        aria-autocomplete="list"
+        aria-controls="test-id_list"
+        aria-expanded="true"
+        aria-haspopup="listbox"
+        aria-owns="test-id_list"
+        autocomplete="off"
+        class="ant-select-input"
+        id="test-id"
+        readonly=""
+        role="combobox"
+        type="search"
+        value=""
+      />
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-cascader-dropdown ant-select-css-var ant-cascader-css-var css-var-test-id ant-select-dropdown-placement-bottomLeft"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; min-width: auto;"
+  >
+    <div>
+      <div
+        class="ant-cascader-menus"
+      >
+        <ul
+          class="ant-cascader-menu"
+          role="menu"
+        >
+          <li
+            aria-checked="false"
+            aria-label="Zhejiang"
+            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
+            data-path-key="zhejiang"
+            data-title="Zhejiang"
+            role="menuitemcheckbox"
+            style="width: 160px;"
+            title="ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang"
+          >
+            <div
+              class="ant-cascader-menu-item-content"
+            >
+              ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang
+            </div>
+            <div
+              class="ant-cascader-menu-item-expand-icon"
+            >
+              <span
+                aria-label="right"
+                class="anticon anticon-right"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="right"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </li>
+          <li
+            aria-checked="false"
+            aria-label="Jiangsu"
+            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
+            data-path-key="jiangsu"
+            data-title="Jiangsu"
+            role="menuitemcheckbox"
+            style="width: 160px;"
+            title="JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu"
+          >
+            <div
+              class="ant-cascader-menu-item-content"
+            >
+              JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu
+            </div>
+            <div
+              class="ant-cascader-menu-item-expand-icon"
+            >
+              <span
+                aria-label="right"
+                class="anticon anticon-right"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="right"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-select ant-cascader ant-select-outlined ant-select-css-var ant-cascader-css-var css-var-test-id ant-select-single ant-select-show-arrow ant-select-open"
+  >
+    <div
+      class="ant-select-content"
+    >
+      <div
+        class="ant-select-placeholder"
+        style="visibility: visible;"
+      >
+        Default width for comparison
+      </div>
+      <input
+        aria-autocomplete="list"
+        aria-controls="test-id_list"
+        aria-expanded="true"
+        aria-haspopup="listbox"
+        aria-owns="test-id_list"
+        autocomplete="off"
+        class="ant-select-input"
+        id="test-id"
+        readonly=""
+        role="combobox"
+        type="search"
+        value=""
+      />
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-cascader-dropdown ant-select-css-var ant-cascader-css-var css-var-test-id ant-select-dropdown-placement-bottomLeft"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; min-width: auto;"
+  >
+    <div>
+      <div
+        class="ant-cascader-menus"
+      >
+        <ul
+          class="ant-cascader-menu"
+          role="menu"
+        >
+          <li
+            aria-checked="false"
+            aria-label="Zhejiang"
+            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
+            data-path-key="zhejiang"
+            data-title="Zhejiang"
+            role="menuitemcheckbox"
+            title="ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang"
+          >
+            <div
+              class="ant-cascader-menu-item-content"
+            >
+              ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang
+            </div>
+            <div
+              class="ant-cascader-menu-item-expand-icon"
+            >
+              <span
+                aria-label="right"
+                class="anticon anticon-right"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="right"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </li>
+          <li
+            aria-checked="false"
+            aria-label="Jiangsu"
+            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
+            data-path-key="jiangsu"
+            data-title="Jiangsu"
+            role="menuitemcheckbox"
+            title="JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu"
+          >
+            <div
+              class="ant-cascader-menu-item-content"
+            >
+              JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu
+            </div>
+            <div
+              class="ant-cascader-menu-item-expand-icon"
+            >
+              <span
+                aria-label="right"
+                class="anticon anticon-right"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="right"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/cascader/demo/ellipsis-debug.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/cascader/demo/fields-name.tsx extend context correctly 1`] = `
 Array [
   <div

--- a/components/cascader/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/cascader/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1293,6 +1293,13 @@ exports[`renders components/cascader/demo/ellipsis-debug.tsx extend context corr
 <div
   class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-flex-start ant-flex-gap-middle"
 >
+  <style>
+      .cascader-panel-ellipsis-debug-fixed .ant-cascader-menu {
+        width: 160px;
+        min-width: 160px;
+        flex: none;
+      }
+  </style>
   <div
     class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
   >
@@ -1304,7 +1311,7 @@ exports[`renders components/cascader/demo/ellipsis-debug.tsx extend context corr
       </strong>
     </span>
     <div
-      class="ant-cascader-panel css-var-test-id ant-cascader-css-var"
+      class="ant-cascader-panel cascader-panel-ellipsis-debug-fixed css-var-test-id ant-cascader-css-var"
     >
       <div
         class="ant-cascader-menus"

--- a/components/cascader/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/cascader/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1291,214 +1291,92 @@ exports[`renders components/cascader/demo/disabled-option.tsx extend context cor
 
 exports[`renders components/cascader/demo/ellipsis-debug.tsx extend context correctly 1`] = `
 <div
-  class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-flex-start ant-flex-gap-middle"
+  class="ant-cascader-panel css-var-test-id ant-cascader-css-var"
 >
-  <style>
-      .cascader-panel-ellipsis-debug-fixed .ant-cascader-menu {
-        width: 160px;
-        min-width: 160px;
-        flex: none;
-      }
-  </style>
   <div
-    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+    class="ant-cascader-menus"
   >
-    <span
-      class="ant-typography css-var-test-id"
+    <ul
+      class="ant-cascader-menu"
+      role="menu"
     >
-      <strong>
-        Constrained item width
-      </strong>
-    </span>
-    <div
-      class="ant-cascader-panel cascader-panel-ellipsis-debug-fixed css-var-test-id ant-cascader-css-var"
-    >
-      <div
-        class="ant-cascader-menus"
+      <li
+        aria-checked="false"
+        aria-label="Zhejiang"
+        class="ant-cascader-menu-item ant-cascader-menu-item-expand"
+        data-path-key="zhejiang"
+        data-title="Zhejiang"
+        role="menuitemcheckbox"
+        title="ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang"
       >
-        <ul
-          class="ant-cascader-menu"
-          role="menu"
+        <div
+          class="ant-cascader-menu-item-content"
         >
-          <li
-            aria-checked="false"
-            aria-label="Zhejiang"
-            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
-            data-path-key="zhejiang"
-            data-title="Zhejiang"
-            role="menuitemcheckbox"
-            title="ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang"
+          ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang
+        </div>
+        <div
+          class="ant-cascader-menu-item-expand-icon"
+        >
+          <span
+            aria-label="right"
+            class="anticon anticon-right"
+            role="img"
           >
-            <div
-              class="ant-cascader-menu-item-content"
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
             >
-              ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang
-            </div>
-            <div
-              class="ant-cascader-menu-item-expand-icon"
-            >
-              <span
-                aria-label="right"
-                class="anticon anticon-right"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="right"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </li>
-          <li
-            aria-checked="false"
-            aria-label="Jiangsu"
-            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
-            data-path-key="jiangsu"
-            data-title="Jiangsu"
-            role="menuitemcheckbox"
-            title="JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu"
-          >
-            <div
-              class="ant-cascader-menu-item-content"
-            >
-              JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu
-            </div>
-            <div
-              class="ant-cascader-menu-item-expand-icon"
-            >
-              <span
-                aria-label="right"
-                class="anticon anticon-right"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="right"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-  >
-    <span
-      class="ant-typography css-var-test-id"
-    >
-      <strong>
-        Default item width
-      </strong>
-    </span>
-    <div
-      class="ant-cascader-panel css-var-test-id ant-cascader-css-var"
-    >
-      <div
-        class="ant-cascader-menus"
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+      </li>
+      <li
+        aria-checked="false"
+        aria-label="Jiangsu"
+        class="ant-cascader-menu-item ant-cascader-menu-item-expand"
+        data-path-key="jiangsu"
+        data-title="Jiangsu"
+        role="menuitemcheckbox"
+        title="JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu"
       >
-        <ul
-          class="ant-cascader-menu"
-          role="menu"
+        <div
+          class="ant-cascader-menu-item-content"
         >
-          <li
-            aria-checked="false"
-            aria-label="Zhejiang"
-            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
-            data-path-key="zhejiang"
-            data-title="Zhejiang"
-            role="menuitemcheckbox"
-            title="ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang"
+          JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu
+        </div>
+        <div
+          class="ant-cascader-menu-item-expand-icon"
+        >
+          <span
+            aria-label="right"
+            class="anticon anticon-right"
+            role="img"
           >
-            <div
-              class="ant-cascader-menu-item-content"
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
             >
-              ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang
-            </div>
-            <div
-              class="ant-cascader-menu-item-expand-icon"
-            >
-              <span
-                aria-label="right"
-                class="anticon anticon-right"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="right"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </li>
-          <li
-            aria-checked="false"
-            aria-label="Jiangsu"
-            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
-            data-path-key="jiangsu"
-            data-title="Jiangsu"
-            role="menuitemcheckbox"
-            title="JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu"
-          >
-            <div
-              class="ant-cascader-menu-item-content"
-            >
-              JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu
-            </div>
-            <div
-              class="ant-cascader-menu-item-expand-icon"
-            >
-              <span
-                aria-label="right"
-                class="anticon anticon-right"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="right"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </li>
-        </ul>
-      </div>
-    </div>
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+      </li>
+    </ul>
   </div>
 </div>
 `;

--- a/components/cascader/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/cascader/__tests__/__snapshots__/demo.test.tsx.snap
@@ -430,104 +430,206 @@ exports[`renders components/cascader/demo/disabled-option.tsx correctly 1`] = `
 
 exports[`renders components/cascader/demo/ellipsis-debug.tsx correctly 1`] = `
 <div
-  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-flex-start ant-flex-gap-middle"
 >
   <div
-    class="ant-select ant-cascader ant-select-outlined ant-select-css-var ant-cascader-css-var css-var-test-id ant-select-single ant-select-show-arrow"
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
   >
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <strong>
+        Constrained item width
+      </strong>
+    </span>
     <div
-      class="ant-select-content"
+      class="ant-cascader-panel css-var-test-id ant-cascader-css-var"
     >
       <div
-        class="ant-select-placeholder"
-        style="visibility:visible"
+        class="ant-cascader-menus"
       >
-        Constrained width for ellipsis
-      </div>
-      <input
-        aria-autocomplete="list"
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        autocomplete="off"
-        class="ant-select-input"
-        id="test-id"
-        readonly=""
-        role="combobox"
-        type="search"
-        value=""
-      />
-    </div>
-    <div
-      class="ant-select-suffix"
-    >
-      <span
-        aria-label="down"
-        class="anticon anticon-down"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="down"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
+        <ul
+          class="ant-cascader-menu"
+          role="menu"
         >
-          <path
-            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-          />
-        </svg>
-      </span>
+          <li
+            aria-checked="false"
+            aria-label="Zhejiang"
+            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
+            data-path-key="zhejiang"
+            data-title="Zhejiang"
+            role="menuitemcheckbox"
+            title="ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang"
+          >
+            <div
+              class="ant-cascader-menu-item-content"
+            >
+              ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang
+            </div>
+            <div
+              class="ant-cascader-menu-item-expand-icon"
+            >
+              <span
+                aria-label="right"
+                class="anticon anticon-right"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="right"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </li>
+          <li
+            aria-checked="false"
+            aria-label="Jiangsu"
+            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
+            data-path-key="jiangsu"
+            data-title="Jiangsu"
+            role="menuitemcheckbox"
+            title="JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu"
+          >
+            <div
+              class="ant-cascader-menu-item-content"
+            >
+              JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu
+            </div>
+            <div
+              class="ant-cascader-menu-item-expand-icon"
+            >
+              <span
+                aria-label="right"
+                class="anticon anticon-right"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="right"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
   <div
-    class="ant-select ant-cascader ant-select-outlined ant-select-css-var ant-cascader-css-var css-var-test-id ant-select-single ant-select-show-arrow"
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
   >
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <strong>
+        Default item width
+      </strong>
+    </span>
     <div
-      class="ant-select-content"
+      class="ant-cascader-panel css-var-test-id ant-cascader-css-var"
     >
       <div
-        class="ant-select-placeholder"
-        style="visibility:visible"
+        class="ant-cascader-menus"
       >
-        Default width for comparison
-      </div>
-      <input
-        aria-autocomplete="list"
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        autocomplete="off"
-        class="ant-select-input"
-        id="test-id"
-        readonly=""
-        role="combobox"
-        type="search"
-        value=""
-      />
-    </div>
-    <div
-      class="ant-select-suffix"
-    >
-      <span
-        aria-label="down"
-        class="anticon anticon-down"
-        role="img"
-      >
-        <svg
-          aria-hidden="true"
-          data-icon="down"
-          fill="currentColor"
-          focusable="false"
-          height="1em"
-          viewBox="64 64 896 896"
-          width="1em"
+        <ul
+          class="ant-cascader-menu"
+          role="menu"
         >
-          <path
-            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-          />
-        </svg>
-      </span>
+          <li
+            aria-checked="false"
+            aria-label="Zhejiang"
+            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
+            data-path-key="zhejiang"
+            data-title="Zhejiang"
+            role="menuitemcheckbox"
+            title="ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang"
+          >
+            <div
+              class="ant-cascader-menu-item-content"
+            >
+              ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang
+            </div>
+            <div
+              class="ant-cascader-menu-item-expand-icon"
+            >
+              <span
+                aria-label="right"
+                class="anticon anticon-right"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="right"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </li>
+          <li
+            aria-checked="false"
+            aria-label="Jiangsu"
+            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
+            data-path-key="jiangsu"
+            data-title="Jiangsu"
+            role="menuitemcheckbox"
+            title="JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu"
+          >
+            <div
+              class="ant-cascader-menu-item-content"
+            >
+              JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu
+            </div>
+            <div
+              class="ant-cascader-menu-item-expand-icon"
+            >
+              <span
+                aria-label="right"
+                class="anticon anticon-right"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="right"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/components/cascader/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/cascader/__tests__/__snapshots__/demo.test.tsx.snap
@@ -430,214 +430,92 @@ exports[`renders components/cascader/demo/disabled-option.tsx correctly 1`] = `
 
 exports[`renders components/cascader/demo/ellipsis-debug.tsx correctly 1`] = `
 <div
-  class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-flex-start ant-flex-gap-middle"
+  class="ant-cascader-panel css-var-test-id ant-cascader-css-var"
 >
-  <style>
-      .cascader-panel-ellipsis-debug-fixed .ant-cascader-menu {
-        width: 160px;
-        min-width: 160px;
-        flex: none;
-      }
-  </style>
   <div
-    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+    class="ant-cascader-menus"
   >
-    <span
-      class="ant-typography css-var-test-id"
+    <ul
+      class="ant-cascader-menu"
+      role="menu"
     >
-      <strong>
-        Constrained item width
-      </strong>
-    </span>
-    <div
-      class="ant-cascader-panel cascader-panel-ellipsis-debug-fixed css-var-test-id ant-cascader-css-var"
-    >
-      <div
-        class="ant-cascader-menus"
+      <li
+        aria-checked="false"
+        aria-label="Zhejiang"
+        class="ant-cascader-menu-item ant-cascader-menu-item-expand"
+        data-path-key="zhejiang"
+        data-title="Zhejiang"
+        role="menuitemcheckbox"
+        title="ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang"
       >
-        <ul
-          class="ant-cascader-menu"
-          role="menu"
+        <div
+          class="ant-cascader-menu-item-content"
         >
-          <li
-            aria-checked="false"
-            aria-label="Zhejiang"
-            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
-            data-path-key="zhejiang"
-            data-title="Zhejiang"
-            role="menuitemcheckbox"
-            title="ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang"
+          ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang
+        </div>
+        <div
+          class="ant-cascader-menu-item-expand-icon"
+        >
+          <span
+            aria-label="right"
+            class="anticon anticon-right"
+            role="img"
           >
-            <div
-              class="ant-cascader-menu-item-content"
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
             >
-              ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang
-            </div>
-            <div
-              class="ant-cascader-menu-item-expand-icon"
-            >
-              <span
-                aria-label="right"
-                class="anticon anticon-right"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="right"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </li>
-          <li
-            aria-checked="false"
-            aria-label="Jiangsu"
-            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
-            data-path-key="jiangsu"
-            data-title="Jiangsu"
-            role="menuitemcheckbox"
-            title="JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu"
-          >
-            <div
-              class="ant-cascader-menu-item-content"
-            >
-              JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu
-            </div>
-            <div
-              class="ant-cascader-menu-item-expand-icon"
-            >
-              <span
-                aria-label="right"
-                class="anticon anticon-right"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="right"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </div>
-  <div
-    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
-  >
-    <span
-      class="ant-typography css-var-test-id"
-    >
-      <strong>
-        Default item width
-      </strong>
-    </span>
-    <div
-      class="ant-cascader-panel css-var-test-id ant-cascader-css-var"
-    >
-      <div
-        class="ant-cascader-menus"
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+      </li>
+      <li
+        aria-checked="false"
+        aria-label="Jiangsu"
+        class="ant-cascader-menu-item ant-cascader-menu-item-expand"
+        data-path-key="jiangsu"
+        data-title="Jiangsu"
+        role="menuitemcheckbox"
+        title="JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu"
       >
-        <ul
-          class="ant-cascader-menu"
-          role="menu"
+        <div
+          class="ant-cascader-menu-item-content"
         >
-          <li
-            aria-checked="false"
-            aria-label="Zhejiang"
-            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
-            data-path-key="zhejiang"
-            data-title="Zhejiang"
-            role="menuitemcheckbox"
-            title="ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang"
+          JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu
+        </div>
+        <div
+          class="ant-cascader-menu-item-expand-icon"
+        >
+          <span
+            aria-label="right"
+            class="anticon anticon-right"
+            role="img"
           >
-            <div
-              class="ant-cascader-menu-item-content"
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
             >
-              ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang
-            </div>
-            <div
-              class="ant-cascader-menu-item-expand-icon"
-            >
-              <span
-                aria-label="right"
-                class="anticon anticon-right"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="right"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </li>
-          <li
-            aria-checked="false"
-            aria-label="Jiangsu"
-            class="ant-cascader-menu-item ant-cascader-menu-item-expand"
-            data-path-key="jiangsu"
-            data-title="Jiangsu"
-            role="menuitemcheckbox"
-            title="JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu"
-          >
-            <div
-              class="ant-cascader-menu-item-content"
-            >
-              JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu
-            </div>
-            <div
-              class="ant-cascader-menu-item-expand-icon"
-            >
-              <span
-                aria-label="right"
-                class="anticon anticon-right"
-                role="img"
-              >
-                <svg
-                  aria-hidden="true"
-                  data-icon="right"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
-                  />
-                </svg>
-              </span>
-            </div>
-          </li>
-        </ul>
-      </div>
-    </div>
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+      </li>
+    </ul>
   </div>
 </div>
 `;

--- a/components/cascader/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/cascader/__tests__/__snapshots__/demo.test.tsx.snap
@@ -428,6 +428,111 @@ exports[`renders components/cascader/demo/disabled-option.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/cascader/demo/ellipsis-debug.tsx correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+>
+  <div
+    class="ant-select ant-cascader ant-select-outlined ant-select-css-var ant-cascader-css-var css-var-test-id ant-select-single ant-select-show-arrow"
+  >
+    <div
+      class="ant-select-content"
+    >
+      <div
+        class="ant-select-placeholder"
+        style="visibility:visible"
+      >
+        Constrained width for ellipsis
+      </div>
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="off"
+        class="ant-select-input"
+        id="test-id"
+        readonly=""
+        role="combobox"
+        type="search"
+        value=""
+      />
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select ant-cascader ant-select-outlined ant-select-css-var ant-cascader-css-var css-var-test-id ant-select-single ant-select-show-arrow"
+  >
+    <div
+      class="ant-select-content"
+    >
+      <div
+        class="ant-select-placeholder"
+        style="visibility:visible"
+      >
+        Default width for comparison
+      </div>
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="off"
+        class="ant-select-input"
+        id="test-id"
+        readonly=""
+        role="combobox"
+        type="search"
+        value=""
+      />
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/cascader/demo/fields-name.tsx correctly 1`] = `
 <div
   class="ant-select ant-cascader ant-select-outlined ant-select-css-var ant-cascader-css-var css-var-test-id ant-select-single ant-select-show-arrow"

--- a/components/cascader/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/cascader/__tests__/__snapshots__/demo.test.tsx.snap
@@ -432,6 +432,13 @@ exports[`renders components/cascader/demo/ellipsis-debug.tsx correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-flex-start ant-flex-gap-middle"
 >
+  <style>
+      .cascader-panel-ellipsis-debug-fixed .ant-cascader-menu {
+        width: 160px;
+        min-width: 160px;
+        flex: none;
+      }
+  </style>
   <div
     class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
   >
@@ -443,7 +450,7 @@ exports[`renders components/cascader/demo/ellipsis-debug.tsx correctly 1`] = `
       </strong>
     </span>
     <div
-      class="ant-cascader-panel css-var-test-id ant-cascader-css-var"
+      class="ant-cascader-panel cascader-panel-ellipsis-debug-fixed css-var-test-id ant-cascader-css-var"
     >
       <div
         class="ant-cascader-menus"

--- a/components/cascader/demo/ellipsis-debug.md
+++ b/components/cascader/demo/ellipsis-debug.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-调试 Cascader.Panel 菜单项长文本省略样式。左侧示例限制项宽以观察 `...`，右侧保留默认宽度用于对比。
+调试 Cascader.Panel 菜单项长文本省略样式。左侧示例通过局部样式限制列宽以观察 `...`，右侧保留默认宽度用于对比。
 
 ## en-US
 
-Debug Cascader.Panel menu item ellipsis. The left panel constrains item width to make `...` visible, while the right panel keeps the default width for comparison.
+Debug Cascader.Panel menu item ellipsis. The left panel constrains column width with local styles to make `...` visible, while the right panel keeps the default width for comparison.

--- a/components/cascader/demo/ellipsis-debug.md
+++ b/components/cascader/demo/ellipsis-debug.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-调试 Cascader 菜单项长文本省略样式。上方示例限制列宽以观察 `...`，下方保留默认宽度用于对比。
+调试 Cascader.Panel 菜单项长文本省略样式。左侧示例限制项宽以观察 `...`，右侧保留默认宽度用于对比。
 
 ## en-US
 
-Debug Cascader menu item ellipsis. The first example constrains column width to make `...` visible, while the second keeps the default width for comparison.
+Debug Cascader.Panel menu item ellipsis. The left panel constrains item width to make `...` visible, while the right panel keeps the default width for comparison.

--- a/components/cascader/demo/ellipsis-debug.md
+++ b/components/cascader/demo/ellipsis-debug.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-调试 Cascader.Panel 菜单项长文本省略样式。左侧示例通过局部样式限制列宽以观察 `...`，右侧保留默认宽度用于对比。
+调试 Cascader.Panel 菜单项长文本省略样式。
 
 ## en-US
 
-Debug Cascader.Panel menu item ellipsis. The left panel constrains column width with local styles to make `...` visible, while the right panel keeps the default width for comparison.
+Debug Cascader.Panel menu item ellipsis.

--- a/components/cascader/demo/ellipsis-debug.md
+++ b/components/cascader/demo/ellipsis-debug.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+调试 Cascader 菜单项长文本省略样式。上方示例限制列宽以观察 `...`，下方保留默认宽度用于对比。
+
+## en-US
+
+Debug Cascader menu item ellipsis. The first example constrains column width to make `...` visible, while the second keeps the default width for comparison.

--- a/components/cascader/demo/ellipsis-debug.tsx
+++ b/components/cascader/demo/ellipsis-debug.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import type { CascaderProps } from 'antd';
+import { Cascader, Flex } from 'antd';
+import type { HTMLAriaDataAttributes } from 'antd/es/_util/aria-data-attrs';
+
+type Option = {
+  value: string;
+  label: string;
+  children?: Option[];
+} & HTMLAriaDataAttributes;
+
+const options: Option[] = [
+  {
+    value: 'zhejiang',
+    label: 'ZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiangZhejiang',
+    'aria-label': 'Zhejiang',
+    'data-title': 'Zhejiang',
+    children: [
+      {
+        value: 'hangzhou',
+        label: 'HangzhouHangzhouHangzhouHangzhouHangzhouHangzhou',
+        'aria-label': 'Hangzhou',
+        'data-title': 'Hangzhou',
+        children: [
+          {
+            value: 'xihu',
+            label: 'West LakeWest LakeWest LakeWest LakeWest Lake',
+            'aria-label': 'West Lake',
+            'data-title': 'West Lake',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    value: 'jiangsu',
+    label: 'JiangsuJiangsuJiangsuJiangsuJiangsuJiangsuJiangsu',
+    'aria-label': 'Jiangsu',
+    'data-title': 'Jiangsu',
+    children: [
+      {
+        value: 'nanjing',
+        label: 'NanjingNanjingNanjingNanjingNanjing',
+        'aria-label': 'Nanjing',
+        'data-title': 'Nanjing',
+        children: [
+          {
+            value: 'zhonghuamen',
+            label: 'Zhong Hua MenZhong Hua MenZhong Hua Men',
+            'aria-label': 'Zhong Hua Men',
+            'data-title': 'Zhong Hua Men',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const onChange: CascaderProps<Option>['onChange'] = (value) => {
+  console.log(value);
+};
+
+const App: React.FC = () => (
+  <Flex vertical gap="small">
+    <Cascader
+      open
+      options={options}
+      onChange={onChange}
+      placeholder="Constrained width for ellipsis"
+      popupMenuColumnStyle={{ width: 160 }}
+    />
+    <Cascader
+      open
+      options={options}
+      onChange={onChange}
+      placeholder="Default width for comparison"
+    />
+  </Flex>
+);
+
+export default App;

--- a/components/cascader/demo/ellipsis-debug.tsx
+++ b/components/cascader/demo/ellipsis-debug.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { CascaderProps } from 'antd';
-import { Cascader, Flex } from 'antd';
+import { Cascader, Flex, Typography } from 'antd';
 import type { HTMLAriaDataAttributes } from 'antd/es/_util/aria-data-attrs';
 
 type Option = {
@@ -61,20 +61,16 @@ const onChange: CascaderProps<Option>['onChange'] = (value) => {
 };
 
 const App: React.FC = () => (
-  <Flex vertical gap="small">
-    <Cascader
-      open
-      options={options}
-      onChange={onChange}
-      placeholder="Constrained width for ellipsis"
-      popupMenuColumnStyle={{ width: 160 }}
-    />
-    <Cascader
-      open
-      options={options}
-      onChange={onChange}
-      placeholder="Default width for comparison"
-    />
+  <Flex gap="middle" wrap align="flex-start">
+    <Flex vertical gap="small">
+      <Typography.Text strong>Constrained item width</Typography.Text>
+      <Cascader.Panel options={options} onChange={onChange} popupMenuColumnStyle={{ width: 160 }} />
+    </Flex>
+
+    <Flex vertical gap="small">
+      <Typography.Text strong>Default item width</Typography.Text>
+      <Cascader.Panel options={options} onChange={onChange} />
+    </Flex>
   </Flex>
 );
 

--- a/components/cascader/demo/ellipsis-debug.tsx
+++ b/components/cascader/demo/ellipsis-debug.tsx
@@ -62,9 +62,21 @@ const onChange: CascaderProps<Option>['onChange'] = (value) => {
 
 const App: React.FC = () => (
   <Flex gap="middle" wrap align="flex-start">
+    <style>{`
+      .cascader-panel-ellipsis-debug-fixed .ant-cascader-menu {
+        width: 160px;
+        min-width: 160px;
+        flex: none;
+      }
+    `}</style>
+
     <Flex vertical gap="small">
       <Typography.Text strong>Constrained item width</Typography.Text>
-      <Cascader.Panel options={options} onChange={onChange} popupMenuColumnStyle={{ width: 160 }} />
+      <Cascader.Panel
+        className="cascader-panel-ellipsis-debug-fixed"
+        options={options}
+        onChange={onChange}
+      />
     </Flex>
 
     <Flex vertical gap="small">

--- a/components/cascader/demo/ellipsis-debug.tsx
+++ b/components/cascader/demo/ellipsis-debug.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { CascaderProps } from 'antd';
-import { Cascader, Flex, Typography } from 'antd';
+import { Cascader } from 'antd';
 import type { HTMLAriaDataAttributes } from 'antd/es/_util/aria-data-attrs';
 
 type Option = {
@@ -60,30 +60,6 @@ const onChange: CascaderProps<Option>['onChange'] = (value) => {
   console.log(value);
 };
 
-const App: React.FC = () => (
-  <Flex gap="middle" wrap align="flex-start">
-    <style>{`
-      .cascader-panel-ellipsis-debug-fixed .ant-cascader-menu {
-        width: 160px;
-        min-width: 160px;
-        flex: none;
-      }
-    `}</style>
-
-    <Flex vertical gap="small">
-      <Typography.Text strong>Constrained item width</Typography.Text>
-      <Cascader.Panel
-        className="cascader-panel-ellipsis-debug-fixed"
-        options={options}
-        onChange={onChange}
-      />
-    </Flex>
-
-    <Flex vertical gap="small">
-      <Typography.Text strong>Default item width</Typography.Text>
-      <Cascader.Panel options={options} onChange={onChange} />
-    </Flex>
-  </Flex>
-);
+const App: React.FC = () => <Cascader.Panel options={options} onChange={onChange} />;
 
 export default App;

--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -38,6 +38,7 @@ demo:
 <code src="./demo/status.tsx">Status</code>
 <code src="./demo/style-class.tsx" version="6.0.0">Custom semantic dom styling</code>
 <code src="./demo/panel.tsx" version=">= 5.10.0">Panel</code>
+<code src="./demo/ellipsis-debug.tsx" debug>Menu item ellipsis</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>
 <code src="./demo/component-token.tsx" debug>Component Token</code>
 

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -39,6 +39,7 @@ demo:
 <code src="./demo/status.tsx">自定义状态</code>
 <code src="./demo/style-class.tsx" version="6.0.0">自定义语义结构的样式和类</code>
 <code src="./demo/panel.tsx" version=">= 5.10.0">面板使用</code>
+<code src="./demo/ellipsis-debug.tsx" debug>菜单项省略样式调试</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>
 <code src="./demo/component-token.tsx" debug>Component Token</code>
 

--- a/components/cascader/style/columns.ts
+++ b/components/cascader/style/columns.ts
@@ -66,6 +66,7 @@ const getColumnsStyle: GenerateStyle<CascaderToken, CSSInterpolation> = (token) 
 
           '&-item': {
             display: 'flex',
+            maxWidth: 400,
             flexWrap: 'nowrap',
             alignItems: 'center',
             padding: token.optionPadding,
@@ -101,7 +102,6 @@ const getColumnsStyle: GenerateStyle<CascaderToken, CSSInterpolation> = (token) 
             '&-content': {
               flex: 'auto',
               minWidth: 0,
-              maxWidth: 400,
               ...textEllipsis,
             },
 

--- a/components/cascader/style/columns.ts
+++ b/components/cascader/style/columns.ts
@@ -65,7 +65,6 @@ const getColumnsStyle: GenerateStyle<CascaderToken, CSSInterpolation> = (token) 
           },
 
           '&-item': {
-            ...textEllipsis,
             display: 'flex',
             flexWrap: 'nowrap',
             alignItems: 'center',
@@ -101,6 +100,8 @@ const getColumnsStyle: GenerateStyle<CascaderToken, CSSInterpolation> = (token) 
 
             '&-content': {
               flex: 'auto',
+              minWidth: 0,
+              ...textEllipsis,
             },
 
             [iconCls]: {

--- a/components/cascader/style/columns.ts
+++ b/components/cascader/style/columns.ts
@@ -101,6 +101,7 @@ const getColumnsStyle: GenerateStyle<CascaderToken, CSSInterpolation> = (token) 
             '&-content': {
               flex: 'auto',
               minWidth: 0,
+              maxWidth: 400,
               ...textEllipsis,
             },
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] 📽️ 演示代码改进

### 🔗 相关 Issue

fix #57539

### 💡 需求背景和解决方案

Cascader 菜单项在 flex 布局下将省略样式应用在了父节点上，长文本 label 无法在菜单列中正确显示省略号。

这个 PR 将省略样式移动到实际承载文本的 `.ant-cascader-menu-item-content`，并补充了一个 debug demo，用于对比受限列宽和默认列宽下的展示效果。该改动不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Cascader menu item ellipsis styles for long option labels. |
| 🇨🇳 中文 | 🐞 修复 Cascader 菜单项长选项文本的省略样式。 |
