### PR TITLE
docs(Tree): clarify switcherIcon rotation in showLine mode

### DIFF
--- a/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -6371,6 +6371,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx extend context correctly
                 aria-label="down"
                 class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
+                style="transform: rotate(0deg); transition: transform 0.3s;"
               >
                 <svg
                   aria-hidden="true"
@@ -6422,6 +6423,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx extend context correctly
                 aria-label="down"
                 class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
+                style="transform: rotate(0deg); transition: transform 0.3s;"
               >
                 <svg
                   aria-hidden="true"
@@ -6584,6 +6586,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx extend context correctly
                 aria-label="down"
                 class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
+                style="transform: rotate(-90deg); transition: transform 0.3s;"
               >
                 <svg
                   aria-hidden="true"
@@ -6635,6 +6638,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx extend context correctly
                 aria-label="down"
                 class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
+                style="transform: rotate(-90deg); transition: transform 0.3s;"
               >
                 <svg
                   aria-hidden="true"

--- a/components/tree/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo.test.ts.snap
@@ -6249,6 +6249,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx correctly 1`] = `
                 aria-label="down"
                 class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
+                style="transform:rotate(0deg);transition:transform 0.3s"
               >
                 <svg
                   aria-hidden="true"
@@ -6300,6 +6301,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx correctly 1`] = `
                 aria-label="down"
                 class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
+                style="transform:rotate(0deg);transition:transform 0.3s"
               >
                 <svg
                   aria-hidden="true"
@@ -6462,6 +6464,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx correctly 1`] = `
                 aria-label="down"
                 class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
+                style="transform:rotate(-90deg);transition:transform 0.3s"
               >
                 <svg
                   aria-hidden="true"
@@ -6513,6 +6516,7 @@ exports[`renders components/tree/demo/switcher-icon.tsx correctly 1`] = `
                 aria-label="down"
                 class="anticon anticon-down ant-tree-switcher-line-icon"
                 role="img"
+                style="transform:rotate(-90deg);transition:transform 0.3s"
               >
                 <svg
                   aria-hidden="true"

--- a/components/tree/demo/switcher-icon.tsx
+++ b/components/tree/demo/switcher-icon.tsx
@@ -62,7 +62,11 @@ const App: React.FC = () => {
   return (
     <Tree
       showLine
-      switcherIcon={<DownOutlined />}
+      switcherIcon={({ expanded }) => (
+        <DownOutlined
+          style={{ transform: `rotate(${expanded ? 0 : -90}deg)`, transition: 'transform 0.3s' }}
+        />
+      )}
       defaultExpandedKeys={['0-0-0']}
       onSelect={onSelect}
       treeData={treeData}

--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -74,7 +74,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | showLine | Shows a connecting line | boolean \| {showLeafIcon: ReactNode \| ((props: AntTreeNodeProps) => ReactNode)} | false |  |
 | style | Style of Tree component | CSSProperties | - |  |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
-| switcherIcon | Customize expand/collapse icons for tree nodes (With default rotate angular style) | ReactNode \| ((props: AntTreeNodeProps) => ReactNode) | - | renderProps: 4.20.0 |
+| switcherIcon | Customize expand/collapse icons for tree nodes (Will not rotate automatically in `showLine` mode) | ReactNode \| ((props: AntTreeNodeProps) => ReactNode) | - | renderProps: 4.20.0 |
 | switcherLoadingIcon | Customize loading icons for tree nodes | ReactNode | - | 5.20.0 |
 | titleRender | Customize tree node title render | (nodeData) => ReactNode | - | 4.5.0 |
 | treeData | The treeNodes data Array, if set it then you need not to construct children TreeNode. (key should be unique across the whole array) | array&lt;{ key, title, children, \[disabled, selectable] }> | - |  |

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -73,7 +73,7 @@ demo:
 | showIcon | 控制是否展示 `icon` 节点，没有默认样式 | boolean | false |  |
 | showLine | 是否展示连接线 | boolean \| { showLeafIcon: ReactNode \| ((props: AntTreeNodeProps) => ReactNode) } | false |  |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | |
-| switcherIcon | 自定义树节点的展开/折叠图标（带有默认 rotate 角度样式） | ReactNode \| ((props: AntTreeNodeProps) => ReactNode) | - | renderProps: 4.20.0 |
+| switcherIcon | 自定义树节点的展开/折叠图标（`showLine` 下不会自动 rotate） | ReactNode \| ((props: AntTreeNodeProps) => ReactNode) | - | renderProps: 4.20.0 |
 | switcherLoadingIcon | 自定义树节点的加载图标 | ReactNode | - | 5.20.0 |
 | titleRender | 自定义渲染节点 | (nodeData) => ReactNode | - | 4.5.0 |
 | treeData | treeNodes 数据，如果设置则不需要手动构造 TreeNode 节点（key 在整个树范围内唯一） | array&lt;{key, title, children, \[disabled, selectable]}> | - |  |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #57761

### 💡 需求背景和解决方案

Tree 的 `switcherIcon` demo 在 `showLine` 场景下使用自定义图标时不会自动 rotate。

本次将 demo 改为使用 render props，根据 `expanded` 状态设置图标旋转样式，并同步更新 API 文档，说明 `showLine` 下不会自动 rotate。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A      |
| 🇨🇳 中文 | N/A      |
