### PR TITLE
demo: fix List virtual demo message style

### DIFF
--- a/components/list/demo/virtual-list.tsx
+++ b/components/list/demo/virtual-list.tsx
@@ -13,6 +13,7 @@ const CONTAINER_HEIGHT = 400;
 const PAGE_SIZE = 20;
 
 const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
   const [data, setData] = useState<UserItem[]>([]);
   const [page, setPage] = useState(1);
 
@@ -24,7 +25,7 @@ const App: React.FC = () => {
         const results = Array.isArray(body) ? body : [];
         setData(data.concat(results));
         setPage(page + 1);
-        showMessage && message.success(`${results.length} more items loaded!`);
+        showMessage && messageApi.success(`${results.length} more items loaded!`);
       })
       .catch(() => {
         console.log('fetch mock data failed');
@@ -45,26 +46,29 @@ const App: React.FC = () => {
   };
 
   return (
-    <List>
-      <VirtualList
-        data={data}
-        height={CONTAINER_HEIGHT}
-        itemHeight={47}
-        itemKey="email"
-        onScroll={onScroll}
-      >
-        {(item: UserItem) => (
-          <List.Item key={item.email}>
-            <List.Item.Meta
-              avatar={<Avatar src={item.avatar} />}
-              title={<a href="https://ant.design">{item.name}</a>}
-              description={item.email}
-            />
-            <div>Content</div>
-          </List.Item>
-        )}
-      </VirtualList>
-    </List>
+    <>
+      {contextHolder}
+      <List>
+        <VirtualList
+          data={data}
+          height={CONTAINER_HEIGHT}
+          itemHeight={47}
+          itemKey="email"
+          onScroll={onScroll}
+        >
+          {(item: UserItem) => (
+            <List.Item key={item.email}>
+              <List.Item.Meta
+                avatar={<Avatar src={item.avatar} />}
+                title={<a href="https://ant.design">{item.name}</a>}
+                description={item.email}
+              />
+              <div>Content</div>
+            </List.Item>
+          )}
+        </VirtualList>
+      </List>
+    </>
   );
 };
 


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

List 虚拟滚动加载 demo 使用静态 `message.success`，在站点 CSS layer 环境中触发提示后可能注入非 layer 的 icon reset 样式，导致 Message 图标状态色被覆盖。

改为通过 `message.useMessage()` 创建 message 实例并渲染 `contextHolder`，让提示样式跟随当前 demo 的 React 上下文，避免影响后续 demo 中的 Message 图标颜色。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |