### PR TITLE
fix: allow contributor welcome workflow to run for fork PRs

### DIFF
--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -20,8 +20,8 @@ jobs:
     permissions:
       issues: write  # for actions-cool/maintain-one-comment to modify or create issue comments
       pull-requests: write  # for actions-cool/maintain-one-comment to modify or create PR comments
-    # Only run for merged PRs from the same repo (not from forks)
-    if: github.event.pull_request.merged == true && github.repository == 'ant-design/ant-design' && github.event.pull_request.head.repo.full_name == github.repository
+    # Only run for merged PRs on the main repo
+    if: github.event.pull_request.merged == true && github.repository == 'ant-design/ant-design'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
@@ -36,7 +36,7 @@ jobs:
             echo "COUNT=999" >> $GITHUB_OUTPUT
             exit 0
           fi
-          RESULT_DATA=$(curl -s "https://api.github.com/repos/${{ github.repository }}/commits?author=${PR_AUTHOR}&per_page=5")
+          RESULT_DATA=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${{ github.repository }}/commits?author=${PR_AUTHOR}&per_page=5")
           DATA_LENGTH=$(echo $RESULT_DATA | jq 'if type == "array" then length else 0 end')
           echo "COUNT=$DATA_LENGTH" >> $GITHUB_OUTPUT
       - name: Comment on PR

--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -29,6 +29,7 @@ jobs:
         id: get_commit_count
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Validate username format (GitHub usernames: alphanumeric and hyphens, max 39 chars)
           if ! [[ "$PR_AUTHOR" =~ ^[a-zA-Z0-9-]{1,39}$ ]]; then
@@ -36,7 +37,7 @@ jobs:
             echo "COUNT=999" >> $GITHUB_OUTPUT
             exit 0
           fi
-          RESULT_DATA=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${{ github.repository }}/commits?author=${PR_AUTHOR}&per_page=5")
+          RESULT_DATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${{ github.repository }}/commits?author=${PR_AUTHOR}&per_page=5")
           DATA_LENGTH=$(echo $RESULT_DATA | jq 'if type == "array" then length else 0 end')
           echo "COUNT=$DATA_LENGTH" >> $GITHUB_OUTPUT
       - name: Comment on PR


### PR DESCRIPTION
## Summary

- Remove `head.repo.full_name == github.repository` condition that prevented the welcome workflow from running for fork PRs, which excluded all external contributors
- Add `Authorization` header to the GitHub API curl call to avoid anonymous rate limits (60/hr → 1000/hr)

## Background

之前在修改此 workflow 时误加了 `github.event.pull_request.head.repo.full_name == github.repository` 条件，导致所有来自 fork 的 PR 合并后该 workflow 均被 skip。而新贡献者几乎都是从 fork 提交 PR 的，所以欢迎评论一直无法发出，最近几个月新贡献者也无法收到进群邀请。由于 `pull_request_target` 事件本身已经安全地处理了 fork PR 的 secrets 访问，该限制条件是多余的。

## Test Plan

- [ ] Merge a PR from a fork and verify the welcome comment is posted for first-time contributors (commit count < 3)
- [ ] Verify that existing contributors (commit count ≥ 3) do not receive the welcome comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)