### PR TITLE
fix(Select): hide labelRender content while searching

### DIFF
--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -305,6 +305,10 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
 
             '&-has-search-value': {
               color: 'transparent',
+
+              [`> :not(${componentCls}-input)`]: {
+                opacity: 0,
+              },
             },
 
             // >>> Value


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Fixes #57951

### 💡 需求背景和解决方案

当 Select 或 TreeSelect 使用 `labelRender` 渲染图片、图标等非文本内容时，搜索状态下原本只通过 `color: transparent` 隐藏文本，非文本节点仍会显示。

本次在搜索已有输入值时隐藏非 input 子节点，让自定义 label 内容在搜索过程中完整消失，避免图片或图标残留。TreeSelect 共用 Select 输入样式，因此同步覆盖该场景。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Select and TreeSelect non-text `labelRender` content remaining visible while searching. |
| 🇨🇳 中文 | 🐞 修复 Select 和 TreeSelect 搜索时 `labelRender` 非文本内容仍可见的问题。 |
