### PR TITLE
fix(Alert): add focus-visible outline for Alert close button

### DIFF
--- a/components/alert/style/index.ts
+++ b/components/alert/style/index.ts
@@ -2,7 +2,7 @@ import type { CSSProperties } from 'react';
 import type { CSSObject } from '@ant-design/cssinjs';
 import { unit } from '@ant-design/cssinjs';
 
-import { resetComponent } from '../../style';
+import { genFocusStyle, resetComponent } from '../../style';
 import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genStyleHooks } from '../../theme/internal';
 
@@ -216,8 +216,8 @@ export const genActionStyle: GenerateStyle<AlertToken, CSSObject> = (token) => {
         lineHeight: unit(fontSizeIcon),
         backgroundColor: 'transparent',
         border: 'none',
-        outline: 'none',
         cursor: 'pointer',
+        ...genFocusStyle(token),
 
         [`${iconCls}-close`]: {
           color: colorIcon,


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

I don’t know if there is a related issue for this one — if there is, I couldn’t find it. 

### 💡 Background and Solution

The problem is that the close button from the `Alert` component hides its outline, but does *not* apply focus styles, so it’s essentially unusable with a keyboard (well, it’s usable, but it’s not easy since you don’t know if you’re focusing it).

The solution is just to apply the focus ring to it.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the `Alert`’s close button not having focus styles          |
| 🇨🇳 Chinese | 修复 `Alert` 的关闭按钮没有焦点样式的问题          |
