### PR TITLE
fix: add guard to handle null values in getRealHeight

### DIFF
--- a/components/_util/motion.ts
+++ b/components/_util/motion.ts
@@ -9,11 +9,11 @@ import { defaultPrefixCls } from '../config-provider';
 
 // ================== Collapse Motion ==================
 const getCollapsedHeight: MotionEventHandler = () => ({ height: 0, opacity: 0 });
-const getRealHeight: MotionEventHandler = (node) => {
-  const { scrollHeight } = node;
-  return { height: scrollHeight, opacity: 1 };
-};
-const getCurrentHeight: MotionEventHandler = (node) => ({ height: node ? node.offsetHeight : 0 });
+const getRealHeight: MotionEventHandler = (node) => ({
+  height: node?.scrollHeight ?? 0,
+  opacity: node ? 1 : 0,
+});
+const getCurrentHeight: MotionEventHandler = (node) => ({ height: node?.offsetHeight ?? 0 });
 const skipOpacityTransition: MotionEndEventHandler = (_, event: MotionEvent) =>
   event?.deadline === true || (event as TransitionEvent).propertyName === 'height';
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- The issue was uncovered in the course of implementing https://github.com/rjsf-team/react-jsonschema-form/issues/4995 (see [this](https://github.com/rjsf-team/react-jsonschema-form/issues/4995#issuecomment-4223869789) comment in particular for more details)

### 💡 Background and Solution

During our attempt to upgrade `@rjfs/antd` (which uses `antd` as a peer dependency) from v5 to v6 we noticed that the form component would crash immediately upon first render. The crash turned out to be caused by `getRealHeight` in antd's motion utility that doesn't guard against the possibility of the passed argument `node` being `null`. Interestingly the function `getCurrentHeight` that immediately follows it _has_ such a guard. Addressing this bug is a prerequisite for the adoption of antd v6 in `@rjsf/antd`.

#### Stacktrace:

```
Uncaught TypeError: Cannot destructure property 'scrollHeight' of 'node' as it is null.
    at Object.getRealHeight [as active] (antd.js?v=43a5f100:10037:5)
    at antd.js?v=43a5f100:3320:41
    at antd.js?v=43a5f100:3204:22
    at commitHookEffectListMount (chunk-UYA5EVPH.js?v=ba86f111:16963:34)
    at commitLayoutEffectOnFiber (chunk-UYA5EVPH.js?v=ba86f111:17050:23)
    at commitLayoutMountEffects_complete (chunk-UYA5EVPH.js?v=ba86f111:18030:17)
    at commitLayoutEffects_begin (chunk-UYA5EVPH.js?v=ba86f111:18019:15)
    at commitLayoutEffects (chunk-UYA5EVPH.js?v=ba86f111:17970:11)
    at commitRootImpl (chunk-UYA5EVPH.js?v=ba86f111:19406:13)
    at commitRoot (chunk-UYA5EVPH.js?v=ba86f111:19330:13)
```

#### Screenshot of the active break point in Chrome dev-tools:

<img width="946" height="750" alt="image" src="https://github.com/user-attachments/assets/dc153f8d-aa2d-43fe-a439-1c46bffe5118" />

You can clearly see that `node` _is_ in fact `null` which inevitably leads to the crash in the next line when `.scrollHeight` is accessed.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Prevent crash when the `node` argument is `null` in `getRealHeight` in the motion utility |
| 🇨🇳 Chinese | 在 motion 工具中，当 `getRealHeight` 的 `node` 参数为 `null` 时，防止程序崩溃 |
