### PR TITLE
chore(deps): group Jest dependencies in Renovate

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -89,6 +89,14 @@
   },
   "overrides": [
     {
+      "includes": ["renovate.json"],
+      "json": {
+        "parser": {
+          "allowComments": true
+        }
+      }
+    },
+    {
       "includes": ["**/*.test.ts", "**/*.test.tsx", "tests/**/*", "scripts/**/*", ".dumi/**/*"],
       "linter": {
         "rules": {

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,17 @@
       "matchPackageNames": ["@rc-component/*", "rc-*", "@ant-design/*"],
       "enabled": false
     },
+    // https://github.com/ant-design/ant-design/pull/57888
+    {
+      "groupName": "jest dependencies",
+      "matchPackageNames": [
+        "jest",
+        "jest-*",
+        "@types/jest*",
+        "@testing-library/jest-dom",
+        "eslint-plugin-jest"
+      ]
+    },
     {
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["actions/upload-artifact", "dawidd6/action-download-artifact"],


### PR DESCRIPTION

### 🤔 This is a ...

- [ ] ❓ Other (about what?)


### 💡 Background and Solution
jest 相关的每次会创建好几个pr，可以放一个分组管理起来
<img width="689" height="108" alt="image" src="https://github.com/user-attachments/assets/08bceadf-e9d0-49e0-8282-f9239a491225" />

刚好这次jest 出问题了，可以加一个配置，让 renvote 支持一下 json 里面加注释（本身也是支持的，就是biome 提示出错了）。
<img width="1257" height="598" alt="image" src="https://github.com/user-attachments/assets/82b22561-fc47-46ec-bb8d-7bcd0e794c1c" />

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |        -   |
| 🇨🇳 Chinese |     -      |
