### PR TITLE
fix: lock focus inside preview when opened via keyboard

### DIFF
--- a/components/image/demo/_semantic.tsx
+++ b/components/image/demo/_semantic.tsx
@@ -71,7 +71,7 @@ const Block: React.FC<Readonly<ImagePropsBlock>> = ({ classNames, ...restProps }
           ]}
           classNames={classNames}
           styles={{ popup: { root: { position: 'absolute' } } }}
-          preview={{ getContainer: () => holderRef.current!, open: true }}
+          preview={{ getContainer: () => holderRef.current!, open: true, focusTrap: false }}
         />
       </div>
     </Flex>

--- a/components/image/style/index.ts
+++ b/components/image/style/index.ts
@@ -4,6 +4,7 @@ import { FastColor } from '@ant-design/fast-color';
 
 import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genStyleHooks, mergeToken } from '../../theme/internal';
+import { genFocusOutline, genFocusStyle } from '../../style';
 
 export interface ComponentToken {
   /**
@@ -73,7 +74,7 @@ export const genImageCoverStyle: GenerateStyle<ImageToken, CSSObject> = (token) 
         opacity: 0,
         transition: `opacity ${motionDurationSlow}`,
       },
-      '&:hover': {
+      '&:hover, &:focus-visible': {
         [`${componentCls}-cover`]: {
           opacity: 1,
         },
@@ -131,6 +132,7 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken, CSSObject> = (token
     '&:active': {
       backgroundColor: operationBg.toRgbString(),
     },
+    '&:focus-visible': genFocusOutline(token),
   };
 
   return {
@@ -254,6 +256,7 @@ export const genImagePreviewStyle: GenerateStyle<ImageToken, CSSObject> = (token
           [`&:not(${previewCls}-actions-action-disabled):hover`]: {
             color: previewOperationHoverColor,
           },
+          '&:focus-visible': genFocusOutline(token),
           '&-disabled': {
             color: previewOperationColorDisabled,
             cursor: 'not-allowed',
@@ -271,6 +274,7 @@ const genImageStyle: GenerateStyle<ImageToken, CSSObject> = (token) => {
     [componentCls]: {
       position: 'relative',
       display: 'inline-block',
+      ...genFocusStyle(token),
       [`${componentCls}-img`]: {
         width: '100%',
         height: 'auto',


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [x] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/react-component/image/pull/505

### 💡 需求背景和解决方案

升级 `@rc-component/image` 依赖版本，从 `~1.8.0` 升至 `~1.9.0`。

主要包含以下修复：
- 通过键盘（Enter/Space）打开 Image 预览时，焦点未被正确锁定在预览内部
- 关闭预览后，焦点未回到触发元素

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | ⌨️ Fix Image preview focus not being locked when opened via keyboard, and restore focus to trigger element after preview closes. |
| 🇨🇳 中文 | ⌨️ 修复 Image 通过键盘打开预览时焦点未被正确锁定的问题，并在关闭预览后恢复焦点到触发元素。 |