### PR TITLE
fix(Notification): reserve close spacing without title

### DIFF
--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -98,12 +98,7 @@ export const PureContent: React.FC<PureContentProps> = (props) => {
   const hasTitle = isNonNullable(title) && title !== false && title !== '';
 
   return (
-    <div
-      className={clsx({
-        [`${prefixCls}-with-icon`]: iconNode,
-      })}
-      role={role}
-    >
+    <div className={clsx({ [`${prefixCls}-with-icon`]: iconNode })} role={role}>
       {iconNode}
       {hasTitle && (
         <div className={clsx(`${prefixCls}-title`, pureContentCls.title)} style={styles.title}>

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -11,7 +11,7 @@ import { clsx } from 'clsx';
 
 import { pickClosable, useClosable, useMergeSemantic } from '../_util/hooks';
 import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks';
-import { isPlainObject } from '../_util/is';
+import { isNonNullable, isPlainObject } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import { useComponentConfig } from '../config-provider/context';
@@ -95,10 +95,17 @@ export const PureContent: React.FC<PureContentProps> = (props) => {
       style: styles.icon,
     });
   }
+  const hasTitle = isNonNullable(title) && title !== false && title !== '';
+
   return (
-    <div className={clsx({ [`${prefixCls}-with-icon`]: iconNode })} role={role}>
+    <div
+      className={clsx({
+        [`${prefixCls}-with-icon`]: iconNode,
+      })}
+      role={role}
+    >
       {iconNode}
-      {title && (
+      {hasTitle && (
         <div className={clsx(`${prefixCls}-title`, pureContentCls.title)} style={styles.title}>
           {title}
         </div>
@@ -124,8 +131,7 @@ export const PureContent: React.FC<PureContentProps> = (props) => {
 };
 
 export interface PurePanelProps
-  extends
-    Omit<NoticeProps, 'prefixCls' | 'eventKey' | 'classNames' | 'styles'>,
+  extends Omit<NoticeProps, 'prefixCls' | 'eventKey' | 'classNames' | 'styles'>,
     Omit<PureContentProps, 'prefixCls' | 'children' | 'classNames' | 'styles'> {
   prefixCls?: string;
   classNames?: PurePanelClassNamesType;

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -174,15 +174,19 @@ export const genNoticeStyle: GenerateStyle<NotificationToken, CSSObject> = (toke
     [`${noticeCls}-description`]: {
       fontSize,
       color: colorText,
-      marginTop: token.marginXS,
-
-      '&:first-child': {
-        marginTop: 0,
-      },
+      marginTop: 0,
     },
 
-    [`${noticeCls}-closable ${noticeCls}-description:first-child`]: {
+    [`${noticeCls}-title + ${noticeCls}-description`]: {
+      marginTop: token.marginXS,
+    },
+
+    [`${noticeCls}-closable ${noticeCls}-description`]: {
       paddingInlineEnd: token.paddingLG,
+    },
+
+    [`${noticeCls}-closable ${noticeCls}-title + ${noticeCls}-description`]: {
+      paddingInlineEnd: 0,
     },
 
     [`${noticeCls}-closable ${noticeCls}-title`]: {

--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -178,8 +178,11 @@ export const genNoticeStyle: GenerateStyle<NotificationToken, CSSObject> = (toke
 
       '&:first-child': {
         marginTop: 0,
-        marginInlineEnd: token.marginSM,
       },
+    },
+
+    [`${noticeCls}-closable ${noticeCls}-description:first-child`]: {
+      paddingInlineEnd: token.paddingLG,
     },
 
     [`${noticeCls}-closable ${noticeCls}-title`]: {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #57817

### 💡 需求背景和解决方案

Notification 在未提供 `title`、仅提供 `description` 时，关闭按钮仍可能与描述内容重叠。此前只为首个描述元素预留了较小的 inline margin，无法覆盖长文本或多行内容场景。

本次为无标题内容增加明确的布局状态，并在可关闭场景下为 `description` 预留与 `title` 一致的关闭按钮空间，同时保持无标题时描述内容顶部无额外间距。

该改动不新增 API。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Notification close button overlapping description when `title` is not provided. |
| 🇨🇳 中文 | 🐞 修复 Notification 在未传入 `title` 时关闭按钮与描述内容重叠的问题。 |