### PR TITLE
docs: fix TimePicker Chinese demo title

### DIFF
--- a/components/time-picker/index.zh-CN.md
+++ b/components/time-picker/index.zh-CN.md
@@ -27,7 +27,7 @@ demo:
 <code src="./demo/addon.tsx">附加内容</code>
 <code src="./demo/12hours.tsx">12 小时制</code>
 <code src="./demo/change-on-scroll.tsx" version="5.14.0">滚动即改变</code>
-<code src="./demo/colored-popup.tsx" debug>色付きポップアップ</code>
+<code src="./demo/colored-popup.tsx" debug>彩色弹出层</code>
 <code src="./demo/range-picker.tsx">范围选择器</code>
 <code src="./demo/variant.tsx" version="5.13.0">形态变体</code>
 <code src="./demo/status.tsx">自定义状态</code>


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

TimePicker 中文文档中 `colored-popup` demo 的标题误用了日文文案。

本次将其修正为中文标题「彩色弹出层」。该改动仅影响文档展示，不涉及 API、组件逻辑或交互变化。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A      |
| 🇨🇳 中文 | 无需更新日志 |
