### PR TITLE
fix: prevent Space.Addon content from wrapping

### DIFF
--- a/components/space/__tests__/space-compact.test.tsx
+++ b/components/space/__tests__/space-compact.test.tsx
@@ -50,17 +50,6 @@ describe('Space.Compact', () => {
     expect(container.querySelector('.ant-space-compact')).toHaveClass('ant-space-compact-block');
   });
 
-  it('should prevent wrapping in addon content', () => {
-    const { container } = render(
-      <Space.Compact>
-        <Space.Addon>中文</Space.Addon>
-        <Input placeholder="input here" />
-      </Space.Compact>,
-    );
-
-    expect(container.querySelector('.ant-space-addon')).toHaveStyle({ whiteSpace: 'nowrap' });
-  });
-
   it('compact-item className', () => {
     const { container } = render(
       <Space.Compact>

--- a/components/space/__tests__/space-compact.test.tsx
+++ b/components/space/__tests__/space-compact.test.tsx
@@ -50,6 +50,17 @@ describe('Space.Compact', () => {
     expect(container.querySelector('.ant-space-compact')).toHaveClass('ant-space-compact-block');
   });
 
+  it('should prevent wrapping in addon content', () => {
+    const { container } = render(
+      <Space.Compact>
+        <Space.Addon>中文</Space.Addon>
+        <Input placeholder="input here" />
+      </Space.Compact>,
+    );
+
+    expect(container.querySelector('.ant-space-addon')).toHaveStyle({ whiteSpace: 'nowrap' });
+  });
+
   it('compact-item className', () => {
     const { container } = render(
       <Space.Compact>

--- a/components/space/style/addon.ts
+++ b/components/space/style/addon.ts
@@ -40,6 +40,7 @@ const genSpaceAddonStyle: GenerateStyle<SpaceToken, CSSObject> = (token) => {
         display: 'inline-flex',
         alignItems: 'center',
         gap: 0,
+        whiteSpace: 'nowrap',
         paddingInline: paddingSM,
         margin: 0,
         borderWidth: lineWidth,


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] ✅ 测试用例

### 🔗 相关 Issue

fix #57620

### 💡 需求背景和解决方案

`Space.Addon` 当前只有 `display: inline-flex`，没有显式限制文本换行，因此在中文等 CJK 文本场景下会按浏览器默认规则断行，表现和英文内容不一致。

这个行为和旧版 `Input` 的 addon 区域并不一致。旧的 `Input` group addon 已经显式设置了 `whiteSpace: 'nowrap'`，因此 `addonBefore` / `addonAfter` 不会因为 CJK 文本而换行。这次修复是让 `Space.Addon` 和已有 addon 语义保持一致，而不是引入新的布局规则。

本次改动为 `Space.Addon` 增加了 `whiteSpace: 'nowrap'`，并补充了一个中文内容的回归测试，确保紧凑布局中的 addon 内容保持单行展示。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Space.Addon wrapping CJK content in compact layouts. |
| 🇨🇳 中文 | 🐞 修复 Space.Addon 在紧凑布局中展示中文等 CJK 内容时会换行的问题。 |
