### PR TITLE
fix(Menu): correct item extra layout with icon

### DIFF
--- a/components/menu/style/index.ts
+++ b/components/menu/style/index.ts
@@ -559,6 +559,8 @@ const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
     lineType,
     groupTitleLineHeight,
     groupTitleFontSize,
+    iconSize,
+    iconMarginInlineEnd,
   } = token;
 
   return [
@@ -659,6 +661,15 @@ const getBaseStyle: GenerateStyle<MenuToken> = (token) => {
             marginInlineStart: 'auto',
             paddingInlineStart: token.padding,
           },
+        },
+
+        [`${componentCls}-item-icon + ${componentCls}-title-content-with-extra`]: {
+          width: `calc(100% - ${unit(
+            token
+              .calc(iconSize)
+              .add(iconMarginInlineEnd ?? 0)
+              .equal(),
+          )})`,
         },
 
         [`${componentCls}-item a`]: {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #57816

### 💡 需求背景和解决方案

Menu item 同时设置 `icon` 和 `extra` 时，`extra` 会让 title content 使用 `width: 100%` 来支持额外内容靠右展示。但在 vertical popup 等普通布局中，前置 icon 和间距没有被扣除，导致内容宽度溢出并被 ellipsis 截断。

本次在 icon 后紧跟 `extra` title content 的场景中，扣除 icon 宽度和 icon 间距，避免文本被错误截断，同时保留 `extra` 靠右布局。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Menu item text truncation when `icon` and `extra` are used together. |
| 🇨🇳 中文 | 🐞 修复 Menu 同时使用 `icon` 和 `extra` 时菜单项文本被截断的问题。 |
