### PR TITLE
docs: add changelog for 6.4.1

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,13 @@ tag: vVERSION
 
 ---
 
+## 6.4.1
+
+`2026-05-14`
+
+- 🐞 Revert the `exports` field added in [#57930](https://github.com/ant-design/ant-design/pull/57930) to fix antd TypeScript type resolution failure under `moduleResolution: "bundler"`. [#57968](https://github.com/ant-design/ant-design/pull/57968) [@afc163](https://github.com/afc163)
+- 🐞 Fix BorderBeam beam animation breaking at rounded corners. [#57969](https://github.com/ant-design/ant-design/pull/57969) [@QDyanbing](https://github.com/QDyanbing)
+
 ## 6.4.0
 
 `2026-05-14`

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,13 @@ tag: vVERSION
 
 ---
 
+## 6.4.1
+
+`2026-05-14`
+
+- 🐞 回滚 [#57930](https://github.com/ant-design/ant-design/pull/57930) 中新增的 `exports` 字段，修复 antd 在 `moduleResolution: "bundler"` 下 TypeScript 类型解析失败的问题。[#57968](https://github.com/ant-design/ant-design/pull/57968) [@afc163](https://github.com/afc163)
+- 🐞 修复 BorderBeam 光束动画在圆角转弯处断开的问题。[#57969](https://github.com/ant-design/ant-design/pull/57969) [@QDyanbing](https://github.com/QDyanbing)
+
 ## 6.4.0
 
 `2026-05-14`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "description": "An enterprise-class UI design language and React components implementation",
   "license": "MIT",
   "funding": {


### PR DESCRIPTION
### 🤔 What is the nature of this change?

- [ ] 🐞 Bug fix
- [ ] 🆕 New feature
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo code improvement
- [ ] 💄 Style / interaction improvement
- [ ] 🤖 TypeScript definition update
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance improvement
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility
- [ ] ❓ Other (about what?)

### 🔗 Related Issue

N/A

### 💡 Background and Solution

Release 6.4.1 patch version with the following changes:

- 🐞 Revert the `exports` field added in #57930 to fix antd TypeScript type resolution failure under `moduleResolution: "bundler"`. #57968
- 🐞 Fix BorderBeam beam animation breaking at rounded corners. #57969

### 📝 Changelog

| Language | Description |
| -------- | ----------- |
| 🇺🇸 English | Add changelog for 6.4.1 |
| 🇨🇳 Chinese | 添加 6.4.1 更新日志 |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>