### PR TITLE
feat(Tag): support per-option className and style in CheckableTagGroup

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,12 @@ tag: vVERSION
 
 ---
 
+## 6.4.0
+
+`2026-05-02`
+
+- 🆕 Add Tag.CheckableTagGroup per-option `className` and `style` support. [#57839](https://github.com/ant-design/ant-design/pull/57839) [@ZQDesigned](https://github.com/ZQDesigned)
+
 ## 6.3.7
 
 `2026-04-27`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,12 @@ tag: vVERSION
 
 ---
 
+## 6.4.0
+
+`2026-05-02`
+
+- 🆕 新增 Tag.CheckableTagGroup 支持按选项配置 `className` 和 `style`。 [#57839](https://github.com/ant-design/ant-design/pull/57839) [@ZQDesigned](https://github.com/ZQDesigned)
+
 ## 6.3.7
 
 `2026-04-27`

--- a/components/tag/CheckableTagGroup.tsx
+++ b/components/tag/CheckableTagGroup.tsx
@@ -15,6 +15,8 @@ import useStyle from './style';
 export type CheckableTagOption<CheckableTagValue> = {
   value: CheckableTagValue;
   label: ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
 };
 
 interface CheckableTagGroupSingleProps<CheckableTagValue> {
@@ -194,8 +196,8 @@ const CheckableTagGroup = React.forwardRef<
       {parsedOptions.map((option) => (
         <CheckableTag
           key={option.value}
-          className={clsx(`${groupPrefixCls}-item`, mergedClassNames.item)}
-          style={mergedStyles.item}
+          className={clsx(`${groupPrefixCls}-item`, mergedClassNames.item, option.className)}
+          style={{ ...mergedStyles.item, ...option.style }}
           checked={
             multiple
               ? ((mergedValue as CheckableTagValue[]) || []).includes(option.value)

--- a/components/tag/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tag/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -389,6 +389,186 @@ exports[`renders components/tag/demo/checkable.tsx extend context correctly 1`] 
 
 exports[`renders components/tag/demo/checkable.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/tag/demo/checkable-group-style.tsx extend context correctly 1`] = `
+<form
+  class="ant-form ant-form-horizontal css-var-test-id ant-form-css-var"
+>
+  <div
+    class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-horizontal"
+  >
+    <div
+      class="ant-row ant-form-item-row css-var-test-id"
+    >
+      <div
+        class="ant-col ant-col-6 ant-form-item-label css-var-test-id"
+      >
+        <label
+          class=""
+          title="Single"
+        >
+          Single
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control css-var-test-id"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-tag-checkable-group css-var-test-id"
+            >
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-group-item acss-b9s86b css-var-test-id"
+              >
+                <span>
+                  Movies
+                </span>
+              </span>
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-checked ant-tag-checkable-group-item acss-16t55iv css-var-test-id"
+              >
+                <span>
+                  Books
+                </span>
+              </span>
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-group-item acss-1u0qbv0 css-var-test-id"
+              >
+                <span>
+                  Music
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-horizontal"
+  >
+    <div
+      class="ant-row ant-form-item-row css-var-test-id"
+    >
+      <div
+        class="ant-col ant-col-6 ant-form-item-label css-var-test-id"
+      >
+        <label
+          class=""
+          title="Multiple"
+        >
+          Multiple
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control css-var-test-id"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-tag-checkable-group css-var-test-id"
+            >
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-checked ant-tag-checkable-group-item css-var-test-id"
+                style="border-color: rgb(145, 202, 255); box-shadow: inset 0 0 0 1px rgba(22, 119, 255, 0.15);"
+              >
+                <span>
+                  React
+                </span>
+              </span>
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-checked ant-tag-checkable-group-item css-var-test-id"
+                style="border-color: rgb(183, 235, 143); box-shadow: inset 0 0 0 1px rgba(82, 196, 26, 0.15);"
+              >
+                <span>
+                  Vue
+                </span>
+              </span>
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-group-item css-var-test-id"
+                style="border-color: rgb(255, 187, 150); box-shadow: inset 0 0 0 1px rgba(250, 84, 28, 0.15);"
+              >
+                <span>
+                  Svelte
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-horizontal"
+  >
+    <div
+      class="ant-row ant-form-item-row css-var-test-id"
+    >
+      <div
+        class="ant-col ant-col-6 ant-form-item-label css-var-test-id"
+      >
+        <label
+          class=""
+          title="Merged Styles"
+        >
+          Merged Styles
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control css-var-test-id"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-tag-checkable-group css-var-test-id"
+            >
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-checked ant-tag-checkable-group-item css-var-test-id"
+                style="border-width: 1px; border-style: solid; border-color: rgb(145, 202, 255);"
+              >
+                <span>
+                  Blue
+                </span>
+              </span>
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-group-item css-var-test-id"
+                style="border-width: 1px; border-style: solid; border-color: rgb(183, 235, 143);"
+              >
+                <span>
+                  Green
+                </span>
+              </span>
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-group-item css-var-test-id"
+                style="border-width: 1px; border-style: solid; border-color: rgb(255, 187, 150);"
+              >
+                <span>
+                  Orange
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`renders components/tag/demo/checkable-group-style.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/tag/demo/colorful.tsx extend context correctly 1`] = `
 Array [
   <div>

--- a/components/tag/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.tsx.snap
@@ -383,6 +383,184 @@ exports[`renders components/tag/demo/checkable.tsx correctly 1`] = `
 </form>
 `;
 
+exports[`renders components/tag/demo/checkable-group-style.tsx correctly 1`] = `
+<form
+  class="ant-form ant-form-horizontal css-var-test-id ant-form-css-var"
+>
+  <div
+    class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-horizontal"
+  >
+    <div
+      class="ant-row ant-form-item-row css-var-test-id"
+    >
+      <div
+        class="ant-col ant-col-6 ant-form-item-label css-var-test-id"
+      >
+        <label
+          class=""
+          title="Single"
+        >
+          Single
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control css-var-test-id"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-tag-checkable-group css-var-test-id"
+            >
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-group-item acss-b9s86b css-var-test-id"
+              >
+                <span>
+                  Movies
+                </span>
+              </span>
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-checked ant-tag-checkable-group-item acss-16t55iv css-var-test-id"
+              >
+                <span>
+                  Books
+                </span>
+              </span>
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-group-item acss-1u0qbv0 css-var-test-id"
+              >
+                <span>
+                  Music
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-horizontal"
+  >
+    <div
+      class="ant-row ant-form-item-row css-var-test-id"
+    >
+      <div
+        class="ant-col ant-col-6 ant-form-item-label css-var-test-id"
+      >
+        <label
+          class=""
+          title="Multiple"
+        >
+          Multiple
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control css-var-test-id"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-tag-checkable-group css-var-test-id"
+            >
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-checked ant-tag-checkable-group-item css-var-test-id"
+                style="border-color:#91caff;box-shadow:inset 0 0 0 1px rgba(22, 119, 255, 0.15)"
+              >
+                <span>
+                  React
+                </span>
+              </span>
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-checked ant-tag-checkable-group-item css-var-test-id"
+                style="border-color:#b7eb8f;box-shadow:inset 0 0 0 1px rgba(82, 196, 26, 0.15)"
+              >
+                <span>
+                  Vue
+                </span>
+              </span>
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-group-item css-var-test-id"
+                style="border-color:#ffbb96;box-shadow:inset 0 0 0 1px rgba(250, 84, 28, 0.15)"
+              >
+                <span>
+                  Svelte
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-horizontal"
+  >
+    <div
+      class="ant-row ant-form-item-row css-var-test-id"
+    >
+      <div
+        class="ant-col ant-col-6 ant-form-item-label css-var-test-id"
+      >
+        <label
+          class=""
+          title="Merged Styles"
+        >
+          Merged Styles
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control css-var-test-id"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-tag-checkable-group css-var-test-id"
+            >
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-checked ant-tag-checkable-group-item css-var-test-id"
+                style="border-width:1px;border-style:solid;border-color:#91caff"
+              >
+                <span>
+                  Blue
+                </span>
+              </span>
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-group-item css-var-test-id"
+                style="border-width:1px;border-style:solid;border-color:#b7eb8f"
+              >
+                <span>
+                  Green
+                </span>
+              </span>
+              <span
+                class="ant-tag ant-tag-checkable ant-tag-checkable-group-item css-var-test-id"
+                style="border-width:1px;border-style:solid;border-color:#ffbb96"
+              >
+                <span>
+                  Orange
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`renders components/tag/demo/colorful.tsx correctly 1`] = `
 Array [
   <div>

--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -392,6 +392,85 @@ describe('Tag', () => {
       expect(onChange).toHaveBeenCalledWith(['foo', 'bar']);
     });
 
+    it('should check single tag in group with styled options', () => {
+      const onChange = jest.fn();
+
+      const { container } = render(
+        <Tag.CheckableTagGroup
+          defaultValue="foo"
+          options={[
+            {
+              value: 'foo',
+              label: 'Foo',
+              className: 'foo-option',
+              style: { borderColor: 'rgb(255, 0, 0)' },
+            },
+            {
+              value: 'bar',
+              label: 'Bar',
+              className: 'bar-option',
+              style: { borderColor: 'rgb(0, 0, 255)' },
+            },
+          ]}
+          onChange={onChange}
+        />,
+      );
+
+      fireEvent.click(container.querySelectorAll('.ant-tag-checkable')[1]);
+      expect(onChange).toHaveBeenCalledWith('bar');
+      fireEvent.click(container.querySelectorAll('.ant-tag-checkable')[1]);
+      expect(onChange).toHaveBeenCalledWith(null);
+    });
+
+    it('should check multiple tag in group with styled options', () => {
+      const onChange = jest.fn();
+
+      const { container } = render(
+        <Tag.CheckableTagGroup
+          multiple
+          defaultValue={['foo']}
+          options={[
+            {
+              value: 'foo',
+              label: 'Foo',
+              className: 'foo-option',
+              style: { borderColor: 'rgb(255, 0, 0)' },
+            },
+            {
+              value: 'bar',
+              label: 'Bar',
+              className: 'bar-option',
+              style: { borderColor: 'rgb(0, 0, 255)' },
+            },
+          ]}
+          onChange={onChange}
+        />,
+      );
+
+      fireEvent.click(container.querySelectorAll('.ant-tag-checkable')[1]);
+      expect(onChange).toHaveBeenCalledWith(['foo', 'bar']);
+      fireEvent.click(container.querySelectorAll('.ant-tag-checkable')[0]);
+      expect(onChange).toHaveBeenCalledWith(['bar']);
+    });
+
+    it('should still support primitive options in multiple mode', () => {
+      const onChange = jest.fn();
+
+      const { container } = render(
+        <Tag.CheckableTagGroup
+          multiple
+          defaultValue={['foo']}
+          options={['foo', 'bar']}
+          onChange={onChange}
+        />,
+      );
+
+      fireEvent.click(container.querySelectorAll('.ant-tag-checkable')[1]);
+      expect(onChange).toHaveBeenCalledWith(['foo', 'bar']);
+      fireEvent.click(container.querySelectorAll('.ant-tag-checkable')[0]);
+      expect(onChange).toHaveBeenCalledWith(['bar']);
+    });
+
     it('id', () => {
       const { container } = render(<Tag.CheckableTagGroup id="test-id" />);
 

--- a/components/tag/__tests__/semantic.test.tsx
+++ b/components/tag/__tests__/semantic.test.tsx
@@ -190,4 +190,59 @@ describe('Tag.Semantic', () => {
       });
     });
   });
+
+  it('checkableTagGroup support option className and style', () => {
+    const { container } = render(
+      <Tag.CheckableTagGroup
+        options={[
+          {
+            value: 'react',
+            label: 'React',
+            className: 'option-react',
+            style: { color: 'rgb(255, 0, 0)' },
+          },
+          { value: 'vue', label: 'Vue' },
+        ]}
+      />,
+    );
+
+    const itemElements = container.querySelectorAll('.ant-tag-checkable');
+
+    expect(itemElements[0]).toHaveClass('option-react');
+    expect(itemElements[0]).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+    expect(itemElements[1]).not.toHaveClass('option-react');
+    expect(itemElements[1]).not.toHaveStyle({ color: 'rgb(255, 0, 0)' });
+  });
+
+  it('checkableTagGroup option style should override group item styles', () => {
+    const { container } = render(
+      <Tag.CheckableTagGroup
+        styles={{
+          item: {
+            color: 'rgb(0, 0, 255)',
+            borderRadius: '4px',
+          },
+        }}
+        options={[
+          {
+            value: 'react',
+            label: 'React',
+            style: { color: 'rgb(255, 0, 0)' },
+          },
+          { value: 'vue', label: 'Vue' },
+        ]}
+      />,
+    );
+
+    const itemElements = container.querySelectorAll('.ant-tag-checkable');
+
+    expect(itemElements[0]).toHaveStyle({
+      color: 'rgb(255, 0, 0)',
+      borderRadius: '4px',
+    });
+    expect(itemElements[1]).toHaveStyle({
+      color: 'rgb(0, 0, 255)',
+      borderRadius: '4px',
+    });
+  });
 });

--- a/components/tag/demo/checkable-group-style.md
+++ b/components/tag/demo/checkable-group-style.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+`CheckableTagGroup` 的对象型 `options` 支持为每一项单独设置 `className` 和 `style`，并且可以和组级 `styles.item` 一起使用。
+
+## en-US
+
+Object `options` in `CheckableTagGroup` support per-item `className` and `style`, and can be combined with group-level `styles.item`.

--- a/components/tag/demo/checkable-group-style.tsx
+++ b/components/tag/demo/checkable-group-style.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import { Form, Tag } from 'antd';
+import { createStaticStyles } from 'antd-style';
+
+const itemClassNames = createStaticStyles(({ css }) => ({
+  movies: css`
+    &.ant-tag-checkable {
+      color: #1677ff;
+      background: #e6f4ff;
+      border-color: #91caff;
+    }
+
+    &.ant-tag-checkable.ant-tag-checkable-checked {
+      color: #fff;
+      background: #1677ff;
+      border-color: #1677ff;
+    }
+  `,
+  books: css`
+    &.ant-tag-checkable {
+      color: #389e0d;
+      background: #f6ffed;
+      border-color: #b7eb8f;
+    }
+
+    &.ant-tag-checkable.ant-tag-checkable-checked {
+      color: #fff;
+      background: #389e0d;
+      border-color: #389e0d;
+    }
+  `,
+  music: css`
+    &.ant-tag-checkable {
+      color: #d4380d;
+      background: #fff2e8;
+      border-color: #ffbb96;
+    }
+
+    &.ant-tag-checkable.ant-tag-checkable-checked {
+      color: #fff;
+      background: #d4380d;
+      border-color: #d4380d;
+    }
+  `,
+}));
+
+const App: React.FC = () => {
+  const [singleValue, setSingleValue] = useState<string | null>('books');
+  const [multipleValue, setMultipleValue] = useState<string[]>(['react', 'vue']);
+  const [mixedValue, setMixedValue] = useState<string[]>(['blue']);
+
+  return (
+    <Form labelCol={{ span: 6 }}>
+      <Form.Item label="Single">
+        <Tag.CheckableTagGroup
+          value={singleValue}
+          onChange={setSingleValue}
+          options={[
+            { label: 'Movies', value: 'movies', className: itemClassNames.movies },
+            { label: 'Books', value: 'books', className: itemClassNames.books },
+            { label: 'Music', value: 'music', className: itemClassNames.music },
+          ]}
+        />
+      </Form.Item>
+      <Form.Item label="Multiple">
+        <Tag.CheckableTagGroup
+          multiple
+          value={multipleValue}
+          onChange={setMultipleValue}
+          options={[
+            {
+              label: 'React',
+              value: 'react',
+              style: {
+                borderColor: '#91caff',
+                boxShadow: 'inset 0 0 0 1px rgba(22, 119, 255, 0.15)',
+              },
+            },
+            {
+              label: 'Vue',
+              value: 'vue',
+              style: {
+                borderColor: '#b7eb8f',
+                boxShadow: 'inset 0 0 0 1px rgba(82, 196, 26, 0.15)',
+              },
+            },
+            {
+              label: 'Svelte',
+              value: 'svelte',
+              style: {
+                borderColor: '#ffbb96',
+                boxShadow: 'inset 0 0 0 1px rgba(250, 84, 28, 0.15)',
+              },
+            },
+          ]}
+        />
+      </Form.Item>
+      <Form.Item label="Merged Styles">
+        <Tag.CheckableTagGroup
+          multiple
+          value={mixedValue}
+          onChange={setMixedValue}
+          styles={{
+            item: {
+              borderWidth: 1,
+              borderStyle: 'solid',
+              borderColor: '#d9d9d9',
+            },
+          }}
+          options={[
+            { label: 'Blue', value: 'blue', style: { borderColor: '#91caff' } },
+            { label: 'Green', value: 'green', style: { borderColor: '#b7eb8f' } },
+            { label: 'Orange', value: 'orange', style: { borderColor: '#ffbb96' } },
+          ]}
+        />
+      </Form.Item>
+    </Form>
+  );
+};
+
+export default App;

--- a/components/tag/index.en-US.md
+++ b/components/tag/index.en-US.md
@@ -22,6 +22,7 @@ demo:
 <code src="./demo/colorful.tsx">Colorful Tag</code>
 <code src="./demo/control.tsx">Add & Remove Dynamically</code>
 <code src="./demo/checkable.tsx">Checkable</code>
+<code src="./demo/checkable-group-style.tsx" version="6.4.0">Per-item styles</code>
 <code src="./demo/animation.tsx">Animate</code>
 <code src="./demo/icon.tsx">Icon</code>
 <code src="./demo/status.tsx">Status Tag</code>
@@ -67,7 +68,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | defaultValue | Initial value | `string \| number \| Array<string \| number> \| null` | - |  |
 | disabled | Disable check/uncheck | `boolean` | - |  |
 | multiple | Multiple select mode | `boolean` | - |  |
-| options | Option list | `Array<{ label: ReactNode; value: string \| number } \| string \| number>` | - |  |
+| options | Option list. Object options support per-item `className` and `style`. | `Array<{ className?: string; label: ReactNode; style?: CSSProperties; value: string \| number } \| string \| number>` | - | 6.4.0 |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-group), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-group), CSSProperties> | - |  |
 | value | Value of checked tag(s) | `string \| number \| Array<string \| number> \| null` | - |  |
 | onChange | Callback when Tag is checked/unchecked | `(value: string \| number \| Array<string \| number> \| null) => void` | - |  |

--- a/components/tag/index.zh-CN.md
+++ b/components/tag/index.zh-CN.md
@@ -22,6 +22,7 @@ demo:
 <code src="./demo/colorful.tsx">多彩标签</code>
 <code src="./demo/control.tsx">动态添加和删除</code>
 <code src="./demo/checkable.tsx">可选择标签</code>
+<code src="./demo/checkable-group-style.tsx" version="6.4.0">单独配置标签项样式</code>
 <code src="./demo/animation.tsx">添加动画</code>
 <code src="./demo/icon.tsx">图标按钮</code>
 <code src="./demo/status.tsx">预设状态的标签</code>
@@ -67,7 +68,7 @@ demo:
 | defaultValue | 初始选中值 | `string \| number \| Array<string \| number> \| null` | - |  |
 | disabled | 禁用选中 | `boolean` | - |  |
 | multiple | 多选模式 | `boolean` | - |  |
-| options | 选项列表 | `Array<{ label: ReactNode; value: string \| number } \| string \| number>` | - |  |
+| options | 选项列表。对象类型的选项支持为每一项单独设置 `className` 和 `style` | `Array<{ className?: string; label: ReactNode; style?: CSSProperties; value: string \| number } \| string \| number>` | - | 6.4.0 |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-group), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-group), CSSProperties> | - |  |
 | value | 选中值 | `string \| number \| Array<string \| number> \| null` | - |  |
 | onChange | 点击标签时触发的回调 | `(value: string \| number \| Array<string \| number> \| null) => void` | - |  |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [x] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #57752

### 💡 需求背景和解决方案

`Tag.CheckableTagGroup` 目前只能通过组级 `styles.item` / `classNames.item` 为所有子项设置统一样式，无法像 `Checkbox.Group` 和 `Radio.Group` 一样为单个 option 提供独立样式。

这个改动在对象类型的 `options` 上新增了可选的 `className` 和 `style` 字段，并在渲染每个 `CheckableTag` 时与组级语义样式合并。这样可以在保持现有 `string | number` 简写和组级 `styles` / `classNames` API 不变的前提下，为每个 tag 单独定制外观。

同时补充了单项样式的 demo、双语文档说明，以及对应的行为与语义测试。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🆕 Add `className` and `style` support for each `Tag.CheckableTagGroup` option. |
| 🇨🇳 中文 | 🆕 为 `Tag.CheckableTagGroup` 的每个选项新增 `className` 和 `style` 配置能力。 |