### PR TITLE
fix(Typography): allow copyable button click when Link is disabled

### DIFF
--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -72,6 +72,13 @@ export const getLinkStyles: GenerateStyle<TypographyToken, CSSObject> = (token) 
 
         '&:active': {
           pointerEvents: 'none',
+
+          // Action buttons (copy, edit, expand) must remain interactive even when
+          // the disabled link is being clicked, otherwise their click events get
+          // swallowed by the parent's pointer-events: none during :active.
+          [`${componentCls}-actions`]: {
+            pointerEvents: 'auto',
+          },
         },
       },
     },


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

fix #54265

### 💡 Background and Solution

`<Typography.Link disabled copyable>` swallows the copy button's click event because the disabled link's `:active` state sets `pointer-events: none` on itself, which prevents descendant interactive elements (the `ant-typography-actions` operations span and its child copy / edit buttons) from receiving `mouseup` while the user is pressing them. The same `disabled + copyable` combination works on `Typography.Text` and `Typography.Title` because those components do not apply the `:active { pointer-events: none }` rule (only `Link` has it via `getLinkStyles`).

The existing `pointer-events: none` rule is intentional: it prevents a disabled link from navigating when activated. Removing it entirely would re-introduce navigation on disabled links. Instead, this PR keeps the link itself non-interactive during `:active` but re-enables `pointer-events` on the descendant `ant-typography-actions` wrapper so the copy / edit / expand buttons remain clickable.

### 📝 Changelog

| Language    | Changelog |
| ----------- | --------- |
| 🇺🇸 English | 🐞 Fix Typography.Link disabled state blocking the copyable / editable / expand action button click. |
| 🇨🇳 Chinese | 🐞 修复 Typography.Link 在 disabled 状态下点击 copyable / editable / 展开操作按钮无效的问题。 |

### ☑️ Self Check before Merge

- [x] Doc has been updated / no doc change needed
- [x] Changelog has been provided
- [x] Unit tests have been added / no unit test needed (CSS-only fix; jsdom does not compute `pointer-events`, same exception as #57622, #57636)
- [x] Demo has been added / no demo needed
