### PR TITLE
demo: fix static message style in component demos

### DIFF
--- a/components/dropdown/demo/dropdown-button.tsx
+++ b/components/dropdown/demo/dropdown-button.tsx
@@ -3,16 +3,6 @@ import { DownOutlined, EllipsisOutlined, UserOutlined } from '@ant-design/icons'
 import type { MenuProps } from 'antd';
 import { Button, Dropdown, message, Space, Tooltip } from 'antd';
 
-const handleButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-  message.info('Click on left button.');
-  console.log('click left button', e);
-};
-
-const handleMenuClick: MenuProps['onClick'] = (e) => {
-  message.info('Click on menu item.');
-  console.log('click', e);
-};
-
 const items: MenuProps['items'] = [
   {
     label: '1st menu item',
@@ -39,55 +29,72 @@ const items: MenuProps['items'] = [
   },
 ];
 
-const menuProps = {
-  items,
-  onClick: handleMenuClick,
-};
+const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
 
-const App: React.FC = () => (
-  <Space wrap>
-    <Space.Compact>
-      <Button onClick={handleButtonClick}>Dropdown</Button>
-      <Dropdown menu={menuProps} placement="bottomRight">
-        <Button icon={<EllipsisOutlined />} />
-      </Dropdown>
-    </Space.Compact>
-    <Space.Compact>
-      <Button onClick={handleButtonClick}>Dropdown</Button>
-      <Dropdown menu={menuProps} placement="bottomRight">
-        <Button icon={<UserOutlined />} />
-      </Dropdown>
-    </Space.Compact>
-    <Space.Compact>
-      <Button onClick={handleButtonClick} disabled>
-        Dropdown
-      </Button>
-      <Dropdown menu={menuProps} placement="bottomRight" disabled>
-        <Button icon={<EllipsisOutlined />} disabled />
-      </Dropdown>
-    </Space.Compact>
-    <Space.Compact>
-      <Tooltip title="tooltip">
-        <Button onClick={handleButtonClick}>With Tooltip</Button>
-      </Tooltip>
-      <Dropdown menu={menuProps} placement="bottomRight">
-        <Button loading />
-      </Dropdown>
-    </Space.Compact>
-    <Dropdown menu={menuProps}>
-      <Button onClick={handleButtonClick} icon={<DownOutlined />} iconPlacement="end">
-        Button
-      </Button>
-    </Dropdown>
-    <Space.Compact>
-      <Button onClick={handleButtonClick} danger>
-        Danger
-      </Button>
-      <Dropdown menu={menuProps} placement="bottomRight">
-        <Button icon={<EllipsisOutlined />} danger />
-      </Dropdown>
-    </Space.Compact>
-  </Space>
-);
+  const handleButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    messageApi.info('Click on left button.');
+    console.log('click left button', e);
+  };
+
+  const handleMenuClick: MenuProps['onClick'] = (e) => {
+    messageApi.info('Click on menu item.');
+    console.log('click', e);
+  };
+
+  const menuProps = {
+    items,
+    onClick: handleMenuClick,
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <Space wrap>
+        <Space.Compact>
+          <Button onClick={handleButtonClick}>Dropdown</Button>
+          <Dropdown menu={menuProps} placement="bottomRight">
+            <Button icon={<EllipsisOutlined />} />
+          </Dropdown>
+        </Space.Compact>
+        <Space.Compact>
+          <Button onClick={handleButtonClick}>Dropdown</Button>
+          <Dropdown menu={menuProps} placement="bottomRight">
+            <Button icon={<UserOutlined />} />
+          </Dropdown>
+        </Space.Compact>
+        <Space.Compact>
+          <Button onClick={handleButtonClick} disabled>
+            Dropdown
+          </Button>
+          <Dropdown menu={menuProps} placement="bottomRight" disabled>
+            <Button icon={<EllipsisOutlined />} disabled />
+          </Dropdown>
+        </Space.Compact>
+        <Space.Compact>
+          <Tooltip title="tooltip">
+            <Button onClick={handleButtonClick}>With Tooltip</Button>
+          </Tooltip>
+          <Dropdown menu={menuProps} placement="bottomRight">
+            <Button loading />
+          </Dropdown>
+        </Space.Compact>
+        <Dropdown menu={menuProps}>
+          <Button onClick={handleButtonClick} icon={<DownOutlined />} iconPlacement="end">
+            Button
+          </Button>
+        </Dropdown>
+        <Space.Compact>
+          <Button onClick={handleButtonClick} danger>
+            Danger
+          </Button>
+          <Dropdown menu={menuProps} placement="bottomRight">
+            <Button icon={<EllipsisOutlined />} danger />
+          </Dropdown>
+        </Space.Compact>
+      </Space>
+    </>
+  );
+};
 
 export default App;

--- a/components/dropdown/demo/event.tsx
+++ b/components/dropdown/demo/event.tsx
@@ -3,10 +3,6 @@ import { DownOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import { Dropdown, message, Space } from 'antd';
 
-const onClick: MenuProps['onClick'] = ({ key }) => {
-  message.info(`Click on item ${key}`);
-};
-
 const items: MenuProps['items'] = [
   {
     label: '1st menu item',
@@ -22,15 +18,26 @@ const items: MenuProps['items'] = [
   },
 ];
 
-const App: React.FC = () => (
-  <Dropdown menu={{ items, onClick }}>
-    <a onClick={(e) => e.preventDefault()}>
-      <Space>
-        Hover me, Click menu item
-        <DownOutlined />
-      </Space>
-    </a>
-  </Dropdown>
-);
+const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
+
+  const onClick: MenuProps['onClick'] = ({ key }) => {
+    messageApi.info(`Click on item ${key}`);
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <Dropdown menu={{ items, onClick }}>
+        <a onClick={(e) => e.preventDefault()}>
+          <Space>
+            Hover me, Click menu item
+            <DownOutlined />
+          </Space>
+        </a>
+      </Dropdown>
+    </>
+  );
+};
 
 export default App;

--- a/components/form/demo/warning-only.tsx
+++ b/components/form/demo/warning-only.tsx
@@ -2,14 +2,15 @@ import React from 'react';
 import { Button, Form, Input, message, Space } from 'antd';
 
 const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
   const [form] = Form.useForm();
 
   const onFinish = () => {
-    message.success('Submit success!');
+    messageApi.success('Submit success!');
   };
 
   const onFinishFailed = () => {
-    message.error('Submit failed!');
+    messageApi.error('Submit failed!');
   };
 
   const onFill = () => {
@@ -19,31 +20,38 @@ const App: React.FC = () => {
   };
 
   return (
-    <Form
-      form={form}
-      layout="vertical"
-      onFinish={onFinish}
-      onFinishFailed={onFinishFailed}
-      autoComplete="off"
-    >
-      <Form.Item
-        name="url"
-        label="URL"
-        rules={[{ required: true }, { type: 'url', warningOnly: true }, { type: 'string', min: 6 }]}
+    <>
+      {contextHolder}
+      <Form
+        form={form}
+        layout="vertical"
+        onFinish={onFinish}
+        onFinishFailed={onFinishFailed}
+        autoComplete="off"
       >
-        <Input placeholder="input placeholder" />
-      </Form.Item>
-      <Form.Item>
-        <Space>
-          <Button type="primary" htmlType="submit">
-            Submit
-          </Button>
-          <Button htmlType="button" onClick={onFill}>
-            Fill
-          </Button>
-        </Space>
-      </Form.Item>
-    </Form>
+        <Form.Item
+          name="url"
+          label="URL"
+          rules={[
+            { required: true },
+            { type: 'url', warningOnly: true },
+            { type: 'string', min: 6 },
+          ]}
+        >
+          <Input placeholder="input placeholder" />
+        </Form.Item>
+        <Form.Item>
+          <Space>
+            <Button type="primary" htmlType="submit">
+              Submit
+            </Button>
+            <Button htmlType="button" onClick={onFill}>
+              Fill
+            </Button>
+          </Space>
+        </Form.Item>
+      </Form>
+    </>
   );
 };
 

--- a/components/popconfirm/demo/dynamic-trigger.tsx
+++ b/components/popconfirm/demo/dynamic-trigger.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Button, message, Popconfirm, Switch } from 'antd';
 
 const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
   const [open, setOpen] = useState(false);
   const [condition, setCondition] = useState(true);
 
@@ -11,12 +12,12 @@ const App: React.FC = () => {
 
   const confirm = () => {
     setOpen(false);
-    message.success('Next step.');
+    messageApi.success('Next step.');
   };
 
   const cancel = () => {
     setOpen(false);
-    message.error('Click on cancel.');
+    messageApi.error('Click on cancel.');
   };
 
   const handleOpenChange = (newOpen: boolean) => {
@@ -34,24 +35,27 @@ const App: React.FC = () => {
   };
 
   return (
-    <div>
-      <Popconfirm
-        title="Delete the task"
-        description="Are you sure to delete this task?"
-        open={open}
-        onOpenChange={handleOpenChange}
-        onConfirm={confirm}
-        onCancel={cancel}
-        okText="Yes"
-        cancelText="No"
-      >
-        <Button danger>Delete a task</Button>
-      </Popconfirm>
-      <br />
-      <br />
-      Whether directly execute：
-      <Switch defaultChecked onChange={changeCondition} />
-    </div>
+    <>
+      {contextHolder}
+      <div>
+        <Popconfirm
+          title="Delete the task"
+          description="Are you sure to delete this task?"
+          open={open}
+          onOpenChange={handleOpenChange}
+          onConfirm={confirm}
+          onCancel={cancel}
+          okText="Yes"
+          cancelText="No"
+        >
+          <Button danger>Delete a task</Button>
+        </Popconfirm>
+        <br />
+        <br />
+        Whether directly execute：
+        <Switch defaultChecked onChange={changeCondition} />
+      </div>
+    </>
   );
 };
 

--- a/components/steps/demo/step-next.tsx
+++ b/components/steps/demo/step-next.tsx
@@ -17,6 +17,7 @@ const steps = [
 ];
 
 const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
   const { token } = theme.useToken();
   const [current, setCurrent] = useState(0);
 
@@ -42,6 +43,7 @@ const App: React.FC = () => {
 
   return (
     <>
+      {contextHolder}
       <Steps current={current} items={items} />
       <div style={contentStyle}>{steps[current].content}</div>
       <div style={{ marginTop: 24 }}>
@@ -51,7 +53,7 @@ const App: React.FC = () => {
           </Button>
         )}
         {current === steps.length - 1 && (
-          <Button type="primary" onClick={() => message.success('Processing complete!')}>
+          <Button type="primary" onClick={() => messageApi.success('Processing complete!')}>
             Done
           </Button>
         )}

--- a/components/tag/demo/disabled.tsx
+++ b/components/tag/demo/disabled.tsx
@@ -5,11 +5,12 @@ import { CheckCircleOutlined, CloseCircleOutlined } from '@ant-design/icons';
 const { CheckableTag } = Tag;
 
 const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
   const [selectedTags, setSelectedTags] = useState<string[]>(['Books']);
 
   const handleClose = (tagName: string) => {
     console.log(`Tag ${tagName} closed`);
-    message.info(`Tag ${tagName} closed`);
+    messageApi.info(`Tag ${tagName} closed`);
   };
 
   const handleCheckableChange = (tag: string, checked: boolean) => {
@@ -17,85 +18,93 @@ const App: React.FC = () => {
       ? [...selectedTags, tag]
       : selectedTags.filter((t) => t !== tag);
     setSelectedTags(nextSelectedTags);
-    message.info(`${tag} is ${checked ? 'checked' : 'unchecked'}`);
+    messageApi.info(`${tag} is ${checked ? 'checked' : 'unchecked'}`);
   };
 
   return (
-    <Flex vertical gap="medium">
-      <Flex gap="small" wrap>
-        <Tag disabled>Basic Tag</Tag>
-        <Tag disabled>
-          <a href="https://ant.design">Link Tag</a>
-        </Tag>
-        <Tag disabled href="https://ant.design">
-          Href Tag
-        </Tag>
-        <Tag disabled color="success" icon={<CheckCircleOutlined />}>
-          Icon Tag
-        </Tag>
-      </Flex>
+    <>
+      {contextHolder}
+      <Flex vertical gap="medium">
+        <Flex gap="small" wrap>
+          <Tag disabled>Basic Tag</Tag>
+          <Tag disabled>
+            <a href="https://ant.design">Link Tag</a>
+          </Tag>
+          <Tag disabled href="https://ant.design">
+            Href Tag
+          </Tag>
+          <Tag disabled color="success" icon={<CheckCircleOutlined />}>
+            Icon Tag
+          </Tag>
+        </Flex>
 
-      <Flex gap="small" wrap>
-        <Tag disabled color="red">
-          Preset Color Red
-        </Tag>
-        <Tag disabled color="#f50">
-          Custom Color #f50 Outlined
-        </Tag>
-        <Tag disabled color="#f50" variant="solid">
-          Custom Color #f50 Filled
-        </Tag>
-        <Tag disabled color="#f50" variant="filled">
-          Custom Color #f50 Borderless
-        </Tag>
-        <Tag disabled color="success">
-          Preset Status Success
-        </Tag>
-      </Flex>
+        <Flex gap="small" wrap>
+          <Tag disabled color="red">
+            Preset Color Red
+          </Tag>
+          <Tag disabled color="#f50">
+            Custom Color #f50 Outlined
+          </Tag>
+          <Tag disabled color="#f50" variant="solid">
+            Custom Color #f50 Filled
+          </Tag>
+          <Tag disabled color="#f50" variant="filled">
+            Custom Color #f50 Borderless
+          </Tag>
+          <Tag disabled color="success">
+            Preset Status Success
+          </Tag>
+        </Flex>
 
-      <Flex gap="small" wrap>
-        {['Books', 'Movies', 'Music'].map((tag) => (
-          <CheckableTag
-            key={tag}
+        <Flex gap="small" wrap>
+          {['Books', 'Movies', 'Music'].map((tag) => (
+            <CheckableTag
+              key={tag}
+              disabled
+              checked={selectedTags.includes(tag)}
+              onChange={(checked) => handleCheckableChange(tag, checked)}
+            >
+              {tag}
+            </CheckableTag>
+          ))}
+        </Flex>
+
+        <Flex gap="small" wrap>
+          <Tag disabled closable onClose={() => handleClose('Closable')}>
+            Closable Tag
+          </Tag>
+          <Tag
             disabled
-            checked={selectedTags.includes(tag)}
-            onChange={(checked) => handleCheckableChange(tag, checked)}
+            closable
+            color="success"
+            icon={<CheckCircleOutlined />}
+            onClose={() => handleClose('Closable Success')}
           >
-            {tag}
-          </CheckableTag>
-        ))}
-      </Flex>
+            Closable with Icon
+          </Tag>
+          <Tag disabled closable closeIcon={<CloseCircleOutlined />}>
+            Closable with Custom Icon
+          </Tag>
+        </Flex>
 
-      <Flex gap="small" wrap>
-        <Tag disabled closable onClose={() => handleClose('Closable')}>
-          Closable Tag
-        </Tag>
-        <Tag
-          disabled
-          closable
-          color="success"
-          icon={<CheckCircleOutlined />}
-          onClose={() => handleClose('Closable Success')}
-        >
-          Closable with Icon
-        </Tag>
-        <Tag disabled closable closeIcon={<CloseCircleOutlined />}>
-          Closable with Custom Icon
-        </Tag>
+        <Flex gap="small" wrap>
+          <Tag disabled variant="filled">
+            Borderless Basic
+          </Tag>
+          <Tag disabled variant="filled" color="success" icon={<CheckCircleOutlined />}>
+            Borderless with Icon
+          </Tag>
+          <Tag
+            disabled
+            variant="filled"
+            closable
+            onClose={() => handleClose('Borderless Closable')}
+          >
+            Borderless Closable
+          </Tag>
+        </Flex>
       </Flex>
-
-      <Flex gap="small" wrap>
-        <Tag disabled variant="filled">
-          Borderless Basic
-        </Tag>
-        <Tag disabled variant="filled" color="success" icon={<CheckCircleOutlined />}>
-          Borderless with Icon
-        </Tag>
-        <Tag disabled variant="filled" closable onClose={() => handleClose('Borderless Closable')}>
-          Borderless Closable
-        </Tag>
-      </Flex>
-    </Flex>
+    </>
   );
 };
 

--- a/components/transfer/demo/actions.tsx
+++ b/components/transfer/demo/actions.tsx
@@ -18,6 +18,7 @@ const mockData: RecordType[] = Array.from({ length: 20 }).map((_, i) => ({
 const initialTargetKeys = mockData.filter((item) => Number(item.key) > 10).map((item) => item.key);
 
 const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
   const [targetKeys, setTargetKeys] = useState<string[]>(initialTargetKeys);
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
   const [loadingRight, setLoadingRight] = useState<boolean>(false);
@@ -32,13 +33,13 @@ const App: React.FC = () => {
       setLoadingRight(true);
       setTimeout(() => {
         setLoadingRight(false);
-        message.success(`Successfully added ${moveKeys.length} items to the right`);
+        messageApi.success(`Successfully added ${moveKeys.length} items to the right`);
       }, 1000);
     } else {
       setLoadingLeft(true);
       setTimeout(() => {
         setLoadingLeft(false);
-        message.success(`Successfully added ${moveKeys.length} items to the left`);
+        messageApi.success(`Successfully added ${moveKeys.length} items to the left`);
       }, 1000);
     }
   };
@@ -74,38 +75,41 @@ const App: React.FC = () => {
   };
 
   return (
-    <Transfer
-      dataSource={mockData}
-      targetKeys={targetKeys}
-      selectedKeys={selectedKeys}
-      onChange={handleChange}
-      onSelectChange={handleSelectChange}
-      render={(item) => item.title}
-      actions={[
-        // Custom right button (transfer data to the right)
-        <Button
-          key="to-right"
-          type="primary"
-          icon={<DoubleRightOutlined />}
-          loading={loadingRight}
-          disabled={rightButtonDisabled}
-          onClick={handleRightButtonClick}
-        >
-          Move To Right
-        </Button>,
-        // Custom left button (transfer data to the left)
-        <Button
-          key="to-left"
-          type="primary"
-          icon={<DoubleLeftOutlined />}
-          loading={loadingLeft}
-          disabled={leftButtonDisabled}
-          onClick={handleLeftButtonClick}
-        >
-          Move To Left
-        </Button>,
-      ]}
-    />
+    <>
+      {contextHolder}
+      <Transfer
+        dataSource={mockData}
+        targetKeys={targetKeys}
+        selectedKeys={selectedKeys}
+        onChange={handleChange}
+        onSelectChange={handleSelectChange}
+        render={(item) => item.title}
+        actions={[
+          // Custom right button (transfer data to the right)
+          <Button
+            key="to-right"
+            type="primary"
+            icon={<DoubleRightOutlined />}
+            loading={loadingRight}
+            disabled={rightButtonDisabled}
+            onClick={handleRightButtonClick}
+          >
+            Move To Right
+          </Button>,
+          // Custom left button (transfer data to the left)
+          <Button
+            key="to-left"
+            type="primary"
+            icon={<DoubleLeftOutlined />}
+            loading={loadingLeft}
+            disabled={leftButtonDisabled}
+            onClick={handleLeftButtonClick}
+          >
+            Move To Left
+          </Button>,
+        ]}
+      />
+    </>
   );
 };
 

--- a/components/upload/demo/avatar.tsx
+++ b/components/upload/demo/avatar.tsx
@@ -11,21 +11,22 @@ const getBase64 = (img: FileType, callback: (url: string) => void) => {
   reader.readAsDataURL(img);
 };
 
-const beforeUpload = (file: FileType) => {
-  const isJpgOrPng = file.type === 'image/jpeg' || file.type === 'image/png';
-  if (!isJpgOrPng) {
-    message.error('You can only upload JPG/PNG file!');
-  }
-  const isLt2M = file.size / 1024 / 1024 < 2;
-  if (!isLt2M) {
-    message.error('Image must smaller than 2MB!');
-  }
-  return isJpgOrPng && isLt2M;
-};
-
 const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
   const [loading, setLoading] = useState(false);
   const [imageUrl, setImageUrl] = useState<string>();
+
+  const beforeUpload = (file: FileType) => {
+    const isJpgOrPng = file.type === 'image/jpeg' || file.type === 'image/png';
+    if (!isJpgOrPng) {
+      messageApi.error('You can only upload JPG/PNG file!');
+    }
+    const isLt2M = file.size / 1024 / 1024 < 2;
+    if (!isLt2M) {
+      messageApi.error('Image must smaller than 2MB!');
+    }
+    return isJpgOrPng && isLt2M;
+  };
 
   const handleChange: UploadProps['onChange'] = (info) => {
     if (info.file.status === 'uploading') {
@@ -49,38 +50,41 @@ const App: React.FC = () => {
   );
 
   return (
-    <Flex gap="medium" wrap>
-      <Upload
-        name="avatar"
-        listType="picture-card"
-        className="avatar-uploader"
-        showUploadList={false}
-        action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload"
-        beforeUpload={beforeUpload}
-        onChange={handleChange}
-      >
-        {imageUrl ? (
-          <img draggable={false} src={imageUrl} alt="avatar" style={{ width: '100%' }} />
-        ) : (
-          uploadButton
-        )}
-      </Upload>
-      <Upload
-        name="avatar"
-        listType="picture-circle"
-        className="avatar-uploader"
-        showUploadList={false}
-        action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload"
-        beforeUpload={beforeUpload}
-        onChange={handleChange}
-      >
-        {imageUrl ? (
-          <img draggable={false} src={imageUrl} alt="avatar" style={{ width: '100%' }} />
-        ) : (
-          uploadButton
-        )}
-      </Upload>
-    </Flex>
+    <>
+      {contextHolder}
+      <Flex gap="medium" wrap>
+        <Upload
+          name="avatar"
+          listType="picture-card"
+          className="avatar-uploader"
+          showUploadList={false}
+          action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload"
+          beforeUpload={beforeUpload}
+          onChange={handleChange}
+        >
+          {imageUrl ? (
+            <img draggable={false} src={imageUrl} alt="avatar" style={{ width: '100%' }} />
+          ) : (
+            uploadButton
+          )}
+        </Upload>
+        <Upload
+          name="avatar"
+          listType="picture-circle"
+          className="avatar-uploader"
+          showUploadList={false}
+          action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload"
+          beforeUpload={beforeUpload}
+          onChange={handleChange}
+        >
+          {imageUrl ? (
+            <img draggable={false} src={imageUrl} alt="avatar" style={{ width: '100%' }} />
+          ) : (
+            uploadButton
+          )}
+        </Upload>
+      </Flex>
+    </>
   );
 };
 

--- a/components/upload/demo/basic.tsx
+++ b/components/upload/demo/basic.tsx
@@ -3,28 +3,35 @@ import { UploadOutlined } from '@ant-design/icons';
 import type { UploadProps } from 'antd';
 import { Button, message, Upload } from 'antd';
 
-const props: UploadProps = {
-  name: 'file',
-  action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
-  headers: {
-    authorization: 'authorization-text',
-  },
-  onChange(info) {
-    if (info.file.status !== 'uploading') {
-      console.log(info.file, info.fileList);
-    }
-    if (info.file.status === 'done') {
-      message.success(`${info.file.name} file uploaded successfully`);
-    } else if (info.file.status === 'error') {
-      message.error(`${info.file.name} file upload failed.`);
-    }
-  },
-};
+const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
 
-const App: React.FC = () => (
-  <Upload {...props}>
-    <Button icon={<UploadOutlined />}>Click to Upload</Button>
-  </Upload>
-);
+  const props: UploadProps = {
+    name: 'file',
+    action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
+    headers: {
+      authorization: 'authorization-text',
+    },
+    onChange(info) {
+      if (info.file.status !== 'uploading') {
+        console.log(info.file, info.fileList);
+      }
+      if (info.file.status === 'done') {
+        messageApi.success(`${info.file.name} file uploaded successfully`);
+      } else if (info.file.status === 'error') {
+        messageApi.error(`${info.file.name} file upload failed.`);
+      }
+    },
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <Upload {...props}>
+        <Button icon={<UploadOutlined />}>Click to Upload</Button>
+      </Upload>
+    </>
+  );
+};
 
 export default App;

--- a/components/upload/demo/customize-progress-bar.tsx
+++ b/components/upload/demo/customize-progress-bar.tsx
@@ -3,36 +3,43 @@ import { UploadOutlined } from '@ant-design/icons';
 import type { UploadProps } from 'antd';
 import { Button, message, Upload } from 'antd';
 
-const props: UploadProps = {
-  name: 'file',
-  action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
-  headers: {
-    authorization: 'authorization-text',
-  },
-  onChange(info) {
-    if (info.file.status !== 'uploading') {
-      console.log(info.file, info.fileList);
-    }
-    if (info.file.status === 'done') {
-      message.success(`${info.file.name} file uploaded successfully`);
-    } else if (info.file.status === 'error') {
-      message.error(`${info.file.name} file upload failed.`);
-    }
-  },
-  progress: {
-    strokeColor: {
-      '0%': '#108ee9',
-      '100%': '#87d068',
-    },
-    strokeWidth: 3,
-    format: (percent) => percent && `${Number.parseFloat(percent.toFixed(2))}%`,
-  },
-};
+const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
 
-const App: React.FC = () => (
-  <Upload {...props}>
-    <Button icon={<UploadOutlined />}>Click to Upload</Button>
-  </Upload>
-);
+  const props: UploadProps = {
+    name: 'file',
+    action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
+    headers: {
+      authorization: 'authorization-text',
+    },
+    onChange(info) {
+      if (info.file.status !== 'uploading') {
+        console.log(info.file, info.fileList);
+      }
+      if (info.file.status === 'done') {
+        messageApi.success(`${info.file.name} file uploaded successfully`);
+      } else if (info.file.status === 'error') {
+        messageApi.error(`${info.file.name} file upload failed.`);
+      }
+    },
+    progress: {
+      strokeColor: {
+        '0%': '#108ee9',
+        '100%': '#87d068',
+      },
+      strokeWidth: 3,
+      format: (percent) => percent && `${Number.parseFloat(percent.toFixed(2))}%`,
+    },
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <Upload {...props}>
+        <Button icon={<UploadOutlined />}>Click to Upload</Button>
+      </Upload>
+    </>
+  );
+};
 
 export default App;

--- a/components/upload/demo/drag.tsx
+++ b/components/upload/demo/drag.tsx
@@ -5,37 +5,44 @@ import { message, Upload } from 'antd';
 
 const { Dragger } = Upload;
 
-const props: UploadProps = {
-  name: 'file',
-  multiple: true,
-  action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
-  onChange(info) {
-    const { status } = info.file;
-    if (status !== 'uploading') {
-      console.log(info.file, info.fileList);
-    }
-    if (status === 'done') {
-      message.success(`${info.file.name} file uploaded successfully.`);
-    } else if (status === 'error') {
-      message.error(`${info.file.name} file upload failed.`);
-    }
-  },
-  onDrop(e) {
-    console.log('Dropped files', e.dataTransfer.files);
-  },
-};
+const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
 
-const App: React.FC = () => (
-  <Dragger {...props}>
-    <p className="ant-upload-drag-icon">
-      <InboxOutlined />
-    </p>
-    <p className="ant-upload-text">Click or drag file to this area to upload</p>
-    <p className="ant-upload-hint">
-      Support for a single or bulk upload. Strictly prohibited from uploading company data or other
-      banned files.
-    </p>
-  </Dragger>
-);
+  const props: UploadProps = {
+    name: 'file',
+    multiple: true,
+    action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
+    onChange(info) {
+      const { status } = info.file;
+      if (status !== 'uploading') {
+        console.log(info.file, info.fileList);
+      }
+      if (status === 'done') {
+        messageApi.success(`${info.file.name} file uploaded successfully.`);
+      } else if (status === 'error') {
+        messageApi.error(`${info.file.name} file upload failed.`);
+      }
+    },
+    onDrop(e) {
+      console.log('Dropped files', e.dataTransfer.files);
+    },
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <Dragger {...props}>
+        <p className="ant-upload-drag-icon">
+          <InboxOutlined />
+        </p>
+        <p className="ant-upload-text">Click or drag file to this area to upload</p>
+        <p className="ant-upload-hint">
+          Support for a single or bulk upload. Strictly prohibited from uploading company data or
+          other banned files.
+        </p>
+      </Dragger>
+    </>
+  );
+};
 
 export default App;

--- a/components/upload/demo/paste.tsx
+++ b/components/upload/demo/paste.tsx
@@ -3,29 +3,36 @@ import { UploadOutlined } from '@ant-design/icons';
 import type { UploadProps } from 'antd';
 import { Button, message, Upload } from 'antd';
 
-const props: UploadProps = {
-  name: 'file',
-  pastable: true,
-  action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
-  headers: {
-    authorization: 'authorization-text',
-  },
-  onChange(info) {
-    if (info.file.status !== 'uploading') {
-      console.log(info.file, info.fileList);
-    }
-    if (info.file.status === 'done') {
-      message.success(`${info.file.name} file uploaded successfully`);
-    } else if (info.file.status === 'error') {
-      message.error(`${info.file.name} file upload failed.`);
-    }
-  },
-};
+const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
 
-const App: React.FC = () => (
-  <Upload {...props}>
-    <Button icon={<UploadOutlined />}>Paste or click to upload</Button>
-  </Upload>
-);
+  const props: UploadProps = {
+    name: 'file',
+    pastable: true,
+    action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
+    headers: {
+      authorization: 'authorization-text',
+    },
+    onChange(info) {
+      if (info.file.status !== 'uploading') {
+        console.log(info.file, info.fileList);
+      }
+      if (info.file.status === 'done') {
+        messageApi.success(`${info.file.name} file uploaded successfully`);
+      } else if (info.file.status === 'error') {
+        messageApi.error(`${info.file.name} file upload failed.`);
+      }
+    },
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <Upload {...props}>
+        <Button icon={<UploadOutlined />}>Paste or click to upload</Button>
+      </Upload>
+    </>
+  );
+};
 
 export default App;

--- a/components/upload/demo/upload-manually.tsx
+++ b/components/upload/demo/upload-manually.tsx
@@ -6,6 +6,7 @@ import type { GetProp, UploadFile, UploadProps } from 'antd';
 type FileType = Parameters<GetProp<UploadProps, 'beforeUpload'>>[0];
 
 const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
   const [fileList, setFileList] = useState<UploadFile[]>([]);
   const [uploading, setUploading] = useState(false);
 
@@ -23,10 +24,10 @@ const App: React.FC = () => {
       .then((res) => res.json())
       .then(() => {
         setFileList([]);
-        message.success('upload successfully.');
+        messageApi.success('upload successfully.');
       })
       .catch(() => {
-        message.error('upload failed.');
+        messageApi.error('upload failed.');
       })
       .finally(() => {
         setUploading(false);
@@ -50,6 +51,7 @@ const App: React.FC = () => {
 
   return (
     <>
+      {contextHolder}
       <Upload {...props}>
         <Button icon={<UploadOutlined />}>Select File</Button>
       </Upload>

--- a/components/upload/demo/upload-png-only.tsx
+++ b/components/upload/demo/upload-png-only.tsx
@@ -3,23 +3,30 @@ import { UploadOutlined } from '@ant-design/icons';
 import type { UploadProps } from 'antd';
 import { Button, message, Upload } from 'antd';
 
-const props: UploadProps = {
-  beforeUpload: (file) => {
-    const isPNG = file.type === 'image/png';
-    if (!isPNG) {
-      message.error(`${file.name} is not a png file`);
-    }
-    return isPNG || Upload.LIST_IGNORE;
-  },
-  onChange: (info) => {
-    console.log(info.fileList);
-  },
-};
+const App: React.FC = () => {
+  const [messageApi, contextHolder] = message.useMessage();
 
-const App: React.FC = () => (
-  <Upload {...props}>
-    <Button icon={<UploadOutlined />}>Upload png only</Button>
-  </Upload>
-);
+  const props: UploadProps = {
+    beforeUpload: (file) => {
+      const isPNG = file.type === 'image/png';
+      if (!isPNG) {
+        messageApi.error(`${file.name} is not a png file`);
+      }
+      return isPNG || Upload.LIST_IGNORE;
+    },
+    onChange: (info) => {
+      console.log(info.fileList);
+    },
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <Upload {...props}>
+        <Button icon={<UploadOutlined />}>Upload png only</Button>
+      </Upload>
+    </>
+  );
+};
 
 export default App;


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #57918

Follow up #57899

### 💡 需求背景和解决方案

部分组件 demo 使用 `message.success`、`message.info` 等静态 API 作为操作反馈。在站点 CSS layer 环境中触发这些静态 message 后，可能注入非 layer 的 icon reset 样式，导致后续 demo 中 Popconfirm 等组件的 warning 图标颜色被覆盖。

将这些普通组件 demo 中的静态 message 调用改为 `message.useMessage()`，并渲染 `contextHolder`，让提示样式跟随当前 demo 的 React 上下文，避免影响后续 demo 的图标颜色。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |