### PR TITLE
fix: ensure Watermark covers Table fixed columns by default

### DIFF
--- a/components/watermark/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/watermark/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -9,7 +9,7 @@ exports[`renders components/watermark/demo/basic.tsx extend context correctly 1`
     style="height: 500px;"
   />
   <div
-    style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 218px; visibility: visible !important;"
+    style="z-index: 999; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 218px; visibility: visible !important;"
   />
 </div>
 `;
@@ -1172,6 +1172,399 @@ exports[`renders components/watermark/demo/custom.tsx extend context correctly 1
 
 exports[`renders components/watermark/demo/custom.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/watermark/demo/debug.tsx extend context correctly 1`] = `
+<div
+  class=""
+  style="position: relative; overflow: hidden;"
+>
+  <div
+    class="css-var-test-id ant-table-css-var ant-table-wrapper"
+  >
+    <div
+      aria-busy="false"
+      aria-live="polite"
+      class="ant-spin css-var-test-id"
+    >
+      <div
+        class="ant-spin-container"
+      >
+        <div
+          class="ant-table css-var-test-id ant-table-css-var ant-table-fix-start-shadow ant-table-fix-end-shadow ant-table-fixed-column ant-table-scroll-horizontal ant-table-has-fix-start ant-table-has-fix-end"
+        >
+          <div
+            class="ant-table-container"
+          >
+            <div
+              class="ant-table-content"
+              style="overflow-x: auto; overflow-y: hidden;"
+            >
+              <table
+                style="width: max-content; min-width: 100%; table-layout: auto;"
+              >
+                <colgroup>
+                  <col
+                    style="width: 120px;"
+                  />
+                  <col
+                    style="width: 100px;"
+                  />
+                  <col
+                    style="width: 120px;"
+                  />
+                  <col
+                    style="width: 120px;"
+                  />
+                  <col
+                    style="width: 120px;"
+                  />
+                  <col
+                    style="width: 120px;"
+                  />
+                  <col
+                    style="width: 120px;"
+                  />
+                  <col
+                    style="width: 120px;"
+                  />
+                  <col
+                    style="width: 120px;"
+                  />
+                  <col
+                    style="width: 120px;"
+                  />
+                  <col
+                    style="width: 100px;"
+                  />
+                </colgroup>
+                <thead
+                  class="ant-table-thead"
+                >
+                  <tr>
+                    <th
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-start"
+                      scope="col"
+                      style="inset-inline-start: 0; --z-offset: 22; --z-offset-reverse: 11;"
+                    >
+                      Full Name
+                    </th>
+                    <th
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-start ant-table-cell-fix-start-shadow"
+                      scope="col"
+                      style="inset-inline-start: 0; --z-offset: 21; --z-offset-reverse: 12;"
+                    >
+                      Age
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 1
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 2
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 3
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 4
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 5
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 6
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 7
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 8
+                    </th>
+                    <th
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-end ant-table-cell-fix-end-shadow"
+                      scope="col"
+                      style="inset-inline-end: 0; --z-offset: 10; --z-offset-reverse: 1;"
+                    >
+                      Action
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  class="ant-table-tbody"
+                >
+                  <tr
+                    aria-hidden="true"
+                    class="ant-table-measure-row"
+                    style="height: 0px;"
+                  >
+                    <td
+                      style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden; font-weight: bold;"
+                      >
+                        Full Name
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden; font-weight: bold;"
+                      >
+                        Age
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden; font-weight: bold;"
+                      >
+                        Column 1
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden; font-weight: bold;"
+                      >
+                        Column 2
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden; font-weight: bold;"
+                      >
+                        Column 3
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden; font-weight: bold;"
+                      >
+                        Column 4
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden; font-weight: bold;"
+                      >
+                        Column 5
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden; font-weight: bold;"
+                      >
+                        Column 6
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden; font-weight: bold;"
+                      >
+                        Column 7
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden; font-weight: bold;"
+                      >
+                        Column 8
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
+                    >
+                      <div
+                        style="height: 0px; overflow: hidden; font-weight: bold;"
+                      >
+                        Action
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="ant-table-row ant-table-row-level-0"
+                    data-row-key="1"
+                  >
+                    <td
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-start"
+                      style="inset-inline-start: 0; --z-offset: 22; --z-offset-reverse: 11;"
+                    >
+                      Olivia
+                    </td>
+                    <td
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-start ant-table-cell-fix-start-shadow"
+                      style="inset-inline-start: 0; --z-offset: 21; --z-offset-reverse: 12;"
+                    >
+                      32
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-end ant-table-cell-fix-end-shadow"
+                      style="inset-inline-end: 0; --z-offset: 10; --z-offset-reverse: 1;"
+                    >
+                      <a>
+                        action
+                      </a>
+                    </td>
+                  </tr>
+                  <tr
+                    class="ant-table-row ant-table-row-level-0"
+                    data-row-key="2"
+                  >
+                    <td
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-start"
+                      style="inset-inline-start: 0; --z-offset: 22; --z-offset-reverse: 11;"
+                    >
+                      Ethan
+                    </td>
+                    <td
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-start ant-table-cell-fix-start-shadow"
+                      style="inset-inline-start: 0; --z-offset: 21; --z-offset-reverse: 12;"
+                    >
+                      40
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-end ant-table-cell-fix-end-shadow"
+                      style="inset-inline-end: 0; --z-offset: 10; --z-offset-reverse: 1;"
+                    >
+                      <a>
+                        action
+                      </a>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    style="z-index: 999; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 218px; visibility: visible !important;"
+  />
+</div>
+`;
+
+exports[`renders components/watermark/demo/debug.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/watermark/demo/image.tsx extend context correctly 1`] = `
 <div
   class=""
@@ -1194,7 +1587,7 @@ exports[`renders components/watermark/demo/multi-line.tsx extend context correct
     style="height: 500px;"
   />
   <div
-    style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 226px; visibility: visible !important;"
+    style="z-index: 999; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 226px; visibility: visible !important;"
   />
 </div>
 `;
@@ -1236,7 +1629,7 @@ Array [
     style="position: relative; overflow: hidden;"
   >
     <div
-      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 218px; visibility: visible !important;"
+      style="z-index: 999; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 218px; visibility: visible !important;"
     />
   </div>,
   <div
@@ -1244,7 +1637,7 @@ Array [
     style="position: relative; overflow: hidden;"
   >
     <div
-      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 218px; visibility: visible !important;"
+      style="z-index: 999; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 218px; visibility: visible !important;"
     />
   </div>,
 ]

--- a/components/watermark/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/watermark/__tests__/__snapshots__/demo.test.ts.snap
@@ -746,6 +746,394 @@ exports[`renders components/watermark/demo/custom.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/watermark/demo/debug.tsx correctly 1`] = `
+<div
+  class=""
+  style="position:relative;overflow:hidden"
+>
+  <div
+    class="css-var-test-id ant-table-css-var ant-table-wrapper"
+  >
+    <div
+      aria-busy="false"
+      aria-live="polite"
+      class="ant-spin css-var-test-id"
+    >
+      <div
+        class="ant-spin-container"
+      >
+        <div
+          class="ant-table css-var-test-id ant-table-css-var ant-table-fix-start-shadow ant-table-fix-end-shadow ant-table-fixed-column ant-table-scroll-horizontal ant-table-has-fix-start ant-table-has-fix-end"
+        >
+          <div
+            class="ant-table-container"
+          >
+            <div
+              class="ant-table-content"
+              style="overflow-x:auto;overflow-y:hidden"
+            >
+              <table
+                style="width:max-content;min-width:100%;table-layout:auto"
+              >
+                <colgroup>
+                  <col
+                    style="width:120px"
+                  />
+                  <col
+                    style="width:100px"
+                  />
+                  <col
+                    style="width:120px"
+                  />
+                  <col
+                    style="width:120px"
+                  />
+                  <col
+                    style="width:120px"
+                  />
+                  <col
+                    style="width:120px"
+                  />
+                  <col
+                    style="width:120px"
+                  />
+                  <col
+                    style="width:120px"
+                  />
+                  <col
+                    style="width:120px"
+                  />
+                  <col
+                    style="width:120px"
+                  />
+                  <col
+                    style="width:100px"
+                  />
+                </colgroup>
+                <thead
+                  class="ant-table-thead"
+                >
+                  <tr>
+                    <th
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-start"
+                      scope="col"
+                      style="inset-inline-start:0;--z-offset:22;--z-offset-reverse:11"
+                    >
+                      Full Name
+                    </th>
+                    <th
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-start ant-table-cell-fix-start-shadow"
+                      scope="col"
+                      style="inset-inline-start:0;--z-offset:21;--z-offset-reverse:12"
+                    >
+                      Age
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 1
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 2
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 3
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 4
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 5
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 6
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 7
+                    </th>
+                    <th
+                      class="ant-table-cell"
+                      scope="col"
+                    >
+                      Column 8
+                    </th>
+                    <th
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-end ant-table-cell-fix-end-shadow"
+                      scope="col"
+                      style="inset-inline-end:0;--z-offset:10;--z-offset-reverse:1"
+                    >
+                      Action
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  class="ant-table-tbody"
+                >
+                  <tr
+                    aria-hidden="true"
+                    class="ant-table-measure-row"
+                    style="height:0"
+                  >
+                    <td
+                      style="padding-top:0;padding-bottom:0;border-top:0;border-bottom:0;height:0"
+                    >
+                      <div
+                        style="height:0;overflow:hidden;font-weight:bold"
+                      >
+                        Full Name
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top:0;padding-bottom:0;border-top:0;border-bottom:0;height:0"
+                    >
+                      <div
+                        style="height:0;overflow:hidden;font-weight:bold"
+                      >
+                        Age
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top:0;padding-bottom:0;border-top:0;border-bottom:0;height:0"
+                    >
+                      <div
+                        style="height:0;overflow:hidden;font-weight:bold"
+                      >
+                        Column 1
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top:0;padding-bottom:0;border-top:0;border-bottom:0;height:0"
+                    >
+                      <div
+                        style="height:0;overflow:hidden;font-weight:bold"
+                      >
+                        Column 2
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top:0;padding-bottom:0;border-top:0;border-bottom:0;height:0"
+                    >
+                      <div
+                        style="height:0;overflow:hidden;font-weight:bold"
+                      >
+                        Column 3
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top:0;padding-bottom:0;border-top:0;border-bottom:0;height:0"
+                    >
+                      <div
+                        style="height:0;overflow:hidden;font-weight:bold"
+                      >
+                        Column 4
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top:0;padding-bottom:0;border-top:0;border-bottom:0;height:0"
+                    >
+                      <div
+                        style="height:0;overflow:hidden;font-weight:bold"
+                      >
+                        Column 5
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top:0;padding-bottom:0;border-top:0;border-bottom:0;height:0"
+                    >
+                      <div
+                        style="height:0;overflow:hidden;font-weight:bold"
+                      >
+                        Column 6
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top:0;padding-bottom:0;border-top:0;border-bottom:0;height:0"
+                    >
+                      <div
+                        style="height:0;overflow:hidden;font-weight:bold"
+                      >
+                        Column 7
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top:0;padding-bottom:0;border-top:0;border-bottom:0;height:0"
+                    >
+                      <div
+                        style="height:0;overflow:hidden;font-weight:bold"
+                      >
+                        Column 8
+                      </div>
+                    </td>
+                    <td
+                      style="padding-top:0;padding-bottom:0;border-top:0;border-bottom:0;height:0"
+                    >
+                      <div
+                        style="height:0;overflow:hidden;font-weight:bold"
+                      >
+                        Action
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="ant-table-row ant-table-row-level-0"
+                    data-row-key="1"
+                  >
+                    <td
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-start"
+                      style="inset-inline-start:0;--z-offset:22;--z-offset-reverse:11"
+                    >
+                      Olivia
+                    </td>
+                    <td
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-start ant-table-cell-fix-start-shadow"
+                      style="inset-inline-start:0;--z-offset:21;--z-offset-reverse:12"
+                    >
+                      32
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      New York Park
+                    </td>
+                    <td
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-end ant-table-cell-fix-end-shadow"
+                      style="inset-inline-end:0;--z-offset:10;--z-offset-reverse:1"
+                    >
+                      <a>
+                        action
+                      </a>
+                    </td>
+                  </tr>
+                  <tr
+                    class="ant-table-row ant-table-row-level-0"
+                    data-row-key="2"
+                  >
+                    <td
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-start"
+                      style="inset-inline-start:0;--z-offset:22;--z-offset-reverse:11"
+                    >
+                      Ethan
+                    </td>
+                    <td
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-start ant-table-cell-fix-start-shadow"
+                      style="inset-inline-start:0;--z-offset:21;--z-offset-reverse:12"
+                    >
+                      40
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell"
+                    >
+                      London Park
+                    </td>
+                    <td
+                      class="ant-table-cell ant-table-cell-fix ant-table-cell-fix-end ant-table-cell-fix-end-shadow"
+                      style="inset-inline-end:0;--z-offset:10;--z-offset-reverse:1"
+                    >
+                      <a>
+                        action
+                      </a>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/watermark/demo/image.tsx correctly 1`] = `
 <div
   class=""

--- a/components/watermark/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/watermark/__tests__/__snapshots__/index.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Watermark Image watermark snapshot 1`] = `
     style="position: relative; overflow: hidden;"
   >
     <div
-      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 470px; visibility: visible !important;"
+      style="z-index: 999; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 470px; visibility: visible !important;"
     />
   </div>
 </div>
@@ -20,7 +20,7 @@ exports[`Watermark Interleaved watermark backgroundSize is correct 1`] = `
     style="position: relative; overflow: hidden;"
   >
     <div
-      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 720px; visibility: visible !important;"
+      style="z-index: 999; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 720px; visibility: visible !important;"
     />
   </div>
 </div>
@@ -33,7 +33,7 @@ exports[`Watermark Invalid image watermark 1`] = `
     style="position: relative; overflow: hidden;"
   >
     <div
-      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 470px; visibility: visible !important;"
+      style="z-index: 999; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 470px; visibility: visible !important;"
     />
   </div>
 </div>
@@ -46,7 +46,7 @@ exports[`Watermark MutationObserver should work properly 1`] = `
     style="position: relative; overflow: hidden;"
   >
     <div
-      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 229px; visibility: visible !important;"
+      style="z-index: 999; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 229px; visibility: visible !important;"
     />
   </div>
 </div>
@@ -59,7 +59,7 @@ exports[`Watermark Observe the modification of style watermark 1`] = `
     style="position: relative; overflow: hidden;"
   >
     <div
-      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: -250px -250px; background-image: url('data:image/png;base64,00'); background-size: 229px; visibility: visible !important;"
+      style="z-index: 999; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: -250px -250px; background-image: url('data:image/png;base64,00'); background-size: 229px; visibility: visible !important;"
     />
   </div>
 </div>
@@ -72,7 +72,7 @@ exports[`Watermark The offset should be correct 1`] = `
     style="position: relative; overflow: hidden;"
   >
     <div
-      style="z-index: 9; position: absolute; left: 150px; top: 150px; width: calc(100% - 150px); height: calc(100% - 150px); pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 228px; visibility: visible !important;"
+      style="z-index: 999; position: absolute; left: 150px; top: 150px; width: calc(100% - 150px); height: calc(100% - 150px); pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 228px; visibility: visible !important;"
     />
   </div>
 </div>
@@ -85,7 +85,7 @@ exports[`Watermark The watermark should render successfully 1`] = `
     style="position: relative; overflow: hidden;"
   >
     <div
-      style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 218px; visibility: visible !important;"
+      style="z-index: 999; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 218px; visibility: visible !important;"
     />
   </div>
 </div>
@@ -97,7 +97,7 @@ exports[`Watermark rtl render component should be rendered correctly in RTL dire
   style="position: relative; overflow: hidden;"
 >
   <div
-    style="z-index: 9; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 200px; visibility: visible !important;"
+    style="z-index: 999; position: absolute; left: 0; top: 0; width: 100%; height: 100%; pointer-events: none; background-repeat: repeat; background-position: 0px 0px; background-image: url('data:image/png;base64,00'); background-size: 200px; visibility: visible !important;"
   />
 </div>
 `;

--- a/components/watermark/__tests__/index.test.tsx
+++ b/components/watermark/__tests__/index.test.tsx
@@ -149,7 +149,7 @@ describe('Watermark', () => {
 
         const watermark = getWatermarkElement();
 
-        expect(watermark).toHaveStyle({ zIndex: '9' });
+        expect(watermark).toHaveStyle({ zIndex: '999' });
 
         // Not crash when children removed
         rerender(<Watermark className="test" />);

--- a/components/watermark/demo/debug.tsx
+++ b/components/watermark/demo/debug.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Table, Watermark } from 'antd';
+import type { TableColumnsType } from 'antd';
+
+interface DataType {
+  key: React.Key;
+  name: string;
+  age: number;
+  address: string;
+}
+
+const columns: TableColumnsType<DataType> = [
+  {
+    title: 'Full Name',
+    width: 120,
+    dataIndex: 'name',
+    key: 'name',
+    fixed: 'start',
+  },
+  {
+    title: 'Age',
+    width: 100,
+    dataIndex: 'age',
+    key: 'age',
+    fixed: 'start',
+  },
+  ...Array.from({ length: 8 }, (_, index) => ({
+    title: `Column ${index + 1}`,
+    dataIndex: 'address',
+    key: `column-${index + 1}`,
+    width: 120,
+  })),
+  {
+    title: 'Action',
+    key: 'operation',
+    fixed: 'end',
+    width: 100,
+    render: () => <a>action</a>,
+  },
+];
+
+const dataSource: DataType[] = [
+  { key: '1', name: 'Olivia', age: 32, address: 'New York Park' },
+  { key: '2', name: 'Ethan', age: 40, address: 'London Park' },
+];
+
+const App: React.FC = () => (
+  <Watermark content="Ant Design">
+    <Table<DataType>
+      columns={columns}
+      dataSource={dataSource}
+      pagination={false}
+      scroll={{ x: 'max-content' }}
+    />
+  </Watermark>
+);
+
+export default App;

--- a/components/watermark/index.en-US.md
+++ b/components/watermark/index.en-US.md
@@ -22,6 +22,7 @@ demo:
 <code src="./demo/image.tsx">Image watermark</code>
 <code src="./demo/custom.tsx">Custom configuration</code>
 <code src="./demo/portal.tsx">Modal or Drawer</code>
+<code src="./demo/debug.tsx" debug>Table fixed columns</code>
 
 ## API
 
@@ -37,7 +38,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | height | The height of the watermark, the default value of `content` is its own height | number | 64 |  |
 | inherit | Pass the watermark to the pop-up component such as Modal, Drawer | boolean | true | 5.11.0 |
 | rotate | When the watermark is drawn, the rotation Angle, unit `°` | number | -22 |  |
-| zIndex | The z-index of the appended watermark element | number | 9 |  |
+| zIndex | The z-index of the appended watermark element | number | 999 |  |
 | image | Image source, it is recommended to export 2x or 3x image, high priority (support base64 format) | string | - |  |
 | content | Watermark text content | string \| string[] | - |  |
 | font | Text style | [Font](#font) | [Font](#font) |  |

--- a/components/watermark/index.tsx
+++ b/components/watermark/index.tsx
@@ -52,6 +52,7 @@ function getSizeDiff<T>(prev: Set<T>, next: Set<T>) {
 
 const DEFAULT_GAP_X = 100;
 const DEFAULT_GAP_Y = 100;
+const WATERMARK_Z_INDEX_OFFSET = 1;
 
 const fixedStyle: React.CSSProperties = {
   position: 'relative',
@@ -60,11 +61,7 @@ const fixedStyle: React.CSSProperties = {
 
 const Watermark: React.FC<WatermarkProps> = (props) => {
   const {
-    /**
-     * The antd content layer zIndex is basically below 10
-     * https://github.com/ant-design/ant-design/blob/6192403b2ce517c017f9e58a32d58774921c10cd/components/style/themes/default.less#L335
-     */
-    zIndex = 9,
+    zIndex,
     rotate = -22,
     width,
     height,
@@ -90,6 +87,8 @@ const Watermark: React.FC<WatermarkProps> = (props) => {
   };
 
   const [, token] = useToken();
+  // Keep Watermark above content layers while staying below popup base.
+  const mergedZIndex = zIndex ?? token.zIndexPopupBase - WATERMARK_Z_INDEX_OFFSET;
   const {
     color = token.colorFill,
     fontSize = token.fontSizeLG,
@@ -107,7 +106,7 @@ const Watermark: React.FC<WatermarkProps> = (props) => {
 
   const markStyle = React.useMemo(() => {
     const mergedMarkStyle: React.CSSProperties = {
-      zIndex,
+      zIndex: mergedZIndex,
       position: 'absolute',
       left: 0,
       top: 0,
@@ -133,7 +132,7 @@ const Watermark: React.FC<WatermarkProps> = (props) => {
     mergedMarkStyle.backgroundPosition = `${positionLeft}px ${positionTop}px`;
 
     return mergedMarkStyle;
-  }, [zIndex, offsetLeft, gapXCenter, offsetTop, gapYCenter]);
+  }, [mergedZIndex, offsetLeft, gapXCenter, offsetTop, gapYCenter]);
 
   const [container, setContainer] = React.useState<HTMLDivElement | null>();
 
@@ -265,7 +264,7 @@ const Watermark: React.FC<WatermarkProps> = (props) => {
 
   useEffect(syncWatermark, [
     rotate,
-    zIndex,
+    mergedZIndex,
     width,
     height,
     image,

--- a/components/watermark/index.zh-CN.md
+++ b/components/watermark/index.zh-CN.md
@@ -23,6 +23,7 @@ demo:
 <code src="./demo/image.tsx">图片水印</code>
 <code src="./demo/custom.tsx">自定义配置</code>
 <code src="./demo/portal.tsx">Modal 与 Drawer</code>
+<code src="./demo/debug.tsx" debug>Table 固定列</code>
 
 ## API
 
@@ -38,7 +39,7 @@ demo:
 | height | 水印的高度，`content` 的默认值为自身的高度 | number | 64 |  |
 | inherit | 是否将水印传导给弹出组件如 Modal、Drawer | boolean | true | 5.11.0 |
 | rotate | 水印绘制时，旋转的角度，单位 `°` | number | -22 |  |
-| zIndex | 追加的水印元素的 z-index | number | 9 |  |
+| zIndex | 追加的水印元素的 z-index | number | 999 |  |
 | image | 图片源，建议导出 2 倍或 3 倍图，优先级高 (支持 base64 格式) | string | - |  |
 | content | 水印文字内容 | string \| string[] | - |  |
 | font | 文字样式 | [Font](#font) | [Font](#font) |  |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #57804

### 💡 需求背景和解决方案

Watermark 默认 `zIndex` 为 `9`，在包裹带固定列的 Table 时，固定列会通过动态 `z-index` 层级盖住水印。

本 PR 将 Watermark 默认层级调整为 `token.zIndexPopupBase - 1`，使其默认处于内容层之上，同时仍低于弹层基础层级。同步更新 Watermark API 文档默认值，并新增 Table 固定列 debug demo 方便回归验证。

已验证：
- `jest` Watermark 单测
- `jest` Watermark demo / demo-extend 快照
- `biome check`
- `git diff --check`
- `npm run tsc -- --pretty false`

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Watermark being hidden by Table fixed columns by default. |
| 🇨🇳 中文 | 🐞 修复 Watermark 默认会被 Table 固定列遮挡的问题。 |
