### PR TITLE
fix(Select): use token font family on root

### DIFF
--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -132,7 +132,7 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
         // ==========================================================
         // ==                         Base                         ==
         // ==========================================================
-        ...resetComponent(token, true),
+        ...resetComponent(token),
 
         display: 'inline-flex',
         // gap: calc(token.paddingXXS).mul(1.5).equal(),


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #57895

### 💡 需求背景和解决方案

Select 在选中值区域会继承页面默认字体，导致当页面字体为 Times 等非 antd 默认字体时，选中值字体与下拉选项及其他 antd 组件不一致。

排查发现，`resetComponent(token, true)` 最早是在 #45197 中用于修复 AutoComplete 内部 input 无法继承外层字体的问题。当时该 reset 作用在 `.ant-select-selector` 子节点上，使用 `inherit` 是合理的。后续 #55430 重构 Select 语义结构后，这段 reset 被迁移到 `.ant-select` 根节点，导致根节点本身也继承页面字体，从而覆盖了 antd 的 `fontFamily` token。

本次将 Select 根节点恢复为 `resetComponent(token)`，让 `.ant-select` 默认使用 antd token 字体。没有 API 变化。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Select selected value font family not following antd token. |
| 🇨🇳 中文 | 修复 Select 选中值字体未跟随 antd 字体 token 的问题。 |