### PR TITLE
feat(Typography): add default styles for table elements

### DIFF
--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2778,6 +2778,70 @@ Array [
 
 exports[`renders components/typography/demo/suffix.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/typography/demo/table.tsx extend context correctly 1`] = `
+<article
+  class="ant-typography css-var-test-id"
+>
+  <h1
+    class="ant-typography css-var-test-id"
+  >
+    Typography with Table
+  </h1>
+  <table>
+    <thead>
+      <tr>
+        <th>
+          Plan
+        </th>
+        <th>
+          Price
+        </th>
+        <th>
+          Features
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          Basic
+        </td>
+        <td>
+          Free
+        </td>
+        <td>
+          1GB Storage, Basic Support
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Pro
+        </td>
+        <td>
+          $9.99/month
+        </td>
+        <td>
+          100GB Storage, Priority Support
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Enterprise
+        </td>
+        <td>
+          Contact us
+        </td>
+        <td>
+          Unlimited Storage, 24/7 Support
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+`;
+
+exports[`renders components/typography/demo/table.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/typography/demo/text.tsx extend context correctly 1`] = `
 <div
   class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2782,11 +2782,11 @@ exports[`renders components/typography/demo/table.tsx extend context correctly 1
 <article
   class="ant-typography css-var-test-id"
 >
-  <h1
+  <h4
     class="ant-typography css-var-test-id"
   >
     Typography with Table
-  </h1>
+  </h4>
   <table>
     <thead>
       <tr>

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2041,6 +2041,68 @@ Array [
 ]
 `;
 
+exports[`renders components/typography/demo/table.tsx correctly 1`] = `
+<article
+  class="ant-typography css-var-test-id"
+>
+  <h1
+    class="ant-typography css-var-test-id"
+  >
+    Typography with Table
+  </h1>
+  <table>
+    <thead>
+      <tr>
+        <th>
+          Plan
+        </th>
+        <th>
+          Price
+        </th>
+        <th>
+          Features
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          Basic
+        </td>
+        <td>
+          Free
+        </td>
+        <td>
+          1GB Storage, Basic Support
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Pro
+        </td>
+        <td>
+          $9.99/month
+        </td>
+        <td>
+          100GB Storage, Priority Support
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Enterprise
+        </td>
+        <td>
+          Contact us
+        </td>
+        <td>
+          Unlimited Storage, 24/7 Support
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</article>
+`;
+
 exports[`renders components/typography/demo/text.tsx correctly 1`] = `
 <div
   class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2045,11 +2045,11 @@ exports[`renders components/typography/demo/table.tsx correctly 1`] = `
 <article
   class="ant-typography css-var-test-id"
 >
-  <h1
+  <h4
     class="ant-typography css-var-test-id"
   >
     Typography with Table
-  </h1>
+  </h4>
   <table>
     <thead>
       <tr>

--- a/components/typography/demo/table.md
+++ b/components/typography/demo/table.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+为 Typography 内的原生 `<table>` 元素提供默认样式，适用于在文档中展示表格内容（如价格表、对比表等），无需使用完整的 Table 组件。
+
+## en-US
+
+Provides default styles for native `<table>` elements within Typography, suitable for displaying tabular content in documents (such as pricing tables, comparison charts, etc.) without using the full Table component.

--- a/components/typography/demo/table.tsx
+++ b/components/typography/demo/table.tsx
@@ -8,7 +8,7 @@ const { Title } = Typography;
  */
 const App: React.FC = () => (
   <Typography>
-    <Title>Typography with Table</Title>
+    <Title level={4}>Typography with Table</Title>
 
     <table>
       <thead>

--- a/components/typography/demo/table.tsx
+++ b/components/typography/demo/table.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Typography } from 'antd';
+
+const { Title } = Typography;
+
+/**
+ * Ref: https://github.com/ant-design/ant-design/issues/17125
+ */
+const App: React.FC = () => (
+  <Typography>
+    <Title>Typography with Table</Title>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Plan</th>
+          <th>Price</th>
+          <th>Features</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Basic</td>
+          <td>Free</td>
+          <td>1GB Storage, Basic Support</td>
+        </tr>
+        <tr>
+          <td>Pro</td>
+          <td>$9.99/month</td>
+          <td>100GB Storage, Priority Support</td>
+        </tr>
+        <tr>
+          <td>Enterprise</td>
+          <td>Contact us</td>
+          <td>Unlimited Storage, 24/7 Support</td>
+        </tr>
+      </tbody>
+    </table>
+  </Typography>
+);
+
+export default App;

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -28,7 +28,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 <code src="./demo/suffix.tsx">suffix</code>
 <code src="./demo/componentToken-debug.tsx" debug>Component Token</code>
 <code src="./demo/link-danger-debug.tsx" debug>Link danger Debug</code>
-<code src="./demo/table.tsx" debug>Table</code>
+<code src="./demo/table.tsx">Table</code>
 
 ## API
 

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -28,6 +28,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 <code src="./demo/suffix.tsx">suffix</code>
 <code src="./demo/componentToken-debug.tsx" debug>Component Token</code>
 <code src="./demo/link-danger-debug.tsx" debug>Link danger Debug</code>
+<code src="./demo/table.tsx" debug>Table</code>
 
 ## API
 

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -29,7 +29,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 <code src="./demo/suffix.tsx">后缀</code>
 <code src="./demo/componentToken-debug.tsx" debug>组件 Token</code>
 <code src="./demo/link-danger-debug.tsx" debug>Link danger Debug</code>
-<code src="./demo/table.tsx" debug>表格</code>
+<code src="./demo/table.tsx">表格</code>
 
 ## API
 

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -29,6 +29,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 <code src="./demo/suffix.tsx">后缀</code>
 <code src="./demo/componentToken-debug.tsx" debug>组件 Token</code>
 <code src="./demo/link-danger-debug.tsx" debug>Link danger Debug</code>
+<code src="./demo/table.tsx" debug>表格</code>
 
 ## API
 

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -8,6 +8,7 @@
 }
 */
 import { gold } from '@ant-design/colors';
+import { unit } from '@ant-design/cssinjs';
 import type { CSSObject } from '@ant-design/cssinjs';
 
 import type { TypographyToken } from '.';
@@ -178,6 +179,62 @@ export const getResetStyles: GenerateStyle<TypographyToken, CSSObject> = (token)
     paddingBlock: 0,
     borderInlineStart: '4px solid rgba(100, 100, 100, 0.2)',
     opacity: 0.85,
+  },
+
+  // table - Follow Table component default style
+  table: {
+    width: '100%',
+    textAlign: 'start',
+    borderRadius: `${unit(token.borderRadiusLG)} ${unit(token.borderRadiusLG)} 0 0`,
+    borderCollapse: 'separate',
+    borderSpacing: 0,
+    marginBlock: '1em',
+
+    'th, td': {
+      padding: unit(token.padding),
+      overflowWrap: 'break-word',
+      borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
+    },
+
+    'thead > tr:first-child > th:first-child': {
+      borderStartStartRadius: token.borderRadiusLG,
+    },
+
+    'thead > tr:first-child > th:last-child': {
+      borderStartEndRadius: token.borderRadiusLG,
+    },
+
+    'thead > tr > th': {
+      textAlign: 'start',
+      position: 'relative',
+      color: token.colorTextHeading,
+      fontWeight: token.fontWeightStrong,
+      background: token.colorFillAlter,
+      borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
+      transition: `background-color ${token.motionDurationMid} ease`,
+
+      '&:not(:last-child)::before': {
+        position: 'absolute',
+        top: '50%',
+        insetInlineEnd: 0,
+        width: 1,
+        height: '1.6em',
+        backgroundColor: token.colorSplit,
+        transform: 'translateY(-50%)',
+        transition: `background-color ${token.motionDurationMid}`,
+        content: '""',
+      },
+    },
+
+    'tbody > tr': {
+      '> th, > td': {
+        borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
+        transition: `background-color ${token.motionDurationMid} ease, border-color ${token.motionDurationMid} ease`,
+      },
+      '&:hover > td': {
+        background: token.colorFillAlter,
+      },
+    },
   },
 });
 

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -185,7 +185,6 @@ export const getResetStyles: GenerateStyle<TypographyToken, CSSObject> = (token)
   table: {
     width: '100%',
     textAlign: 'start',
-    borderRadius: `${unit(token.borderRadiusLG)} ${unit(token.borderRadiusLG)} 0 0`,
     borderCollapse: 'separate',
     borderSpacing: 0,
     marginBlock: '1em',
@@ -209,8 +208,7 @@ export const getResetStyles: GenerateStyle<TypographyToken, CSSObject> = (token)
       position: 'relative',
       color: token.colorTextHeading,
       fontWeight: token.fontWeightStrong,
-      background: token.colorFillAlter,
-      borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
+      backgroundColor: token.colorFillAlter,
       transition: `background-color ${token.motionDurationMid} ease`,
 
       '&:not(:last-child)::before': {
@@ -221,18 +219,16 @@ export const getResetStyles: GenerateStyle<TypographyToken, CSSObject> = (token)
         height: '1.6em',
         backgroundColor: token.colorSplit,
         transform: 'translateY(-50%)',
-        transition: `background-color ${token.motionDurationMid}`,
         content: '""',
       },
     },
 
     'tbody > tr': {
       '> th, > td': {
-        borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
-        transition: `background-color ${token.motionDurationMid} ease, border-color ${token.motionDurationMid} ease`,
+        transition: `background-color ${token.motionDurationMid} ease`,
       },
-      '&:hover > td': {
-        background: token.colorFillAlter,
+      '&:hover > th, &:hover > td': {
+        backgroundColor: token.colorFillAlter,
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -329,7 +329,7 @@
   "size-limit": [
     {
       "path": "./dist/antd.min.js",
-      "limit": "436 KiB",
+      "limit": "437 KiB",
       "gzip": true
     },
     {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交

### 🔗 相关 Issue

close #17125

### 💡 需求背景和解决方案

为 Typography 组件内的原生 `<table>` 元素添加默认样式，方便在文档中展示表格内容（如价格表、对比表等），无需使用完整的 Table 组件。

实现方式：
- 在 `getResetStyles` 中添加 table、th、td 的样式
- 参考 Table 组件的设计 token（colorFillAlter、colorSplit、borderRadiusLG 等）
- 支持表头圆角、单元格分割线、行悬停效果

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🆕 Add default table styles for Typography component. |
| 🇨🇳 中文 | 🆕 Typography 组件支持原生 table 元素的默认样式。 |