### PR TITLE
fix(Input): normalize detached onChange target for customInput integrations

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -226,7 +226,27 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     removePasswordTimeout();
-    onChange?.(e);
+    if (onChange) {
+      const realInput = inputRef.current?.input;
+
+      // @rc-component/input may emit an event whose target points to a detached
+      // cloned input element. Normalize to the mounted input element to keep
+      // integrations like react-number-format working.
+      const isDetachedTarget =
+        typeof document !== 'undefined' &&
+        typeof Node !== 'undefined' &&
+        e.target instanceof Node &&
+        !document.contains(e.target);
+      const normalizedEvent =
+        realInput && e.type !== 'click' && e.target !== realInput && isDetachedTarget
+          ? (Object.create(e, {
+              target: { value: realInput, enumerable: true, configurable: true },
+              currentTarget: { value: realInput, enumerable: true, configurable: true },
+            }) as React.ChangeEvent<HTMLInputElement>)
+          : e;
+
+      onChange(normalizedEvent);
+    }
   };
 
   const suffixNode = (hasFeedback || suffix) && (

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -369,6 +369,27 @@ describe('Input allowClear', () => {
     expect(container.querySelector('input')?.value).toBe('111');
   });
 
+  it('onChange event.target and currentTarget should be mounted input element', () => {
+    let argumentEventTarget: EventTarget | null = null;
+    let argumentEventCurrentTarget: EventTarget | null = null;
+
+    const { container } = render(
+      <Input
+        onChange={(e) => {
+          argumentEventTarget = e.target;
+          argumentEventCurrentTarget = e.currentTarget;
+        }}
+      />,
+    );
+
+    const input = container.querySelector('input')!;
+    fireEvent.change(input, { target: { value: '123' } });
+
+    expect(argumentEventTarget).toBe(input);
+    expect(argumentEventCurrentTarget).toBe(input);
+    expect(document.contains(argumentEventTarget as unknown as Node)).toBeTruthy();
+  });
+
   it('should focus input after clear', () => {
     const { container, unmount } = render(<Input allowClear defaultValue="111" />, {
       container: document.body,


### PR DESCRIPTION
### ?? This is a ...

- [ ] ?? New feature
- [x] ?? Bug fix
- [ ] ?? Site / documentation improvement
- [ ] ??? Demo improvement
- [ ] ?? Component style improvement
- [ ] ?? TypeScript definition improvement
- [ ] ?? Bundle size optimization
- [ ] ?? Performance optimization
- [ ] ?? Feature enhancement
- [ ] ?? Internationalization
- [ ] ?? Refactoring
- [ ] ?? Code style optimization
- [x] ? Test Case
- [ ] ?? Branch merge
- [ ] ? Workflow
- [ ] ?? Accessibility improvement
- [ ] ? Other (about what?)

### ?? Related Issues

- fix #46999

### ?? Background and Solution

- When using `react-number-format` with `customInput={Input}`, the emitted `onChange` event can carry a detached target object.
- This change normalizes detached change events so `target`/`currentTarget` are mapped back to the mounted input element, keeping event usage stable for consumers.
- Added regression tests to cover event target/currentTarget behavior.

### ?? Change Log

| Language | Changelog |
| --- | --- |
| ???? English | Fixed `Input` `onChange` event normalization for `react-number-format` custom input integration to ensure stable `target/currentTarget` references. |
| ???? Chinese | ??? `Input` ? `react-number-format` `customInput` ??? `onChange` ????????,?? `target/currentTarget` ????? |
