### PR TITLE
feat: support semantic styles for Layout Sider

### DIFF
--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -6,6 +6,8 @@ import RightOutlined from '@ant-design/icons/RightOutlined';
 import { omit } from '@rc-component/util';
 import { clsx } from 'clsx';
 
+import { useMergeSemantic } from '../_util/hooks';
+import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks';
 import { isFunction } from '../_util/is';
 import type { Breakpoint } from '../_util/responsiveObserver';
 import { ConfigContext } from '../config-provider';
@@ -35,6 +37,20 @@ export type CollapseType = 'clickTrigger' | 'responsive';
 
 export type SiderTheme = 'light' | 'dark';
 
+export type SiderSemanticName = keyof SiderSemanticClassNames & keyof SiderSemanticStyles;
+
+export type SiderSemanticClassNames = {
+  children?: string;
+};
+
+export type SiderSemanticStyles = {
+  children?: React.CSSProperties;
+};
+
+export type SiderClassNamesType = SemanticClassNamesType<SiderProps, SiderSemanticClassNames>;
+
+export type SiderStylesType = SemanticStylesType<SiderProps, SiderSemanticStyles>;
+
 export interface SiderProps extends React.HTMLAttributes<HTMLDivElement> {
   prefixCls?: string;
   collapsible?: boolean;
@@ -49,6 +65,8 @@ export interface SiderProps extends React.HTMLAttributes<HTMLDivElement> {
   breakpoint?: Breakpoint;
   theme?: SiderTheme;
   onBreakpoint?: (broken: boolean) => void;
+  classNames?: SiderClassNamesType;
+  styles?: SiderStylesType;
 }
 
 export interface SiderState {
@@ -81,9 +99,19 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
     breakpoint,
     onCollapse,
     onBreakpoint,
+    classNames,
+    styles,
     ...otherProps
   } = props;
   const { siderHook } = useContext(LayoutContext);
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    SiderClassNamesType,
+    SiderStylesType,
+    SiderProps
+  >([classNames], [styles], {
+    props,
+  });
 
   const [collapsed, setCollapsed] = useState(
     'collapsed' in props ? props.collapsed : defaultCollapsed,
@@ -216,7 +244,12 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
   return (
     <SiderContext.Provider value={contextValue}>
       <aside className={siderCls} {...divProps} style={divStyle} ref={ref}>
-        <div className={`${prefixCls}-children`}>{children}</div>
+        <div
+          className={clsx(`${prefixCls}-children`, mergedClassNames.children)}
+          style={mergedStyles.children}
+        >
+          {children}
+        </div>
         {collapsible || (below && zeroWidthTrigger) ? triggerDom : null}
       </aside>
     </SiderContext.Provider>

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -37,19 +37,25 @@ export type CollapseType = 'clickTrigger' | 'responsive';
 
 export type SiderTheme = 'light' | 'dark';
 
-export type SiderSemanticName = keyof SiderSemanticClassNames & keyof SiderSemanticStyles;
+export interface SiderSemanticClassNames {
+  children?: string;
+}
 
-export type SiderSemanticClassNames = {
+export interface SiderSemanticStyles {
+  children?: React.CSSProperties;
+}
+
+type SiderSemanticClassNamesRecord = {
   children?: string;
 };
 
-export type SiderSemanticStyles = {
+type SiderSemanticStylesRecord = {
   children?: React.CSSProperties;
 };
 
-export type SiderClassNamesType = SemanticClassNamesType<SiderProps, SiderSemanticClassNames>;
+export type SiderClassNamesType = SemanticClassNamesType<SiderProps, SiderSemanticClassNamesRecord>;
 
-export type SiderStylesType = SemanticStylesType<SiderProps, SiderSemanticStyles>;
+export type SiderStylesType = SemanticStylesType<SiderProps, SiderSemanticStylesRecord>;
 
 export interface SiderProps extends React.HTMLAttributes<HTMLDivElement> {
   prefixCls?: string;
@@ -106,8 +112,8 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
   const { siderHook } = useContext(LayoutContext);
 
   const [mergedClassNames, mergedStyles] = useMergeSemantic<
-    SiderClassNamesType,
-    SiderStylesType,
+    SiderSemanticClassNamesRecord,
+    SiderSemanticStylesRecord,
     SiderProps
   >([classNames], [styles], {
     props,

--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -205,6 +205,26 @@ describe('Layout', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
+  it('should customize the children container with semantic classNames and styles', () => {
+    const { container } = render(
+      <Sider
+        classNames={{ children: 'custom-sider-children' }}
+        styles={{ children: { display: 'flex', flexDirection: 'column' } }}
+      >
+        Sider
+      </Sider>,
+    );
+    const sider = container.querySelector<HTMLElement>('.ant-layout-sider')!;
+    const children = container.querySelector<HTMLElement>('.ant-layout-sider-children')!;
+
+    expect(sider).not.toHaveClass('custom-sider-children');
+    expect(children).toHaveClass('custom-sider-children');
+    expect(children).toHaveStyle({
+      display: 'flex',
+      flexDirection: 'column',
+    });
+  });
+
   it('should not add ant-layout-has-sider when `hasSider` is `false`', () => {
     const { container } = render(
       <Layout hasSider={false}>

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -103,15 +103,15 @@ The sidebar.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | breakpoint | [Breakpoints](/components/grid/#col) of the responsive layout | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` \| `xxxl` | - | xxxl: 6.3.0 |
-| classNames | Customize class for each semantic structure inside the Sider component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | className | Container className | string | - |  |
+| classNames | Customize class for each semantic structure inside the Sider component, supports object or function | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | collapsed | To set the current status | boolean | - |  |
 | collapsedWidth | Width of the collapsed sidebar, by setting to 0 a special trigger will appear | number | 80 |  |
 | collapsible | Whether can be collapsed | boolean | false |  |
 | defaultCollapsed | To set the initial status | boolean | false |  |
 | reverseArrow | Reverse direction of arrow, for a sider that expands from the right | boolean | false |  |
 | style | To customize the styles | CSSProperties | - |  |
-| styles | Customize inline style for each semantic structure inside the Sider component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
+| styles | Customize inline style for each semantic structure inside the Sider component, supports object or function | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
 | theme | Color theme of the sidebar | `light` \| `dark` | `dark` |  |
 | trigger | Specify the customized trigger, set to null to hide the trigger | ReactNode | - |  |
 | width | Width of the sidebar | number \| string | 200 |  |

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -103,6 +103,7 @@ The sidebar.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | breakpoint | [Breakpoints](/components/grid/#col) of the responsive layout | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` \| `xxxl` | - | xxxl: 6.3.0 |
+| classNames | Customize class for each semantic structure inside the Sider component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | className | Container className | string | - |  |
 | collapsed | To set the current status | boolean | - |  |
 | collapsedWidth | Width of the collapsed sidebar, by setting to 0 a special trigger will appear | number | 80 |  |
@@ -110,12 +111,19 @@ The sidebar.
 | defaultCollapsed | To set the initial status | boolean | false |  |
 | reverseArrow | Reverse direction of arrow, for a sider that expands from the right | boolean | false |  |
 | style | To customize the styles | CSSProperties | - |  |
+| styles | Customize inline style for each semantic structure inside the Sider component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
 | theme | Color theme of the sidebar | `light` \| `dark` | `dark` |  |
 | trigger | Specify the customized trigger, set to null to hide the trigger | ReactNode | - |  |
 | width | Width of the sidebar | number \| string | 200 |  |
 | zeroWidthTriggerStyle | To customize the styles of the special trigger that appears when `collapsedWidth` is 0 | object | - |  |
 | onBreakpoint | The callback function, executed when [breakpoints](/components/grid/#api) changed | (broken) => {} | - |  |
 | onCollapse | The callback function, executed by clicking the trigger or activating the responsive layout | (collapsed, type) => {} | - |  |
+
+#### Semantic DOM
+
+| Name     | Description                  |
+| -------- | ---------------------------- |
+| children | Content wrapper of the Sider |
 
 #### breakpoint width
 

--- a/components/layout/index.zh-CN.md
+++ b/components/layout/index.zh-CN.md
@@ -104,6 +104,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HdS6Q5vUCDcAAA
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | breakpoint | 触发响应式布局的[断点](/components/grid-cn#col) | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` \| `xxxl` | - | xxxl: 6.3.0 |
+| classNames | 用于自定义 Sider 组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | className | 容器 className | string | - |  |
 | collapsed | 当前收起状态 | boolean | - |  |
 | collapsedWidth | 收缩宽度，设置为 0 会出现特殊 trigger | number | 80 |  |
@@ -111,12 +112,19 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HdS6Q5vUCDcAAA
 | defaultCollapsed | 是否默认收起 | boolean | false |  |
 | reverseArrow | 翻转折叠提示箭头的方向，当 Sider 在右边时可以使用 | boolean | false |  |
 | style | 指定样式 | CSSProperties | - |  |
+| styles | 用于自定义 Sider 组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
 | theme | 主题颜色 | `light` \| `dark` | `dark` |  |
 | trigger | 自定义 trigger，设置为 null 时隐藏 trigger | ReactNode | - |  |
 | width | 宽度 | number \| string | 200 |  |
 | zeroWidthTriggerStyle | 指定当 `collapsedWidth` 为 0 时出现的特殊 trigger 的样式 | object | - |  |
 | onBreakpoint | 触发响应式布局[断点](/components/grid-cn#api)时的回调 | (broken) => {} | - |  |
 | onCollapse | 展开-收起时的回调函数，有点击 trigger 以及响应式反馈两种方式可以触发 | (collapsed, type) => {} | - |  |
+
+#### Semantic DOM
+
+| 名称     | 说明                 |
+| -------- | -------------------- |
+| children | Sider 的内容包裹容器 |
 
 #### breakpoint width
 

--- a/components/layout/index.zh-CN.md
+++ b/components/layout/index.zh-CN.md
@@ -104,8 +104,8 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HdS6Q5vUCDcAAA
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | breakpoint | 触发响应式布局的[断点](/components/grid-cn#col) | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` \| `xxxl` | - | xxxl: 6.3.0 |
-| classNames | 用于自定义 Sider 组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | className | 容器 className | string | - |  |
+| classNames | 用于自定义 Sider 组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | collapsed | 当前收起状态 | boolean | - |  |
 | collapsedWidth | 收缩宽度，设置为 0 会出现特殊 trigger | number | 80 |  |
 | collapsible | 是否可收起 | boolean | false |  |

--- a/scripts/__snapshots__/check-site.ts.snap
+++ b/scripts/__snapshots__/check-site.ts.snap
@@ -124,9 +124,9 @@ exports[`site test Component components/input-number en Page 1`] = `2`;
 
 exports[`site test Component components/input-number zh Page 1`] = `2`;
 
-exports[`site test Component components/layout en Page 1`] = `2`;
+exports[`site test Component components/layout en Page 1`] = `3`;
 
-exports[`site test Component components/layout zh Page 1`] = `2`;
+exports[`site test Component components/layout zh Page 1`] = `3`;
 
 exports[`site test Component components/list en Page 1`] = `5`;
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Improvement
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other

### 🔗 Related issue link

Fixes #13527

### 💡 Background and solution

`Layout.Sider` renders its content inside an internal `${prefixCls}-children` wrapper. As described in #13527, applying `style={{ display: 'flex' }}` to `Sider` only styles the outer `aside`, so users still need an extra wrapper element when they want to lay out the Sider content with flexbox.

This adds the existing semantic DOM customization pattern to `Layout.Sider`:

- `classNames.children` for the internal content wrapper class
- `styles.children` for the internal content wrapper style

The outer `className` and `style` behavior is unchanged, including width/collapse styles and trigger behavior.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support `classNames.children` and `styles.children` on `Layout.Sider` to customize its content wrapper. |
| 🇨🇳 Chinese | 为 `Layout.Sider` 支持 `classNames.children` 与 `styles.children` 以自定义内容包裹容器。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### ✅ Test Plan

- `npm test -- components/layout/__tests__/index.test.tsx --runInBand`
- `npx eslint components/layout/Sider.tsx components/layout/__tests__/index.test.tsx`
- `git diff --check`
