### PR TITLE
fix: lock focus inside preview when opened via keyboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@rc-component/drawer": "~1.4.2",
     "@rc-component/dropdown": "~1.0.2",
     "@rc-component/form": "~1.8.0",
-    "@rc-component/image": "~1.8.0",
+    "@rc-component/image": "~1.9.0",
     "@rc-component/input": "~1.1.2",
     "@rc-component/input-number": "~1.6.2",
     "@rc-component/mentions": "~1.6.0",


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [x] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/react-component/image/pull/505

### 💡 需求背景和解决方案

升级 `@rc-component/image` 依赖版本，从 `~1.8.0` 升至 `~1.9.0`。

主要包含以下修复：
- 通过键盘（Enter/Space）打开 Image 预览时，焦点未被正确锁定在预览内部
- 关闭预览后，焦点未回到触发元素

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | ⌨️ Fix Image preview focus not being locked when opened via keyboard, and restore focus to trigger element after preview closes. |
| 🇨🇳 中文 | ⌨️ 修复 Image 通过键盘打开预览时焦点未被正确锁定的问题，并在关闭预览后恢复焦点到触发元素。 |