### PR TITLE
fix(InputNumber): remove inner input border radius

### DIFF
--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -141,7 +141,7 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token) => {
           textAlign: 'start',
           backgroundColor: 'transparent',
           border: 0,
-          borderRadius,
+          borderRadius: 0,
           outline: 0,
           transition: `all ${motionDurationMid} linear`,
           appearance: 'textfield',


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [ ] 🆕 新特性提交
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #57700

### 💡 需求背景和解决方案

`InputNumber` 的圆角应该由外层容器负责，而不是内层原生 `input`。

当前实现里，内层 `input` 也带有 `border-radius`，所以在双击选中文本时，浏览器绘制的高亮背景会继承这个圆角。`small` size 因为 padding 更小，这个问题最容易看出来；`middle` 和 `large` 实际上也有同样的问题，只是被更大的 padding 遮住了。

这个改动移除了内层 `input` 的圆角，让 `border-radius` 只保留在外层 `InputNumber` 容器上，使选中文本时的高亮表现与 `Input` 保持一致。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix InputNumber selection highlight radius by keeping `border-radius` on the outer wrapper only. |
| 🇨🇳 中文 | 🐞 修复 InputNumber 选中文本时的高亮圆角问题，并将 `border-radius` 仅保留在外层容器上。 |
