### PR TITLE
fix: remove unexpected 1px horizontal padding from Splitter.Panel

### DIFF
--- a/components/splitter/style/index.ts
+++ b/components/splitter/style/index.ts
@@ -362,12 +362,10 @@ const genSplitterStyle: GenerateStyle<SplitterToken, CSSObject> = (token) => {
       // ========================= Panels =========================
       [splitPanelCls]: {
         overflow: 'auto',
-        padding: '0 1px',
         scrollbarWidth: 'thin',
         boxSizing: 'border-box',
 
         '&-hidden': {
-          padding: 0,
           overflow: 'hidden',
         },
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- fix https://github.com/ant-design/ant-design/issues/57825

### 💡 Background and Solution

去掉 Panel 无实际意义的内边距

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 💄 Fix Splitter Panel unexpected 1px horizontal padding. |
| 🇨🇳 Chinese | 💄 修复 Splitter Panel 意外的 1px 水平内边距问题。 |