### PR TITLE
fix(BorderBeam): prevent beam from breaking at corners

### DIFF
--- a/components/border-beam/style/index.ts
+++ b/components/border-beam/style/index.ts
@@ -63,7 +63,7 @@ const genBorderBeamStyle: GenerateStyle<BorderBeamToken, CSSObject> = (token) =>
             backgroundImage: varRef('beam-gradient', defaultBeamGradient),
             offsetAnchor: '90% 50%',
             offsetDistance: '0%',
-            offsetPath: 'rect(0 auto auto 0 round 200px)',
+            offsetPath: 'rect(0 auto auto 0 round 100px)',
             offsetRotate: 'auto',
             animationName: antBorderBeamMove,
             animationDuration: '6s',


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

BorderBeam 的光束伪元素宽度为 `100px`，而 `offsetPath` 中 `rect(... round ...)` 的圆角半径不能大于光束宽度；当半径为 `200px` 时，光束在路径转弯处会出现断开。

将 `offsetPath` 的圆角半径从 `200px` 调整为 `100px`，避免光束动画在圆角转弯处断开，让动画路径保持连续。

验证：
- `./node_modules/.bin/eslint components/border-beam/style/index.ts --cache`
- `./node_modules/.bin/jest --config .jest.js --no-cache components/border-beam --runInBand`

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix BorderBeam beam animation breaking at rounded corners. |
| 🇨🇳 中文 | 修复 BorderBeam 光束动画在圆角转弯处断开的问题。 |