### PR TITLE
fix: stabilize image snapshot tests

### DIFF
--- a/.jest.image.js
+++ b/.jest.image.js
@@ -17,5 +17,5 @@ module.exports = {
     },
   },
   preset: 'jest-puppeteer',
-  testTimeout: 20000,
+  testTimeout: 60000,
 };

--- a/.jest.js
+++ b/.jest.js
@@ -9,6 +9,7 @@ const compileModules = [
   '@rc-component',
   // jsdom 27+ pulls ESM dependencies that need transform
   'parse5',
+  'entities',
   '@exodus',
   'jsdom',
   '@csstools',


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [x] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- Ref #57604

### 💡 需求背景和解决方案

PR #57604 的 visual-diff snapshot CI 在 image tests 启动阶段失败。失败原因是 `jsdom` 依赖链中的 `entities` 包暴露 ESM 入口，而 Jest 默认忽略 `node_modules` 转译，导致 `entities/dist/decode.js` 无法解析。

当前 Jest 配置已经对白名单中的 `jsdom`、`parse5` 等依赖执行预处理。本次将 `entities` 加入同一组转译白名单，让 image test 可以正常解析 `jsdom -> parse5 -> entities` 的依赖链。

在修复依赖解析后，CI 继续暴露出 modal image snapshot 在高负载 runner 上偶发超过 20s 的问题。本次同时将 image snapshot 专用 Jest timeout 从 20s 调整为 60s，避免单个较慢截图触发后续 hook 连锁失败。该 timeout 仅作用于 `.jest.image.js`。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | -        |
| 🇨🇳 中文 | -        |