### PR TITLE
perf: cache flattened keys in table filter

### DIFF
--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -174,33 +174,55 @@ export const getFilterData = <RecordType extends AnyObject = AnyObject>(
       column: { onFilter, filters },
       filteredKeys,
     } = filterState;
+
     if (onFilter && filteredKeys && filteredKeys.length) {
-      return (
-        currentData
-          // shallow copy
-          .map((record) => ({ ...record }))
-          .filter((record: any) =>
-            filteredKeys.some((key) => {
-              const keys = flattenKeys(filters);
-              const keyIndex = keys.findIndex((k) => String(k) === String(key));
-              const realKey = keyIndex !== -1 ? keys[keyIndex] : key;
+      // Optimization 1: preprocess the keys corresponding to the filter tree,
+      // use Map to improve lookup performance to O(1).
+      const flatKeys = flattenKeys(filters);
+      const keyMap = new Map<string, any>(); // realKey
+      flatKeys.forEach((k) => {
+        const strKey = String(k);
+        if (!keyMap.has(strKey)) {
+          keyMap.set(strKey, k); // preserve first-match semantics
+        }
+      });
 
-              // filter children
-              if (record[childrenColumnName]) {
-                record[childrenColumnName] = getFilterData(
-                  record[childrenColumnName],
-                  filterStates,
-                  childrenColumnName,
-                );
-              }
+      // Preconvert the incoming `filteredKeys` to `realKeys`.
+      const realKeys = filteredKeys.map((key) => {
+        const strKey = String(key);
+        return keyMap.has(strKey) ? keyMap.get(strKey) : key;
+      });
 
-              return onFilter(realKey, record);
-            }),
-          )
-      );
+      // Optimization 2 & 3: use `reduce` to merge the original
+      // `map` (shallow copy) + `filter` into a two-pass traversal.
+      return currentData.reduce<RecordType[]>((acc, record) => {
+        // Shallow copy
+        const clonedRecord = { ...record } as any;
+
+        // Optimization: move filtering `children` out of `some` (which runs on every comparison)
+        // to ensure each child node is filtered only once.
+        if (clonedRecord[childrenColumnName]) {
+          clonedRecord[childrenColumnName] = getFilterData(
+            clonedRecord[childrenColumnName],
+            filterStates,
+            childrenColumnName,
+          );
+        }
+
+        // Compare one by one using the preprocessed `realKeys`.
+        const isMatch = realKeys.some((realKey) => onFilter(realKey, clonedRecord));
+
+        if (isMatch) {
+          acc.push(clonedRecord);
+        }
+
+        return acc;
+      }, []);
     }
+
     return currentData;
   }, data);
+
   return filterDatas;
 };
 

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -176,7 +176,7 @@ export const getFilterData = <RecordType extends AnyObject = AnyObject>(
     } = filterState;
 
     if (onFilter && filteredKeys && filteredKeys.length) {
-      // Optimization 1: preprocess the keys corresponding to the filter tree,
+      // Preprocess the keys corresponding to the filter tree,
       // use Map to improve lookup performance to O(1).
       const flatKeys = flattenKeys(filters);
       const keyMap = new Map<string, FilterValue[number]>();
@@ -195,9 +195,15 @@ export const getFilterData = <RecordType extends AnyObject = AnyObject>(
       const internalFilter = (subset: RecordType[]): RecordType[] =>
         subset.reduce<RecordType[]>((acc, record) => {
           const clonedRecord = { ...record } as any;
+
           if (clonedRecord[childrenColumnName]) {
-            clonedRecord[childrenColumnName] = internalFilter(clonedRecord[childrenColumnName]);
+            clonedRecord[childrenColumnName] = getFilterData(
+              clonedRecord[childrenColumnName],
+              filterStates,
+              childrenColumnName,
+            );
           }
+
           if (realKeys.some((realKey) => onFilter(realKey, clonedRecord))) {
             acc.push(clonedRecord);
           }

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -179,45 +179,32 @@ export const getFilterData = <RecordType extends AnyObject = AnyObject>(
       // Optimization 1: preprocess the keys corresponding to the filter tree,
       // use Map to improve lookup performance to O(1).
       const flatKeys = flattenKeys(filters);
-      const keyMap = new Map<string, any>(); // realKey
+      const keyMap = new Map<string, FilterValue[number]>();
       flatKeys.forEach((k) => {
         const strKey = String(k);
         if (!keyMap.has(strKey)) {
-          keyMap.set(strKey, k); // preserve first-match semantics
+          keyMap.set(strKey, k);
         }
       });
 
-      // Preconvert the incoming `filteredKeys` to `realKeys`.
       const realKeys = filteredKeys.map((key) => {
         const strKey = String(key);
-        return keyMap.has(strKey) ? keyMap.get(strKey) : key;
+        return keyMap.get(strKey) ?? key;
       });
 
-      // Optimization 2 & 3: use `reduce` to combine the original
-      // `map` (shallow copy) + `filter` into a single-pass traversal.
-      return currentData.reduce<RecordType[]>((acc, record) => {
-        // Shallow copy
-        const clonedRecord = { ...record } as any;
+      const internalFilter = (subset: RecordType[]): RecordType[] =>
+        subset.reduce<RecordType[]>((acc, record) => {
+          const clonedRecord = { ...record } as any;
+          if (clonedRecord[childrenColumnName]) {
+            clonedRecord[childrenColumnName] = internalFilter(clonedRecord[childrenColumnName]);
+          }
+          if (realKeys.some((realKey) => onFilter(realKey, clonedRecord))) {
+            acc.push(clonedRecord);
+          }
+          return acc;
+        }, []);
 
-        // Optimization: move filtering `children` out of `some` (which runs on every comparison)
-        // to ensure each child node is filtered only once.
-        if (clonedRecord[childrenColumnName]) {
-          clonedRecord[childrenColumnName] = getFilterData(
-            clonedRecord[childrenColumnName],
-            filterStates,
-            childrenColumnName,
-          );
-        }
-
-        // Compare one by one using the preprocessed `realKeys`.
-        const isMatch = realKeys.some((realKey) => onFilter(realKey, clonedRecord));
-
-        if (isMatch) {
-          acc.push(clonedRecord);
-        }
-
-        return acc;
-      }, []);
+      return internalFilter(currentData);
     }
 
     return currentData;


### PR DESCRIPTION
### 🤔 This is a ...

- [X] ⚡️ Performance optimization

### 🔗 Related Issues

N/A

### 💡 Background and Solution
> - Table filtering currently calls flattenKeys(filters) inside a nested loop in `getFilterData()`, which causes repeated recursive flattening for each record and each selected filter key. This makes filtering noticeably slower when filters are nested and the dataset is large.

Solution: move `flattenKeys` function call to outside

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  ⚡️ Improve Table filter performance by caching flattened filter keys.         |
| 🇨🇳 Chinese |   ⚡️ 优化 Table 筛选性能，缓存展开后的筛选键，避免重复计算。        |
