### PR TITLE
fix(Tooltip): reposition popup when ancestor layout shifts due to asy…

### DIFF
--- a/components/tooltip/__tests__/reposition.test.tsx
+++ b/components/tooltip/__tests__/reposition.test.tsx
@@ -1,0 +1,240 @@
+import React from 'react';
+import { spyElementPrototype } from '@rc-component/util/lib/test/domHook';
+
+import Tooltip from '..';
+import { act, pureRender, render, waitFakeTimer } from '../../../tests/utils';
+
+// ---------------------------------------------------------------------------
+// Helper: controllable ResizeObserver mock
+// ---------------------------------------------------------------------------
+
+type ROCallback = (entries: ResizeObserverEntry[]) => void;
+
+interface MockROInstance {
+  cb: ROCallback;
+  targets: Set<Element>;
+}
+
+function createResizeObserverMock() {
+  const instances: MockROInstance[] = [];
+
+  class MockResizeObserver {
+    private cb: ROCallback;
+
+    constructor(cb: ROCallback) {
+      this.cb = cb;
+      instances.push({ cb, targets: new Set() });
+    }
+
+    observe(target: Element) {
+      instances.find((i) => i.cb === this.cb)?.targets.add(target);
+    }
+
+    unobserve(target: Element) {
+      instances.find((i) => i.cb === this.cb)?.targets.delete(target);
+    }
+
+    disconnect() {
+      const idx = instances.findIndex((i) => i.cb === this.cb);
+      if (idx !== -1) instances.splice(idx, 1);
+    }
+  }
+
+  /** Fire all observers that are watching `target`. */
+  function triggerResize(target: Element) {
+    instances.forEach(({ cb, targets }) => {
+      if (targets.has(target)) {
+        cb([{ target } as ResizeObserverEntry]);
+      }
+    });
+  }
+
+  return { MockResizeObserver, triggerResize, instances };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Tooltip.reposition', () => {
+  beforeAll(() => {
+    spyElementPrototype(HTMLElement, 'offsetParent', {
+      get: () => ({}),
+    });
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllTimers();
+  });
+
+  it('attaches ResizeObserver to a scrollable ancestor when open', async () => {
+    const { MockResizeObserver, instances } = createResizeObserverMock();
+    const OriginalResizeObserver = global.ResizeObserver;
+    (global as any).ResizeObserver = MockResizeObserver;
+
+    const { container } = render(
+      <div id="scroll-container" style={{ overflow: 'auto', height: 200 }}>
+        <Tooltip title="tip" open>
+          <span>hover me</span>
+        </Tooltip>
+      </div>,
+    );
+
+    await waitFakeTimer();
+
+    const scrollContainer = container.firstElementChild!;
+    const isObserved = instances.some((i) => i.targets.has(scrollContainer));
+    expect(isObserved).toBe(true);
+
+    (global as any).ResizeObserver = OriginalResizeObserver;
+  });
+
+  it('calling the resize callback after initialization does not throw', async () => {
+    const { MockResizeObserver, triggerResize, instances } = createResizeObserverMock();
+    const OriginalResizeObserver = global.ResizeObserver;
+    (global as any).ResizeObserver = MockResizeObserver;
+
+    const { container } = render(
+      <div style={{ overflow: 'auto', height: 200 }}>
+        <Tooltip title="tip" open>
+          <span>hover me</span>
+        </Tooltip>
+      </div>,
+    );
+
+    await waitFakeTimer();
+
+    const scrollContainer = container.firstElementChild!;
+
+    // At least one instance must observe the scroll container
+    expect(instances.some((i) => i.targets.has(scrollContainer))).toBe(true);
+
+    // Trigger a resize — must not throw and tooltip must still be in DOM
+    expect(() => {
+      act(() => {
+        triggerResize(scrollContainer);
+      });
+    }).not.toThrow();
+
+    expect(document.querySelector('.ant-tooltip')).not.toBeNull();
+
+    (global as any).ResizeObserver = OriginalResizeObserver;
+  });
+
+  it('skips the immediate observe() callback via the initialized guard', async () => {
+    const callsDuringObserve: boolean[] = [];
+    const OriginalResizeObserver = global.ResizeObserver;
+
+    class TrackingResizeObserver {
+      private cb: ROCallback;
+      private initialized = false;
+
+      constructor(cb: ROCallback) {
+        // Wrap callback to track whether it was invoked before initialized flag
+        this.cb = () => {
+          callsDuringObserve.push(this.initialized);
+          cb([]);
+        };
+      }
+
+      observe(_target: Element) {
+        // Fire immediately, as per spec
+        this.cb([]);
+        // Set initialized after observe so subsequent calls would be "real"
+        this.initialized = true;
+      }
+
+      unobserve() {}
+
+      disconnect() {}
+    }
+
+    (global as any).ResizeObserver = TrackingResizeObserver;
+
+    render(
+      <div style={{ overflow: 'auto', height: 200 }}>
+        <Tooltip title="tip" open>
+          <span>hover me</span>
+        </Tooltip>
+      </div>,
+    );
+
+    await waitFakeTimer();
+
+    // The immediate fires during observe() must have been invoked before
+    // the internal initialized flag was set to true — the guard returns early
+    // so forceAlign is never invoked for those calls.
+    // All recorded calls should show initialized=false (i.e. the guard fires).
+    expect(callsDuringObserve.length).toBeGreaterThan(0);
+    expect(callsDuringObserve.every((v) => v === false)).toBe(true);
+
+    (global as any).ResizeObserver = OriginalResizeObserver;
+  });
+
+  it('disconnects the ResizeObserver when tooltip is closed', async () => {
+    const disconnectSpy = jest.fn();
+    const OriginalResizeObserver = global.ResizeObserver;
+
+    class TrackingResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect = disconnectSpy;
+      constructor(_cb: ROCallback) {}
+    }
+
+    (global as any).ResizeObserver = TrackingResizeObserver;
+
+    // Use pureRender to avoid StrictMode double-invoking effects
+    const { rerender } = pureRender(
+      <div style={{ overflow: 'auto', height: 200 }}>
+        <Tooltip title="tip" open>
+          <span>hover me</span>
+        </Tooltip>
+      </div>,
+    );
+
+    await waitFakeTimer();
+
+    const callsBefore = disconnectSpy.mock.calls.length;
+
+    rerender(
+      <div style={{ overflow: 'auto', height: 200 }}>
+        <Tooltip title="tip" open={false}>
+          <span>hover me</span>
+        </Tooltip>
+      </div>,
+    );
+
+    await waitFakeTimer();
+
+    expect(disconnectSpy.mock.calls.length).toBeGreaterThan(callsBefore);
+
+    (global as any).ResizeObserver = OriginalResizeObserver;
+  });
+
+  it('falls back to document.documentElement when no scrollable ancestor exists', async () => {
+    const { MockResizeObserver, instances } = createResizeObserverMock();
+    const OriginalResizeObserver = global.ResizeObserver;
+    (global as any).ResizeObserver = MockResizeObserver;
+
+    render(
+      <div>
+        <Tooltip title="tip" open>
+          <span>hover me</span>
+        </Tooltip>
+      </div>,
+    );
+
+    await waitFakeTimer();
+
+    const isDocumentObserved = instances.some((i) => i.targets.has(document.documentElement));
+    expect(isDocumentObserved).toBe(true);
+
+    (global as any).ResizeObserver = OriginalResizeObserver;
+  });
+});

--- a/components/tooltip/__tests__/reposition.test.tsx
+++ b/components/tooltip/__tests__/reposition.test.tsx
@@ -56,25 +56,34 @@ function createResizeObserverMock() {
 // Tests
 // ---------------------------------------------------------------------------
 
+let restoreOffsetParent: { mockRestore: () => void };
+
 describe('Tooltip.reposition', () => {
+  let OriginalResizeObserver: typeof ResizeObserver;
+
   beforeAll(() => {
-    spyElementPrototype(HTMLElement, 'offsetParent', {
+    restoreOffsetParent = spyElementPrototype(HTMLElement, 'offsetParent', {
       get: () => ({}),
     });
   });
 
   beforeEach(() => {
+    OriginalResizeObserver = global.ResizeObserver;
     jest.useFakeTimers();
   });
 
   afterEach(() => {
+    (global as any).ResizeObserver = OriginalResizeObserver;
     jest.useRealTimers();
     jest.clearAllTimers();
   });
 
+  afterAll(() => {
+    restoreOffsetParent.mockRestore();
+  });
+
   it('attaches ResizeObserver to a scrollable ancestor when open', async () => {
     const { MockResizeObserver, instances } = createResizeObserverMock();
-    const OriginalResizeObserver = global.ResizeObserver;
     (global as any).ResizeObserver = MockResizeObserver;
 
     const { container } = render(
@@ -90,13 +99,10 @@ describe('Tooltip.reposition', () => {
     const scrollContainer = container.firstElementChild!;
     const isObserved = instances.some((i) => i.targets.has(scrollContainer));
     expect(isObserved).toBe(true);
-
-    (global as any).ResizeObserver = OriginalResizeObserver;
   });
 
   it('calling the resize callback after initialization does not throw', async () => {
     const { MockResizeObserver, triggerResize, instances } = createResizeObserverMock();
-    const OriginalResizeObserver = global.ResizeObserver;
     (global as any).ResizeObserver = MockResizeObserver;
 
     const { container } = render(
@@ -122,13 +128,10 @@ describe('Tooltip.reposition', () => {
     }).not.toThrow();
 
     expect(document.querySelector('.ant-tooltip')).not.toBeNull();
-
-    (global as any).ResizeObserver = OriginalResizeObserver;
   });
 
   it('skips the immediate observe() callback via the initialized guard', async () => {
     const callsDuringObserve: boolean[] = [];
-    const OriginalResizeObserver = global.ResizeObserver;
 
     class TrackingResizeObserver {
       private cb: ROCallback;
@@ -172,13 +175,10 @@ describe('Tooltip.reposition', () => {
     // All recorded calls should show initialized=false (i.e. the guard fires).
     expect(callsDuringObserve.length).toBeGreaterThan(0);
     expect(callsDuringObserve.every((v) => v === false)).toBe(true);
-
-    (global as any).ResizeObserver = OriginalResizeObserver;
   });
 
   it('disconnects the ResizeObserver when tooltip is closed', async () => {
     const disconnectSpy = jest.fn();
-    const OriginalResizeObserver = global.ResizeObserver;
 
     class TrackingResizeObserver {
       observe() {}
@@ -213,13 +213,10 @@ describe('Tooltip.reposition', () => {
     await waitFakeTimer();
 
     expect(disconnectSpy.mock.calls.length).toBeGreaterThan(callsBefore);
-
-    (global as any).ResizeObserver = OriginalResizeObserver;
   });
 
   it('falls back to document.documentElement when no scrollable ancestor exists', async () => {
     const { MockResizeObserver, instances } = createResizeObserverMock();
-    const OriginalResizeObserver = global.ResizeObserver;
     (global as any).ResizeObserver = MockResizeObserver;
 
     render(
@@ -234,7 +231,5 @@ describe('Tooltip.reposition', () => {
 
     const isDocumentObserved = instances.some((i) => i.targets.has(document.documentElement));
     expect(isDocumentObserved).toBe(true);
-
-    (global as any).ResizeObserver = OriginalResizeObserver;
   });
 });

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -68,19 +68,20 @@ export interface TooltipAlignConfig {
   useCssTransform?: boolean;
 }
 // remove this after RcTooltip switch visible to open.
-interface LegacyTooltipProps extends Partial<
-  Omit<
-    RcTooltipProps,
-    | 'children'
-    | 'visible'
-    | 'defaultVisible'
-    | 'onVisibleChange'
-    | 'afterVisibleChange'
-    | 'destroyTooltipOnHide'
-    | 'classNames'
-    | 'styles'
-  >
-> {
+interface LegacyTooltipProps
+  extends Partial<
+    Omit<
+      RcTooltipProps,
+      | 'children'
+      | 'visible'
+      | 'defaultVisible'
+      | 'onVisibleChange'
+      | 'afterVisibleChange'
+      | 'destroyTooltipOnHide'
+      | 'classNames'
+      | 'styles'
+    >
+  > {
   open?: RcTooltipProps['visible'];
   defaultOpen?: RcTooltipProps['defaultVisible'];
   onOpenChange?: RcTooltipProps['onVisibleChange'];
@@ -149,6 +150,8 @@ interface InternalTooltipProps extends TooltipProps {
    */
   'data-popover-inject'?: boolean;
 }
+
+const ANCESTOR_SCROLL_STYLES = new Set(['hidden', 'scroll', 'clip', 'auto']);
 
 const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((props, ref) => {
   const {
@@ -314,6 +317,53 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
   if ((!('open' in props) && noTitle) || inTableMeasureRow) {
     tempOpen = false;
   }
+
+  // ============ Reposition when ancestor layout shifts ============
+  // When content is inserted above the trigger element (pushing it down
+  // without any scroll), the popup stays misaligned. We observe every
+  // scrollable ancestor with a ResizeObserver: when one grows due to a
+  // layout change, we force-realign the popup.
+  React.useEffect(() => {
+    if (!tempOpen || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const nativeEl = tooltipRef.current?.nativeElement;
+    if (!nativeEl) {
+      return;
+    }
+
+    const scrollers: Element[] = [];
+    let cur = nativeEl.parentElement;
+    while (cur) {
+      const { overflowX, overflowY, overflow } = window.getComputedStyle(cur);
+      if ([overflowX, overflowY, overflow].some((v) => ANCESTOR_SCROLL_STYLES.has(v))) {
+        scrollers.push(cur);
+      }
+      cur = cur.parentElement;
+    }
+
+    // Fall back to the document root so there is always at least one target
+    if (scrollers.length === 0) {
+      scrollers.push(document.documentElement);
+    }
+
+    // Skip the immediate fire that ResizeObserver triggers on observe() for
+    // each element — only act on genuine subsequent resize events.
+    let initialized = false;
+    const observer = new ResizeObserver(() => {
+      if (!initialized) return;
+      tooltipRef.current?.forceAlign();
+    });
+    for (const el of scrollers) {
+      observer.observe(el);
+    }
+    initialized = true;
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [tempOpen]);
 
   // ============================= Render =============================
   const child =


### PR DESCRIPTION

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues
Fixes: https://github.com/ant-design/ant-design/issues/57809
> When a controlled Tooltip (`open`) is visible and content is asynchronously inserted above the trigger element, the trigger is pushed down by layout reflow but the popup stays at its original position.
>
> The trigger element's *position* changes without any `scroll` or `window.resize` event firing, so the popup is never re-aligned.

### 💡 Background and Solution

**Problem**

When new DOM content is inserted above the trigger (e.g. an async list renders), the trigger is shifted downward purely by layout reflow. No scroll occurs, no resize fires on the trigger element itself, so the popup is never re-aligned.

**Solution**

Added a `useEffect` in `InternalTooltip` that runs while `tempOpen` is `true`. It walks up the DOM from the trigger's `nativeElement` collecting every scrollable ancestor. A `ResizeObserver` is attached to each ancestor — when any of them grows because new content was inserted into it, `forceAlign()` is called to snap the popup back to the trigger.

The observer is disconnected as soon as `tempOpen` becomes `false` or the component unmounts, so there is no overhead when the tooltip is closed.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Tooltip popup position not updating when trigger element is shifted by async content insertion while `open` is controlled |
| 🇨🇳 Chinese | 🐞 修复 Tooltip 受控打开（`open`）时，触发元素因异步内容插入被向下挤压后，浮层位置未随之更新的问题 |