### PR TITLE
fix(Transfer): prevent remove button hover color change when disabled

### DIFF
--- a/components/transfer/style/index.ts
+++ b/components/transfer/style/index.ts
@@ -251,6 +251,11 @@ const genTransferListStyle: GenerateStyle<TransferToken, CSSObject> = (token) =>
             '&:hover, &:focus': {
               color: colorTextSecondary,
             },
+
+            '&:disabled': {
+              color: colorTextDisabled,
+              cursor: 'not-allowed',
+            },
           },
 
           [`&:not(${componentCls}-list-content-item-disabled)`]: {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix


### 🔗 Related Issues

N/A

### 💡 Background and Solution

**Problem:** 
When a Transfer list item is disabled, the remove control is rendered as a disabled `<button>`, but its hover styles still apply, so the icon color continues to change on hover.

**Solution:** 
Update style for the remove button when transfer component in disabled state

**Before**

https://github.com/user-attachments/assets/0ee6b80f-d21d-4480-a669-660ab0afcda4

**After**

https://github.com/user-attachments/assets/b36cf7a6-2675-4e20-afc4-1db9894de247


### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Transfer remove button still changing color on hover when the list item is disabled. |
| 🇨🇳 Chinese | 🐞 修复 Transfer 列表项禁用时移除按钮在悬停下仍会变色的问题。 |