### PR TITLE
chore: remove unused eslint-disable directives

### DIFF
--- a/.dumi/theme/utils/renderReactToHTML.tsx
+++ b/.dumi/theme/utils/renderReactToHTML.tsx
@@ -8,7 +8,7 @@ import { createRoot } from 'react-dom/client';
 export const renderReactToHTMLString = (node: React.ReactNode) => {
   const div = document.createElement('div');
   const root = createRoot(div);
-  // eslint-disable-next-line react/dom-no-flush-sync, react-dom/no-flush-sync
+  // eslint-disable-next-line react-dom/no-flush-sync
   flushSync(() => {
     root.render(node);
   });

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -128,12 +128,10 @@ const InternalForm: React.ForwardRefRenderFunction<FormRef, FormProps> = (props,
 
   const contextValidateMessages = React.useContext(ValidateMessagesContext);
 
-  /* eslint-disable react-hooks/rules-of-hooks */
   if (process.env.NODE_ENV !== 'production') {
     // biome-ignore lint/correctness/useHookAtTopLevel: Development-only warning hook called conditionally
     useFormWarning(props);
   }
-  /* eslint-enable */
 
   const mergedRequiredMark = React.useMemo(() => {
     if (requiredMark !== undefined) {

--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -51,16 +51,17 @@ export type InputSemanticType = {
 
 export type InputSemanticAllType = GenerateSemantic<InputSemanticType, InputProps>;
 
-export interface InputProps extends Omit<
-  RcInputProps,
-  | 'wrapperClassName'
-  | 'groupClassName'
-  | 'inputClassName'
-  | 'affixWrapperClassName'
-  | 'classes'
-  | 'classNames'
-  | 'styles'
-> {
+export interface InputProps
+  extends Omit<
+    RcInputProps,
+    | 'wrapperClassName'
+    | 'groupClassName'
+    | 'inputClassName'
+    | 'affixWrapperClassName'
+    | 'classes'
+    | 'classNames'
+    | 'styles'
+  > {
   rootClassName?: string;
   size?: SizeType;
   disabled?: boolean;
@@ -191,7 +192,6 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
   const inputHasPrefixSuffix = hasPrefixSuffix(props) || !!hasFeedback;
   const prevHasPrefixSuffixRef = useRef<boolean>(inputHasPrefixSuffix);
 
-  /* eslint-disable react-hooks/rules-of-hooks */
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('Input');
 
@@ -207,7 +207,6 @@ const Input = forwardRef<InputRef, InputProps>((props, ref) => {
       prevHasPrefixSuffixRef.current = inputHasPrefixSuffix;
     }, [inputHasPrefixSuffix]);
   }
-  /* eslint-enable */
 
   // ===================== Remove Password value =====================
   const removePasswordTimeout = useRemovePasswordTimeout(inputRef, true);

--- a/components/splitter/SplitBar.tsx
+++ b/components/splitter/SplitBar.tsx
@@ -204,7 +204,7 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
     };
 
     for (const [event, handler] of Object.entries(eventHandlerMap)) {
-      // eslint-disable-next-line react/web-api-no-leaked-event-listener, react-web-api/no-leaked-event-listener
+      // eslint-disable-next-line react/web-api-no-leaked-event-listener
       window.addEventListener(event, handler);
     }
 

--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -132,7 +132,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
 
     // Prevent React18 auto batch since input[upload] trigger process at same time
     // which makes fileList closure problem
-    // eslint-disable-next-line react/dom-no-flush-sync, react-dom/no-flush-sync
+    // eslint-disable-next-line react-dom/no-flush-sync
     flushSync(() => {
       setMergedFileList(cloneList);
     });
@@ -152,7 +152,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
       // We should ignore event if current file is exceed `maxCount`
       cloneList.some((f) => f.uid === file.uid)
     ) {
-      // eslint-disable-next-line react/dom-no-flush-sync, react-dom/no-flush-sync
+      // eslint-disable-next-line react-dom/no-flush-sync
       flushSync(() => {
         onChange?.(changeInfo);
       });


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🛠 重构

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

ESLint 配置中 `react/dom-no-flush-sync`、`react-hooks/rules-of-hooks`、`react-web-api/no-leaked-event-listener` 等规则已被关闭，但对应代码中的 `eslint-disable` 注释仍然引用了这些已关闭的规则名，导致 6 条 "Unused eslint-disable directive" 警告。

本次修复：
- 移除已关闭规则的 `eslint-disable` 注释（`react-hooks/rules-of-hooks` 的 `/* eslint-disable */` / `/* eslint-enable */` 整体移除）
- 保留仍生效规则的 `eslint-disable` 注释，仅删除多余的已关闭规则名（如 `react/dom-no-flush-sync, react-dom/no-flush-sync` → 只保留 `react-dom/no-flush-sync`）

修复后 ESLint 输出从 6 warnings 降为 0。

### 📝 更新日志

无需更新日志