### PR TITLE
fix(Space): fix compact item hover border overlap

### DIFF
--- a/components/style/compact-item-vertical.ts
+++ b/components/style/compact-item-vertical.ts
@@ -18,8 +18,12 @@ function compactItemVerticalBorder(
     },
 
     '&-item': {
-      '&:hover,&:focus,&:active': {
+      '&:focus,&:active': {
         zIndex: 3,
+      },
+
+      '&:hover': {
+        zIndex: 4,
       },
 
       '&[disabled]': {

--- a/components/style/compact-item.ts
+++ b/components/style/compact-item.ts
@@ -27,12 +27,13 @@ function compactItemBorder(
 ): CSSObject {
   const { focusElCls, focus, borderElCls } = options;
   const childCombinator = borderElCls ? '> *' : '';
+  const suffix = childCombinator ? ` ${childCombinator}` : '';
   const genEffects = (effects: (string | null)[]) =>
     effects
       .filter(Boolean)
-      .map((n) => `&:${n}${childCombinator ? ` ${childCombinator}` : ''}`)
+      .map((n) => `&:${n}${suffix}`)
       .join(',');
-  const hoverEffects = genEffects(['hover']);
+  const hoverEffects = genEffects(['hover', focusElCls ? `hover${focusElCls}` : null]);
   const focusEffects = genEffects([focus ? 'focus' : null, 'active']);
 
   return {

--- a/components/style/compact-item.ts
+++ b/components/style/compact-item.ts
@@ -27,10 +27,13 @@ function compactItemBorder(
 ): CSSObject {
   const { focusElCls, focus, borderElCls } = options;
   const childCombinator = borderElCls ? '> *' : '';
-  const hoverEffects = ['hover', focus ? 'focus' : null, 'active']
-    .filter(Boolean)
-    .map((n) => `&:${n} ${childCombinator}`)
-    .join(',');
+  const genEffects = (effects: (string | null)[]) =>
+    effects
+      .filter(Boolean)
+      .map((n) => `&:${n}${childCombinator ? ` ${childCombinator}` : ''}`)
+      .join(',');
+  const hoverEffects = genEffects(['hover']);
+  const focusEffects = genEffects([focus ? 'focus' : null, 'active']);
 
   return {
     [`&-item:not(${parentCls}-last-item)`]: {
@@ -42,8 +45,12 @@ function compactItemBorder(
     },
 
     '&-item': {
-      [hoverEffects]: {
+      [focusEffects]: {
         zIndex: 3,
+      },
+
+      [hoverEffects]: {
+        zIndex: 4,
       },
 
       ...(focusElCls


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #57931

### 💡 需求背景和解决方案

Space.Compact 中相邻按钮通过负 margin 合并边框。此前 hover、focus、active 共享相同 z-index，先聚焦一个按钮再 hover 相邻按钮时，hover 按钮边框会被 focus 按钮遮挡。

本次调整水平和垂直 compact item 的层级，使 hover 状态高于 focus/active 状态，从而保证相邻项的 hover 边框正常显示。

已验证：

- `npx eslint components/style/compact-item.ts components/style/compact-item-vertical.ts components/space/__tests__/space-compact.test.tsx`
- `npx jest --config .jest.js components/space/__tests__/space-compact.test.tsx --runInBand --no-cache`

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Space.Compact hover border being covered by adjacent focused item. |
| 🇨🇳 中文 | 🐞 修复 Space.Compact 相邻项聚焦后 hover 边框被遮挡的问题。 |
