### PR TITLE
feat(Dropdown): support left/right placement directions

### DIFF
--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -33,11 +33,17 @@ const _Placements = [
   'bottomRight',
   'top',
   'bottom',
+  'leftTop',
+  'leftBottom',
+  'left',
+  'rightTop',
+  'rightBottom',
+  'right',
 ] as const;
 
 type Placement = (typeof _Placements)[number];
 
-type DropdownPlacement = Exclude<Placement, 'topCenter' | 'bottomCenter'>;
+type DropdownPlacement = Exclude<Placement, 'topCenter' | 'bottomCenter' | 'left' | 'right'>;
 
 export type DropdownArrowOptions = {
   pointAtCenter?: boolean;
@@ -211,6 +217,14 @@ const Dropdown: CompoundedComponent = (props) => {
 
     if (placement.includes('Center')) {
       return placement.slice(0, placement.indexOf('Center')) as DropdownPlacement;
+    }
+
+    // Map bare 'left'/'right' to their default sub-positions
+    if (placement === 'left') {
+      return 'leftTop' as DropdownPlacement;
+    }
+    if (placement === 'right') {
+      return 'rightTop' as DropdownPlacement;
     }
 
     return placement as DropdownPlacement;

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -43,7 +43,7 @@ const _Placements = [
 
 type Placement = (typeof _Placements)[number];
 
-type DropdownPlacement = Exclude<Placement, 'topCenter' | 'bottomCenter' | 'left' | 'right'>;
+type DropdownPlacement = Exclude<Placement, 'topCenter' | 'bottomCenter'>;
 
 export type DropdownArrowOptions = {
   pointAtCenter?: boolean;
@@ -217,14 +217,6 @@ const Dropdown: CompoundedComponent = (props) => {
 
     if (placement.includes('Center')) {
       return placement.slice(0, placement.indexOf('Center')) as DropdownPlacement;
-    }
-
-    // Map bare 'left'/'right' to their default sub-positions
-    if (placement === 'left') {
-      return 'leftTop' as DropdownPlacement;
-    }
-    if (placement === 'right') {
-      return 'rightTop' as DropdownPlacement;
     }
 
     return placement as DropdownPlacement;


### PR DESCRIPTION
Dropdown only supported top and bottom placements, but Popover already supports left/right directions. This adds leftTop, leftBottom, rightTop, rightBottom, left, and right to the Dropdown placement type and the internal placements array.

Bare 'left' and 'right' map to leftTop and rightTop respectively, consistent with how 'top' and 'bottom' map to topLeft and bottomLeft.

Closes #56856