### PR TITLE
fix(Alert): resolve CSS specificity conflict for icon vertical alignment with description

### DIFF
--- a/components/alert/style/index.ts
+++ b/components/alert/style/index.ts
@@ -110,34 +110,34 @@ export const genBaseStyle: GenerateStyle<AlertToken, CSSObject> = (token) => {
         paddingBottom: 0,
         opacity: 0,
       },
-    },
 
-    [`${componentCls}-with-description`]: {
-      alignItems: 'flex-start',
-      padding: withDescriptionPadding,
-      [`${componentCls}-icon`]: {
-        marginInlineEnd: marginSM,
-        fontSize: withDescriptionIconSize,
-        lineHeight: 0,
+      '&-with-description': {
+        alignItems: 'flex-start',
+        padding: withDescriptionPadding,
+        [`${componentCls}-icon`]: {
+          marginInlineEnd: marginSM,
+          fontSize: withDescriptionIconSize,
+          lineHeight: 0,
+        },
+
+        [`${componentCls}-title`]: {
+          display: 'block',
+          marginBottom: marginXS,
+          color: colorTextHeading,
+          fontSize: fontSizeLG,
+        },
+
+        [`${componentCls}-description`]: {
+          display: 'block',
+          color: colorText,
+        },
       },
 
-      [`${componentCls}-title`]: {
-        display: 'block',
-        marginBottom: marginXS,
-        color: colorTextHeading,
-        fontSize: fontSizeLG,
+      '&-banner': {
+        marginBottom: 0,
+        border: '0 !important',
+        borderRadius: 0,
       },
-
-      [`${componentCls}-description`]: {
-        display: 'block',
-        color: colorText,
-      },
-    },
-
-    [`${componentCls}-banner`]: {
-      marginBottom: 0,
-      border: '0 !important',
-      borderRadius: 0,
     },
   };
 };

--- a/components/alert/style/index.ts
+++ b/components/alert/style/index.ts
@@ -111,7 +111,7 @@ export const genBaseStyle: GenerateStyle<AlertToken, CSSObject> = (token) => {
         opacity: 0,
       },
 
-      '&-with-description': {
+      [`&${componentCls}-with-description`]: {
         alignItems: 'flex-start',
         padding: withDescriptionPadding,
         [`${componentCls}-icon`]: {
@@ -133,7 +133,7 @@ export const genBaseStyle: GenerateStyle<AlertToken, CSSObject> = (token) => {
         },
       },
 
-      '&-banner': {
+      [`&${componentCls}-banner`]: {
         marginBottom: 0,
         border: '0 !important',
         borderRadius: 0,


### PR DESCRIPTION
 Description:
  ## What

  Fix the Alert component icon vertical alignment when `description` prop is provided.

  ## Why

  The `with-description` and `banner` modifier styles were defined as sibling selectors to the base `componentCls` block
   in `genBaseStyle`. This produced CSS rules at the same specificity as the base `align-items: center`. When CSS-in-JS
  injection order caused the base rule to appear after the modifier rule, the icon remained vertically centered instead
  of aligning to `flex-start`.

  ## How

  Nest `with-description` and `banner` styles inside `componentCls` using `&-with-description` and `&-banner` compound
  selectors. These produce higher-specificity selectors that guarantee the override always takes effect.