### PR TITLE
fix: add package.json exports field for Yarn PnP / strict module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,18 @@
   "sideEffects": [
     "*.css"
   ],
+  "exports": {
+    ".": {
+      "types": "./es/index.d.ts",
+      "import": "./es/index.js",
+      "require": "./lib/index.js"
+    },
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
+    "./dist/*": "./dist/*",
+    "./locale/*": "./locale/*",
+    "./package.json": "./package.json"
+  },
   "main": "lib/index.js",
   "module": "es/index.js",
   "unpkg": "dist/antd.min.js",


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

close #56858

### 💡 Background and Solution

**Background**

When `antd` is consumed via Yarn PnP (Plug'n'Play), subpath imports like `antd/es/input/Search` fail to resolve with:

> Qualified path resolution failed

This is because Yarn PnP strictly validates package exports through the `exports` field in `package.json`, and `antd` currently does not declare one. As @MadCcc noted in the issue:

> Sounds good, but need to care not break current import path.

A minimal reproduction is provided by the reporter at https://github.com/OrlovAlexei/antd-exports-issue.

**Solution**

Added an `exports` field to `package.json` that:

1. Declares the main entry (`.`) with explicit `types`, `import` and `require` conditions matching the existing `typings`, `module` and `main` fields.
2. Maps `./es/*`, `./lib/*`, `./dist/*`, `./locale/*` to themselves using wildcard patterns. This preserves every existing subpath import without enumerating individual files.
3. Exposes `./package.json` so consumers and tooling can read it.

This is the minimal change needed to unblock Yarn PnP while keeping every current import pattern working:

| Import | Resolved via |
| ------ | ------------ |
| `import { Button } from 'antd'` | `.` |
| `import Button from 'antd/es/button'` | `./es/*` |
| `import Button from 'antd/lib/button'` | `./lib/*` |
| `import 'antd/dist/reset.css'` | `./dist/*` |
| `import zhCN from 'antd/locale/zh_CN'` | `./locale/*` |
| `import 'antd/es/button/style'` (deep subpath) | `./es/*` |
| `import pkg from 'antd/package.json'` | `./package.json` |

**Verification**

- `npm run lint` — passes (only pre-existing warnings unrelated to this change)
- `npm test` — 558 suites, 7041 tests, 3957 snapshots all passed (2 suites skipped as expected)
- No source files modified — only `package.json`

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 📦 Add `exports` field to `package.json` to fix Yarn PnP subpath resolution failures while preserving all existing import paths. |
| 🇨🇳 Chinese | 📦 为 `package.json` 添加 `exports` 字段，修复 Yarn PnP 下子路径解析失败的问题，同时保留所有现有导入路径。 |
