### PR TITLE
[WIP]fix(Table): adjust row expand icon margin

### DIFF
--- a/components/table/style/expand.ts
+++ b/components/table/style/expand.ts
@@ -41,6 +41,7 @@ const genExpandStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
 
         [`${componentCls}-row-expand-icon`]: {
           display: 'inline-flex',
+          float: 'none',
           verticalAlign: 'sub',
         },
       },

--- a/components/table/style/expand.ts
+++ b/components/table/style/expand.ts
@@ -41,20 +41,17 @@ const genExpandStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
 
         [`${componentCls}-row-expand-icon`]: {
           display: 'inline-flex',
-          float: 'none',
           verticalAlign: 'sub',
         },
       },
 
       [`${componentCls}-row-indent`]: {
         height: 1,
-        float: 'left',
       },
 
       [`${componentCls}-row-expand-icon`]: {
         ...operationUnit(token),
         position: 'relative',
-        float: 'left',
         width: expandIconSize,
         height: expandIconSize,
         color: 'inherit',
@@ -110,9 +107,14 @@ const genExpandStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
         },
       },
 
+      [`${componentCls}-cell-with-append`]: {
+        display: 'inline-flex',
+      },
+
       [`${componentCls}-row-indent + ${componentCls}-row-expand-icon`]: {
-        marginTop: expandIconMarginTop,
+        marginTop: unit(calc(expandIconMarginTop).add(1).equal()),
         marginInlineEnd: paddingXS,
+        flexShrink: 0,
       },
 
       [`tr${componentCls}-expanded-row`]: {

--- a/components/table/style/expand.ts
+++ b/components/table/style/expand.ts
@@ -47,6 +47,7 @@ const genExpandStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
 
       [`${componentCls}-row-indent`]: {
         height: 1,
+        flexShrink: 0,
       },
 
       [`${componentCls}-row-expand-icon`]: {
@@ -60,6 +61,7 @@ const genExpandStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
         border: tableBorder,
         borderRadius,
         transform: `scale(${expandIconScale})`,
+        flexShrink: 0,
 
         '&:focus, &:hover, &:active': {
           borderColor: 'currentcolor',
@@ -112,9 +114,8 @@ const genExpandStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
       },
 
       [`${componentCls}-row-indent + ${componentCls}-row-expand-icon`]: {
-        marginTop: unit(calc(expandIconMarginTop).add(1).equal()),
+        marginTop: unit(calc(expandIconMarginTop).add(lineWidth).equal()),
         marginInlineEnd: paddingXS,
-        flexShrink: 0,
       },
 
       [`tr${componentCls}-expanded-row`]: {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] 💄 组件样式/交互改进

### 🔗 相关 Issue

fix #43871

### 💡 需求背景和解决方案

> 1. 修复 Table 组件行展开图标的外边距问题
> 2. 移除 float 属性，改用 flex 布局，优化图标与缩进的对齐
> 3. 调整 marginTop 计算值以获得更精准的垂直居中

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 💄 Adjust Table row expand icon margin and layout |
| 🇨🇳 中文 | 💄 优化 Table 行展开图标的外边距和布局 |