### PR TITLE
feat(DatePicker): support tagRender in multiple mode

### DIFF
--- a/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/components/date-picker/__tests__/DatePicker.test.tsx
@@ -125,7 +125,7 @@ describe('DatePicker', () => {
           value={value}
           onChange={(nextValue) => setValue(nextValue ?? [])}
           tagRender={({ label, onClose, value: tagValue }) => {
-            const locked = tagValue.isBefore(dayjs().startOf('day'), 'day');
+            const locked = tagValue.isBefore(dayjs('2016-11-22'), 'day');
 
             return (
               <span data-testid={`tag-${tagValue.format('YYYY-MM-DD')}`}>

--- a/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/components/date-picker/__tests__/DatePicker.test.tsx
@@ -115,6 +115,43 @@ describe('DatePicker', () => {
     expect(wrapper.container.querySelector('input')?.placeholder).toEqual('Select date');
   });
 
+  it('multiple tagRender should support custom remove logic', () => {
+    const Demo = () => {
+      const [value, setValue] = React.useState([dayjs('2016-11-20'), dayjs('2016-11-23')]);
+
+      return (
+        <DatePicker
+          multiple
+          value={value}
+          onChange={(nextValue) => setValue(nextValue ?? [])}
+          tagRender={({ label, onClose, value: tagValue }) => {
+            const locked = tagValue.isBefore(dayjs().startOf('day'), 'day');
+
+            return (
+              <span data-testid={`tag-${tagValue.format('YYYY-MM-DD')}`}>
+                <span>{label}</span>
+                {!locked && (
+                  <button type="button" onClick={onClose}>
+                    remove
+                  </button>
+                )}
+              </span>
+            );
+          }}
+        />
+      );
+    };
+
+    const { container } = render(<Demo />);
+
+    expect(container.querySelector('[data-testid="tag-2016-11-20"] button')).toBeNull();
+
+    fireEvent.click(container.querySelector('[data-testid="tag-2016-11-23"] button')!);
+
+    expect(container.querySelector('[data-testid="tag-2016-11-20"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="tag-2016-11-23"]')).not.toBeInTheDocument();
+  });
+
   it('showTime={{ showHour: true, showMinute: true }}', () => {
     const { container } = render(
       <DatePicker

--- a/components/date-picker/__tests__/type.test.tsx
+++ b/components/date-picker/__tests__/type.test.tsx
@@ -95,4 +95,27 @@ describe('DatePicker.typescript', () => {
 
     expect(datePicker).toBeTruthy();
   });
+
+  it('DatePicker should support tagRender when multiple is true', () => {
+    const datePicker = (
+      <DatePicker
+        multiple
+        tagRender={({ label, value, closable, disabled, onClose }) => {
+          value.format('YYYY-MM-DD');
+          const isClosable: boolean = closable;
+          const isDisabled: boolean = disabled;
+          void isClosable;
+          void isDisabled;
+
+          return (
+            <button type="button" onClick={onClose}>
+              {label}
+            </button>
+          );
+        }}
+      />
+    );
+
+    expect(datePicker).toBeTruthy();
+  });
 });

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -162,7 +162,6 @@ The following APIs are shared by DatePicker, RangePicker.
 | ~~showTime.defaultValue~~ | Use `showTime.defaultOpenValue` instead | [dayjs](https://day.js.org/) | dayjs() | 5.27.3 |
 | showTime.defaultOpenValue | To set default time of selected date, [demo](#date-picker-demo-disabled-date) | [dayjs](https://day.js.org/) | dayjs() |  |
 | showWeek | Show week info when in DatePicker | boolean | false | 5.14.0 |
-| tagRender | Customize tag render, only applies when `multiple` is set | (props) => ReactNode | - | 6.4.0 |
 | value | To set date | [dayjs](https://day.js.org/) | - |  |
 | onChange | Callback function, can be executed when the selected time is changing | function(date: dayjs \| null, dateString: string \| null) | - |  |
 | onOk | Callback when click ok button | function() | - |  |

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -162,6 +162,7 @@ The following APIs are shared by DatePicker, RangePicker.
 | ~~showTime.defaultValue~~ | Use `showTime.defaultOpenValue` instead | [dayjs](https://day.js.org/) | dayjs() | 5.27.3 |
 | showTime.defaultOpenValue | To set default time of selected date, [demo](#date-picker-demo-disabled-date) | [dayjs](https://day.js.org/) | dayjs() |  |
 | showWeek | Show week info when in DatePicker | boolean | false | 5.14.0 |
+| tagRender | Customize tag render, only applies when `multiple` is set | (props) => ReactNode | - | 6.4.0 |
 | value | To set date | [dayjs](https://day.js.org/) | - |  |
 | onChange | Callback function, can be executed when the selected time is changing | function(date: dayjs \| null, dateString: string \| null) | - |  |
 | onOk | Callback when click ok button | function() | - |  |
@@ -175,6 +176,7 @@ The following APIs are shared by DatePicker, RangePicker.
 | format | To set the date format. refer to [dayjs#format](https://day.js.org/docs/en/display/format) | [formatType](#formattype) | `YYYY` |  |
 | multiple | Enable multiple selection | boolean | false | 5.14.0 |
 | renderExtraFooter | Render extra footer in panel | () => React.ReactNode | - |  |
+| tagRender | Customize tag render, only applies when `multiple` is set | (props) => ReactNode | - | 6.4.0 |
 | value | To set date | [dayjs](https://day.js.org/) | - |  |
 | onChange | Callback function, can be executed when the selected time is changing | function(date: dayjs \| null, dateString: string \| null) | - |  |
 
@@ -188,6 +190,7 @@ Added in `4.1.0`.
 | format | To set the date format. refer to [dayjs#format](https://day.js.org/docs/en/display/format) | [formatType](#formattype) | `YYYY-\QQ` |  |
 | multiple | Enable multiple selection | boolean | false | 5.14.0 |
 | renderExtraFooter | Render extra footer in panel | () => React.ReactNode | - |  |
+| tagRender | Customize tag render, only applies when `multiple` is set | (props) => ReactNode | - | 6.4.0 |
 | value | To set date | [dayjs](https://day.js.org/) | - |  |
 | onChange | Callback function, can be executed when the selected time is changing | function(date: dayjs \| null, dateString: string \| null) | - |  |
 
@@ -199,6 +202,7 @@ Added in `4.1.0`.
 | format | To set the date format. refer to [dayjs#format](https://day.js.org/docs/en/display/format) | [formatType](#formattype) | `YYYY-MM` |  |
 | multiple | Enable multiple selection | boolean | false | 5.14.0 |
 | renderExtraFooter | Render extra footer in panel | () => React.ReactNode | - |  |
+| tagRender | Customize tag render, only applies when `multiple` is set | (props) => ReactNode | - | 6.4.0 |
 | value | To set date | [dayjs](https://day.js.org/) | - |  |
 | onChange | Callback function, can be executed when the selected time is changing | function(date: dayjs \| null, dateString: string \| null) | - |  |
 
@@ -210,6 +214,7 @@ Added in `4.1.0`.
 | format | To set the date format. refer to [dayjs#format](https://day.js.org/docs/en/display/format) | [formatType](#formattype) | `YYYY-wo` |  |
 | multiple | Enable multiple selection | boolean | false | 5.14.0 |
 | renderExtraFooter | Render extra footer in panel | (mode) => React.ReactNode | - |  |
+| tagRender | Customize tag render, only applies when `multiple` is set | (props) => ReactNode | - | 6.4.0 |
 | value | To set date | [dayjs](https://day.js.org/) | - |  |
 | onChange | Callback function, can be executed when the selected time is changing | function(date: dayjs \| null, dateString: string \| null) | - |  |
 | showWeek | Show week info when in DatePicker | boolean | true | 5.14.0 |

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -163,7 +163,6 @@ dayjs.locale('zh-cn');
 | ~~showTime.defaultValue~~ | 请使用 `showTime.defaultOpenValue` | [dayjs](https://day.js.org/) | dayjs() | 5.27.3 |
 | showTime.defaultOpenValue | 设置用户选择日期时默认的时分秒，[例子](#date-picker-demo-disabled-date) | [dayjs](https://day.js.org/) | dayjs() |  |
 | showWeek | DatePicker 下展示当前周 | boolean | false | 5.14.0 |
-| tagRender | 自定义 tag 内容 render，仅在 `multiple` 模式下生效 | (props) => ReactNode | - | 6.4.0 |
 | value | 日期 | [dayjs](https://day.js.org/) | - |  |
 | onChange | 时间发生变化的回调 | function(date: dayjs \| null, dateString: string \| null) | - |  |
 | onOk | 点击确定按钮的回调 | function() | - |  |

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -163,6 +163,7 @@ dayjs.locale('zh-cn');
 | ~~showTime.defaultValue~~ | 请使用 `showTime.defaultOpenValue` | [dayjs](https://day.js.org/) | dayjs() | 5.27.3 |
 | showTime.defaultOpenValue | 设置用户选择日期时默认的时分秒，[例子](#date-picker-demo-disabled-date) | [dayjs](https://day.js.org/) | dayjs() |  |
 | showWeek | DatePicker 下展示当前周 | boolean | false | 5.14.0 |
+| tagRender | 自定义 tag 内容 render，仅在 `multiple` 模式下生效 | (props) => ReactNode | - | 6.4.0 |
 | value | 日期 | [dayjs](https://day.js.org/) | - |  |
 | onChange | 时间发生变化的回调 | function(date: dayjs \| null, dateString: string \| null) | - |  |
 | onOk | 点击确定按钮的回调 | function() | - |  |
@@ -176,6 +177,7 @@ dayjs.locale('zh-cn');
 | format | 展示的日期格式，配置参考 [dayjs#format](https://day.js.org/docs/zh-CN/display/format#%E6%94%AF%E6%8C%81%E7%9A%84%E6%A0%BC%E5%BC%8F%E5%8C%96%E5%8D%A0%E4%BD%8D%E7%AC%A6%E5%88%97%E8%A1%A8)。 | [formatType](#formattype) | `YYYY` |  |
 | multiple | 是否为多选 | boolean | false | 5.14.0 |
 | renderExtraFooter | 在面板中添加额外的页脚 | () => React.ReactNode | - |  |
+| tagRender | 自定义 tag 内容 render，仅在 `multiple` 模式下生效 | (props) => ReactNode | - | 6.4.0 |
 | value | 日期 | [dayjs](https://day.js.org/) | - |  |
 | onChange | 时间发生变化的回调，发生在用户选择时间时 | function(date: dayjs \| null, dateString: string \| null) | - |  |
 
@@ -189,6 +191,7 @@ dayjs.locale('zh-cn');
 | format | 展示的日期格式，配置参考 [dayjs#format](https://day.js.org/docs/zh-CN/display/format#%E6%94%AF%E6%8C%81%E7%9A%84%E6%A0%BC%E5%BC%8F%E5%8C%96%E5%8D%A0%E4%BD%8D%E7%AC%A6%E5%88%97%E8%A1%A8)。 | [formatType](#formattype) | `YYYY-\QQ` |  |
 | multiple | 是否为多选 | boolean | false | 5.14.0 |
 | renderExtraFooter | 在面板中添加额外的页脚 | () => React.ReactNode | - |  |
+| tagRender | 自定义 tag 内容 render，仅在 `multiple` 模式下生效 | (props) => ReactNode | - | 6.4.0 |
 | value | 日期 | [dayjs](https://day.js.org/) | - |  |
 | onChange | 时间发生变化的回调，发生在用户选择时间时 | function(date: dayjs \| null, dateString: string \| null) | - |  |
 
@@ -200,6 +203,7 @@ dayjs.locale('zh-cn');
 | format | 展示的日期格式，配置参考 [dayjs#format](https://day.js.org/docs/zh-CN/display/format#%E6%94%AF%E6%8C%81%E7%9A%84%E6%A0%BC%E5%BC%8F%E5%8C%96%E5%8D%A0%E4%BD%8D%E7%AC%A6%E5%88%97%E8%A1%A8)。 | [formatType](#formattype) | `YYYY-MM` |  |
 | multiple | 是否为多选 | boolean | false | 5.14.0 |
 | renderExtraFooter | 在面板中添加额外的页脚 | () => React.ReactNode | - |  |
+| tagRender | 自定义 tag 内容 render，仅在 `multiple` 模式下生效 | (props) => ReactNode | - | 6.4.0 |
 | value | 日期 | [dayjs](https://day.js.org/) | - |  |
 | onChange | 时间发生变化的回调，发生在用户选择时间时 | function(date: dayjs \| null, dateString: string \| null) | - |  |
 
@@ -211,6 +215,7 @@ dayjs.locale('zh-cn');
 | format | 展示的日期格式，配置参考 [dayjs#format](https://day.js.org/docs/zh-CN/display/format#%E6%94%AF%E6%8C%81%E7%9A%84%E6%A0%BC%E5%BC%8F%E5%8C%96%E5%8D%A0%E4%BD%8D%E7%AC%A6%E5%88%97%E8%A1%A8)。 | [formatType](#formattype) | `YYYY-wo` |  |
 | multiple | 是否为多选 | boolean | false | 5.14.0 |
 | renderExtraFooter | 在面板中添加额外的页脚 | (mode) => React.ReactNode | - |  |
+| tagRender | 自定义 tag 内容 render，仅在 `multiple` 模式下生效 | (props) => ReactNode | - | 6.4.0 |
 | value | 日期 | [dayjs](https://day.js.org/) | - |  |
 | onChange | 时间发生变化的回调，发生在用户选择时间时 | function(date: dayjs \| null, dateString: string \| null) | - |  |
 | showWeek | DatePicker 下展示当前周 | boolean | true | 5.14.0 |

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@rc-component/mutate-observer": "^2.0.1",
     "@rc-component/notification": "~1.2.0",
     "@rc-component/pagination": "~1.2.0",
-    "@rc-component/picker": "~1.9.1",
+    "@rc-component/picker": "~1.10.0",
     "@rc-component/progress": "~1.0.2",
     "@rc-component/qrcode": "~1.1.1",
     "@rc-component/rate": "~1.0.1",


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [x] 🤖 TypeScript 定义更新
- [x] ✅ 测试用例

### 🔗 相关 Issue

- close #57703

### 💡 需求背景和解决方案

- `@rc-component/picker@1.10.0` 已支持 DatePicker 在 `multiple` 模式下的 `tagRender`。
- 升级 antd 侧依赖并透出 `tagRender`，让使用方可以自定义多选标签内容和移除逻辑。
- 补充 `tagRender` 的运行时与类型测试，并在中英文文档 API 表中补充对应说明。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🆕 Add `tagRender` support for DatePicker in `multiple` mode. |
| 🇨🇳 中文 | 🆕 为 DatePicker 的 `multiple` 模式增加 `tagRender` 支持。 |
