### PR TITLE
fix: avoid native ellipsis measurement without tooltip

### DIFF
--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -252,7 +252,12 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
     setCssEllipsis(canUseCssEllipsis && mergedEnableEllipsis);
   }, [canUseCssEllipsis, mergedEnableEllipsis]);
 
-  const isMergedEllipsis = mergedEnableEllipsis && (cssEllipsis ? isNativeEllipsis : isJsEllipsis);
+  const tooltipProps = useTooltipProps(ellipsisConfig.tooltip, editConfig.text, children);
+  const needNativeEllipsisMeasure = cssEllipsis && !!tooltipProps.title;
+
+  const isMergedEllipsis =
+    mergedEnableEllipsis &&
+    (cssEllipsis ? needNativeEllipsisMeasure && isNativeEllipsis : isJsEllipsis);
 
   const cssTextOverflow = mergedEnableEllipsis && rows === 1 && cssEllipsis;
   const cssLineClamp = mergedEnableEllipsis && rows > 1 && cssEllipsis;
@@ -284,14 +289,21 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
   React.useEffect(() => {
     const textEle = typographyRef.current;
 
-    if (enableEllipsis && cssEllipsis && textEle) {
+    if (enableEllipsis && needNativeEllipsisMeasure && textEle) {
       const currentEllipsis = isEleEllipsis(textEle);
 
       if (isNativeEllipsis !== currentEllipsis) {
         setIsNativeEllipsis(currentEllipsis);
       }
     }
-  }, [enableEllipsis, cssEllipsis, children, cssLineClamp, isNativeVisible, ellipsisWidth]);
+  }, [
+    enableEllipsis,
+    needNativeEllipsisMeasure,
+    children,
+    cssLineClamp,
+    isNativeVisible,
+    ellipsisWidth,
+  ]);
 
   // https://github.com/ant-design/ant-design/issues/36786
   // Use IntersectionObserver to check if element is invisible
@@ -300,7 +312,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
     if (
       typeof IntersectionObserver === 'undefined' ||
       !textEle ||
-      !cssEllipsis ||
+      !needNativeEllipsisMeasure ||
       !mergedEnableEllipsis
     ) {
       return;
@@ -314,11 +326,9 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
     return () => {
       observer.disconnect();
     };
-  }, [cssEllipsis, mergedEnableEllipsis]);
+  }, [needNativeEllipsisMeasure, mergedEnableEllipsis]);
 
   // ========================== Tooltip ===========================
-  const tooltipProps = useTooltipProps(ellipsisConfig.tooltip, editConfig.text, children);
-
   const topAriaLabel = React.useMemo(() => {
     if (!enableEllipsis || cssEllipsis) {
       return undefined;

--- a/components/typography/__tests__/ellipsis.test.tsx
+++ b/components/typography/__tests__/ellipsis.test.tsx
@@ -159,23 +159,6 @@ describe('Typography.Ellipsis', () => {
     ellipsisSpy.mockRestore();
   });
 
-  it('should measure native ellipsis when tooltip is configured', async () => {
-    const ellipsisSpy = jest.spyOn(baseUtil, 'isEleEllipsis').mockReturnValue(true);
-    const ref = React.createRef<HTMLElement>();
-
-    render(
-      <Base ellipsis={{ tooltip: true }} component="p" ref={ref}>
-        {fullStr}
-      </Base>,
-    );
-
-    triggerResize(ref.current!);
-    await waitFakeTimer();
-
-    expect(ellipsisSpy).toHaveBeenCalled();
-    ellipsisSpy.mockRestore();
-  });
-
   it('string with parentheses', async () => {
     const parenthesesStr = `Ant Design, a design language (for background applications, is refined by
         Ant UED Team. Ant Design, a design language for background applications,

--- a/components/typography/__tests__/ellipsis.test.tsx
+++ b/components/typography/__tests__/ellipsis.test.tsx
@@ -14,6 +14,7 @@ import type { ConfigProviderProps } from '../../config-provider';
 import zhCN from '../../locale/zh_CN';
 import type { EllipsisConfig } from '../Base';
 import Base from '../Base';
+import * as baseUtil from '../Base/util';
 
 type Locale = ConfigProviderProps['locale'];
 jest.mock('copy-to-clipboard');
@@ -139,6 +140,40 @@ describe('Typography.Ellipsis', () => {
           ?.style as any
       )?.WebkitLineClamp,
     ).toEqual('2');
+  });
+
+  it('should skip native ellipsis measure when tooltip is not configured', async () => {
+    const ellipsisSpy = jest.spyOn(baseUtil, 'isEleEllipsis').mockReturnValue(true);
+    const ref = React.createRef<HTMLElement>();
+
+    render(
+      <Base ellipsis component="p" ref={ref}>
+        {fullStr}
+      </Base>,
+    );
+
+    triggerResize(ref.current!);
+    await waitFakeTimer();
+
+    expect(ellipsisSpy).not.toHaveBeenCalled();
+    ellipsisSpy.mockRestore();
+  });
+
+  it('should measure native ellipsis when tooltip is configured', async () => {
+    const ellipsisSpy = jest.spyOn(baseUtil, 'isEleEllipsis').mockReturnValue(true);
+    const ref = React.createRef<HTMLElement>();
+
+    render(
+      <Base ellipsis={{ tooltip: true }} component="p" ref={ref}>
+        {fullStr}
+      </Base>,
+    );
+
+    triggerResize(ref.current!);
+    await waitFakeTimer();
+
+    expect(ellipsisSpy).toHaveBeenCalled();
+    ellipsisSpy.mockRestore();
   });
 
   it('string with parentheses', async () => {
@@ -328,7 +363,11 @@ describe('Typography.Ellipsis', () => {
         disconnect = disconnectFn;
       };
 
-      const { container, unmount } = render(<Base ellipsis component="p" />);
+      const { container, unmount } = render(
+        <Base ellipsis={{ tooltip: true }} component="p">
+          {fullStr}
+        </Base>,
+      );
 
       expect(observeFn).toHaveBeenCalled();
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [x] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- Close #57563

### 💡 Background and Solution

- `Typography` native CSS ellipsis always called `isEleEllipsis`, which could trigger expensive reflow in dense table scenarios even when consumers only needed visual truncation.
- Native ellipsis measurement is now only enabled when ellipsis tooltip content is configured, since that is the only CSS ellipsis path that still needs to know whether truncation actually happened.
- Added regression tests to verify the native measurement helper is skipped without tooltip and still runs when tooltip is enabled.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | ⚡️ Optimize Typography ellipsis performance by skipping native ellipsis measurement when no ellipsis tooltip is configured. |
| 🇨🇳 Chinese | ⚡️ 优化 Typography 省略场景性能，在未配置省略 tooltip 时跳过原生 ellipsis 测量。 |
