### PR TITLE
fix: keep Input onChange target attached for custom inputs

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -239,8 +239,8 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     ) {
       onChange(
         Object.create(e, {
-          target: { value: liveInput, enumerable: true, configurable: true },
-          currentTarget: { value: liveInput, enumerable: true, configurable: true },
+          target: { value: liveInput, enumerable: true, configurable: true, writable: true },
+          currentTarget: { value: liveInput, enumerable: true, configurable: true, writable: true },
         }) as React.ChangeEvent<HTMLInputElement>,
       );
       return;

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -226,7 +226,22 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     removePasswordTimeout();
-    onChange?.(e);
+    if (!onChange) {
+      return;
+    }
+
+    const liveInput = inputRef.current?.input;
+    if (liveInput && e.type !== 'click' && e.target !== liveInput) {
+      onChange(
+        Object.create(e, {
+          target: { value: liveInput, enumerable: true, configurable: true },
+          currentTarget: { value: liveInput, enumerable: true, configurable: true },
+        }) as React.ChangeEvent<HTMLInputElement>,
+      );
+      return;
+    }
+
+    onChange(e);
   };
 
   const suffixNode = (hasFeedback || suffix) && (

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -231,7 +231,12 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     }
 
     const liveInput = inputRef.current?.input;
-    if (liveInput && e.type !== 'click' && e.target !== liveInput) {
+    if (
+      liveInput &&
+      e.type !== 'click' &&
+      e.target !== liveInput &&
+      e.target.value === liveInput.value
+    ) {
       onChange(
         Object.create(e, {
           target: { value: liveInput, enumerable: true, configurable: true },

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -369,17 +369,37 @@ describe('Input allowClear', () => {
     expect(container.querySelector('input')?.value).toBe('111');
   });
 
-  it('should keep onChange target compatible with mounted-input checks', () => {
+  it('should normalize non-click onChange target back to the mounted input', () => {
+    let receivedTarget: EventTarget | null = null;
+    let receivedCurrentTarget: EventTarget | null = null;
+
+    const { container } = render(
+      <Input
+        onChange={(e) => {
+          receivedTarget = e.target;
+          receivedCurrentTarget = e.currentTarget;
+        }}
+      />,
+    );
+
+    const input = container.querySelector('input')!;
+    fireEvent.change(input, { target: { value: '123' } });
+
+    expect(receivedTarget).toBe(input);
+    expect(receivedCurrentTarget).toBe(input);
+    expect(document.contains(receivedTarget as Node)).toBe(true);
+  });
+
+  it('should preserve exceedFormatter trimmed value in onChange', () => {
     const Demo = () => {
       const [value, setValue] = useState('');
 
       return (
         <Input
+          count={{ max: 2, exceedFormatter: (currentValue) => currentValue.slice(0, 2) }}
           value={value}
           onChange={(e) => {
-            if (document.contains(e.target as Node)) {
-              setValue(e.target.value);
-            }
+            setValue(e.target.value);
           }}
         />
       );
@@ -389,7 +409,7 @@ describe('Input allowClear', () => {
 
     fireEvent.change(container.querySelector('input')!, { target: { value: '123' } });
 
-    expect(container.querySelector('input')?.value).toBe('123');
+    expect(container.querySelector('input')?.value).toBe('12');
   });
 
   it('should focus input after clear', () => {

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -372,22 +372,38 @@ describe('Input allowClear', () => {
   it('should normalize non-click onChange target back to the mounted input', () => {
     let receivedTarget: EventTarget | null = null;
     let receivedCurrentTarget: EventTarget | null = null;
+    const targetsBeforeChange: EventTarget[] = [];
+    let targetWasMounted = false;
 
-    const { container } = render(
-      <Input
-        onChange={(e) => {
-          receivedTarget = e.target;
-          receivedCurrentTarget = e.currentTarget;
-        }}
-      />,
-    );
+    const Demo = () => {
+      const [value, setValue] = useState('');
+
+      return (
+        <Input
+          value={value}
+          onChange={(e) => {
+            targetsBeforeChange.push(e.target);
+            receivedTarget = e.target;
+            receivedCurrentTarget = e.currentTarget;
+            targetWasMounted = document.contains(e.target as Node);
+
+            if (targetWasMounted) {
+              setValue(e.target.value);
+            }
+          }}
+        />
+      );
+    };
+
+    const { container } = render(<Demo />);
 
     const input = container.querySelector('input')!;
     fireEvent.change(input, { target: { value: '123' } });
 
-    expect(receivedTarget).toBe(input);
-    expect(receivedCurrentTarget).toBe(input);
-    expect(document.contains(receivedTarget as Node)).toBe(true);
+    expect(targetsBeforeChange).toHaveLength(1);
+    expect(receivedTarget).toBe(receivedCurrentTarget);
+    expect(targetWasMounted).toBe(true);
+    expect(input.value).toBe('123');
   });
 
   it('should preserve exceedFormatter trimmed value in onChange', () => {

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -369,6 +369,29 @@ describe('Input allowClear', () => {
     expect(container.querySelector('input')?.value).toBe('111');
   });
 
+  it('should keep onChange target compatible with mounted-input checks', () => {
+    const Demo = () => {
+      const [value, setValue] = useState('');
+
+      return (
+        <Input
+          value={value}
+          onChange={(e) => {
+            if (document.contains(e.target as Node)) {
+              setValue(e.target.value);
+            }
+          }}
+        />
+      );
+    };
+
+    const { container } = render(<Demo />);
+
+    fireEvent.change(container.querySelector('input')!, { target: { value: '123' } });
+
+    expect(container.querySelector('input')?.value).toBe('123');
+  });
+
   it('should focus input after clear', () => {
     const { container, unmount } = render(<Input allowClear defaultValue="111" />, {
       container: document.body,

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -380,6 +380,7 @@ describe('Input allowClear', () => {
 
       return (
         <Input
+          count={{ max: 2, exceedFormatter: (currentValue) => currentValue }}
           value={value}
           onChange={(e) => {
             targetsBeforeChange.push(e.target);
@@ -401,6 +402,7 @@ describe('Input allowClear', () => {
     fireEvent.change(input, { target: { value: '123' } });
 
     expect(targetsBeforeChange).toHaveLength(1);
+    expect(receivedTarget).toBe(input);
     expect(receivedTarget).toBe(receivedCurrentTarget);
     expect(targetWasMounted).toBe(true);
     expect(input.value).toBe('123');


### PR DESCRIPTION
## Summary

Fix `Input` compatibility with wrappers like `react-number-format` when they depend on `document.contains(e.target)` or element identity checks.

This keeps the fix intentionally narrow:
- normalize `event.target` / `event.currentTarget` only for non-`click` `onChange` paths
- preserve `allowClear` click semantics, which still need the synthesized empty value
- cover the regression with an observable controlled-input test instead of asserting only SyntheticEvent internals

## Why this approach

Issue #46999 is caused by `@rc-component/input` forwarding a detached cloned node in some change paths. Third-party `customInput` wrappers can treat that as an invalid target and skip their normal controlled update flow.

There are already open PRs around the same root cause. This patch tries to stay conservative by avoiding the `click` clear path entirely, since that path intentionally relies on a synthesized target value.

## Changes

- In `components/input/Input.tsx`, normalize `target/currentTarget` back to the mounted input element only when:
  - `onChange` exists
  - the event is not a `click`
  - the forwarded target is not the live mounted input
- In `components/input/__tests__/index.test.tsx`, add a regression test that updates a controlled input only when `document.contains(e.target as Node)` is true, and assert the visible value still updates.

## Verification

Ran:

```bash
npm test -- components/input/__tests__/index.test.tsx --runInBand
npx eslint components/input/Input.tsx components/input/__tests__/index.test.tsx
```

The test file passes in full. ESLint reports one pre-existing warning in `components/input/Input.tsx` for an unused `eslint-disable` directive unrelated to this patch.

Closes #46999
