### PR TITLE
fix: adjust Mentions popup z-index

### DIFF
--- a/components/mentions/index.tsx
+++ b/components/mentions/index.tsx
@@ -9,7 +9,7 @@ import { composeRef } from '@rc-component/util/lib/ref';
 import { clsx } from 'clsx';
 
 import getAllowClear from '../_util/getAllowClear';
-import { useMergeSemantic } from '../_util/hooks';
+import { useMergeSemantic, useZIndex } from '../_util/hooks';
 import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks';
 import genPurePanel from '../_util/PurePanel';
 import type { InputStatus } from '../_util/statusUtils';
@@ -223,6 +223,9 @@ const InternalMentions = React.forwardRef<MentionsRef, MentionProps>((props, ref
 
   const [variant, enableVariantCls] = useVariant('mentions', customVariant);
 
+  // ====================== zIndex =========================
+  const [zIndex] = useZIndex('SelectLike', mergedStyles.popup?.zIndex as number);
+
   const suffixNode = hasFeedback && <>{feedbackIcon}</>;
 
   const mergedClassName = clsx(
@@ -257,7 +260,7 @@ const InternalMentions = React.forwardRef<MentionsRef, MentionProps>((props, ref
       suffix={suffixNode}
       styles={{
         textarea: mergedStyles.textarea,
-        popup: mergedStyles.popup,
+        popup: { zIndex, ...mergedStyles.popup },
         suffix: mergedStyles.suffix,
       }}
       classNames={{

--- a/components/mentions/index.tsx
+++ b/components/mentions/index.tsx
@@ -260,7 +260,7 @@ const InternalMentions = React.forwardRef<MentionsRef, MentionProps>((props, ref
       suffix={suffixNode}
       styles={{
         textarea: mergedStyles.textarea,
-        popup: { zIndex, ...mergedStyles.popup },
+        popup: { ...mergedStyles.popup, zIndex },
         suffix: mergedStyles.suffix,
       }}
       classNames={{


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- fix #57871

### 💡 需求背景和解决方案

Mentions 在嵌套弹层容器中没有消费 z-index 上下文，导致 Drawer 内 Modal 等场景中下拉层可能被上层弹层遮挡。

本次将 Mentions 的 popup 接入 `useZIndex('SelectLike')`，使其与 Select 类弹层一致，会根据父级弹层容器自动提升 z-index，同时保留用户通过 `styles.popup.zIndex` 自定义层级的能力。

<img width="2704" height="990" alt="image" src="https://github.com/user-attachments/assets/45668ce7-e08f-4219-987a-74deebe6e089" />


### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Mentions popup being covered in nested popup containers. |
| 🇨🇳 中文 | 🐞 修复 Mentions 在嵌套弹层容器中下拉层被遮挡的问题。 |
