### PR TITLE
chore: add missing frontmatter for changelog collect skill

### DIFF
--- a/.agents/skills/changelog-collect/SKILL.md
+++ b/.agents/skills/changelog-collect/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: changelog-collect
+description: 收集 ant-design 两个版本之间的 PR 信息并整理 changelog 草稿，更新到 CHANGELOG.zh-CN.md 和 CHANGELOG.en-US.md 时使用。适用于收集 changelog、生成 changelog、更新 changelog、版本对比等场景。
+---
+
 # Changelog 收集工具
 
 ## 目标


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [x] ❓ Other (skill metadata fix)

### 🔗 Related Issues

 None.

### 💡 Background and Solution

Codex:

<img width="1012" height="84" alt="image" src="https://github.com/user-attachments/assets/24f16ff8-1d3d-447a-b6d5-20b0199e58d9" />


  The `changelog-collect` skill was skipped during startup because its `SKILL.md` missed the required YAML frontmatter.

  This PR adds the missing frontmatter so the skill can be loaded correctly.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |
