### PR TITLE
fix: avoid deep rc notification runtime import

### DIFF
--- a/BUG_VERSIONS.json
+++ b/BUG_VERSIONS.json
@@ -80,5 +80,6 @@
   "5.25.0": ["https://github.com/ant-design/ant-design/issues/53764"],
   ">= 5.28.1 <= 5.29.0": ["https://github.com/ant-design/ant-design/issues/55755"],
   "6.3.0": ["https://github.com/ant-design/ant-design/pull/56946"],
-  "6.4.0": ["https://github.com/ant-design/ant-design/issues/56858"]
+  "6.4.0": ["https://github.com/ant-design/ant-design/issues/56858"],
+  "6.4.1": ["https://github.com/ant-design/ant-design/issues/57975"]
 }

--- a/components/message/PureList.tsx
+++ b/components/message/PureList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import NotificationList from '@rc-component/notification/es/NotificationList';
+import { NotificationList } from '@rc-component/notification';
 import type { NotificationListConfig } from '@rc-component/notification/es/NotificationList';
 import { clsx } from 'clsx';
 

--- a/components/notification/PureList.tsx
+++ b/components/notification/PureList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import NotificationList from '@rc-component/notification/es/NotificationList';
+import { NotificationList } from '@rc-component/notification';
 import type { NotificationListConfig } from '@rc-component/notification/es/NotificationList';
 import { clsx } from 'clsx';
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #57975

### 💡 需求背景和解决方案

6.4.1 中 Message 和 Notification 的 PureList 运行时代码直接深层导入 `@rc-component/notification/es/NotificationList`。在 Vite 8 / React Router v7 等严格 ESM 构建链路中，会继续加载 rc 内部无后缀 ESM 导入并导致构建报错。

本次将运行时导入调整为 `@rc-component/notification` 包入口，避免消费侧构建直接进入 rc notification 的内部 ESM 路径。同时将 6.4.1 标记到 `BUG_VERSIONS.json`。

已验证：
- `npm run tsc`
- Vite 8 临时项目构建通过

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Message and Notification build error in strict ESM toolchains caused by deep rc notification runtime import. |
| 🇨🇳 中文 | 修复 Message 和 Notification 在严格 ESM 构建链路下因 rc notification 运行时深层导入导致的构建报错。 |
