### PR TITLE
fix(Card): avoid rendering empty body when content is absent

### DIFF
--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -187,10 +187,12 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
     props.onTabChange?.(key);
   };
 
-  const isContainGrid = React.useMemo<boolean>(() => {
-    const childNodes: React.ReactNode[] = toArray(children);
-    return childNodes.some((child) => React.isValidElement(child) && child.type === CardGrid);
-  }, [children]);
+  const childNodes = React.useMemo<React.ReactNode[]>(() => toArray(children), [children]);
+
+  const isContainGrid = React.useMemo<boolean>(
+    () => childNodes.some((child) => React.isValidElement(child) && child.type === CardGrid),
+    [childNodes],
+  );
 
   const prefixCls = getPrefixCls('card', customizePrefixCls);
   const [hashId, cssVarCls] = useStyle(prefixCls);
@@ -258,11 +260,12 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
     ...bodyStyle,
     ...mergedStyles.body,
   };
-  const body = (
-    <div className={bodyClasses} style={mergedBodyStyle}>
-      {loading ? loadingBlock : children}
-    </div>
-  );
+  const body =
+    loading || childNodes.length ? (
+      <div className={bodyClasses} style={mergedBodyStyle}>
+        {loading ? loadingBlock : children}
+      </div>
+    ) : null;
 
   const actionClasses = clsx(`${prefixCls}-actions`, mergedClassNames.actions);
   const actionDom = actions?.length ? (

--- a/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1074,6 +1074,46 @@ exports[`renders components/card/demo/meta.tsx extend context correctly 1`] = `
 
 exports[`renders components/card/demo/meta.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/card/demo/no-body-debug.tsx extend context correctly 1`] = `
+<div
+  class="ant-card ant-card-bordered css-var-test-id"
+  style="width: 300px;"
+>
+  <div
+    class="ant-card-cover"
+  >
+    <img
+      alt="example"
+      src="https://api.dicebear.com/7.x/miniavs/svg?seed=8"
+    />
+  </div>
+  <ul
+    class="ant-card-actions"
+  >
+    <li
+      style="width: 50%;"
+    >
+      <span>
+        <span>
+          setting
+        </span>
+      </span>
+    </li>
+    <li
+      style="width: 50%;"
+    >
+      <span>
+        <span>
+          edit
+        </span>
+      </span>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`renders components/card/demo/no-body-debug.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/card/demo/simple.tsx extend context correctly 1`] = `
 <div
   class="ant-card ant-card-bordered css-var-test-id"

--- a/components/card/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.ts.snap
@@ -1033,6 +1033,44 @@ exports[`renders components/card/demo/meta.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/card/demo/no-body-debug.tsx correctly 1`] = `
+<div
+  class="ant-card ant-card-bordered css-var-test-id"
+  style="width:300px"
+>
+  <div
+    class="ant-card-cover"
+  >
+    <img
+      alt="example"
+      src="https://api.dicebear.com/7.x/miniavs/svg?seed=8"
+    />
+  </div>
+  <ul
+    class="ant-card-actions"
+  >
+    <li
+      style="width:50%"
+    >
+      <span>
+        <span>
+          setting
+        </span>
+      </span>
+    </li>
+    <li
+      style="width:50%"
+    >
+      <span>
+        <span>
+          edit
+        </span>
+      </span>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`renders components/card/demo/simple.tsx correctly 1`] = `
 <div
   class="ant-card ant-card-bordered css-var-test-id"

--- a/components/card/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/card/__tests__/__snapshots__/index.test.tsx.snap
@@ -252,20 +252,13 @@ exports[`Card correct pass tabList props 1`] = `
       </div>
     </div>
   </div>
-  <div
-    class="ant-card-body"
-  />
 </div>
 `;
 
 exports[`Card rtl render component should be rendered correctly in RTL direction 1`] = `
 <div
   class="ant-card ant-card-bordered ant-card-rtl css-var-root"
->
-  <div
-    class="ant-card-body"
-  />
-</div>
+/>
 `;
 
 exports[`Card should still have padding when card which set padding to 0 is loading 1`] = `

--- a/components/card/demo/no-body-debug.tsx
+++ b/components/card/demo/no-body-debug.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Card } from 'antd';
+
+const App: React.FC = () => (
+  <Card
+    style={{ width: 300 }}
+    cover={<img alt="example" src="https://api.dicebear.com/7.x/miniavs/svg?seed=8" />}
+    actions={[<span key="setting">setting</span>, <span key="edit">edit</span>]}
+  />
+);
+
+export default App;

--- a/components/card/index.en-US.md
+++ b/components/card/index.en-US.md
@@ -25,6 +25,7 @@ A card can be used to display content related to a single subject. The content c
 <code src="./demo/tabs.tsx">With tabs</code>
 <code src="./demo/meta.tsx">Support more content configuration</code>
 <code src="./demo/style-class.tsx" version="6.0.0">Custom semantic dom styling</code>
+<code src="./demo/no-body-debug.tsx" debug>Cover and actions without body</code>
 <code src="./demo/component-token.tsx" debug>Component Token</code>
 
 ## API

--- a/components/card/index.zh-CN.md
+++ b/components/card/index.zh-CN.md
@@ -26,6 +26,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*5WDvQp_H7LUAAA
 <code src="./demo/tabs.tsx">带页签的卡片</code>
 <code src="./demo/meta.tsx">支持更多内容配置</code>
 <code src="./demo/style-class.tsx" version="6.0.0">自定义语义结构的样式和类</code>
+<code src="./demo/no-body-debug.tsx" debug>封面和操作区不渲染 body</code>
 <code src="./demo/component-token.tsx" debug>组件 Token</code>
 
 ## API


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Card 在未传入内容时仍会渲染空的 `.ant-card-body`，会给 `cover + actions` 这类场景额外带来一层无意义的结构和 body padding。

这个改动让 Card 只在 `loading` 或存在实际 `children` 内容时渲染 body 区域，同时补充了 debug demo，并更新相关快照来覆盖无 body 内容时的结构表现。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Card rendering an empty body wrapper when no content is provided. |
| 🇨🇳 中文 | 🐞 修复 Card 在未传入内容时仍渲染空 body 容器的问题。 |
