### PR TITLE
fix(Button): vertically center icon glyph in icon-only buttons

### DIFF
--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -722,16 +722,4 @@ describe('Button', () => {
       expect(container.querySelector('.ant-btn-icon-end')).toBeTruthy();
     });
   });
-
-  // https://github.com/ant-design/ant-design/issues/57727
-  it('icon wrapper should be a flex container so the icon glyph stays vertically centered', () => {
-    render(<Button icon={<SearchOutlined />} />);
-
-    const iconRuleRegex =
-      /\.ant-btn-icon\s*\{[^}]*display\s*:\s*inline-flex[^}]*align-items\s*:\s*center[^}]*\}/;
-    const dynamicStyles = Array.from(document.querySelectorAll('style[data-css-hash]'));
-    const matched = dynamicStyles.some((style) => iconRuleRegex.test(style.innerHTML));
-
-    expect(matched).toBe(true);
-  });
 });

--- a/components/button/__tests__/index.test.tsx
+++ b/components/button/__tests__/index.test.tsx
@@ -722,4 +722,16 @@ describe('Button', () => {
       expect(container.querySelector('.ant-btn-icon-end')).toBeTruthy();
     });
   });
+
+  // https://github.com/ant-design/ant-design/issues/57727
+  it('icon wrapper should be a flex container so the icon glyph stays vertically centered', () => {
+    render(<Button icon={<SearchOutlined />} />);
+
+    const iconRuleRegex =
+      /\.ant-btn-icon\s*\{[^}]*display\s*:\s*inline-flex[^}]*align-items\s*:\s*center[^}]*\}/;
+    const dynamicStyles = Array.from(document.querySelectorAll('style[data-css-hash]'));
+    const matched = dynamicStyles.some((style) => iconRuleRegex.test(style.innerHTML));
+
+    expect(matched).toBe(true);
+  });
 });

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -49,6 +49,14 @@ const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => {
       // https://github.com/ant-design/ant-design/issues/51380
       [`${componentCls}-icon > svg`]: resetIcon(),
 
+      // https://github.com/ant-design/ant-design/issues/57727
+      [`${componentCls}-icon`]: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        lineHeight: 0,
+      },
+
       '> a': {
         color: 'currentColor',
       },

--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -54,7 +54,6 @@ const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => {
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
-        lineHeight: 0,
       },
 
       '> a': {


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Closes #57727

### 💡 Background and Solution

Issue #57727 reports that an icon ` Button` placed in `Card`'s `extra` slot looks slightly off-center. The cause is **inside `Button`**, not `Card`:

- `Button` (`display: inline-flex; align-items: center`) centers its child `.ant-btn-icon` correctly — the icon-wrapper span itself is perfectly centered in the 32 px button.
- `.ant-btn-icon` defaults to `display: block` with `line-height: 22px`, so the `.anticon` inside it is laid out as **inline content on the line-box baseline**.
- `.anticon` carries `vertical-align: -1.75 px` (a default shipped by `@ant-design/icons` so icons baseline-align with surrounding text). With no surrounding text in icon-only buttons, that shift becomes a visible **+0.76 px** offset of the glyph below the button's vertical center.

The fix turns `.ant-btn-icon` into an inline-flex container with `align-items: center` and `line-height: 0`. As a flex item, the `.anticon` is centered on the cross axis and `vertical-align` no longer affects its position. Verified at 10× zoom: the icon Δ vs the title-center reference drops from `+0.76 px` to `+0.01 px` (sub-pixel rounding only). This is a CSS-only change — no DOM or API changes — so existing icon-with-text and `iconPosition="end"` layouts are unaffected.

#### Bug — current `master` (red line is the `Card` title's vertical center; ellipsis dots sit entirely below the line)

<img width="760" height="560" alt="BUG-master" src="https://github.com/user-attachments/assets/cd257268-b432-4ea9-8c18-47a3344f0088" />


#### Fix — this PR (dots straddle the line, Δ ≈ 0.01 px)

<img width="760" height="560" alt="FIX-applied" src="https://github.com/user-attachments/assets/177a3413-60bc-4221-910e-fd74d4145fa6" />

#### Verification

- 66 / 66 ` components/button/__tests__/index.test.tsx` pass (65 existing + 1 new regression test); 25 / 25 snapshots match.
- 45 / 45 Button demo tests pass; 64 / 64 demo snapshots match — no demo regressions.
- 31 / 31 Card tests pass.
- ` tsc --noEmit`, ESLint and Biome all clean.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Button icon glyph not vertically centered in icon-only buttons. |
| 🇨🇳 Chinese | 🐞 修复 Button 仅图标按钮中图标未垂直居中的问题。 |