### PR TITLE
docs: deprecate Cascader popupMenuColumnStyle in favor of styles.popup.listItem

### DIFF
--- a/components/cascader/__tests__/index.test.tsx
+++ b/components/cascader/__tests__/index.test.tsx
@@ -613,10 +613,50 @@ describe('Cascader', () => {
         />,
       );
       expect(errSpy).toHaveBeenCalledWith(
-        'Warning: [antd: Cascader] `dropdownMenuColumnStyle` is deprecated. Please use `popupMenuColumnStyle` instead.',
+        'Warning: [antd: Cascader] `dropdownMenuColumnStyle` is deprecated. Please use `styles.popup.listItem` instead.',
       );
       const menuColumn = getByRole('menuitemcheckbox');
       expect(menuColumn).toHaveStyle({ padding: '10px' });
+
+      errSpy.mockRestore();
+    });
+
+    it('deprecated popupMenuColumnStyle', () => {
+      resetWarned();
+
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { getByRole } = render(
+        <Cascader
+          options={[{ label: 'test', value: 1 }]}
+          popupMenuColumnStyle={{ padding: 10 }}
+          open
+        />,
+      );
+      expect(errSpy).toHaveBeenCalledWith(
+        'Warning: [antd: Cascader] `popupMenuColumnStyle` is deprecated. Please use `styles.popup.listItem` instead.',
+      );
+      const menuColumn = getByRole('menuitemcheckbox');
+      expect(menuColumn).toHaveStyle({ padding: '10px' });
+
+      errSpy.mockRestore();
+    });
+
+    it('styles.popup.listItem should override popupMenuColumnStyle', () => {
+      resetWarned();
+
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { getByRole } = render(
+        <Cascader
+          options={[{ label: 'test', value: 1 }]}
+          popupMenuColumnStyle={{ padding: 10 }}
+          styles={{ popup: { listItem: { padding: 20 } } }}
+          open
+        />,
+      );
+
+      expect(getByRole('menuitemcheckbox')).toHaveStyle({ padding: '20px' });
 
       errSpy.mockRestore();
     });

--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -95,8 +95,8 @@ Common props ref：[Common props](/docs/react/common-props)
 | showCheckedStrategy | The way to show selected items in the box (only effective when `multiple` is `true`). `Cascader.SHOW_CHILD`: just show child treeNode. `Cascader.SHOW_PARENT`: just show parent treeNode (when all child treeNode under the parent treeNode are checked) | `Cascader.SHOW_PARENT` \| `Cascader.SHOW_CHILD` | `Cascader.SHOW_PARENT` | 4.20.0 |
 | ~~searchValue~~ | Set search value, Need work with `showSearch` | string | - | 4.17.0 |
 | ~~onSearch~~ | The callback function triggered when input changed | (search: string) => void | - | 4.17.0 |
-| ~~dropdownMenuColumnStyle~~ | The style of the drop-down menu column, use `popupMenuColumnStyle` instead | CSSProperties | - |  |
-| popupMenuColumnStyle | The style of the drop-down menu column | CSSProperties | - |  |
+| ~~dropdownMenuColumnStyle~~ | The style of the drop-down menu column, use `styles.popup.listItem` instead | CSSProperties | - |  |
+| ~~popupMenuColumnStyle~~ | The style of the drop-down menu column, use `styles.popup.listItem` instead | CSSProperties | - |  |
 | optionRender | Customize the rendering dropdown options | (option: Option) => React.ReactNode | - | 5.16.0 |
 
 ### showSearch

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -179,8 +179,9 @@ export interface CascaderProps<
   /** @deprecated Please use `popupRender` instead */
   dropdownRender?: (menu: React.ReactElement) => React.ReactElement;
   popupRender?: (menu: React.ReactElement) => React.ReactElement;
-  /** @deprecated Please use `popupMenuColumnStyle` instead */
+  /** @deprecated Please use `styles.popup.listItem` instead */
   dropdownMenuColumnStyle?: React.CSSProperties;
+  /** @deprecated Please use `styles.popup.listItem` instead */
   popupMenuColumnStyle?: React.CSSProperties;
   /** @deprecated Please use `onOpenChange` instead */
   onDropdownVisibleChange?: (visible: boolean) => void;
@@ -280,7 +281,8 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
       dropdownClassName: 'classNames.popup.root',
       dropdownStyle: 'styles.popup.root',
       dropdownRender: 'popupRender',
-      dropdownMenuColumnStyle: 'popupMenuColumnStyle',
+      dropdownMenuColumnStyle: 'styles.popup.listItem',
+      popupMenuColumnStyle: 'styles.popup.listItem',
       onDropdownVisibleChange: 'onOpenChange',
       onPopupVisibleChange: 'onOpenChange',
       bordered: 'variant',

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -96,8 +96,8 @@ demo:
 | removeIcon | 自定义的多选框清除图标 | ReactNode | - |  |
 | ~searchValue~ | 设置搜索的值，需要与 `showSearch` 配合使用 | string | - | 4.17.0 |
 | ~onSearch~ | 监听搜索，返回输入的值 | (search: string) => void | - | 4.17.0 |
-| ~~dropdownMenuColumnStyle~~ | 下拉菜单列的样式，请使用 `popupMenuColumnStyle` 替换 | CSSProperties | - |  |
-| popupMenuColumnStyle | 下拉菜单列的样式 | CSSProperties | - |  |
+| ~~dropdownMenuColumnStyle~~ | 下拉菜单列的样式，请使用 `styles.popup.listItem` 替换 | CSSProperties | - |  |
+| ~~popupMenuColumnStyle~~ | 下拉菜单列的样式，请使用 `styles.popup.listItem` 替换 | CSSProperties | - |  |
 | optionRender | 自定义渲染下拉选项 | (option: Option) => React.ReactNode | - | 5.16.0 |
 
 ### showSearch

--- a/docs/react/migration-v6.en-US.md
+++ b/docs/react/migration-v6.en-US.md
@@ -114,7 +114,7 @@ If you encounter build errors during the upgrade, please verify that your `@ant-
   - `dropdownClassName` is deprecated and replaced by `classNames.popup.root`.
   - `dropdownStyle` is deprecated and replaced by `styles.popup.root`.
   - `dropdownRender` is deprecated and replaced by `popupRender`.
-  - `dropdownMenuColumnStyle` is deprecated and replaced by `popupMenuColumnStyle`.
+  - `dropdownMenuColumnStyle` is deprecated and replaced by `styles.popup.listItem`.
   - `onDropdownVisibleChange` is deprecated and replaced by `onOpenChange`.
   - `onPopupVisibleChange` is deprecated and replaced by `onOpenChange`.
   - `bordered` is deprecated and replaced by `variant`.

--- a/docs/react/migration-v6.zh-CN.md
+++ b/docs/react/migration-v6.zh-CN.md
@@ -112,7 +112,7 @@ pnpm add @ant-design/icons@6
   - `dropdownClassName` 弃用，变为 `classNames.popup.root`。
   - `dropdownStyle` 弃用，变为 `styles.popup.root`。
   - `dropdownRender` 弃用，变为 `popupRender`。
-  - `dropdownMenuColumnStyle` 弃用，变为 `popupMenuColumnStyle`。
+  - `dropdownMenuColumnStyle` 弃用，变为 `styles.popup.listItem`。
   - `onDropdownVisibleChange` 弃用，变为 `onOpenChange`。
   - `onPopupVisibleChange` 弃用，变为 `onOpenChange`。
   - `bordered` 弃用，变为 `variant`。


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Cascader 仍然将 `popupMenuColumnStyle` 作为 `dropdownMenuColumnStyle` 的替代属性写在文档和迁移说明中，但当前推荐使用的 API 实际上是 `styles.popup.listItem`。

本次修改统一更新了废弃提示、组件文档和 v6 迁移文档中的替代说明，明确引导开发者改用 `styles.popup.listItem`。同时补充测试，覆盖 `popupMenuColumnStyle` 的废弃提示以及其被 `styles.popup.listItem` 覆盖时的行为。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |