### PR TITLE
docs: fix broken common-props links

### DIFF
--- a/components/app/index.en-US.md
+++ b/components/app/index.en-US.md
@@ -122,7 +122,7 @@ export default () => {
 
 ## API
 
-Common props ref：[Common props](/docs/react/common-props.en-US.md)
+Common props ref: [Common props](/docs/react/common-props)
 
 > This component is available since `antd@5.1.0`.
 

--- a/components/app/index.en-US.md
+++ b/components/app/index.en-US.md
@@ -122,7 +122,7 @@ export default () => {
 
 ## API
 
-Common props ref：[Common props](/docs/react/common-props)
+Common props ref：[Common props](/docs/react/common-props.en-US.md)
 
 > This component is available since `antd@5.1.0`.
 

--- a/components/app/index.zh-CN.md
+++ b/components/app/index.zh-CN.md
@@ -123,7 +123,7 @@ export default () => {
 
 ## API
 
-通用属性参考：[通用属性](/docs/react/common-props.zh-CN.md)
+通用属性参考：[通用属性](/docs/react/common-props-cn)
 
 > 自 `antd@5.1.0` 版本开始提供该组件。
 

--- a/components/app/index.zh-CN.md
+++ b/components/app/index.zh-CN.md
@@ -123,7 +123,7 @@ export default () => {
 
 ## API
 
-通用属性参考：[通用属性](/docs/react/common-props)
+通用属性参考：[通用属性](/docs/react/common-props.zh-CN.md)
 
 > 自 `antd@5.1.0` 版本开始提供该组件。
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 📝 Site / documentation improvement

### 🔗 Related Issues

> - N/A

### 💡 Background and Solution

> - Fixed broken common-props links in index.en-US.md and index.zh-CN.md

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fixed broken documentation links.     |
| 🇨🇳 Chinese |      修复了失效的文档链接。     |
