### PR TITLE
fix(Select): align error status colors with Input across outlined, fi…

### DIFF
--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -336,7 +336,7 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
         // Error
         {
           border: token.colorError,
-          borderHover: token.colorErrorHover,
+          borderHover: token.colorErrorBorderHover,
           borderActive: token.colorError,
           borderOutline: token.colorErrorOutline,
         },
@@ -366,6 +366,7 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
         },
         // Error
         {
+          color: token.colorErrorText,
           background: token.colorErrorBg,
           backgroundHover: token.colorErrorBgHover,
           borderActive: token.colorError,
@@ -401,7 +402,7 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
         // Error
         {
           border: token.colorError,
-          borderHover: token.colorErrorHover,
+          borderHover: token.colorErrorBorderHover,
           borderActive: token.colorError,
         },
         // Warning


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Fixes: https://github.com/ant-design/ant-design/issues/57605

### 💡 Background and Solution

`Select`, `AutoComplete`, and `Cascader` share the Select style system (`select/style/select-input.ts`), while `Input` and `DatePicker` share the Input style system (`input/style/variants.ts`). These two style systems used different design tokens for error status, causing visible color inconsistencies when the same `status="error"` prop was applied across components side by side.

Two mismatches were fixed:

1. **Outlined & Underlined — hover border color**: Select/AutoComplete/Cascader used `colorErrorHover` (palette index 5), while Input/DatePicker used `colorErrorBorderHover` (palette index 4). Fixed by switching to `colorErrorBorderHover`.

2. **Filled — text color**: Select/AutoComplete/Cascader fell back to `colorError` (palette index 6) for input text, while Input/DatePicker explicitly used `colorErrorText` (palette index 9) for better readability on a colored background. Fixed by adding `color: token.colorErrorText` to the filled error override.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 💄 Fix Select, AutoComplete, and Cascader `status="error"` color inconsistency with Input and DatePicker in outlined, filled, and underlined variants |
| 🇨🇳 Chinese | 💄 修复 Select、AutoComplete、Cascader 在 `status="error"` 时与 Input、DatePicker 的边框悬浮色和填充文字色不一致的问题 |