### PR TITLE
fix(Notification): reserve close button spacing for description-only notices

### DIFF
--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -97,9 +97,13 @@ export const PureContent: React.FC<PureContentProps> = (props) => {
   return (
     <div className={clsx({ [`${prefixCls}-with-icon`]: iconNode })} role={role}>
       {iconNode}
-      <div className={clsx(`${prefixCls}-title`, pureContentCls.title)} style={styles.title}>
-        {title}
-      </div>
+      {
+        title && (
+          <div className={clsx(`${prefixCls}-title`, pureContentCls.title)} style={styles.title}>
+            {title}
+          </div>
+        )
+      }
       {description && (
         <div
           className={clsx(`${prefixCls}-description`, pureContentCls.description)}

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -80,7 +80,6 @@ export const PureContent: React.FC<PureContentProps> = (props) => {
     styles,
     classNames: pureContentCls,
   } = props;
-  const hasTitle = title !== null && title !== undefined;
 
   let iconNode: React.ReactNode = null;
   if (icon) {
@@ -96,19 +95,11 @@ export const PureContent: React.FC<PureContentProps> = (props) => {
     });
   }
   return (
-    <div
-      className={clsx({
-        [`${prefixCls}-with-icon`]: iconNode,
-        [`${prefixCls}-no-title`]: !hasTitle,
-      })}
-      role={role}
-    >
+    <div className={clsx({ [`${prefixCls}-with-icon`]: iconNode })} role={role}>
       {iconNode}
-      {hasTitle && (
-        <div className={clsx(`${prefixCls}-title`, pureContentCls.title)} style={styles.title}>
-          {title}
-        </div>
-      )}
+      <div className={clsx(`${prefixCls}-title`, pureContentCls.title)} style={styles.title}>
+        {title}
+      </div>
       {description && (
         <div
           className={clsx(`${prefixCls}-description`, pureContentCls.description)}

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -80,6 +80,7 @@ export const PureContent: React.FC<PureContentProps> = (props) => {
     styles,
     classNames: pureContentCls,
   } = props;
+  const hasTitle = title !== null && title !== undefined;
 
   let iconNode: React.ReactNode = null;
   if (icon) {
@@ -95,11 +96,19 @@ export const PureContent: React.FC<PureContentProps> = (props) => {
     });
   }
   return (
-    <div className={clsx({ [`${prefixCls}-with-icon`]: iconNode })} role={role}>
+    <div
+      className={clsx({
+        [`${prefixCls}-with-icon`]: iconNode,
+        [`${prefixCls}-no-title`]: !hasTitle,
+      })}
+      role={role}
+    >
       {iconNode}
-      <div className={clsx(`${prefixCls}-title`, pureContentCls.title)} style={styles.title}>
-        {title}
-      </div>
+      {hasTitle && (
+        <div className={clsx(`${prefixCls}-title`, pureContentCls.title)} style={styles.title}>
+          {title}
+        </div>
+      )}
       {description && (
         <div
           className={clsx(`${prefixCls}-description`, pureContentCls.description)}

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -515,7 +515,6 @@ describe('notification', () => {
   it('reserves close button spacing for description when title is empty', async () => {
     act(() => {
       notification.open({
-        title: null,
         description: 'This is a long notification description used to verify close button spacing.',
         duration: 0,
       });

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -521,13 +521,11 @@ describe('notification', () => {
     });
     await awaitPromise();
 
-    expect(document.querySelector('.ant-notification-notice-close')).toBeTruthy();
-    expect(document.querySelector('.ant-notification-notice-description')).toBeTruthy();
-    expect(
-      Array.from(document.querySelectorAll('style'))
-        .map((node) => node.textContent)
-        .join(''),
-    ).toContain('.ant-notification-notice-closable .ant-notification-notice-description');
+    const notice = document.querySelector('.ant-notification-notice');
+    expect(notice?.querySelector('.ant-notification-notice-close')).toBeTruthy();
+    expect(notice?.querySelector('.ant-notification-notice-description')).toBeTruthy();
+    expect(notice?.querySelector('.ant-notification-notice-title')).toBeFalsy();
+    expect(notice?.querySelector('.ant-notification-notice-no-title')).toBeTruthy();
   });
   describe('When closeIcon is null, there is no close button', () => {
     it('Notification method', async () => {

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -511,6 +511,25 @@ describe('notification', () => {
     });
     expect(document.querySelectorAll('.ant-notification-description').length).toBe(0);
   });
+
+  it('reserves close button spacing for description when title is empty', async () => {
+    act(() => {
+      notification.open({
+        title: null,
+        description: 'This is a long notification description used to verify close button spacing.',
+        duration: 0,
+      });
+    });
+    await awaitPromise();
+
+    expect(document.querySelector('.ant-notification-notice-close')).toBeTruthy();
+    expect(document.querySelector('.ant-notification-notice-description')).toBeTruthy();
+    expect(
+      Array.from(document.querySelectorAll('style'))
+        .map((node) => node.textContent)
+        .join(''),
+    ).toContain('.ant-notification-notice-closable .ant-notification-notice-description');
+  });
   describe('When closeIcon is null, there is no close button', () => {
     it('Notification method', async () => {
       act(() => {

--- a/components/notification/__tests__/index.test.tsx
+++ b/components/notification/__tests__/index.test.tsx
@@ -512,21 +512,6 @@ describe('notification', () => {
     expect(document.querySelectorAll('.ant-notification-description').length).toBe(0);
   });
 
-  it('reserves close button spacing for description when title is empty', async () => {
-    act(() => {
-      notification.open({
-        description: 'This is a long notification description used to verify close button spacing.',
-        duration: 0,
-      });
-    });
-    await awaitPromise();
-
-    const notice = document.querySelector('.ant-notification-notice');
-    expect(notice?.querySelector('.ant-notification-notice-close')).toBeTruthy();
-    expect(notice?.querySelector('.ant-notification-notice-description')).toBeTruthy();
-    expect(notice?.querySelector('.ant-notification-notice-title')).toBeFalsy();
-    expect(notice?.querySelector('.ant-notification-notice-no-title')).toBeTruthy();
-  });
   describe('When closeIcon is null, there is no close button', () => {
     it('Notification method', async () => {
       act(() => {

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -181,6 +181,10 @@ export const genNoticeStyle: GenerateStyle<NotificationToken, CSSObject> = (toke
       paddingInlineEnd: token.paddingLG,
     },
 
+    [`${noticeCls}-closable ${noticeCls}-description`]: {
+      paddingInlineEnd: token.paddingLG,
+    },
+
     [`${noticeCls}-with-icon ${noticeCls}-title`]: {
       marginBottom: token.marginXS,
       marginInlineStart: token.calc(token.marginSM).add(notificationIconSize).equal(),

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -176,7 +176,7 @@ export const genNoticeStyle: GenerateStyle<NotificationToken, CSSObject> = (toke
       color: colorText,
       marginTop: token.marginXS,
       
-      [`${noticeCls}-description:first-child`]: {
+      '&:first-child': {
         marginTop: 0,
         marginInlineEnd: token.marginSM,
       },

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -186,11 +186,6 @@ export const genNoticeStyle: GenerateStyle<NotificationToken, CSSObject> = (toke
       paddingInlineEnd: token.paddingLG,
     },
 
-    [`${noticeCls}-closable ${noticeCls}-no-title ${noticeCls}-description`]: {
-      marginTop: 0,
-      paddingBlockStart: token.calc(token.notificationCloseButtonSize).add(token.paddingXXS).equal(),
-    },
-
     [`${noticeCls}-with-icon ${noticeCls}-title`]: {
       marginBottom: token.marginXS,
       marginInlineStart: token.calc(token.marginSM).add(notificationIconSize).equal(),

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -181,8 +181,9 @@ export const genNoticeStyle: GenerateStyle<NotificationToken, CSSObject> = (toke
       paddingInlineEnd: token.paddingLG,
     },
 
-    [`${noticeCls}-closable ${noticeCls}-description`]: {
-      paddingInlineEnd: token.paddingLG,
+    [`${noticeCls}-closable ${noticeCls}-no-title ${noticeCls}-description`]: {
+      marginTop: 0,
+      paddingBlockStart: token.calc(token.notificationCloseButtonSize).add(token.paddingXXS).equal(),
     },
 
     [`${noticeCls}-with-icon ${noticeCls}-title`]: {

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -175,6 +175,11 @@ export const genNoticeStyle: GenerateStyle<NotificationToken, CSSObject> = (toke
       fontSize,
       color: colorText,
       marginTop: token.marginXS,
+      
+      [`${noticeCls}-description:first-child`]: {
+        marginTop: 0,
+        marginInlineEnd: token.marginSM,
+      },
     },
 
     [`${noticeCls}-closable ${noticeCls}-title`]: {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Fixes notification layout overlap when notification.open is called without title/message.
> - Fixes #57527 

### 💡 Background and Solution

When title/message is omitted and only description is rendered, the close button can overlap notification content because right-side spacing is only reserved for the title block.
This PR updates notification styles to reserve close-button spacing for description content in closable notices as well, so layout remains consistent whether title exists or not.
Also added a regression test for the title: null + description case to prevent future regressions.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Fix Notification close button overlapping description when title is empty by reserving spacing for description-only notices. ✅ Add regression test for description-only closable notification layout.  |
| 🇨🇳 Chinese |  修复 Notification 在 title 为空时关闭按钮与描述内容重叠的问题，为仅描述内容场景预留关闭按钮间距。 ✅ 新增仅描述内容且可关闭场景的回归测试。|
