### PR TITLE
fix: use ant.design URLs for component LLMs links

### DIFF
--- a/.dumi/theme/builtins/ComponentMeta/index.tsx
+++ b/.dumi/theme/builtins/ComponentMeta/index.tsx
@@ -137,7 +137,7 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
       return [
         `https://github.com/${repo}/blob/master/components/${kebabComponent}`,
         `components/${kebabComponent}`,
-        `/components/${kebabComponent}${isZhCN ? '-cn' : ''}.md`,
+        `https://ant.design/components/${kebabComponent}${isZhCN ? '-cn' : ''}.md`,
       ];
     }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🐞 Bug fix

### 🔗 Related Issues

close https://github.com/ant-design/ant-design/issues/57255

### 💡 Background and Solution

 `LLMs.md` 的使用者基本都可以正常访问`ant.design`，无法访问海外站点的用户，大多也不会实际点击这个入口

### 📝 Change Log



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       use ant.design URLs for component LLMs links    |
| 🇨🇳 Chinese |      使用 ant.design 的 URL 作为组件 LLM 的链接     |
