### PR TITLE
fix(Tooltip): isolate ConfigProvider tooltip config for popover-injected instances

### DIFF
--- a/components/popconfirm/__tests__/index.test.tsx
+++ b/components/popconfirm/__tests__/index.test.tsx
@@ -418,6 +418,35 @@ describe('Popconfirm', () => {
     expect(getTooltipArrow()).not.toBeNull();
   });
 
+  it('should not leak ConfigProvider tooltip semantic config', () => {
+    const { container } = render(
+      <ConfigProvider
+        tooltip={{
+          classNames: {
+            root: 'custom-tooltip-root',
+            arrow: 'custom-tooltip-arrow',
+          },
+          styles: {
+            root: { padding: 99 },
+            arrow: { opacity: 0.25 },
+          },
+        }}
+      >
+        <Popconfirm open title="title">
+          <span>show me your code</span>
+        </Popconfirm>
+      </ConfigProvider>,
+    );
+
+    const popconfirmElement = container.querySelector<HTMLElement>('.ant-popconfirm')!;
+    const popconfirmArrowElement = container.querySelector<HTMLElement>('.ant-popover-arrow')!;
+
+    expect(popconfirmElement).not.toHaveClass('custom-tooltip-root');
+    expect(popconfirmArrowElement).not.toHaveClass('custom-tooltip-arrow');
+    expect(popconfirmElement).not.toHaveStyle({ padding: '99px' });
+    expect(popconfirmArrowElement).not.toHaveStyle({ opacity: '0.25' });
+  });
+
   it('should warn when onOpenChange has more than one argument', () => {
     resetWarned();
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -202,6 +202,35 @@ describe('Popover', () => {
     expect(getTooltipArrow()).not.toBeNull();
   });
 
+  it('should not leak ConfigProvider tooltip semantic config', () => {
+    const { container } = render(
+      <ConfigProvider
+        tooltip={{
+          classNames: {
+            root: 'custom-tooltip-root',
+            arrow: 'custom-tooltip-arrow',
+          },
+          styles: {
+            root: { padding: 99 },
+            arrow: { opacity: 0.25 },
+          },
+        }}
+      >
+        <Popover open content="content" title="title">
+          <span>show me your code</span>
+        </Popover>
+      </ConfigProvider>,
+    );
+
+    const popoverElement = container.querySelector<HTMLElement>('.ant-popover')!;
+    const popoverArrowElement = container.querySelector<HTMLElement>('.ant-popover-arrow')!;
+
+    expect(popoverElement).not.toHaveClass('custom-tooltip-root');
+    expect(popoverArrowElement).not.toHaveClass('custom-tooltip-arrow');
+    expect(popoverElement).not.toHaveStyle({ padding: '99px' });
+    expect(popoverArrowElement).not.toHaveStyle({ opacity: '0.25' });
+  });
+
   it('should warn when onOpenChange has more than one argument', () => {
     resetWarned();
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -21,7 +21,6 @@ import { cloneElement, isFragment } from '../_util/reactNode';
 import type { LiteralUnion } from '../_util/type';
 import { devUseWarning } from '../_util/warning';
 import ZIndexContext from '../_util/zindexContext';
-import type { ConfigComponentProps } from '../config-provider/context';
 import { useComponentConfig } from '../config-provider/context';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import TableMeasureRowContext from '../table/TableMeasureRowContext';
@@ -151,18 +150,6 @@ interface InternalTooltipProps extends TooltipProps {
   'data-popover-inject'?: boolean;
 }
 
-type TooltipContextConfig = Pick<
-  NonNullable<ConfigComponentProps['tooltip']>,
-  'className' | 'style' | 'classNames' | 'styles' | 'arrow' | 'trigger'
->;
-
-const getTooltipContextConfig = (
-  injectFromPopover: boolean,
-  config: TooltipContextConfig,
-): Partial<TooltipContextConfig> => {
-  return injectFromPopover ? {} : config;
-};
-
 const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
@@ -203,17 +190,9 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
   const [, token] = useToken();
   const injectFromPopover = !!props['data-popover-inject'];
 
-  const {
-    getPopupContainer: getContextPopupContainer,
-    getPrefixCls,
-    direction,
-    className: tooltipContextClassName,
-    style: tooltipContextStyle,
-    classNames: tooltipContextClassNames,
-    styles: tooltipContextStyles,
-    arrow: tooltipContextArrow,
-    trigger: tooltipContextTrigger,
-  } = useComponentConfig('tooltip');
+  const tooltipConfig = useComponentConfig('tooltip');
+
+  const { getPopupContainer: getContextPopupContainer, getPrefixCls, direction } = tooltipConfig;
 
   const {
     className: contextClassName,
@@ -222,14 +201,7 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
     styles: contextStyles,
     arrow: contextArrow,
     trigger: contextTrigger,
-  } = getTooltipContextConfig(injectFromPopover, {
-    className: tooltipContextClassName,
-    style: tooltipContextStyle,
-    classNames: tooltipContextClassNames,
-    styles: tooltipContextStyles,
-    arrow: tooltipContextArrow,
-    trigger: tooltipContextTrigger,
-  });
+  }: Partial<typeof tooltipConfig> = injectFromPopover ? {} : tooltipConfig;
 
   const mergedArrow = useMergedArrow(tooltipArrow, contextArrow);
   const mergedShowArrow = mergedArrow.show;

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -21,6 +21,7 @@ import { cloneElement, isFragment } from '../_util/reactNode';
 import type { LiteralUnion } from '../_util/type';
 import { devUseWarning } from '../_util/warning';
 import ZIndexContext from '../_util/zindexContext';
+import type { ConfigComponentProps } from '../config-provider/context';
 import { useComponentConfig } from '../config-provider/context';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import TableMeasureRowContext from '../table/TableMeasureRowContext';
@@ -150,6 +151,18 @@ interface InternalTooltipProps extends TooltipProps {
   'data-popover-inject'?: boolean;
 }
 
+type TooltipContextConfig = Pick<
+  NonNullable<ConfigComponentProps['tooltip']>,
+  'className' | 'style' | 'classNames' | 'styles' | 'arrow' | 'trigger'
+>;
+
+const getTooltipContextConfig = (
+  injectFromPopover: boolean,
+  config: TooltipContextConfig,
+): Partial<TooltipContextConfig> => {
+  return injectFromPopover ? {} : config;
+};
+
 const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
@@ -188,18 +201,35 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
   } = props;
 
   const [, token] = useToken();
+  const injectFromPopover = !!props['data-popover-inject'];
 
   const {
     getPopupContainer: getContextPopupContainer,
     getPrefixCls,
     direction,
+    className: tooltipContextClassName,
+    style: tooltipContextStyle,
+    classNames: tooltipContextClassNames,
+    styles: tooltipContextStyles,
+    arrow: tooltipContextArrow,
+    trigger: tooltipContextTrigger,
+  } = useComponentConfig('tooltip');
+
+  const {
     className: contextClassName,
     style: contextStyle,
     classNames: contextClassNames,
     styles: contextStyles,
     arrow: contextArrow,
     trigger: contextTrigger,
-  } = useComponentConfig('tooltip');
+  } = getTooltipContextConfig(injectFromPopover, {
+    className: tooltipContextClassName,
+    style: tooltipContextStyle,
+    classNames: tooltipContextClassNames,
+    styles: tooltipContextStyles,
+    arrow: tooltipContextArrow,
+    trigger: tooltipContextTrigger,
+  });
 
   const mergedArrow = useMergedArrow(tooltipArrow, contextArrow);
   const mergedShowArrow = mergedArrow.show;
@@ -300,8 +330,6 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
   const prefixCls = getPrefixCls('tooltip', customizePrefixCls);
 
   const rootPrefixCls = getPrefixCls();
-
-  const injectFromPopover = props['data-popover-inject'];
 
   let tempOpen = open;
   // Hide tooltip when there is no title or in table measure row


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #57716

### 💡 需求背景和解决方案

在 `ConfigProvider` 中配置 `tooltip` 的 `classNames`、`styles` 等语义化项时，这些配置会通过内部共用 `Tooltip` 的路径一并作用到 `Popover`、`Popconfirm`，例如箭头被改成与 Tooltip 一致的颜色，而用户期望仅 `ConfigProvider` 的 `popover` / `popconfirm` 能影响对应组件。

本次在 `components/tooltip/index.tsx` 中，当存在 `data-popover-inject`（由 Popover 注入）时，通过 `getTooltipContextConfig` 跳过对 `useComponentConfig('tooltip')` 返回的语义化 `className`、`style`、`classNames`、`styles`、`arrow`、`trigger` 的合并，避免全局 Tooltip 主题污染 Popover 链路。并在 `Popconfirm`、`Popover` 单测中增加回归用例。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 English | 🐞 Fix Popover and Popconfirm incorrectly inheriting ConfigProvider `tooltip` semantic `classNames` and `styles`. |
| 🇨🇳 中文 | 🐞 修复 Popover、Popconfirm 错误继承 ConfigProvider `tooltip` 语义化 `classNames` 与 `styles` 的问题。 |
