### PR TITLE
docs(Icon): update twoToneColor type documentation

### DIFF
--- a/components/icon/index.en-US.md
+++ b/components/icon/index.en-US.md
@@ -41,7 +41,7 @@ Remember to use `@ant-design/icons@6.x` with `antd@6.x`, see: [#53275](https://g
 | rotate | Rotate by n degrees (not working in IE9) | number | - |  |
 | spin | Rotate icon with animation | boolean | false |  |
 | style | The style properties of icon, like `fontSize` and `color` | CSSProperties | - |  |
-| twoToneColor | Only supports the two-tone icon. Specify the primary color | string (hex color) | - |  |
+| twoToneColor | Only supports the two-tone icon. Specify the primary color, or primary and secondary colors | string \| [string, string] | - |  |
 
 We still have three different themes for icons, icon component name is the icon name suffixed by the theme name.
 

--- a/components/icon/index.en-US.md
+++ b/components/icon/index.en-US.md
@@ -41,7 +41,7 @@ Remember to use `@ant-design/icons@6.x` with `antd@6.x`, see: [#53275](https://g
 | rotate | Rotate by n degrees (not working in IE9) | number | - |  |
 | spin | Rotate icon with animation | boolean | false |  |
 | style | The style properties of icon, like `fontSize` and `color` | CSSProperties | - |  |
-| twoToneColor | Only supports the two-tone icon. Specify the primary color, or primary and secondary colors | string \| [string, string] | - |  |
+| twoToneColor | Only supports the two-tone icon. Specify the primary color, or primary and secondary colors | string \| \[string, string] | - |  |
 
 We still have three different themes for icons, icon component name is the icon name suffixed by the theme name.
 

--- a/components/icon/index.zh-CN.md
+++ b/components/icon/index.zh-CN.md
@@ -48,7 +48,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*xEDOTJx2DEkAAA
 | rotate | 图标旋转角度（IE9 无效） | number | - |  |
 | spin | 是否有旋转动画 | boolean | false |  |
 | style | 设置图标的样式，例如 `fontSize` 和 `color` | CSSProperties | - |  |
-| twoToneColor | 仅适用双色图标。设置双色图标的主要颜色，或主要颜色和次要颜色 | string \| [string, string] | - |  |
+| twoToneColor | 仅适用双色图标。设置双色图标的主要颜色，或主要颜色和次要颜色 | string \| \[string, string] | - |  |
 
 其中我们提供了三种主题的图标，不同主题的 Icon 组件名为图标名加主题做为后缀。
 

--- a/components/icon/index.zh-CN.md
+++ b/components/icon/index.zh-CN.md
@@ -48,7 +48,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*xEDOTJx2DEkAAA
 | rotate | 图标旋转角度（IE9 无效） | number | - |  |
 | spin | 是否有旋转动画 | boolean | false |  |
 | style | 设置图标的样式，例如 `fontSize` 和 `color` | CSSProperties | - |  |
-| twoToneColor | 仅适用双色图标。设置双色图标的主要颜色，支持设置十六进制颜色字符串 | string \| string[] | - |  |
+| twoToneColor | 仅适用双色图标。设置双色图标的主要颜色，或主要颜色和次要颜色 | string \| [string, string] | - |  |
 
 其中我们提供了三种主题的图标，不同主题的 Icon 组件名为图标名加主题做为后缀。
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

更新 Icon 文档中 `twoToneColor` 的类型描述，使其与 `@ant-design/icons` 的实际类型 `string | [string, string]` 保持一致。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |
