### PR TITLE
perf(Table): ⚡️optimize table filter search value normalization

### DIFF
--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -120,7 +120,7 @@ const renderFilterItems = (options: RenderFilterItemsOptions): Required<MenuProp
     };
     if (normalizedSearchValue) {
       if (typeof filterSearch === 'function') {
-        return filterSearch(searchValue, filter) ? item : null;
+        return filterSearch(normalizedSearchValue, filter) ? item : null;
       }
       return searchValueMatched(normalizedSearchValue, filter.text) ? item : null;
     }
@@ -256,7 +256,12 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
 
   // search in tree mode column filter
   const [searchValue, setSearchValue] = React.useState('');
-  const normalizedSearchValue = React.useMemo(() => searchValue.trim().toLowerCase(), [searchValue]);
+
+  const normalizedSearchValue = React.useMemo<string>(
+    () => searchValue.trim().toLowerCase(),
+    [searchValue],
+  );
+
   const onSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
     setSearchValue(value);

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -256,7 +256,7 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
 
   // search in tree mode column filter
   const [searchValue, setSearchValue] = React.useState('');
-  const normalizedSearchValue = searchValue.trim().toLowerCase();
+  const normalizedSearchValue = React.useMemo(() => searchValue.trim().toLowerCase(), [searchValue]);
   const onSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
     setSearchValue(value);

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -59,28 +59,34 @@ function hasSubMenu(filters: ColumnFilterItem[]) {
   return filters.some(({ children }) => children);
 }
 
-function searchValueMatched(searchValue: string, text: React.ReactNode) {
+const searchValueMatched = (normalizedSearchValue: string, text: React.ReactNode) => {
   if (typeof text === 'string' || isNumber(text)) {
-    return text?.toString().toLowerCase().includes(searchValue.trim().toLowerCase());
+    return text.toString().toLowerCase().includes(normalizedSearchValue);
   }
   return false;
-}
+};
 
-function renderFilterItems({
-  filters,
-  prefixCls,
-  filteredKeys,
-  filterMultiple,
-  searchValue,
-  filterSearch,
-}: {
+interface RenderFilterItemsOptions {
   filters: ColumnFilterItem[];
   prefixCls: string;
   filteredKeys: Key[];
   filterMultiple: boolean;
   searchValue: string;
+  normalizedSearchValue: string;
   filterSearch: FilterSearchType<ColumnFilterItem>;
-}): Required<MenuProps>['items'] {
+}
+
+const renderFilterItems = (options: RenderFilterItemsOptions): Required<MenuProps>['items'] => {
+  const {
+    filters,
+    prefixCls,
+    filteredKeys,
+    filterMultiple,
+    searchValue,
+    normalizedSearchValue,
+    filterSearch,
+  } = options;
+
   return filters.map((filter, index) => {
     const key = String(filter.value);
 
@@ -95,6 +101,7 @@ function renderFilterItems({
           filteredKeys,
           filterMultiple,
           searchValue,
+          normalizedSearchValue,
           filterSearch,
         }),
       };
@@ -111,15 +118,15 @@ function renderFilterItems({
         </>
       ),
     };
-    if (searchValue.trim()) {
+    if (normalizedSearchValue) {
       if (typeof filterSearch === 'function') {
         return filterSearch(searchValue, filter) ? item : null;
       }
-      return searchValueMatched(searchValue, filter.text) ? item : null;
+      return searchValueMatched(normalizedSearchValue, filter.text) ? item : null;
     }
     return item;
   });
-}
+};
 
 export type TreeColumnFilterItem = ColumnFilterItem & FilterTreeDataNode;
 
@@ -249,6 +256,7 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
 
   // search in tree mode column filter
   const [searchValue, setSearchValue] = React.useState('');
+  const normalizedSearchValue = searchValue.trim().toLowerCase();
   const onSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
     setSearchValue(value);
@@ -437,12 +445,12 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
                 autoExpandParent
                 defaultExpandAll
                 filterTreeNode={
-                  searchValue.trim()
+                  normalizedSearchValue
                     ? (node) => {
                         if (typeof filterSearch === 'function') {
                           return filterSearch(searchValue, getFilterData(node));
                         }
-                        return searchValueMatched(searchValue, node.title);
+                        return searchValueMatched(normalizedSearchValue, node.title);
                       }
                     : undefined
                 }
@@ -451,6 +459,7 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
           </>
         );
       }
+
       const items = renderFilterItems({
         filters: column.filters || [],
         filterSearch,
@@ -458,7 +467,9 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
         filteredKeys: getFilteredKeysSync(),
         filterMultiple,
         searchValue,
+        normalizedSearchValue,
       });
+
       const isEmpty = items.every((item) => item === null);
 
       return (


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [x] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

在 FilterDropdown 的默认筛选搜索流程里，searchValue.trim().toLowerCase() 会在匹配每个筛选项时重复执行。
当筛选项较多时，这部分重复计算会带来不必要的开销。这个改动将搜索值归一化处理，提升到调用方，在一次搜索过程中只计算一次规范化后的值。

不改变现有行为：
- 默认搜索仍然保持 trim + toLowerCase 的匹配逻辑
- 自定义 filterSearch 仍然接收原始输入值

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 优化 Table 在 FilterDropdown 中的筛选搜索性能，复用规范化后的搜索输入 |
| 🇨🇳 Chinese | 优化 Table 在 FilterDropdown 中的筛选搜索性能，复用规范化后的搜索输入 |