### PR TITLE
feat(Table): upgrade rc-table to 1.10.0 and add scrollTo align parameter

### DIFF
--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -156,7 +156,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | Property | Description | Type | Version |
 | --- | --- | --- | --- |
 | nativeElement | The wrap element | HTMLDivElement | 5.11.0 |
-| scrollTo | Trigger to scroll to target position. `key` match with record `rowKey`. When `offset` is specified, the table will scroll to align the target row to the top with the given offset and not working with `top`. Optional `align` param to control alignment: `start` align to top, `center` align to center, `end` align to bottom, `nearest` smart align (default). `center` align is not supported in virtual scrolling mode | (config: { index?: number, key?: React.Key, top?: number, offset?: number, align?: 'start' | 'center' | 'end' | 'nearest' }) => void | 5.11.0 |
+| scrollTo | Trigger to scroll to target position. `key` match with record `rowKey`. When `offset` is specified, the table will scroll to align the target row to the top with the given offset and not working with `top`. Optional `align` param to control alignment: `start` align to top, `center` align to center, `end` align to bottom, `nearest` smart align (default). `center` align is not supported in virtual scrolling mode | (config: { index?: number, key?: React.Key, top?: number, offset?: number, align?: 'start' \| 'center' \| 'end' \| 'nearest' }) => void | 5.11.0 |
 
 #### onRow usage
 

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -154,7 +154,7 @@ Common props ref：[Common props](/docs/react/common-props)
 ### Table ref
 
 | Property | Description | Type | Version |
-| --- | --- | --- | --- | --- | --- | --- |
+| --- | --- | --- | --- |
 | nativeElement | The wrap element | HTMLDivElement | 5.11.0 |
 | scrollTo | Trigger to scroll to target position. `key` match with record `rowKey`. When `offset` is specified, the table will scroll to align the target row to the top with the given offset and not working with `top`. Optional `align` param to control alignment: `start` align to top, `center` align to center, `end` align to bottom, `nearest` smart align (default). `center` align is not supported in virtual scrolling mode | (config: { index?: number, key?: React.Key, top?: number, offset?: number, align?: 'start' | 'center' | 'end' | 'nearest' }) => void | 5.11.0 |
 

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -154,9 +154,9 @@ Common props ref：[Common props](/docs/react/common-props)
 ### Table ref
 
 | Property | Description | Type | Version |
-| --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- | --- |
 | nativeElement | The wrap element | HTMLDivElement | 5.11.0 |
-| scrollTo | Trigger to scroll to target position. `key` match with record `rowKey`. When `offset` is specified, the table will scroll to align the target row to the top with the given offset and not working with `top` | (config: { index?: number, key?: React.Key, top?: number, offset?: number }) => void | 5.11.0 |
+| scrollTo | Trigger to scroll to target position. `key` match with record `rowKey`. When `offset` is specified, the table will scroll to align the target row to the top with the given offset and not working with `top`. Optional `align` param to control alignment: `start` align to top, `center` align to center, `end` align to bottom, `nearest` smart align (default). `center` align is not supported in virtual scrolling mode | (config: { index?: number, key?: React.Key, top?: number, offset?: number, align?: 'start' | 'center' | 'end' | 'nearest' }) => void | 5.11.0 |
 
 #### onRow usage
 

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -158,7 +158,7 @@ const columns = [
 | 参数 | 说明 | 类型 | 版本 |
 | --- | --- | --- | --- |
 | nativeElement | 最外层 div 元素 | HTMLDivElement | 5.11.0 |
-| scrollTo | 滚动到目标位置（设置 `key` 时为 Record 对应的 `rowKey`）。当指定 `offset` 时，表格会滚动至目标行顶部对齐并应用指定的偏移量。`offset` 对 `top` 无效 | (config: { index?: number, key?: React.Key, top?: number, offset?: number }) => void | 5.11.0 |
+| scrollTo | 滚动到目标位置（设置 `key` 时为 Record 对应的 `rowKey`）。当指定 `offset` 时，表格会滚动至目标行顶部对齐并应用指定的偏移量。`offset` 对 `top` 无效。可选 `align` 参数控制对齐方式：`start` 顶部对齐、`center` 中间对齐、`end` 底部对齐、`nearest` 智能对齐（默认）。虚拟滚动模式下不支持 `center` 对齐 | (config: { index?: number, key?: React.Key, top?: number, offset?: number, align?: 'start' \| 'center' \| 'end' \| 'nearest' }) => void | 5.11.0 |
 
 #### onRow 用法
 

--- a/package.json
+++ b/package.json
@@ -343,7 +343,7 @@
   "size-limit": [
     {
       "path": "./dist/antd.min.js",
-      "limit": "435 KiB",
+      "limit": "436 KiB",
       "gzip": true
     },
     {

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "@rc-component/slider": "~1.0.1",
     "@rc-component/steps": "~1.2.2",
     "@rc-component/switch": "~1.0.3",
-    "@rc-component/table": "~1.9.1",
+    "@rc-component/table": "~1.10.0",
     "@rc-component/tabs": "~1.8.0",
     "@rc-component/tooltip": "~1.4.0",
     "@rc-component/tour": "~2.4.0",


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [ ] 📝 站点、文档改进
- [ ] ⭐️ 功能增强

### 🔗 相关 Issue

close #45945

### 💡 需求背景和解决方案

升级 `@rc-component/table` 依赖到 `1.10.0` 版本，并为 `Table` 组件的 `scrollTo` 方法新增 `align` 参数，支持 `start`、`center`、`end`、`nearest` 四种对齐方式。同时更新文档说明 `center` 对齐在虚拟滚动模式下不支持。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🆕 Table `scrollTo` support `align` parameter to control scroll position alignment |
| 🇨🇳 中文 | 🆕 Table `scrollTo` 新增 `align` 参数控制滚动对齐位置 |