### PR TITLE
feat: support semantic styles for Layout Sider

### DIFF
--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -6,8 +6,8 @@ import RightOutlined from '@ant-design/icons/RightOutlined';
 import { omit } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { useMergeSemantic } from '../_util/hooks';
-import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks';
+import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { isFunction } from '../_util/is';
 import type { Breakpoint } from '../_util/responsiveObserver';
 import { ConfigContext } from '../config-provider';
@@ -37,17 +37,16 @@ export type CollapseType = 'clickTrigger' | 'responsive';
 
 export type SiderTheme = 'light' | 'dark';
 
-export type SiderSemanticClassNames = {
-  children?: string;
+export type SiderSemanticType = {
+  classNames?: {
+    children?: string;
+  };
+  styles?: {
+    children?: React.CSSProperties;
+  };
 };
 
-export type SiderSemanticStyles = {
-  children?: React.CSSProperties;
-};
-
-export type SiderClassNamesType = SemanticClassNamesType<SiderProps, SiderSemanticClassNames>;
-
-export type SiderStylesType = SemanticStylesType<SiderProps, SiderSemanticStyles>;
+export type SiderSemanticAllType = GenerateSemantic<SiderSemanticType, SiderProps>;
 
 export interface SiderProps extends React.HTMLAttributes<HTMLDivElement> {
   prefixCls?: string;
@@ -63,8 +62,8 @@ export interface SiderProps extends React.HTMLAttributes<HTMLDivElement> {
   breakpoint?: Breakpoint;
   theme?: SiderTheme;
   onBreakpoint?: (broken: boolean) => void;
-  classNames?: SiderClassNamesType;
-  styles?: SiderStylesType;
+  classNames?: SiderSemanticAllType['classNamesAndFn'];
+  styles?: SiderSemanticAllType['stylesAndFn'];
 }
 
 export interface SiderState {
@@ -137,11 +136,7 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
     onBreakpoint,
   };
 
-  const [mergedClassNames, mergedStyles] = useMergeSemantic<
-    SiderSemanticClassNames,
-    SiderSemanticStyles,
-    SiderProps
-  >([classNames], [styles], {
+  const [mergedClassNames, mergedStyles] = useMergeSemantic([classNames], [styles], {
     props: semanticProps,
   });
 

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -37,25 +37,17 @@ export type CollapseType = 'clickTrigger' | 'responsive';
 
 export type SiderTheme = 'light' | 'dark';
 
-export interface SiderSemanticClassNames {
-  children?: string;
-}
-
-export interface SiderSemanticStyles {
-  children?: React.CSSProperties;
-}
-
-type SiderSemanticClassNamesRecord = {
+export type SiderSemanticClassNames = {
   children?: string;
 };
 
-type SiderSemanticStylesRecord = {
+export type SiderSemanticStyles = {
   children?: React.CSSProperties;
 };
 
-export type SiderClassNamesType = SemanticClassNamesType<SiderProps, SiderSemanticClassNamesRecord>;
+export type SiderClassNamesType = SemanticClassNamesType<SiderProps, SiderSemanticClassNames>;
 
-export type SiderStylesType = SemanticStylesType<SiderProps, SiderSemanticStylesRecord>;
+export type SiderStylesType = SemanticStylesType<SiderProps, SiderSemanticStyles>;
 
 export interface SiderProps extends React.HTMLAttributes<HTMLDivElement> {
   prefixCls?: string;
@@ -112,8 +104,8 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
   const { siderHook } = useContext(LayoutContext);
 
   const [mergedClassNames, mergedStyles] = useMergeSemantic<
-    SiderSemanticClassNamesRecord,
-    SiderSemanticStylesRecord,
+    SiderSemanticClassNames,
+    SiderSemanticStyles,
     SiderProps
   >([classNames], [styles], {
     props,

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -39,10 +39,10 @@ export type SiderTheme = 'light' | 'dark';
 
 export type SiderSemanticType = {
   classNames?: {
-    children?: string;
+    body?: string;
   };
   styles?: {
-    children?: React.CSSProperties;
+    body?: React.CSSProperties;
   };
 };
 
@@ -254,8 +254,8 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
     <SiderContext.Provider value={contextValue}>
       <aside className={siderCls} {...divProps} style={divStyle} ref={ref}>
         <div
-          className={clsx(`${prefixCls}-children`, mergedClassNames.children)}
-          style={mergedStyles.children}
+          className={clsx(`${prefixCls}-children`, mergedClassNames.body)}
+          style={mergedStyles.body}
         >
           {children}
         </div>

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -39,9 +39,11 @@ export type SiderTheme = 'light' | 'dark';
 
 export type SiderSemanticType = {
   classNames?: {
+    root?: string;
     body?: string;
   };
   styles?: {
+    root?: React.CSSProperties;
     body?: React.CSSProperties;
   };
 };
@@ -241,6 +243,7 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
       [`${prefixCls}-zero-width`]: Number.parseFloat(siderWidth) === 0,
     },
     className,
+    mergedClassNames.root,
     hashId,
     cssVarCls,
   );
@@ -252,7 +255,12 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
 
   return (
     <SiderContext.Provider value={contextValue}>
-      <aside className={siderCls} {...divProps} style={divStyle} ref={ref}>
+      <aside
+        className={siderCls}
+        {...divProps}
+        style={{ ...mergedStyles.root, ...divStyle }}
+        ref={ref}
+      >
         <div
           className={clsx(`${prefixCls}-children`, mergedClassNames.body)}
           style={mergedStyles.body}

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -103,14 +103,6 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
   } = props;
   const { siderHook } = useContext(LayoutContext);
 
-  const [mergedClassNames, mergedStyles] = useMergeSemantic<
-    SiderSemanticClassNames,
-    SiderSemanticStyles,
-    SiderProps
-  >([classNames], [styles], {
-    props,
-  });
-
   const [collapsed, setCollapsed] = useState(
     'collapsed' in props ? props.collapsed : defaultCollapsed,
   );
@@ -128,6 +120,30 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
     }
     onCollapse?.(value, type);
   };
+
+  const semanticProps: SiderProps = {
+    ...props,
+    collapsed,
+    defaultCollapsed,
+    theme,
+    style,
+    collapsible,
+    reverseArrow,
+    width,
+    collapsedWidth,
+    zeroWidthTriggerStyle,
+    breakpoint,
+    onCollapse,
+    onBreakpoint,
+  };
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    SiderSemanticClassNames,
+    SiderSemanticStyles,
+    SiderProps
+  >([classNames], [styles], {
+    props: semanticProps,
+  });
 
   // =========================== Prefix ===========================
   const { getPrefixCls, direction } = useContext(ConfigContext);

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -6,6 +6,8 @@ import RightOutlined from '@ant-design/icons/RightOutlined';
 import { omit } from '@rc-component/util';
 import { clsx } from 'clsx';
 
+import { useMergeSemantic } from '../_util/hooks';
+import type { SemanticClassNamesType, SemanticStylesType } from '../_util/hooks';
 import { isFunction } from '../_util/is';
 import type { Breakpoint } from '../_util/responsiveObserver';
 import { ConfigContext } from '../config-provider';
@@ -35,6 +37,26 @@ export type CollapseType = 'clickTrigger' | 'responsive';
 
 export type SiderTheme = 'light' | 'dark';
 
+export interface SiderSemanticClassNames {
+  children?: string;
+}
+
+export interface SiderSemanticStyles {
+  children?: React.CSSProperties;
+}
+
+type SiderSemanticClassNamesRecord = {
+  children?: string;
+};
+
+type SiderSemanticStylesRecord = {
+  children?: React.CSSProperties;
+};
+
+export type SiderClassNamesType = SemanticClassNamesType<SiderProps, SiderSemanticClassNamesRecord>;
+
+export type SiderStylesType = SemanticStylesType<SiderProps, SiderSemanticStylesRecord>;
+
 export interface SiderProps extends React.HTMLAttributes<HTMLDivElement> {
   prefixCls?: string;
   collapsible?: boolean;
@@ -49,6 +71,8 @@ export interface SiderProps extends React.HTMLAttributes<HTMLDivElement> {
   breakpoint?: Breakpoint;
   theme?: SiderTheme;
   onBreakpoint?: (broken: boolean) => void;
+  classNames?: SiderClassNamesType;
+  styles?: SiderStylesType;
 }
 
 export interface SiderState {
@@ -81,9 +105,19 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
     breakpoint,
     onCollapse,
     onBreakpoint,
+    classNames,
+    styles,
     ...otherProps
   } = props;
   const { siderHook } = useContext(LayoutContext);
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    SiderSemanticClassNamesRecord,
+    SiderSemanticStylesRecord,
+    SiderProps
+  >([classNames], [styles], {
+    props,
+  });
 
   const [collapsed, setCollapsed] = useState(
     'collapsed' in props ? props.collapsed : defaultCollapsed,
@@ -216,7 +250,12 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
   return (
     <SiderContext.Provider value={contextValue}>
       <aside className={siderCls} {...divProps} style={divStyle} ref={ref}>
-        <div className={`${prefixCls}-children`}>{children}</div>
+        <div
+          className={clsx(`${prefixCls}-children`, mergedClassNames.children)}
+          style={mergedStyles.children}
+        >
+          {children}
+        </div>
         {collapsible || (below && zeroWidthTrigger) ? triggerDom : null}
       </aside>
     </SiderContext.Provider>

--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -205,6 +205,26 @@ describe('Layout', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
+  it('should customize the children container with semantic classNames and styles', () => {
+    const { container } = render(
+      <Sider
+        classNames={{ children: 'custom-sider-children' }}
+        styles={{ children: { display: 'flex', flexDirection: 'column' } }}
+      >
+        Sider
+      </Sider>,
+    );
+    const sider = container.querySelector<HTMLElement>('.ant-layout-sider')!;
+    const children = container.querySelector<HTMLElement>('.ant-layout-sider-children')!;
+
+    expect(sider).not.toHaveClass('custom-sider-children');
+    expect(children).toHaveClass('custom-sider-children');
+    expect(children).toHaveStyle({
+      display: 'flex',
+      flexDirection: 'column',
+    });
+  });
+
   it('should not add ant-layout-has-sider when `hasSider` is `false`', () => {
     const { container } = render(
       <Layout hasSider={false}>

--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -205,21 +205,21 @@ describe('Layout', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
-  it('should customize the children container with semantic classNames and styles', () => {
+  it('should customize the body container with semantic classNames and styles', () => {
     const { container } = render(
       <Sider
-        classNames={{ children: 'custom-sider-children' }}
-        styles={{ children: { display: 'flex', flexDirection: 'column' } }}
+        classNames={{ body: 'custom-sider-body' }}
+        styles={{ body: { display: 'flex', flexDirection: 'column' } }}
       >
         Sider
       </Sider>,
     );
     const sider = container.querySelector<HTMLElement>('.ant-layout-sider')!;
-    const children = container.querySelector<HTMLElement>('.ant-layout-sider-children')!;
+    const body = container.querySelector<HTMLElement>('.ant-layout-sider-children')!;
 
-    expect(sider).not.toHaveClass('custom-sider-children');
-    expect(children).toHaveClass('custom-sider-children');
-    expect(children).toHaveStyle({
+    expect(sider).not.toHaveClass('custom-sider-body');
+    expect(body).toHaveClass('custom-sider-body');
+    expect(body).toHaveStyle({
       display: 'flex',
       flexDirection: 'column',
     });
@@ -230,25 +230,25 @@ describe('Layout', () => {
       <Sider
         collapsible
         classNames={({ props }) => ({
-          children: props.collapsed ? 'children-collapsed' : 'children-expanded',
+          body: props.collapsed ? 'body-collapsed' : 'body-expanded',
         })}
         styles={({ props }) => ({
-          children: { opacity: props.collapsed ? 0.5 : 1 },
+          body: { opacity: props.collapsed ? 0.5 : 1 },
         })}
       >
         Sider
       </Sider>,
     );
-    const children = container.querySelector<HTMLElement>('.ant-layout-sider-children')!;
+    const body = container.querySelector<HTMLElement>('.ant-layout-sider-children')!;
     const trigger = container.querySelector<HTMLElement>('.ant-layout-sider-trigger')!;
 
-    expect(children).toHaveClass('children-expanded');
-    expect(children).toHaveStyle({ opacity: '1' });
+    expect(body).toHaveClass('body-expanded');
+    expect(body).toHaveStyle({ opacity: '1' });
 
     fireEvent.click(trigger);
 
-    expect(children).toHaveClass('children-collapsed');
-    expect(children).toHaveStyle({ opacity: '0.5' });
+    expect(body).toHaveClass('body-collapsed');
+    expect(body).toHaveStyle({ opacity: '0.5' });
   });
 
   it('should not add ant-layout-has-sider when `hasSider` is `false`', () => {

--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -205,11 +205,14 @@ describe('Layout', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
-  it('should customize the body container with semantic classNames and styles', () => {
+  it('should customize root and body with semantic classNames and styles', () => {
     const { container } = render(
       <Sider
-        classNames={{ body: 'custom-sider-body' }}
-        styles={{ body: { display: 'flex', flexDirection: 'column' } }}
+        classNames={{ root: 'custom-sider-root', body: 'custom-sider-body' }}
+        styles={{
+          root: { backgroundColor: 'rgb(1, 2, 3)' },
+          body: { display: 'flex', flexDirection: 'column' },
+        }}
       >
         Sider
       </Sider>,
@@ -217,6 +220,8 @@ describe('Layout', () => {
     const sider = container.querySelector<HTMLElement>('.ant-layout-sider')!;
     const body = container.querySelector<HTMLElement>('.ant-layout-sider-children')!;
 
+    expect(sider).toHaveClass('custom-sider-root');
+    expect(sider).toHaveStyle({ backgroundColor: 'rgb(1, 2, 3)' });
     expect(sider).not.toHaveClass('custom-sider-body');
     expect(body).toHaveClass('custom-sider-body');
     expect(body).toHaveStyle({

--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -225,6 +225,32 @@ describe('Layout', () => {
     });
   });
 
+  it('should pass merged state to semantic classNames and styles callbacks', () => {
+    const { container } = render(
+      <Sider
+        collapsible
+        classNames={({ props }) => ({
+          children: props.collapsed ? 'children-collapsed' : 'children-expanded',
+        })}
+        styles={({ props }) => ({
+          children: { opacity: props.collapsed ? 0.5 : 1 },
+        })}
+      >
+        Sider
+      </Sider>,
+    );
+    const children = container.querySelector<HTMLElement>('.ant-layout-sider-children')!;
+    const trigger = container.querySelector<HTMLElement>('.ant-layout-sider-trigger')!;
+
+    expect(children).toHaveClass('children-expanded');
+    expect(children).toHaveStyle({ opacity: '1' });
+
+    fireEvent.click(trigger);
+
+    expect(children).toHaveClass('children-collapsed');
+    expect(children).toHaveStyle({ opacity: '0.5' });
+  });
+
   it('should not add ant-layout-has-sider when `hasSider` is `false`', () => {
     const { container } = render(
       <Layout hasSider={false}>

--- a/components/layout/demo/_semantic.tsx
+++ b/components/layout/demo/_semantic.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Layout } from 'antd';
+
+import useLocale from '../../../.dumi/hooks/useLocale';
+import SemanticPreview from '../../../.dumi/theme/common/SemanticPreview';
+
+const { Sider } = Layout;
+
+const locales = {
+  cn: {
+    root: '根元素，包含 Sider 的布局、主题、宽度和折叠状态样式',
+    body: '内容包裹元素，包含 Sider 子内容的布局和展示样式',
+  },
+  en: {
+    root: 'Root element with Sider layout, theme, width and collapsed state styles',
+    body: 'Body element that wraps Sider children layout and display styles',
+  },
+};
+
+const App: React.FC = () => {
+  const [locale] = useLocale(locales);
+  return (
+    <SemanticPreview
+      componentName="Layout.Sider"
+      semantics={[
+        { name: 'root', desc: locale.root },
+        { name: 'body', desc: locale.body },
+      ]}
+    >
+      <Sider styles={{ body: { minHeight: 96 } }}>Sider</Sider>
+    </SemanticPreview>
+  );
+};
+
+export default App;

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -117,7 +117,7 @@ The sidebar.
 
 #### Semantic DOM
 
-- `children`: Content wrapper of the Sider
+- `body`: Content wrapper of the Sider
 
 #### breakpoint width
 

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -115,9 +115,9 @@ The sidebar.
 | onBreakpoint | The callback function, executed when [breakpoints](/components/grid/#api) changed | (broken) => {} | - |  |
 | onCollapse | The callback function, executed by clicking the trigger or activating the responsive layout | (collapsed, type) => {} | - |  |
 
-#### Semantic DOM
+## Semantic DOM
 
-- `body`: Content wrapper of the Sider
+<code src="./demo/_semantic.tsx" simplify="true"></code>
 
 #### breakpoint width
 

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -101,17 +101,23 @@ The sidebar.
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | breakpoint | [Breakpoints](/components/grid/#col) of the responsive layout | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` \| `xxxl` | - | xxxl: 6.3.0 |
+| classNames | Customize class for each semantic structure inside the Sider component, supports object or function | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | collapsed | To set the current status | boolean | - |  |
 | collapsedWidth | Width of the collapsed sidebar, by setting to 0 a special trigger will appear | number | 80 |  |
 | collapsible | Whether can be collapsed | boolean | false |  |
 | defaultCollapsed | To set the initial status | boolean | false |  |
 | reverseArrow | Reverse direction of arrow, for a sider that expands from the right | boolean | false |  |
+| styles | Customize inline style for each semantic structure inside the Sider component, supports object or function | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
 | theme | Color theme of the sidebar | `light` \| `dark` | `dark` |  |
 | trigger | Specify the customized trigger, set to null to hide the trigger | ReactNode | - |  |
 | width | Width of the sidebar | number \| string | 200 |  |
 | zeroWidthTriggerStyle | To customize the styles of the special trigger that appears when `collapsedWidth` is 0 | object | - |  |
 | onBreakpoint | The callback function, executed when [breakpoints](/components/grid/#api) changed | (broken) => {} | - |  |
 | onCollapse | The callback function, executed by clicking the trigger or activating the responsive layout | (collapsed, type) => {} | - |  |
+
+#### Semantic DOM
+
+- `children`: Content wrapper of the Sider
 
 #### breakpoint width
 

--- a/components/layout/index.zh-CN.md
+++ b/components/layout/index.zh-CN.md
@@ -116,9 +116,9 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HdS6Q5vUCDcAAA
 | onBreakpoint | 触发响应式布局[断点](/components/grid-cn#api)时的回调 | (broken) => {} | - |  |
 | onCollapse | 展开-收起时的回调函数，有点击 trigger 以及响应式反馈两种方式可以触发 | (collapsed, type) => {} | - |  |
 
-#### Semantic DOM
+## Semantic DOM
 
-- `body`：Sider 的内容包裹容器
+<code src="./demo/_semantic.tsx" simplify="true"></code>
 
 #### breakpoint width
 

--- a/components/layout/index.zh-CN.md
+++ b/components/layout/index.zh-CN.md
@@ -102,17 +102,23 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HdS6Q5vUCDcAAA
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | breakpoint | 触发响应式布局的[断点](/components/grid-cn#col) | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` \| `xxxl` | - | xxxl: 6.3.0 |
+| classNames | 用于自定义 Sider 组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | collapsed | 当前收起状态 | boolean | - |  |
 | collapsedWidth | 收缩宽度，设置为 0 会出现特殊 trigger | number | 80 |  |
 | collapsible | 是否可收起 | boolean | false |  |
 | defaultCollapsed | 是否默认收起 | boolean | false |  |
 | reverseArrow | 翻转折叠提示箭头的方向，当 Sider 在右边时可以使用 | boolean | false |  |
+| styles | 用于自定义 Sider 组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
 | theme | 主题颜色 | `light` \| `dark` | `dark` |  |
 | trigger | 自定义 trigger，设置为 null 时隐藏 trigger | ReactNode | - |  |
 | width | 宽度 | number \| string | 200 |  |
 | zeroWidthTriggerStyle | 指定当 `collapsedWidth` 为 0 时出现的特殊 trigger 的样式 | object | - |  |
 | onBreakpoint | 触发响应式布局[断点](/components/grid-cn#api)时的回调 | (broken) => {} | - |  |
 | onCollapse | 展开-收起时的回调函数，有点击 trigger 以及响应式反馈两种方式可以触发 | (collapsed, type) => {} | - |  |
+
+#### Semantic DOM
+
+- `children`：Sider 的内容包裹容器
 
 #### breakpoint width
 

--- a/components/layout/index.zh-CN.md
+++ b/components/layout/index.zh-CN.md
@@ -118,7 +118,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HdS6Q5vUCDcAAA
 
 #### Semantic DOM
 
-- `children`：Sider 的内容包裹容器
+- `body`：Sider 的内容包裹容器
 
 #### breakpoint width
 


### PR DESCRIPTION
## Summary

Fixes #13527.

This adds semantic `classNames` and `styles` support to `Layout.Sider`, allowing consumers to style the internal Sider content wrapper directly without adding an extra wrapper element.

This supersedes #57937 with a clean branch: the final diff only touches `components/layout/*` implementation, tests, and docs. It does not modify `.github/`, `scripts/`, or changelog files.

## Changes

- Add `classNames` and `styles` props to `SiderProps`
- Merge semantic class/style props with `useMergeSemantic`
- Apply the `body` semantic class/style to the existing `.ant-layout-sider-children` wrapper
- Add regression coverage for applying semantic styles to the Sider body wrapper, not the root
- Document the `body` semantic target in English and Chinese docs

## Verification

- `npm test -- components/layout/__tests__/index.test.tsx --runInBand`
- `npm run lint:biome -- components/layout/Sider.tsx components/layout/__tests__/index.test.tsx components/layout/index.en-US.md components/layout/index.zh-CN.md`
- `git diff --check`

I also checked `npm run tsc`; the current local checkout fails on existing generated/dependency type issues outside Layout (for example `.dumi` and `@rc-component/*` type exports), so the targeted Layout verification above is the reliable signal for this PR scope.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#13527: Make it possible to directly turn a Slider into a flexbox](https://oss.issuehunt.io/repos/34526884/issues/13527)
---
</details>
<!-- /Issuehunt content-->