### PR TITLE
fix: add forwardRef to Dropdown for React 18 compatibility

### DIFF
--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -106,11 +106,13 @@ export interface DropdownProps {
   autoAdjustOverflow?: boolean | AdjustOverflow;
 }
 
-type CompoundedComponent = React.FC<DropdownProps> & {
+type CompoundedComponent = React.ForwardRefExoticComponent<
+  DropdownProps & React.RefAttributes<HTMLElement>
+> & {
   _InternalPanelDoNotUseOrYouWillBeFired: typeof WrapPurePanel;
 };
 
-const Dropdown: CompoundedComponent = (props) => {
+const Dropdown: CompoundedComponent = React.forwardRef<HTMLElement, DropdownProps>((props, ref) => {
   const {
     menu,
     arrow,
@@ -233,6 +235,7 @@ const Dropdown: CompoundedComponent = (props) => {
       child.props.className,
     ),
     disabled: child.props.disabled ?? disabled,
+    ref,
   });
   const triggerActions = disabled ? [] : trigger;
   const alignPoint = !!triggerActions?.includes('contextMenu');
@@ -369,7 +372,7 @@ const Dropdown: CompoundedComponent = (props) => {
   }
 
   return renderNode;
-};
+}) as CompoundedComponent;
 
 // We don't care debug panel
 const PurePanel = genPurePanel(Dropdown, 'align', undefined, 'dropdown', (prefixCls) => prefixCls);

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -5,6 +5,7 @@ import RcDropdown from '@rc-component/dropdown';
 import type { MenuProps as RcMenuProps } from '@rc-component/menu';
 import type { AlignType } from '@rc-component/trigger';
 import { omit, useControlledState, useEvent } from '@rc-component/util';
+import { useComposeRef } from '@rc-component/util/lib/ref';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic, useZIndex } from '../_util/hooks';
@@ -228,6 +229,8 @@ const Dropdown: CompoundedComponent = React.forwardRef<HTMLElement, DropdownProp
     isPrimitive(children) ? <span>{children}</span> : children,
   ) as React.ReactElement<{ className?: string; disabled?: boolean }>;
 
+  const composedRef = useComposeRef(ref, (child as any).ref);
+
   const popupTrigger = cloneElement(child, {
     className: clsx(
       `${prefixCls}-trigger`,
@@ -235,7 +238,7 @@ const Dropdown: CompoundedComponent = React.forwardRef<HTMLElement, DropdownProp
       child.props.className,
     ),
     disabled: child.props.disabled ?? disabled,
-    ref,
+    ref: composedRef,
   });
   const triggerActions = disabled ? [] : trigger;
   const alignPoint = !!triggerActions?.includes('contextMenu');


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

close #57893

Related to #39098

### 💡 Background and Solution

**Problem:**

When wrapping `Dropdown` with `Tooltip` in React 18, the tooltip does not work and throws a console error:

```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. 
Did you mean to use React.forwardRef()?
```

This happens because `Tooltip` needs to access the ref of its child component to position itself correctly, but `Dropdown` was not forwarding refs.

**Root Cause:**

`Dropdown` was defined as a regular function component without `React.forwardRef`. In React 18, refs are not automatically forwarded to function components. React 19 changed this behavior to make refs work by default, which is why the same code works in React 19.

**Solution:**

Wrap `Dropdown` component with `React.forwardRef` and forward the ref to the trigger element (child). This allows parent components like `Tooltip` to access the DOM node for positioning.

**Changes:**

- `components/dropdown/dropdown.tsx`
  - Change `CompoundedComponent` type from `React.FC` to `React.ForwardRefExoticComponent`
  - Wrap component definition with `React.forwardRef<HTMLElement, DropdownProps>`
  - Forward ref to the cloned child element (`popupTrigger`)
  - Cast the result back to `CompoundedComponent` to preserve static properties

**Impact:**

- ✅ Fixes `Tooltip` + `Dropdown` combination in React 18
- ✅ Maintains backward compatibility (refs are optional)
- ✅ No breaking changes for existing code
- ✅ Aligns with React 18 best practices
- ✅ Works in both React 18 and React 19

**Example:**

```tsx
// Before: Error in React 18
<Tooltip title="Tip">
  <Dropdown menu={{ items }}>
    <Button>Actions</Button>
  </Dropdown>
</Tooltip>

// After: Works in both React 18 and React 19 ✓
<Tooltip title="Tip">
  <Dropdown menu={{ items }}>
    <Button>Actions</Button>
  </Dropdown>
</Tooltip>
```

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Dropdown not forwarding ref, causing Tooltip to fail in React 18. |
| 🇨🇳 Chinese | 🐞 修复 Dropdown 未转发 ref 导致 Tooltip 在 React 18 中失效的问题。 |