### PR TITLE
fix(Table):V5  prevent rowSelection crash when selectedRowKeys becomes undefined

### DIFF
--- a/components/table/__tests__/Table.rowSelection.test.tsx
+++ b/components/table/__tests__/Table.rowSelection.test.tsx
@@ -1837,6 +1837,37 @@ describe('Table.rowSelection', () => {
       expect(onChange).toHaveBeenCalledWith(['Jack'], [{ name: 'Jack' }], { type: 'single' });
     });
 
+    it('works with preserveSelectedRowKeys after receive selectedRowKeys from [] to undefined', () => {
+      const onChange = jest.fn();
+      const dataSource = [{ name: 'Jack' }];
+      const { container, rerender } = render(
+        <Table
+          dataSource={dataSource}
+          rowSelection={{ onChange, selectedRowKeys: ['Jack'] }}
+          rowKey="name"
+        />,
+      );
+
+      rerender(
+        <Table
+          dataSource={dataSource}
+          rowSelection={{ onChange, selectedRowKeys: [] }}
+          rowKey="name"
+        />,
+      );
+
+      rerender(
+        <Table
+          dataSource={dataSource}
+          rowSelection={{ onChange, preserveSelectedRowKeys: true }}
+          rowKey="name"
+        />,
+      );
+
+      fireEvent.click(container.querySelector('tbody input')!);
+      expect(onChange).toHaveBeenCalledWith(['Jack'], [{ name: 'Jack' }], { type: 'single' });
+    });
+
     it('works with selectionType radio receive selectedRowKeys from [] to undefined', () => {
       const onChange = jest.fn();
       const dataSource = [{ name: 'Jack' }];

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -123,6 +123,7 @@ const useSelection = <RecordType extends AnyObject = AnyObject>(
       value: selectedRowKeys,
     },
   );
+  const mergedSelectedKeyList = mergedSelectedKeys ?? EMPTY_LIST;
 
   // ======================== Caches ========================
   const preserveRecordsRef = React.useRef(new Map<Key, RecordType>());
@@ -150,8 +151,8 @@ const useSelection = <RecordType extends AnyObject = AnyObject>(
 
   // Update cache with selectedKeys
   React.useEffect(() => {
-    updatePreserveRecordsCache(mergedSelectedKeys);
-  }, [mergedSelectedKeys]);
+    updatePreserveRecordsCache(mergedSelectedKeyList);
+  }, [mergedSelectedKeyList, updatePreserveRecordsCache]);
 
   // Get flatten data
   const flattedData = useMemo(
@@ -213,16 +214,16 @@ const useSelection = <RecordType extends AnyObject = AnyObject>(
 
   const [derivedSelectedKeys, derivedHalfSelectedKeys] = useMemo(() => {
     if (checkStrictly) {
-      return [mergedSelectedKeys || [], []];
+      return [mergedSelectedKeyList, []];
     }
     const { checkedKeys, halfCheckedKeys } = conductCheck(
-      mergedSelectedKeys,
+      mergedSelectedKeyList,
       true,
       keyEntities as any,
       isCheckboxDisabled as any,
     );
     return [checkedKeys || [], halfCheckedKeys];
-  }, [mergedSelectedKeys, checkStrictly, keyEntities, isCheckboxDisabled]);
+  }, [mergedSelectedKeyList, checkStrictly, keyEntities, isCheckboxDisabled]);
 
   const derivedSelectedKeySet = useMemo<Set<Key>>(() => {
     const keys = selectionType === 'radio' ? derivedSelectedKeys.slice(0, 1) : derivedSelectedKeys;


### PR DESCRIPTION
### 🤔 这是一个 ...

- [ ] 🆕 新特性
- [x] 🐞 Bug 修复
- [ ] 📝 站点 / 文档优化
- [ ] 📽️ 示例代码改进
- [ ] 💄 组件样式优化
- [ ] 🤖 TypeScript 类型优化
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍增强
- [ ] ❓ 其他（请说明）:

### 🔗 相关 Issues

- fix https://github.com/ant-design/ant-design/issues/57416

### 💡 背景和解决方案

- `Table` 在 `rowSelection.selectedRowKeys` 从 `[]` 切换为 `undefined`，同时开启 `preserveSelectedRowKeys` 时会触发运行时错误。
- 问题原因是 `useSelection` 在后续逻辑中直接将 `mergedSelectedKeys` 当作数组使用，更新阶段可能拿到 `undefined`，从而在缓存更新流程中触发 `forEach` 报错。
- 这次修复保留了原有的受控 / 非受控语义，只在消费 `mergedSelectedKeys` 的位置统一兜底为 `[]`，避免 `undefined` 继续流入缓存与派生选中态逻辑。
- 同时补充了回归测试，覆盖 `selectedRowKeys: []` 再切换到 `preserveSelectedRowKeys: true` 的场景。

### 📝 更新日志

| 语言   | 更新描述 |
| ------ | -------- |
| 🇺🇸 英文 | 🐞 Fix Table `rowSelection` crash when `selectedRowKeys` becomes `undefined` with `preserveSelectedRowKeys`. |
| 🇨🇳 中文 | 🐞 修复 Table 在 `preserveSelectedRowKeys` 下 `selectedRowKeys` 变为 `undefined` 时的报错问题。 |
