### PR TITLE
docs: unify API property headers in English docs

### DIFF
--- a/components/drawer/index.en-US.md
+++ b/components/drawer/index.en-US.md
@@ -47,7 +47,7 @@ A Drawer is a panel that is typically overlaid on top of a page and slides in fr
 
 Common props ref：[Common props](/docs/react/common-props)
 
-| Props | Description | Type | Default | Version |
+| Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | afterOpenChange | Callback after the animation ends when switching drawers | function(open) | - |  |
 | className | Config Drawer Panel className. Use `rootClassName` if want to config top DOM style | string | - |  |
@@ -83,7 +83,7 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### ResizableConfig
 
-| Props         | Description                 | Type                   | Default | Version |
+| Property      | Description                 | Type                   | Default | Version |
 | ------------- | --------------------------- | ---------------------- | ------- | ------- |
 | onResizeStart | Callback when resize starts | () => void             | -       | 6.0.0   |
 | onResize      | Callback during resizing    | (size: number) => void | -       | 6.0.0   |

--- a/components/form/index.en-US.md
+++ b/components/form/index.en-US.md
@@ -527,7 +527,7 @@ type FilterFunc = (meta: { touched: boolean; validating: boolean }) => boolean;
 
 ### FieldData
 
-| Name       | Description              | Type                     |
+| Property   | Description              | Type                     |
 | ---------- | ------------------------ | ------------------------ |
 | errors     | Error messages           | string\[]                |
 | warnings   | Warning messages         | string\[]                |
@@ -544,7 +544,7 @@ Rule supports a config object, or a function returning config object:
 type Rule = RuleConfig | ((form: FormInstance) => RuleConfig);
 ```
 
-| Name | Description | Type | Version |
+| Property | Description | Type | Version |
 | --- | --- | --- | --- |
 | defaultField | Validate rule for all array elements, valid when `type` is `array` | [rule](#rule) |  |
 | enum | Match enum value. You need to set `type` to `enum` to enable this | any\[] |  |
@@ -564,7 +564,7 @@ type Rule = RuleConfig | ((form: FormInstance) => RuleConfig);
 
 ### WatchOptions
 
-| Name | Description | Type | Default | Version |
+| Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | form | Form instance | FormInstance | Current form in context | 5.4.0 |
 | preserve | Whether to watch the field which has no matched `Form.Item` | boolean | false | 5.4.0 |

--- a/components/masonry/index.en-US.md
+++ b/components/masonry/index.en-US.md
@@ -46,7 +46,7 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### MasonryItem
 
-| Parameter | Description | Type | Default Value |
+| Property | Description | Type | Default Value |
 | --- | --- | --- | --- |
 | children | Custom display content, takes precedence over `itemRender` | `React.ReactNode` | - |
 | column | Specifies the column to which the item belongs | `number` | - |

--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -45,7 +45,7 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### Menu
 
-| Param | Description | Type | Default value | Version |
+| Property | Description | Type | Default value | Version |
 | --- | --- | --- | --- | --- |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | defaultOpenKeys | Array with the keys of default opened sub menus | string\[] | - |  |
@@ -82,7 +82,7 @@ Common props ref：[Common props](/docs/react/common-props)
 
 #### MenuItemType
 
-| Param    | Description                          | Type      | Default value | Version |
+| Property | Description                          | Type      | Default value | Version |
 | -------- | ------------------------------------ | --------- | ------------- | ------- |
 | danger   | Display the danger style             | boolean   | false         |         |
 | disabled | Whether menu item is disabled        | boolean   | false         |         |
@@ -120,7 +120,7 @@ const groupItem = {
 };
 ```
 
-| Param    | Description            | Type                              | Default value | Version |
+| Property | Description            | Type                              | Default value | Version |
 | -------- | ---------------------- | --------------------------------- | ------------- | ------- |
 | children | Sub-menu items         | [MenuItemType\[\]](#menuitemtype) | -             |         |
 | label    | The title of the group | ReactNode                         | -             |         |
@@ -135,9 +135,9 @@ const dividerItem = {
 };
 ```
 
-| Param  | Description            | Type    | Default value | Version |
-| ------ | ---------------------- | ------- | ------------- | ------- |
-| dashed | Whether line is dashed | boolean | false         |         |
+| Property | Description            | Type    | Default value | Version |
+| -------- | ---------------------- | ------- | ------------- | ------- |
+| dashed   | Whether line is dashed | boolean | false         |         |
 
 ## FAQ
 

--- a/components/popconfirm/index.en-US.md
+++ b/components/popconfirm/index.en-US.md
@@ -34,7 +34,7 @@ The difference with the `confirm` modal dialog is that it's more lightweight tha
 
 Common props ref：[Common props](/docs/react/common-props)
 
-| Param | Description | Type | Default value | Version |
+| Property | Description | Type | Default value | Version |
 | --- | --- | --- | --- | --- |
 | cancelButtonProps | The cancel button props | [ButtonProps](/components/button/#api) | - |  |
 | cancelText | The text of the Cancel button | string | `Cancel` |  |

--- a/components/popover/index.en-US.md
+++ b/components/popover/index.en-US.md
@@ -35,7 +35,7 @@ Comparing with `Tooltip`, besides information `Popover` card can also provide ac
 
 Common props ref：[Common props](/docs/react/common-props)
 
-| Param | Description | Type | Default value | Version |
+| Property | Description | Type | Default value | Version |
 | --- | --- | --- | --- | --- |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | content | Content of the card | ReactNode \| () => ReactNode | - |  |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

`@ant-design/cli` 依赖英文 API 表格的首列标题为 `Property`。当前部分英文文档仍使用了 `Props`、`Param`、`Parameter` 以及少量不一致的属性表头，导致 CLI 识别异常。

这个 PR 将受影响英文文档中的 API 属性表首列统一调整为 `Property`，保持文档格式一致，并避免 CLI 解析出错。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | No changelog required. |
| 🇨🇳 中文 | 无需更新日志。 |
