### PR TITLE
fix: normalize cloned Input change target to mounted input

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -233,7 +233,7 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
     const liveInput = inputRef.current?.input;
 
     if (liveInput && e.target !== liveInput) {
-      const eventValue = e.target.value;
+      const eventValue = String(e.target.value);
       const originalValue = liveInput.value;
       const shouldPatchValue = eventValue !== originalValue;
 

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -226,7 +226,37 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     removePasswordTimeout();
-    onChange?.(e);
+    if (!onChange) {
+      return;
+    }
+
+    const liveInput = inputRef.current?.input;
+
+    if (liveInput && e.target !== liveInput) {
+      const eventValue = e.target.value;
+      const originalValue = liveInput.value;
+      const shouldPatchValue = eventValue !== originalValue;
+
+      if (shouldPatchValue) {
+        liveInput.value = eventValue;
+      }
+
+      try {
+        onChange(
+          Object.create(e, {
+            target: { value: liveInput, enumerable: true, configurable: true },
+            currentTarget: { value: liveInput, enumerable: true, configurable: true },
+          }) as React.ChangeEvent<HTMLInputElement>,
+        );
+      } finally {
+        if (shouldPatchValue && liveInput.value === eventValue) {
+          liveInput.value = originalValue;
+        }
+      }
+      return;
+    }
+
+    onChange(e);
   };
 
   const suffixNode = (hasFeedback || suffix) && (

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -372,7 +372,7 @@ describe('Input allowClear', () => {
   it('should pass the mounted input as the change target when rc-input clones the event', () => {
     let argumentEventTarget: EventTarget | null = null;
     let argumentEventCurrentTarget: EventTarget | null = null;
-    let argumentEventObjectValue;
+    let argumentEventObjectValue: string | undefined;
 
     const onChange: InputProps['onChange'] = (e) => {
       argumentEventTarget = e.target;

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -369,6 +369,29 @@ describe('Input allowClear', () => {
     expect(container.querySelector('input')?.value).toBe('111');
   });
 
+  it('should pass the mounted input as the change target when rc-input clones the event', () => {
+    let argumentEventTarget: EventTarget | null = null;
+    let argumentEventCurrentTarget: EventTarget | null = null;
+    let argumentEventObjectValue;
+
+    const onChange: InputProps['onChange'] = (e) => {
+      argumentEventTarget = e.target;
+      argumentEventCurrentTarget = e.currentTarget;
+      argumentEventObjectValue = e.target.value;
+    };
+
+    const { container } = render(<Input allowClear value="111" onChange={onChange} />);
+    const input = container.querySelector('input')!;
+
+    fireEvent.click(container.querySelector('.ant-input-clear-icon')!);
+
+    expect(argumentEventTarget).toBe(input);
+    expect(argumentEventCurrentTarget).toBe(input);
+    expect(document.contains(argumentEventTarget as Node)).toBe(true);
+    expect(argumentEventObjectValue).toBe('');
+    expect(input.value).toBe('111');
+  });
+
   it('should focus input after clear', () => {
     const { container, unmount } = render(<Input allowClear defaultValue="111" />, {
       container: document.body,


### PR DESCRIPTION
### Summary

- Normalize cloned `Input` change events so `target` and `currentTarget` point to the mounted input element.
- Preserve cloned event values during the callback, including controlled `allowClear`, without committing those temporary values to the DOM afterward.
- Add regression coverage for connected target/currentTarget and controlled clear value behavior.

Fixes #46999.

### Test

- npm.cmd test -- components/input/__tests__/index.test.tsx --runInBand


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#46999: Antd Input: To use with react-number-format customInput feature.](https://oss.issuehunt.io/repos/34526884/issues/46999)
---
</details>
<!-- /Issuehunt content-->