### PR TITLE
fix(Tooltip): exclude ConfigProvider tooltip config from Popover and Popconfirm

### DIFF
--- a/components/popconfirm/__tests__/index.test.tsx
+++ b/components/popconfirm/__tests__/index.test.tsx
@@ -435,4 +435,29 @@ describe('Popconfirm', () => {
 
     errorSpy.mockRestore();
   });
+
+  // Test `styles` (useMergeSemantic path) and `className` (direct injection path)
+  // to cover both ConfigProvider tooltip injection mechanisms
+  it('ConfigProvider tooltip config should not leak into Popconfirm', () => {
+    const { container } = render(
+      <ConfigProvider
+        tooltip={{
+          className: 'custom-tooltip-root',
+          styles: {
+            arrow: { background: 'red' },
+          },
+        }}
+      >
+        <Popconfirm title="Are you sure?" open>
+          <span>Delete</span>
+        </Popconfirm>
+      </ConfigProvider>,
+    );
+
+    const popconfirm = container.querySelector('.ant-popover');
+    expect(popconfirm).not.toHaveClass('custom-tooltip-root');
+
+    const arrow = container.querySelector('.ant-popover-arrow');
+    expect(arrow).not.toHaveStyle({ background: 'red' });
+  });
 });

--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -219,4 +219,29 @@ describe('Popover', () => {
 
     errorSpy.mockRestore();
   });
+
+  // Test `styles` (useMergeSemantic path) and `className` (direct injection path)
+  // to cover both ConfigProvider tooltip injection mechanisms
+  it('ConfigProvider tooltip config should not leak into Popover', () => {
+    const { container } = render(
+      <ConfigProvider
+        tooltip={{
+          className: 'custom-tooltip-root',
+          styles: {
+            arrow: { background: 'red' },
+          },
+        }}
+      >
+        <Popover content="hello" open>
+          <span>Show</span>
+        </Popover>
+      </ConfigProvider>,
+    );
+
+    const popover = container.querySelector('.ant-popover');
+    expect(popover).not.toHaveClass('custom-tooltip-root');
+
+    const arrow = container.querySelector('.ant-popover-arrow');
+    expect(arrow).not.toHaveStyle({ background: 'red' });
+  });
 });

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -633,4 +633,29 @@ describe('Tooltip', () => {
       });
     });
   });
+
+  // Test `styles` (useMergeSemantic path) and `className` (direct injection path)
+  // to cover both ConfigProvider tooltip injection mechanisms
+  it('ConfigProvider tooltip config should apply to Tooltip', () => {
+    const { container } = render(
+      <ConfigProvider
+        tooltip={{
+          className: 'custom-tooltip-root',
+          styles: {
+            arrow: { background: 'red' },
+          },
+        }}
+      >
+        <Tooltip title="hello" open>
+          <span>Hover me</span>
+        </Tooltip>
+      </ConfigProvider>,
+    );
+
+    const tooltip = container.querySelector('.ant-tooltip');
+    expect(tooltip).toHaveClass('custom-tooltip-root');
+
+    const arrow = container.querySelector('.ant-tooltip-arrow');
+    expect(arrow).toHaveStyle({ background: 'red' });
+  });
 });

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -189,17 +189,25 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
 
   const [, token] = useToken();
 
+  const injectFromPopover = props['data-popover-inject'];
+
   const {
     getPopupContainer: getContextPopupContainer,
     getPrefixCls,
     direction,
+    ...semanticConfig
+  } = useComponentConfig('tooltip');
+
+  // When injected from Popover/Popconfirm, skip tooltip-specific semantic config
+  // to prevent ConfigProvider tooltip config from leaking into those components
+  const {
     className: contextClassName,
     style: contextStyle,
     classNames: contextClassNames,
     styles: contextStyles,
     arrow: contextArrow,
     trigger: contextTrigger,
-  } = useComponentConfig('tooltip');
+  }: Partial<typeof semanticConfig> = injectFromPopover ? {} : semanticConfig;
 
   const mergedArrow = useMergedArrow(tooltipArrow, contextArrow);
   const mergedShowArrow = mergedArrow.show;
@@ -300,8 +308,6 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
   const prefixCls = getPrefixCls('tooltip', customizePrefixCls);
 
   const rootPrefixCls = getPrefixCls();
-
-  const injectFromPopover = props['data-popover-inject'];
 
   let tempOpen = open;
   // Hide tooltip when there is no title or in table measure row


### PR DESCRIPTION
Prevent the `tooltip` configuration of the global `ConfigProvider` from leaking into the internal `Tooltip` components of `Popover` and `Popconfirm` to ensure properly isolated behavior.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close #57716

### 💡 Background and Solution

When setting semantic config (`className`, `style`, `classNames`, `styles`, `arrow`, `trigger`) on `ConfigProvider`'s `tooltip` prop, the config unexpectedly leaks into `Popover` and `Popconfirm`, because they internally render through `<Tooltip data-popover-inject>` and Tooltip reads `useComponentConfig('tooltip')` unconditionally.

The fix skips tooltip semantic config when `data-popover-inject` is true, keeping only shared config (`getPrefixCls`, `direction`, `getPopupContainer`). `Popover` and `Popconfirm` already read their own config via `useComponentConfig('popover')` / `useComponentConfig('popconfirm')`.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Tooltip `ConfigProvider` semantic config (`className`, `styles`, etc.) leaking into Popover and Popconfirm. |
| 🇨🇳 Chinese | 🐞 修复 Tooltip 的 `ConfigProvider` 语义化配置（`className`、`styles` 等）泄漏到 Popover 和 Popconfirm 的问题。 |