### PR TITLE
fix(InputNumber): avoid hover style on disabled handlers

### DIFF
--- a/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1805,6 +1805,356 @@ Array [
 
 exports[`renders components/input-number/demo/disabled.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/input-number/demo/disabled-hover-debug.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+  style="gap: 16px;"
+>
+  <span
+    class="ant-typography ant-typography-secondary css-var-test-id"
+  >
+    Hover the disabled step controls when the value reaches min or max.
+  </span>
+  <div
+    class="ant-flex css-var-test-id ant-flex-wrap-wrap"
+    style="gap: 16px;"
+  >
+    <div
+      class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+      style="gap: 8px;"
+    >
+      <span
+        class="ant-typography css-var-test-id"
+      >
+        Input mode at max
+      </span>
+      <div
+        class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+        style="width: 180px;"
+      >
+        <input
+          aria-valuemax="3"
+          aria-valuemin="0"
+          aria-valuenow="3"
+          autocomplete="off"
+          class="ant-input-number-input"
+          role="spinbutton"
+          step="1"
+          value="3"
+        />
+        <div
+          class="ant-input-number-actions"
+        >
+          <span
+            aria-disabled="true"
+            aria-label="Increase Value"
+            class="ant-input-number-action ant-input-number-action-up ant-input-number-action-up-disabled"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="up"
+              class="anticon anticon-up"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="up"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            aria-disabled="false"
+            aria-label="Decrease Value"
+            class="ant-input-number-action ant-input-number-action-down"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="down"
+              class="anticon anticon-down"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="down"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+      style="gap: 8px;"
+    >
+      <span
+        class="ant-typography css-var-test-id"
+      >
+        Input mode at min
+      </span>
+      <div
+        class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+        style="width: 180px;"
+      >
+        <input
+          aria-valuemax="3"
+          aria-valuemin="0"
+          aria-valuenow="0"
+          autocomplete="off"
+          class="ant-input-number-input"
+          role="spinbutton"
+          step="1"
+          value="0"
+        />
+        <div
+          class="ant-input-number-actions"
+        >
+          <span
+            aria-disabled="false"
+            aria-label="Increase Value"
+            class="ant-input-number-action ant-input-number-action-up"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="up"
+              class="anticon anticon-up"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="up"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            aria-disabled="true"
+            aria-label="Decrease Value"
+            class="ant-input-number-action ant-input-number-action-down ant-input-number-action-down-disabled"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="down"
+              class="anticon anticon-down"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="down"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+      style="gap: 8px;"
+    >
+      <span
+        class="ant-typography css-var-test-id"
+      >
+        Spinner mode at max
+      </span>
+      <div
+        class="ant-input-number ant-input-number-mode-spinner css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+        style="width: 180px;"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Decrease Value"
+          class="ant-input-number-action ant-input-number-action-down"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="minus"
+            class="anticon anticon-minus"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="minus"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M872 474H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h720c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
+              />
+            </svg>
+          </span>
+        </span>
+        <input
+          aria-valuemax="3"
+          aria-valuemin="0"
+          aria-valuenow="3"
+          autocomplete="off"
+          class="ant-input-number-input"
+          role="spinbutton"
+          step="1"
+          value="3"
+        />
+        <span
+          aria-disabled="true"
+          aria-label="Increase Value"
+          class="ant-input-number-action ant-input-number-action-up ant-input-number-action-up-disabled"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="plus"
+            class="anticon anticon-plus"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="plus"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
+              />
+              <path
+                d="M192 474h672q8 0 8 8v60q0 8-8 8H160q-8 0-8-8v-60q0-8 8-8z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+    <div
+      class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+      style="gap: 8px;"
+    >
+      <span
+        class="ant-typography css-var-test-id"
+      >
+        Spinner mode at min
+      </span>
+      <div
+        class="ant-input-number ant-input-number-mode-spinner css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+        style="width: 180px;"
+      >
+        <span
+          aria-disabled="true"
+          aria-label="Decrease Value"
+          class="ant-input-number-action ant-input-number-action-down ant-input-number-action-down-disabled"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="minus"
+            class="anticon anticon-minus"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="minus"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M872 474H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h720c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
+              />
+            </svg>
+          </span>
+        </span>
+        <input
+          aria-valuemax="3"
+          aria-valuemin="0"
+          aria-valuenow="0"
+          autocomplete="off"
+          class="ant-input-number-input"
+          role="spinbutton"
+          step="1"
+          value="0"
+        />
+        <span
+          aria-disabled="false"
+          aria-label="Increase Value"
+          class="ant-input-number-action ant-input-number-action-up"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="plus"
+            class="anticon anticon-plus"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="plus"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
+              />
+              <path
+                d="M192 474h672q8 0 8 8v60q0 8-8 8H160q-8 0-8-8v-60q0-8 8-8z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/input-number/demo/disabled-hover-debug.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/input-number/demo/filled-debug.tsx extend context correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"

--- a/components/input-number/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input-number/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1334,6 +1334,354 @@ Array [
 ]
 `;
 
+exports[`renders components/input-number/demo/disabled-hover-debug.tsx correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+  style="gap:16px"
+>
+  <span
+    class="ant-typography ant-typography-secondary css-var-test-id"
+  >
+    Hover the disabled step controls when the value reaches min or max.
+  </span>
+  <div
+    class="ant-flex css-var-test-id ant-flex-wrap-wrap"
+    style="gap:16px"
+  >
+    <div
+      class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+      style="gap:8px"
+    >
+      <span
+        class="ant-typography css-var-test-id"
+      >
+        Input mode at max
+      </span>
+      <div
+        class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+        style="width:180px"
+      >
+        <input
+          aria-valuemax="3"
+          aria-valuemin="0"
+          aria-valuenow="3"
+          autocomplete="off"
+          class="ant-input-number-input"
+          role="spinbutton"
+          step="1"
+          value="3"
+        />
+        <div
+          class="ant-input-number-actions"
+        >
+          <span
+            aria-disabled="true"
+            aria-label="Increase Value"
+            class="ant-input-number-action ant-input-number-action-up ant-input-number-action-up-disabled"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="up"
+              class="anticon anticon-up"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="up"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            aria-disabled="false"
+            aria-label="Decrease Value"
+            class="ant-input-number-action ant-input-number-action-down"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="down"
+              class="anticon anticon-down"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="down"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+      style="gap:8px"
+    >
+      <span
+        class="ant-typography css-var-test-id"
+      >
+        Input mode at min
+      </span>
+      <div
+        class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+        style="width:180px"
+      >
+        <input
+          aria-valuemax="3"
+          aria-valuemin="0"
+          aria-valuenow="0"
+          autocomplete="off"
+          class="ant-input-number-input"
+          role="spinbutton"
+          step="1"
+          value="0"
+        />
+        <div
+          class="ant-input-number-actions"
+        >
+          <span
+            aria-disabled="false"
+            aria-label="Increase Value"
+            class="ant-input-number-action ant-input-number-action-up"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="up"
+              class="anticon anticon-up"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="up"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            aria-disabled="true"
+            aria-label="Decrease Value"
+            class="ant-input-number-action ant-input-number-action-down ant-input-number-action-down-disabled"
+            role="button"
+            unselectable="on"
+          >
+            <span
+              aria-label="down"
+              class="anticon anticon-down"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="down"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+      style="gap:8px"
+    >
+      <span
+        class="ant-typography css-var-test-id"
+      >
+        Spinner mode at max
+      </span>
+      <div
+        class="ant-input-number ant-input-number-mode-spinner css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+        style="width:180px"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Decrease Value"
+          class="ant-input-number-action ant-input-number-action-down"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="minus"
+            class="anticon anticon-minus"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="minus"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M872 474H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h720c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
+              />
+            </svg>
+          </span>
+        </span>
+        <input
+          aria-valuemax="3"
+          aria-valuemin="0"
+          aria-valuenow="3"
+          autocomplete="off"
+          class="ant-input-number-input"
+          role="spinbutton"
+          step="1"
+          value="3"
+        />
+        <span
+          aria-disabled="true"
+          aria-label="Increase Value"
+          class="ant-input-number-action ant-input-number-action-up ant-input-number-action-up-disabled"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="plus"
+            class="anticon anticon-plus"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="plus"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
+              />
+              <path
+                d="M192 474h672q8 0 8 8v60q0 8-8 8H160q-8 0-8-8v-60q0-8 8-8z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+    <div
+      class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+      style="gap:8px"
+    >
+      <span
+        class="ant-typography css-var-test-id"
+      >
+        Spinner mode at min
+      </span>
+      <div
+        class="ant-input-number ant-input-number-mode-spinner css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+        style="width:180px"
+      >
+        <span
+          aria-disabled="true"
+          aria-label="Decrease Value"
+          class="ant-input-number-action ant-input-number-action-down ant-input-number-action-down-disabled"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="minus"
+            class="anticon anticon-minus"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="minus"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M872 474H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h720c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
+              />
+            </svg>
+          </span>
+        </span>
+        <input
+          aria-valuemax="3"
+          aria-valuemin="0"
+          aria-valuenow="0"
+          autocomplete="off"
+          class="ant-input-number-input"
+          role="spinbutton"
+          step="1"
+          value="0"
+        />
+        <span
+          aria-disabled="false"
+          aria-label="Increase Value"
+          class="ant-input-number-action ant-input-number-action-up"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="plus"
+            class="anticon anticon-plus"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="plus"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
+              />
+              <path
+                d="M192 474h672q8 0 8 8v60q0 8-8 8H160q-8 0-8-8v-60q0-8 8-8z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/input-number/demo/filled-debug.tsx correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"

--- a/components/input-number/demo/disabled-hover-debug.md
+++ b/components/input-number/demo/disabled-hover-debug.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+禁用步进按钮 hover 排查。
+
+## en-US
+
+Disabled handler hover debug.

--- a/components/input-number/demo/disabled-hover-debug.tsx
+++ b/components/input-number/demo/disabled-hover-debug.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Flex, InputNumber, Typography } from 'antd';
+
+const sharedProps = {
+  min: 0,
+  max: 3,
+  controls: true,
+  style: { width: 180 },
+};
+
+const App: React.FC = () => (
+  <Flex vertical gap={16}>
+    <Typography.Text type="secondary">
+      Hover the disabled step controls when the value reaches min or max.
+    </Typography.Text>
+
+    <Flex gap={16} wrap>
+      <Flex vertical gap={8}>
+        <Typography.Text>Input mode at max</Typography.Text>
+        <InputNumber {...sharedProps} defaultValue={3} />
+      </Flex>
+
+      <Flex vertical gap={8}>
+        <Typography.Text>Input mode at min</Typography.Text>
+        <InputNumber {...sharedProps} defaultValue={0} />
+      </Flex>
+
+      <Flex vertical gap={8}>
+        <Typography.Text>Spinner mode at max</Typography.Text>
+        <InputNumber {...sharedProps} defaultValue={3} mode="spinner" />
+      </Flex>
+
+      <Flex vertical gap={8}>
+        <Typography.Text>Spinner mode at min</Typography.Text>
+        <InputNumber {...sharedProps} defaultValue={0} mode="spinner" />
+      </Flex>
+    </Flex>
+  </Flex>
+);
+
+export default App;

--- a/components/input-number/index.en-US.md
+++ b/components/input-number/index.en-US.md
@@ -26,6 +26,7 @@ When a numeric value needs to be provided.
 <code src="./demo/change-on-wheel.tsx" version="5.14.0">Wheel</code>
 <code src="./demo/variant.tsx" version="5.13.0">Variants</code>
 <code src="./demo/spinner.tsx" version="6.0.0">Spinner</code>
+<code src="./demo/disabled-hover-debug.tsx" debug>Disabled handler hover</code>
 <code src="./demo/filled-debug.tsx" debug>Filled Debug</code>
 <code src="./demo/borderless-height-debug.tsx" debug>Borderless height alignment</code>
 <code src="./demo/out-of-range.tsx">Out of range</code>

--- a/components/input-number/index.zh-CN.md
+++ b/components/input-number/index.zh-CN.md
@@ -27,6 +27,7 @@ demo:
 <code src="./demo/change-on-wheel.tsx" version="5.14.0">鼠标滚轮</code>
 <code src="./demo/variant.tsx" version="5.13.0">形态变体</code>
 <code src="./demo/spinner.tsx" version="6.0.0">拨轮</code>
+<code src="./demo/disabled-hover-debug.tsx" debug>禁用步进按钮 hover</code>
 <code src="./demo/filled-debug.tsx" debug>Filled Debug</code>
 <code src="./demo/borderless-height-debug.tsx" debug>Borderless 高度对齐</code>
 <code src="./demo/out-of-range.tsx">超出边界</code>

--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -185,10 +185,13 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token) => {
           cursor: 'pointer',
           transition: `all ${motionDurationMid} linear`,
 
-          '&:active': {
-            background: handleActiveBg,
-          },
-          // Hover
+          // Active: change background not disabled only;
+          [`&:active:not(${componentCls}-action-up-disabled):not(${componentCls}-action-down-disabled)`]:
+            {
+              background: handleActiveBg,
+            },
+
+          // Hover: change color not disabled only;
           [`&:hover:not(${componentCls}-action-up-disabled):not(${componentCls}-action-down-disabled)`]:
             {
               color: handleHoverColor,
@@ -196,10 +199,7 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token) => {
 
           [`&${componentCls}-action-up-disabled, &${componentCls}-action-down-disabled`]: {
             cursor: 'not-allowed',
-
-            '&:hover': {
-              color: colorTextDisabled,
-            },
+            color: colorTextDisabled,
           },
         },
 
@@ -245,16 +245,10 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token) => {
             height: '50%',
             borderInlineStart: borderStyle,
 
-            // Hover
+            // Hover: change height not disabled only;
             [`&:hover:not(${componentCls}-action-up-disabled):not(${componentCls}-action-down-disabled)`]:
               {
                 height: `60%`,
-              },
-
-            [`&${componentCls}-action-up-disabled:hover, &${componentCls}-action-down-disabled:hover`]:
-              {
-                color: colorTextDisabled,
-                height: '50%',
               },
           },
 

--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -173,13 +173,6 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token) => {
     {
       [componentCls]: {
         // ======================= Shared =======================
-        [`
-          ${componentCls}-action-up-disabled,
-          ${componentCls}-action-down-disabled
-        `]: {
-          cursor: 'not-allowed',
-        },
-
         [`${componentCls}-action`]: {
           ...resetIcon(),
 
@@ -197,6 +190,10 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token) => {
           // Hover
           '&:hover': {
             color: handleHoverColor,
+          },
+
+          [`&${componentCls}-action-up-disabled, &${componentCls}-action-down-disabled`]: {
+            cursor: 'not-allowed',
           },
         },
 

--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -32,6 +32,7 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token) => {
     paddingBlockLG,
     paddingInlineLG,
     colorIcon,
+    colorTextDisabled,
     motionDurationMid,
     handleHoverColor,
     handleOpacity,
@@ -188,12 +189,17 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token) => {
             background: handleActiveBg,
           },
           // Hover
-          '&:hover': {
-            color: handleHoverColor,
-          },
+          [`&:hover:not(${componentCls}-action-up-disabled):not(${componentCls}-action-down-disabled)`]:
+            {
+              color: handleHoverColor,
+            },
 
           [`&${componentCls}-action-up-disabled, &${componentCls}-action-down-disabled`]: {
             cursor: 'not-allowed',
+
+            '&:hover': {
+              color: colorTextDisabled,
+            },
           },
         },
 
@@ -240,9 +246,16 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token) => {
             borderInlineStart: borderStyle,
 
             // Hover
-            '&:hover': {
-              height: `60%`,
-            },
+            [`&:hover:not(${componentCls}-action-up-disabled):not(${componentCls}-action-down-disabled)`]:
+              {
+                height: `60%`,
+              },
+
+            [`&${componentCls}-action-up-disabled:hover, &${componentCls}-action-down-disabled:hover`]:
+              {
+                color: colorTextDisabled,
+                height: '50%',
+              },
           },
 
           [`&${componentCls}-disabled, &${componentCls}-readonly`]: {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

InputNumber 的禁用上下步进按钮仍然继承了通用 hover 颜色样式，导致禁用态下鼠标悬浮时会出现不应该有的视觉反馈。

这个修改把禁用态的选择器合并到 `${componentCls}-action` 作用域内，让禁用按钮继续保持 `not-allowed` 光标且不再被通用 hover 样式错误影响。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix InputNumber disabled handlers showing hover styles. |
| 🇨🇳 中文 | 🐞 修复 InputNumber 禁用步进按钮仍显示悬浮样式的问题。 |