### PR TITLE
fix: normalize input clear event target

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -226,6 +226,19 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     removePasswordTimeout();
+
+    const input = inputRef.current?.input;
+    if (onChange && input && e.target !== input) {
+      input.value = e.target.value;
+      onChange(
+        Object.create(e, {
+          target: { value: input },
+          currentTarget: { value: input },
+        }),
+      );
+      return;
+    }
+
     onChange?.(e);
   };
 

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -383,7 +383,7 @@ describe('Input allowClear', () => {
 
     expect(argumentEventTarget).toBe(input);
     expect(argumentEventCurrentTarget).toBe(input);
-    expect(document.contains(argumentEventTarget as Node)).toBeTruthy();
+    expect(document.contains(argumentEventTarget as unknown as Node)).toBeTruthy();
   });
 
   it('should focus input after clear', () => {

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -369,6 +369,23 @@ describe('Input allowClear', () => {
     expect(container.querySelector('input')?.value).toBe('111');
   });
 
+  it('should pass the real input element when normalized change event target is cloned', () => {
+    let argumentEventTarget: EventTarget | null = null;
+    let argumentEventCurrentTarget: EventTarget | null = null;
+    const onChange: InputProps['onChange'] = (e) => {
+      argumentEventTarget = e.target;
+      argumentEventCurrentTarget = e.currentTarget;
+    };
+    const { container } = render(<Input allowClear defaultValue="111" onChange={onChange} />);
+    const input = container.querySelector('input')!;
+
+    fireEvent.click(container.querySelector('.ant-input-clear-icon')!);
+
+    expect(argumentEventTarget).toBe(input);
+    expect(argumentEventCurrentTarget).toBe(input);
+    expect(document.contains(argumentEventTarget as Node)).toBeTruthy();
+  });
+
   it('should focus input after clear', () => {
     const { container, unmount } = render(<Input allowClear defaultValue="111" />, {
       container: document.body,


### PR DESCRIPTION
## Summary

- Normalize the `Input` change event target back to the real input element when rc-input provides a cloned target.
- Keep `currentTarget` aligned with the real input so integrations such as `react-number-format` can safely compare DOM nodes.
- Add a regression test for the normalized allowClear change event target.

## Test Plan

- `npm run version`
- `npx jest --config .jest.js components/input/__tests__/index.test.tsx -t "real input element" --runInBand --no-cache`
- `npx jest --config .jest.js components/input/__tests__/index.test.tsx --runInBand --no-cache --silent`

Fixes #46999


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#46999: Antd Input: To use with react-number-format customInput feature.](https://oss.issuehunt.io/repos/34526884/issues/46999)
---
</details>
<!-- /Issuehunt content-->