### PR TITLE
fix(form): avoid forced reflow on Form.Item initial render (#57855)

### DIFF
--- a/components/form/FormItem/ItemHolder.tsx
+++ b/components/form/FormItem/ItemHolder.tsx
@@ -65,7 +65,11 @@ export default function ItemHolder(props: ItemHolderProps) {
   const debounceWarnings = useDebounce(warnings);
   const hasHelp = isNonNullable(help);
   const hasError = !!(hasHelp || errors.length || warnings.length);
-  const isOnScreen = !!itemRef.current && isVisible(itemRef.current);
+  // `offsetParent` access in `isVisible` triggers a synchronous layout. Skip
+  // it when there is no help/error/warning to read computed margin from, so
+  // the initial render of large forms does not incur a forced reflow per item.
+  // See: https://github.com/ant-design/ant-design/issues/57855
+  const isOnScreen = hasError && !!itemRef.current && isVisible(itemRef.current);
   const [marginBottom, setMarginBottom] = React.useState<number | null>(null);
 
   useLayoutEffect(() => {

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -2044,6 +2044,73 @@ describe('Form', () => {
     });
   });
 
+  // https://github.com/ant-design/ant-design/issues/57855
+  it('should not read offsetParent on initial render when there is no error or help', () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'offsetParent',
+    );
+    const offsetParentGetter = jest.fn(() => document.body);
+    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+      configurable: true,
+      get: offsetParentGetter,
+    });
+
+    try {
+      render(
+        <Form>
+          {Array.from({ length: 5 }).map((_, index) => (
+            <Form.Item key={index} name={`field-${index}`} label={`Field ${index}`}>
+              <Input />
+            </Form.Item>
+          ))}
+        </Form>,
+      );
+
+      expect(offsetParentGetter).not.toHaveBeenCalled();
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'offsetParent', originalDescriptor);
+      } else {
+        delete (HTMLElement.prototype as any).offsetParent;
+      }
+    }
+  });
+
+  // https://github.com/ant-design/ant-design/issues/57855
+  // Regression pin: when help/error/warning is present, the visibility check
+  // must still run so the margin-bottom effect re-reads computed style after
+  // the item becomes visible (e.g. inside a Modal that opens later).
+  it('still reads offsetParent when help text is present', () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'offsetParent',
+    );
+    const offsetParentGetter = jest.fn(() => document.body);
+    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+      configurable: true,
+      get: offsetParentGetter,
+    });
+
+    try {
+      render(
+        <Form>
+          <Form.Item name="with-help" label="Help" help="some help text">
+            <Input />
+          </Form.Item>
+        </Form>,
+      );
+
+      expect(offsetParentGetter).toHaveBeenCalled();
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'offsetParent', originalDescriptor);
+      } else {
+        delete (HTMLElement.prototype as any).offsetParent;
+      }
+    }
+  });
+
   it('form child components should be given priority to own disabled props when it in a disabled form', () => {
     const props = {
       name: 'file',


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [x] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close #57855

### 💡 Background and Solution

`Form.Item`'s `ItemHolder` always called `isVisible(itemRef.current)` during render. `isVisible` reads `element.offsetParent` (and falls back to `getBBox`/`getBoundingClientRect`), all of which trigger a synchronous layout. On a vertical `Form` with ~70 `Form.Item` fields the reporter observed ~140 `offsetParent` reads on initial render and Lighthouse flagged it as Forced reflow.

`isOnScreen` is only used as a dependency for the margin-bottom `useLayoutEffect`, and that effect's body is already gated by `hasError`:

```tsx
useLayoutEffect(() => {
  if (hasError && itemRef.current) {
    const itemStyle = getComputedStyle(itemRef.current);
    setMarginBottom(Number.parseInt(itemStyle.marginBottom, 10));
  }
}, [hasError, isOnScreen]);
```

So when there is no help/error/warning, calling `isVisible` during render is wasted work.

This PR gates the visibility read behind `hasError`:

```tsx
const isOnScreen = hasError && !!itemRef.current && isVisible(itemRef.current);
```

Behaviour preserved:

- When `hasError` flips from `false` to `true`, the effect still re-runs because `hasError` itself changed, so the margin is read on the first render that needs it.
- When `hasError` stays `true` and the item later becomes visible (e.g. the original Modal case from #40519), the next render still reads `offsetParent`, the dep flips, and the effect re-runs to recompute `marginBottom`.
- The dep array still contains `isOnScreen` so the visibility-flip path is unchanged.

Two regression tests are added in `components/form/__tests__/index.test.tsx`:

1. Renders a 5-item `Form` with no errors and asserts `HTMLElement.prototype.offsetParent` is not accessed during the initial render.
2. Renders a single `Form.Item` with `help` set and asserts `offsetParent` is still accessed, pinning the Modal/help-text path.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Avoid forced reflow on `Form.Item` initial render by skipping the `offsetParent` visibility check when there is no help, error, or warning. |
| 🇨🇳 Chinese | 在没有 help / error / warning 时跳过 `Form.Item` 的 `offsetParent` 可见性检查，避免初始渲染时的强制回流。 |
