### PR TITLE
fix(Select): correct search input font styles in Safari

### DIFF
--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -272,7 +272,6 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
             color: varRef('color'),
             fontFamily: 'inherit',
             fontSize: 'inherit',
-            lineHeight: 'inherit',
 
             '&::-webkit-search-cancel-button': {
               display: 'none',
@@ -290,6 +289,7 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
           [`${componentCls}-input`]: {
             position: 'absolute',
             inset: 0,
+            lineHeight: 'inherit',
           },
 
           // Content center align

--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -270,6 +270,9 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
             margin: 0,
             padding: 0,
             color: varRef('color'),
+            fontFamily: 'inherit',
+            fontSize: 'inherit',
+            lineHeight: 'inherit',
 
             '&::-webkit-search-cancel-button': {
               display: 'none',
@@ -287,7 +290,6 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
           [`${componentCls}-input`]: {
             position: 'absolute',
             inset: 0,
-            lineHeight: `calc(${varRef('font-height')} + ${varRef('padding-vertical')} * 2)`,
           },
 
           // Content center align


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #57989

### 💡 需求背景和解决方案

Select 的搜索输入框在 Safari 中会使用表单控件默认字号，导致输入文字和光标偏小。同时 single 模式下输入框使用了按控件高度计算出的行高，Safari 中会表现出文字垂直位置异常。

本次调整让 Select 内部搜索 input 显式继承组件字体和行高，并移除 single 模式中额外的计算行高，使输入文字、光标和展示内容保持一致。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Select search input font size and line-height rendering issue in Safari. |
| 🇨🇳 中文 | 🐞 修复 Select 搜索输入框在 Safari 下字号和行高渲染异常的问题。 |