### PR TITLE
docs: clarify changelog scope for PR reviews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,12 @@ ant-design/
 
 ## Changelog 规范
 
+### 适用范围
+
+- 本节仅适用于用户明确要求收集/生成 changelog、准备 release PR、版本发布，或正在编辑 `CHANGELOG.en-US.md` / `CHANGELOG.zh-CN.md` 的场景。
+- 普通功能、修复、文档、demo PR 不要求直接修改 `CHANGELOG.en-US.md` / `CHANGELOG.zh-CN.md`；代码 CR 时也不应仅因缺少 CHANGELOG 文件改动而提出 finding。
+- 普通 PR 如需填写 PR 模板中的 Change Log，仅描述本 PR 对用户或开发者的影响，或按模板填写 `N/A` / `No changelog required` / `无需更新日志`。正式 CHANGELOG 由 release owner 在发布流程中统一整理。
+
 ### 核心原则
 
 - 文件位置：`CHANGELOG.en-US.md` 和 `CHANGELOG.zh-CN.md`


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

明确 Changelog 规范的适用范围，避免普通 PR 在 CR 时因为没有修改 `CHANGELOG.en-US.md` / `CHANGELOG.zh-CN.md` 被误报为问题。

本次补充说明：普通功能、修复、文档、demo PR 不要求直接修改 CHANGELOG 文件；正式 CHANGELOG 由 release owner 在发布流程中统一整理。

### 📝 更新日志

| 语言    | 更新描述              |
| ------- | --------------------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志          |