### PR TITLE
Fix/input detached event target 46999

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -224,11 +224,27 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     onFocus?.(e);
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     removePasswordTimeout();
-    onChange?.(e);
+    if (onChange) {
+      // @rc-component/input's resolveOnChange clones the DOM node when synthesising
+      // events (e.g. clear button, IME composition).  The clone is detached from the
+      // document, which breaks libraries such as react-number-format that verify
+      // e.target via document.contains().  Swap in the live element so callers
+      // always receive a connected node.
+      const liveInput = inputRef.current?.input;
+      if (liveInput && !e.target.isConnected) {
+        onChange(
+          Object.create(e, {
+            target: { value: liveInput, configurable: true },
+            currentTarget: { value: liveInput, configurable: true },
+          }) as React.ChangeEvent<HTMLInputElement>,
+        );
+        return;
+      }
+      onChange(e);
+    }
   };
-
   const suffixNode = (hasFeedback || suffix) && (
     <>
       {suffix}

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -236,8 +236,8 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       if (liveInput && !e.target.isConnected) {
         onChange(
           Object.create(e, {
-            target: { value: liveInput, configurable: true },
-            currentTarget: { value: liveInput, configurable: true },
+target: { value: liveInput, enumerable: true, configurable: true },
+currentTarget: { value: liveInput, enumerable: true, configurable: true },
           }) as React.ChangeEvent<HTMLInputElement>,
         );
         return;

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -369,6 +369,22 @@ describe('Input allowClear', () => {
     expect(container.querySelector('input')?.value).toBe('111');
   });
 
+  // https://github.com/ant-design/ant-design/issues/46999
+  it('onChange e.target should be document-connected (react-number-format customInput compat)', () => {
+    const receivedTargets: EventTarget[] = [];
+    const { container } = render(
+      <Input
+        allowClear
+        defaultValue="hello"
+        onChange={(e) => receivedTargets.push(e.target)}
+      />,
+    );
+    // Trigger a clear-button click — resolveOnChange synthesises a change event
+    // whose target is a cloneNode() that is NOT connected to the document.
+    fireEvent.click(container.querySelector('.ant-input-clear-icon')!);
+    expect(receivedTargets).toHaveLength(1);
+    expect(document.contains(receivedTargets[0] as Node)).toBe(true);
+  });
   it('should focus input after clear', () => {
     const { container, unmount } = render(<Input allowClear defaultValue="111" />, {
       container: document.body,

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -385,6 +385,25 @@ describe('Input allowClear', () => {
     expect(receivedTargets).toHaveLength(1);
     expect(document.contains(receivedTargets[0] as Node)).toBe(true);
   });
+  
+  // https://github.com/ant-design/ant-design/issues/46999 — IME composition path
+  it('onChange e.target should be document-connected after IME composition', () => {
+    const receivedTargets: EventTarget[] = [];
+    const { container } = render(
+      <Input
+        defaultValue=""
+        onChange={(e) => receivedTargets.push(e.target)}
+      />,
+    );
+    const input = container.querySelector('input')!;
+    fireEvent.compositionStart(input);
+    fireEvent.compositionUpdate(input, { data: '你' });
+    fireEvent.compositionEnd(input, { data: '你好' });
+    expect(receivedTargets.length).toBeGreaterThan(0);
+    receivedTargets.forEach((target) => {
+      expect(document.contains(target as Node)).toBe(true);
+    });
+  });
   it('should focus input after clear', () => {
     const { container, unmount } = render(<Input allowClear defaultValue="111" />, {
       container: document.body,

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -376,7 +376,7 @@ describe('Input allowClear', () => {
       <Input
         allowClear
         defaultValue="hello"
-        onChange={(e) => receivedTargets.push(e.target)}
+onChange={(e) => { receivedTargets.push(e.target); receivedTargets.push(e.currentTarget); }}
       />,
     );
     // Trigger a clear-button click — resolveOnChange synthesises a change event
@@ -392,7 +392,7 @@ describe('Input allowClear', () => {
     const { container } = render(
       <Input
         defaultValue=""
-        onChange={(e) => receivedTargets.push(e.target)}
+        onChange={(e) => { receivedTargets.push(e.target); receivedTargets.push(e.currentTarget); }}
       />,
     );
     const input = container.querySelector('input')!;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [X] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

Related Issues
fix #46999

💡 Background and Solution
@rc-component/input's resolveOnChange calls cloneNode(true) when synthesising change events (clear-button click, IME composition). The cloned node is not attached to the document. Third-party wrappers that use customInput — most notably react-number-format — call document.contains(e.target) internally to gate state updates, so they silently break when given the disconnected clone. This regressed in v5.13.3.

Fix: in handleChange, check e.target.isConnected (the DOM-standard property for this). When the target is disconnected, forward a thin Object.create() patch pointing target and currentTarget at the live element held by inputRef. All other event properties (value, nativeEvent, preventDefault, stopPropagation) are inherited unchanged. Normal typing events hit zero extra branches.

Using isConnected rather than identity comparison (e.target !== inputRef.current.input, the approach in #57216 and #57914) directly tests the invariant consumers rely on and is resilient if the ref is momentarily unset.

Added a behaviour-based regression test: fire a clear-button click, assert document.contains(e.target) on every received onChange call.

### 📝 Change Log

Fix Input onChange receiving a disconnected DOM node as e.target on clear/IME events, restoring compatibility with react-number-format customInput (regression since v5.13.3).

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `Input` `onChange` receiving a disconnected DOM node as `e.target` on clear/IME events, restoring compatibility with `react-number-format` `customInput` (regression since v5.13.3). |
| 🇨🇳 Chinese | 修复 `Input` 组件在 clear 或 IME 事件中 `onChange` 收到未挂载 DOM 节点作为 `e.target` 的问题，恢复与 `react-number-format` `customInput` 的兼容性（自 v5.13.3 起的回归）。 |


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#46999: Antd Input: To use with react-number-format customInput feature.](https://oss.issuehunt.io/repos/34526884/issues/46999)
---
</details>
<!-- /Issuehunt content-->