### PR TITLE
docs: add Qwen Code to AI tools and update component docs links

### DIFF
--- a/docs/react/cli.en-US.md
+++ b/docs/react/cli.en-US.md
@@ -62,6 +62,8 @@ antd migrate 4 5 --apply ./src      # Agent-ready migration prompt
 | `antd usage [dir]` | Import stats, sub-component breakdown (`Form.Item`), non-component exports |
 | `antd lint [target]` | Deprecated APIs, accessibility gaps, performance issues, best practices |
 | `antd migrate <from> <to>` | Migration checklist with auto-fixable/manual split and `--apply` agent prompt |
+| `antd env [dir]` | Collect environment information for bug reports |
+| `antd bug` | Submit a bug to the ant-design repository |
 
 ### Global Flags
 

--- a/docs/react/cli.en-US.md
+++ b/docs/react/cli.en-US.md
@@ -94,7 +94,6 @@ npx skills add ant-design/ant-design-cli
 | **Cursor** | Install skill, the agent will call CLI commands automatically. [Documentation](https://docs.cursor.com/context/@-symbols/@-docs) |
 | **Codex** | Install skill to enable agent access. [Documentation](https://github.com/openai/codex) |
 | **Gemini CLI** | Install skill for automatic command invocation. [Documentation](https://github.com/google-gemini/gemini-cli) |
-| **Qwen Code** | Open-source terminal AI agent with free OAuth tier. Run `qwen` for interactive mode. [Documentation](https://github.com/QwenLM/qwen-code) |
 
 Works with any agent supporting the [skills](https://github.com/nicepkg/agent-skills) protocol.
 

--- a/docs/react/cli.en-US.md
+++ b/docs/react/cli.en-US.md
@@ -94,6 +94,7 @@ npx skills add ant-design/ant-design-cli
 | **Cursor** | Install skill, the agent will call CLI commands automatically. [Documentation](https://docs.cursor.com/context/@-symbols/@-docs) |
 | **Codex** | Install skill to enable agent access. [Documentation](https://github.com/openai/codex) |
 | **Gemini CLI** | Install skill for automatic command invocation. [Documentation](https://github.com/google-gemini/gemini-cli) |
+| **Qwen Code** | Open-source terminal AI agent with free OAuth tier. Run `qwen` for interactive mode. [Documentation](https://github.com/QwenLM/qwen-code) |
 
 Works with any agent supporting the [skills](https://github.com/nicepkg/agent-skills) protocol.
 

--- a/docs/react/cli.zh-CN.md
+++ b/docs/react/cli.zh-CN.md
@@ -62,6 +62,8 @@ antd migrate 4 5 --apply ./src      # 生成 Agent 迁移提示
 | `antd usage [dir]`         | 导入统计、子组件分布（`Form.Item`）、非组件导出                   |
 | `antd lint [target]`       | 废弃 API、无障碍缺陷、性能问题、最佳实践                          |
 | `antd migrate <from> <to>` | 迁移清单，区分自动修复/手动处理，`--apply` 生成 Agent 提示        |
+| `antd env [dir]`           | 收集环境信息，用于 Bug 报告                                       |
+| `antd bug`                 | 提交 Bug 到 ant-design 仓库                                       |
 
 ### 全局参数 {#global-flags}
 

--- a/docs/react/cli.zh-CN.md
+++ b/docs/react/cli.zh-CN.md
@@ -94,6 +94,7 @@ npx skills add ant-design/ant-design-cli
 | **Cursor** | 安装 Skill 后，Agent 会自动调用 CLI 命令。[文档](https://docs.cursor.com/zh/context/@-symbols/@-docs) |
 | **Codex** | 安装 Skill 以启用 Agent 访问。[文档](https://github.com/openai/codex) |
 | **Gemini CLI** | 安装 Skill 以启用自动命令调用。[文档](https://github.com/google-gemini/gemini-cli) |
+| **Qwen Code** | 开源终端 AI 代理，支持 OAuth 免费层级。运行 `qwen` 启动交互模式。[文档](https://github.com/QwenLM/qwen-code) |
 
 支持所有兼容 [skills](https://github.com/nicepkg/agent-skills) 协议的 Agent。
 

--- a/docs/react/cli.zh-CN.md
+++ b/docs/react/cli.zh-CN.md
@@ -94,7 +94,6 @@ npx skills add ant-design/ant-design-cli
 | **Cursor** | 安装 Skill 后，Agent 会自动调用 CLI 命令。[文档](https://docs.cursor.com/zh/context/@-symbols/@-docs) |
 | **Codex** | 安装 Skill 以启用 Agent 访问。[文档](https://github.com/openai/codex) |
 | **Gemini CLI** | 安装 Skill 以启用自动命令调用。[文档](https://github.com/google-gemini/gemini-cli) |
-| **Qwen Code** | 开源终端 AI 代理，支持 OAuth 免费层级。运行 `qwen` 启动交互模式。[文档](https://github.com/QwenLM/qwen-code) |
 
 支持所有兼容 [skills](https://github.com/nicepkg/agent-skills) 协议的 Agent。
 

--- a/docs/react/llms.en-US.md
+++ b/docs/react/llms.en-US.md
@@ -31,15 +31,15 @@ We provide several aggregated files to help AI tools access our documentation:
 
 Add `.md` suffix to the original component documentation URL:
 
-- `https://ant.design/components/button.md` (English)
-- `https://ant.design/components/button-cn.md` (Chinese)
+- [`https://ant.design/components/button.md`](https://ant.design/components/button.md) (English)
+- [`https://ant.design/components/button-cn.md`](https://ant.design/components/button-cn.md) (Chinese)
 
 ### Semantic Documentation
 
 Each component has a semantic description file:
 
-- `https://ant.design/components/button/semantic.md` (English)
-- `https://ant.design/components/button-cn/semantic.md` (Chinese)
+- [`https://ant.design/components/button/semantic.md`](https://ant.design/components/button/semantic.md) (English)
+- [`https://ant.design/components/button-cn/semantic.md`](https://ant.design/components/button-cn/semantic.md) (Chinese)
 
 Semantic documentation includes:
 

--- a/docs/react/llms.en-US.md
+++ b/docs/react/llms.en-US.md
@@ -29,17 +29,17 @@ We provide several aggregated files to help AI tools access our documentation:
 
 ### Single Component Documentation
 
-Access individual component documentation with `.md` suffix:
+Add `.md` suffix to the original component documentation URL:
 
-- [Button Documentation](https://ant.design/components/button.md) (English)
-- [Button Documentation](https://ant.design/components/button-cn.md) (Chinese)
+- `https://ant.design/components/button.md` (English)
+- `https://ant.design/components/button-cn.md` (Chinese)
 
 ### Semantic Documentation
 
 Each component has a semantic description file:
 
-- [Button Semantic Doc](https://ant.design/components/button/semantic.md) (English)
-- [Button Semantic Doc](https://ant.design/components/button-cn/semantic.md) (Chinese)
+- `https://ant.design/components/button/semantic.md` (English)
+- `https://ant.design/components/button-cn/semantic.md` (Chinese)
 
 Semantic documentation includes:
 

--- a/docs/react/llms.en-US.md
+++ b/docs/react/llms.en-US.md
@@ -31,17 +31,18 @@ We provide several aggregated files to help AI tools access our documentation:
 
 Access individual component documentation with `.md` suffix:
 
-- `https://ant.design/components/button.md` (English)
-- `https://ant.design/components/button-cn.md` (Chinese)
+- [Button Documentation](https://ant.design/components/button.md) (English)
+- [Button Documentation](https://ant.design/components/button-cn.md) (Chinese)
 
 ### Semantic Documentation
 
 Each component has a semantic description file:
 
-- `https://ant.design/components/button/semantic.md` (English)
-- `https://ant.design/components/button-cn/semantic.md` (Chinese)
+- [Button Semantic Doc](https://ant.design/components/button/semantic.md) (English)
+- [Button Semantic Doc](https://ant.design/components/button-cn/semantic.md) (Chinese)
 
 Semantic documentation includes:
+
 - Component parts and their purposes
 - Usage examples and best practices
 - DOM structure overview
@@ -58,4 +59,4 @@ Semantic documentation includes:
 | **Trae** | Add to project's knowledge sources in settings. [Documentation](https://trae.ai/docs) | `Read https://ant.design/llms-full.txt and understand Ant Design components. Use this knowledge when writing code with Ant Design.` |
 | **Qoder** | Add to `.qoder/config.yml` or use `@docs` in conversation. [Documentation](https://docs.qoder.com/) | `Read https://ant.design/llms-full.txt and understand Ant Design components. Use this knowledge when writing code with Ant Design.` |
 | **Neovate Code** | Run `neovate` and describe task with prompt. [Documentation](https://github.com/neovateai/neovate-code) | `Read https://ant.design/llms-full.txt and understand Ant Design components. Use this knowledge when writing code with Ant Design.` |
-
+| **Qwen Code** | Open-source terminal AI agent with free OAuth tier. Run `qwen` for interactive mode, use `@` to reference files. [Documentation](https://github.com/QwenLM/qwen-code) | `Read https://ant.design/llms-full.txt and understand Ant Design components. Use this knowledge when writing code with Ant Design.` |

--- a/docs/react/llms.zh-CN.md
+++ b/docs/react/llms.zh-CN.md
@@ -29,17 +29,17 @@ tag: New
 
 ### 单个组件文档
 
-通过 `.md` 后缀直接访问单个组件文档：
+在原始组件文档 URL 后加 `.md` 即可访问 Markdown 格式文档：
 
-- [Button 英文文档](https://ant.design/components/button.md)（英文）
-- [Button 中文文档](https://ant.design/components/button-cn.md)（中文）
+- `https://ant.design/components/button.md`（英文）
+- `https://ant.design/components/button-cn.md`（中文）
 
 ### 语义文档
 
 每个组件都有对应的语义描述文件：
 
-- [Button 语义文档](https://ant.design/components/button/semantic.md)（英文）
-- [Button 语义文档](https://ant.design/components/button-cn/semantic.md)（中文）
+- `https://ant.design/components/button/semantic.md`（英文）
+- `https://ant.design/components/button-cn/semantic.md`（中文）
 
 语义文档包含：
 

--- a/docs/react/llms.zh-CN.md
+++ b/docs/react/llms.zh-CN.md
@@ -31,15 +31,15 @@ tag: New
 
 在原始组件文档 URL 后加 `.md` 即可访问 Markdown 格式文档：
 
-- `https://ant.design/components/button.md`（英文）
-- `https://ant.design/components/button-cn.md`（中文）
+- [`https://ant.design/components/button.md`](https://ant.design/components/button.md)（英文）
+- [`https://ant.design/components/button-cn.md`](https://ant.design/components/button-cn.md)（中文）
 
 ### 语义文档
 
 每个组件都有对应的语义描述文件：
 
-- `https://ant.design/components/button/semantic.md`（英文）
-- `https://ant.design/components/button-cn/semantic.md`（中文）
+- [`https://ant.design/components/button/semantic.md`](https://ant.design/components/button/semantic.md)（英文）
+- [`https://ant.design/components/button-cn/semantic.md`](https://ant.design/components/button-cn/semantic.md)（中文）
 
 语义文档包含：
 

--- a/docs/react/llms.zh-CN.md
+++ b/docs/react/llms.zh-CN.md
@@ -31,17 +31,18 @@ tag: New
 
 通过 `.md` 后缀直接访问单个组件文档：
 
-- `https://ant.design/components/button.md`（英文）
-- `https://ant.design/components/button-cn.md`（中文）
+- [Button 英文文档](https://ant.design/components/button.md)（英文）
+- [Button 中文文档](https://ant.design/components/button-cn.md)（中文）
 
 ### 语义文档
 
 每个组件都有对应的语义描述文件：
 
-- `https://ant.design/components/button/semantic.md`（英文）
-- `https://ant.design/components/button-cn/semantic.md`（中文）
+- [Button 语义文档](https://ant.design/components/button/semantic.md)（英文）
+- [Button 语义文档](https://ant.design/components/button-cn/semantic.md)（中文）
 
 语义文档包含：
+
 - 组件部件及其用途
 - 使用示例和最佳实践
 - DOM 结构概览
@@ -58,4 +59,4 @@ tag: New
 | **Trae** | 添加到项目的知识源设置中。[文档](https://trae.ai/docs) | `阅读 https://ant.design/llms-full.txt 并理解 Ant Design 组件库，在编写 Ant Design 代码时使用这些知识。` |
 | **Qoder** | 添加到 `.qoder/config.yml` 或在对话中使用 `@docs`。[文档](https://docs.qoder.com/) | `阅读 https://ant.design/llms-full.txt 并理解 Ant Design 组件库，在编写 Ant Design 代码时使用这些知识。` |
 | **Neovate Code** | 运行 `neovate` 并使用提示词描述任务。[文档](https://github.com/neovateai/neovate-code) | `阅读 https://ant.design/llms-full.txt 并理解 Ant Design 组件库，在编写 Ant Design 代码时使用这些知识。` |
-
+| **Qwen Code** | 开源终端 AI 代理，支持 OAuth 免费层级。运行 `qwen` 启动交互模式，用 `@` 引用文件。[文档](https://github.com/QwenLM/qwen-code) | `阅读 https://ant.design/llms-full.txt 并理解 Ant Design 组件库，在编写 Ant Design 代码时使用这些知识。` |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

1. 将 LLMs.txt 文档中的单个组件文档 URL 改为可点击的链接格式
2. 添加 [Qwen Code](https://github.com/QwenLM/qwen-code) 到 AI 工具表格中
   - Qwen Code 是开源的终端 AI 代理，支持 OAuth 免费层级（每日 1000 次免费请求）
   - 同时更新了 LLMs.txt 和 CLI 文档

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 📖 Add Qwen Code to AI tools documentation and convert component doc URLs to clickable links. |
| 🇨🇳 中文 | 📖 添加 Qwen Code 到 AI 工具文档，并将组件文档 URL 改为可点击链接。 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)