### PR TITLE
fix(ConfigProvider): make css var prefix follow prefixCls

### DIFF
--- a/components/config-provider/__tests__/theme.test.tsx
+++ b/components/config-provider/__tests__/theme.test.tsx
@@ -249,6 +249,9 @@ describe('ConfigProvider.Theme', () => {
     it('prefix follow prefixCls by default', () => {
       const { container } = render(
         <>
+          <ConfigProvider prefixCls="ak">
+            <Button className="button-ak">Button</Button>
+          </ConfigProvider>
           <ConfigProvider prefixCls="foo" theme={{ cssVar: { key: 'foo' }, hashed: true }}>
             <Button className="button-foo">Button</Button>
           </ConfigProvider>
@@ -270,6 +273,18 @@ describe('ConfigProvider.Theme', () => {
           </ConfigProvider>
         </>,
       );
+
+      const akBtn = container.querySelector('.button-ak')!;
+      expect(akBtn).toHaveClass('css-var-root');
+      expect(akBtn).toHaveStyle({
+        '--ak-btn-shadow': 'var(--ak-button-default-shadow)',
+        'border-radius': 'var(--ak-border-radius)',
+      });
+      expect(
+        Array.from(document.querySelectorAll('style[data-css-hash]')).some(({ innerHTML }) =>
+          innerHTML.includes('--ak-color-text'),
+        ),
+      ).toBeTruthy();
 
       const fooBtn = container.querySelector('.button-foo')!;
       expect(fooBtn).toHaveClass('foo');

--- a/components/theme/useToken.ts
+++ b/components/theme/useToken.ts
@@ -121,10 +121,10 @@ export default function useToken(): [
     zeroRuntime,
   } = React.useContext(DesignTokenContext);
 
-  const { csp } = React.useContext(ConfigContext);
+  const { csp, getPrefixCls } = React.useContext(ConfigContext);
 
   const cssVar = {
-    prefix: ctxCssVar?.prefix ?? 'ant',
+    prefix: ctxCssVar?.prefix ?? getPrefixCls(),
     key: ctxCssVar?.key ?? 'css-var-root',
   };
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #57801

### 💡 需求背景和解决方案

当 ConfigProvider 只配置 `prefixCls`，但没有显式配置 `theme.cssVar.prefix` 时，CSS 变量前缀仍回退为 `ant`，与文档中默认跟随 `prefixCls` 的描述不一致。

本次改动让 `useToken` 在没有显式 `theme.cssVar.prefix` 时，从当前 ConfigProvider 的根 `prefixCls` 读取默认 CSS 变量前缀，并补充了对应回归测试。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix ConfigProvider `prefixCls` not being used as the default CSS variable prefix. |
| 🇨🇳 中文 | 修复 ConfigProvider `prefixCls` 未作为默认 CSS 变量前缀的问题。 |