### PR TITLE
perf: memoize callbacks and computations to reduce unnecessary re-renders across components

### DIFF
--- a/components/button/Button.tsx
+++ b/components/button/Button.tsx
@@ -275,19 +275,15 @@ const InternalCompoundedButton = React.forwardRef<
 
   // Two chinese characters check
   useEffect(() => {
-    // FIXME: for HOC usage like <FormatMessage />
     if (!buttonRef.current || !mergedInsertSpace) {
       return;
     }
     const buttonText = buttonRef.current.textContent || '';
-    if (needInserted && isTwoCNChar(buttonText)) {
-      if (!hasTwoCNChar) {
-        setHasTwoCNChar(true);
-      }
-    } else if (hasTwoCNChar) {
-      setHasTwoCNChar(false);
-    }
-  });
+    setHasTwoCNChar((prev) => {
+      const matched = needInserted && isTwoCNChar(buttonText);
+      return matched === prev ? prev : matched;
+    });
+  }, [needInserted, mergedInsertSpace, children]);
 
   // Auto focus
   useEffect(() => {

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -209,13 +209,17 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
 
   let head: React.ReactNode;
   const tabSize = mergedSize !== 'small' ? 'large' : mergedSize;
-  const tabs = tabList ? (
+  const tabItems = React.useMemo(
+    () => tabList?.map(({ tab, ...item }) => ({ label: tab, ...item })),
+    [tabList],
+  );
+  const tabs = tabItems ? (
     <Tabs
       size={tabSize}
       {...extraProps}
       className={`${prefixCls}-head-tabs`}
       onChange={onTabChange}
-      items={tabList.map(({ tab, ...item }) => ({ label: tab, ...item }))}
+      items={tabItems}
     />
   ) : null;
   if (title || extra || tabs) {

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -440,6 +440,11 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
   );
 
   // ==================== Render =====================
+  const computedBuiltinPlacements = React.useMemo(
+    () => mergedBuiltinPlacements(builtinPlacements, popupOverflow),
+    [builtinPlacements, popupOverflow],
+  );
+
   return (
     <RcCascader
       prefixCls={prefixCls}
@@ -468,7 +473,7 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
       classNames={mergedClassNames}
       styles={mergedStyles}
       {...(restProps as any)}
-      builtinPlacements={mergedBuiltinPlacements(builtinPlacements, popupOverflow)}
+      builtinPlacements={computedBuiltinPlacements}
       direction={mergedDirection}
       placement={memoPlacement}
       notFoundContent={mergedNotFoundContent}

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -257,13 +257,17 @@ const Dropdown: CompoundedComponent = React.forwardRef<HTMLElement, DropdownProp
     { [`${prefixCls}-rtl`]: direction === 'rtl' },
   );
 
-  const builtinPlacements = getPlacements({
-    arrowPointAtCenter: isPlainObject(arrow) && arrow.pointAtCenter,
-    autoAdjustOverflow,
-    offset: token.marginXXS,
-    arrowWidth: arrow ? token.sizePopupArrow : 0,
-    borderRadius: token.borderRadius,
-  });
+  const builtinPlacements = React.useMemo(
+    () =>
+      getPlacements({
+        arrowPointAtCenter: isPlainObject(arrow) && arrow.pointAtCenter,
+        autoAdjustOverflow,
+        offset: token.marginXXS,
+        arrowWidth: arrow ? token.sizePopupArrow : 0,
+        borderRadius: token.borderRadius,
+      }),
+    [arrow, autoAdjustOverflow, token],
+  );
 
   const onMenuClick = useEvent(() => {
     if (menu?.selectable && menu?.multiple) {

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -125,20 +125,24 @@ const Modal: React.FC<ModalProps> = (props) => {
   );
 
   // ============================ Open ============================
-  const handleCancel = (
-    e: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLElement>,
-  ) => {
-    if (confirmLoading) {
-      return;
-    }
-    onCancel?.(e);
-    onClose?.();
-  };
+  const handleCancel = React.useCallback(
+    (e: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLElement>) => {
+      if (confirmLoading) {
+        return;
+      }
+      onCancel?.(e);
+      onClose?.();
+    },
+    [confirmLoading, onCancel, onClose],
+  );
 
-  const handleOk = (e: React.MouseEvent<HTMLButtonElement>) => {
-    onOk?.(e);
-    onClose?.();
-  };
+  const handleOk = React.useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      onOk?.(e);
+      onClose?.();
+    },
+    [onOk, onClose],
+  );
 
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('Modal');
@@ -195,9 +199,15 @@ const Modal: React.FC<ModalProps> = (props) => {
     : false;
 
   // ============================ modalRender ============================
-  const mergedModalRender = modalRender
-    ? (node: React.ReactNode) => <div className={`${prefixCls}-render`}>{modalRender(node)}</div>
-    : undefined;
+  const mergedModalRender = React.useMemo(
+    () =>
+      modalRender
+        ? (node: React.ReactNode) => (
+            <div className={`${prefixCls}-render`}>{modalRender(node)}</div>
+          )
+        : undefined,
+    [modalRender, prefixCls],
+  );
   // ============================ Refs ============================
   // Select `ant-modal-container` by `panelRef`
   const panelClassName = `.${prefixCls}-${modalRender ? 'render' : 'container'}`;

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -420,6 +420,11 @@ const InternalSelect = <
   }
 
   // ====================== zIndex =========================
+  const computedBuiltinPlacements = React.useMemo(
+    () => mergedBuiltinPlacements(builtinPlacements, popupOverflow),
+    [builtinPlacements, popupOverflow],
+  );
+
   const [zIndex] = useZIndex(
     'SelectLike',
     (mergedStyles.popup.root?.zIndex as number) ?? (mergedPopupStyle.zIndex as number),
@@ -437,7 +442,7 @@ const InternalSelect = <
       style={{ ...mergedStyles.root, ...contextStyle, ...style }}
       popupMatchSelectWidth={mergedPopupMatchSelectWidth}
       transitionName={getTransitionName(rootPrefixCls, 'slide-up', transitionName)}
-      builtinPlacements={mergedBuiltinPlacements(builtinPlacements, popupOverflow)}
+      builtinPlacements={computedBuiltinPlacements}
       listHeight={listHeight}
       listItemHeight={listItemHeight}
       mode={mode}

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -450,7 +450,10 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     getPopupContainer: getPopupContainer || getContextPopupContainer,
     rootClassName: clsx(rootClassName, rootCls),
   });
-  const mergedData = getFilterData(sortedData, filterStates, childrenColumnName);
+  const mergedData = React.useMemo(
+    () => getFilterData(sortedData, filterStates, childrenColumnName),
+    [sortedData, filterStates, childrenColumnName],
+  );
 
   changeEventInfo.filters = filters;
   changeEventInfo.filterStates = filterStates;

--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -276,7 +276,10 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     },
   );
 
-  const tableLocale: TableLocale = { ...contextLocale.Table, ...locale };
+  const tableLocale: TableLocale = React.useMemo(
+    () => ({ ...contextLocale.Table, ...locale }),
+    [contextLocale.Table, locale],
+  );
   const [globalLocale] = useLocale('global', defaultLocale.global);
   const rawData: readonly RecordType[] = dataSource || EMPTY_LIST;
 
@@ -294,13 +297,8 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
   const rootCls = useCSSVarCls(prefixCls);
   const [hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
-  const mergedExpandable: ExpandableConfig<RecordType> = {
-    childrenColumnName: legacyChildrenColumnName,
-    expandIconColumnIndex,
-    ...expandable,
-    expandIcon: expandable?.expandIcon ?? table?.expandable?.expandIcon,
-  };
-  const { childrenColumnName = 'children' } = mergedExpandable;
+  const childrenColumnName =
+    expandable?.childrenColumnName ?? legacyChildrenColumnName ?? 'children';
 
   const expandType = React.useMemo<ExpandType>(() => {
     if (rawData.some((item) => item?.[childrenColumnName])) {
@@ -314,9 +312,11 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     return null;
   }, [childrenColumnName, rawData]);
 
-  const internalRef: NonNullable<RcTableProps['internalRefs']> = {
-    body: React.useRef<HTMLDivElement>(null),
-  } as NonNullable<RcTableProps['internalRefs']>;
+  const internalRefBody = React.useRef<HTMLDivElement>(null);
+  const internalRef = React.useMemo<NonNullable<RcTableProps['internalRefs']>>(
+    () => ({ body: internalRefBody as React.MutableRefObject<HTMLDivElement> }),
+    [],
+  );
 
   // ============================ Width =============================
   const getContainerWidth = useContainerWidth(prefixCls);
@@ -539,35 +539,57 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     mergedRowSelection,
   );
 
-  const internalRowClassName = (record: RecordType, index: number, indent: number) => {
-    return clsx(
-      {
-        [`${prefixCls}-row-selected`]: selectedKeySet.has(getRowKey(record, index)),
-      },
-      isFunction(rowClassName) ? rowClassName(record, index, indent) : rowClassName,
-    );
-  };
+  const internalRowClassName = React.useCallback(
+    (record: RecordType, index: number, indent: number) => {
+      return clsx(
+        {
+          [`${prefixCls}-row-selected`]: selectedKeySet.has(getRowKey(record, index)),
+        },
+        isFunction(rowClassName) ? rowClassName(record, index, indent) : rowClassName,
+      );
+    },
+    [prefixCls, selectedKeySet, getRowKey, rowClassName],
+  );
 
   // ========================== Expandable ==========================
+  const mergedExpandable = React.useMemo<ExpandableConfig<RecordType>>(() => {
+    const config: ExpandableConfig<RecordType> = {
+      childrenColumnName: legacyChildrenColumnName,
+      expandIconColumnIndex,
+      ...expandable,
+      expandIcon: expandable?.expandIcon ?? table?.expandable?.expandIcon,
+    };
 
-  // Pass origin render status into `@rc-component/table`, this can be removed when refactor with `@rc-component/table`
-  (mergedExpandable as any).__PARENT_RENDER_ICON__ = mergedExpandable.expandIcon;
+    // Pass origin render status into `@rc-component/table`, this can be removed when refactor with `@rc-component/table`
+    (config as any).__PARENT_RENDER_ICON__ = config.expandIcon;
 
-  // Customize expandable icon
-  mergedExpandable.expandIcon =
-    mergedExpandable.expandIcon || expandIcon || renderExpandIcon(tableLocale);
+    // Customize expandable icon
+    config.expandIcon = config.expandIcon || expandIcon || renderExpandIcon(tableLocale);
 
-  // Adjust expand icon index, no overwrite expandIconColumnIndex if set.
-  if (expandType === 'nest' && mergedExpandable.expandIconColumnIndex === undefined) {
-    mergedExpandable.expandIconColumnIndex = mergedRowSelection ? 1 : 0;
-  } else if (mergedExpandable.expandIconColumnIndex! > 0 && mergedRowSelection) {
-    mergedExpandable.expandIconColumnIndex! -= 1;
-  }
+    // Adjust expand icon index, no overwrite expandIconColumnIndex if set.
+    if (expandType === 'nest' && config.expandIconColumnIndex === undefined) {
+      config.expandIconColumnIndex = mergedRowSelection ? 1 : 0;
+    } else if ((config.expandIconColumnIndex ?? 0) > 0 && mergedRowSelection) {
+      config.expandIconColumnIndex! -= 1;
+    }
 
-  // Indent size
-  if (!isNumber(mergedExpandable.indentSize)) {
-    mergedExpandable.indentSize = isNumber(indentSize) ? indentSize : 15;
-  }
+    // Indent size
+    if (!isNumber(config.indentSize)) {
+      config.indentSize = isNumber(indentSize) ? indentSize : 15;
+    }
+
+    return config;
+  }, [
+    legacyChildrenColumnName,
+    expandIconColumnIndex,
+    expandable,
+    table?.expandable?.expandIcon,
+    expandIcon,
+    tableLocale,
+    expandType,
+    mergedRowSelection,
+    indentSize,
+  ]);
 
   // ============================ Render ============================
   const transformColumns = React.useCallback(
@@ -676,6 +698,20 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
   }, [spinProps?.spinning, rawData, locale?.emptyText, renderEmpty]);
 
   // ========================== Render ==========================
+  const measureGetPopupContainer = React.useCallback(
+    (triggerNode?: HTMLElement) => triggerNode as HTMLElement,
+    [],
+  );
+
+  const measureRowRender = React.useCallback(
+    (measureRow: React.ReactNode) => (
+      <TableMeasureRowContext.Provider value>
+        <ConfigProvider getPopupContainer={measureGetPopupContainer}>{measureRow}</ConfigProvider>
+      </TableMeasureRowContext.Provider>
+    ),
+    [measureGetPopupContainer],
+  );
+
   const TableComponent = virtual ? RcVirtualTable : RcTable;
 
   // >>> Virtual Table props. We set height here since it will affect height collection
@@ -736,13 +772,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
           internalRefs={internalRef}
           transformColumns={transformColumns as any}
           getContainerWidth={getContainerWidth}
-          measureRowRender={(measureRow) => (
-            <TableMeasureRowContext.Provider value>
-              <ConfigProvider getPopupContainer={(node) => node as HTMLElement}>
-                {measureRow}
-              </ConfigProvider>
-            </TableMeasureRowContext.Provider>
-          )}
+          measureRowRender={measureRowRender}
         />
         {bottomPaginationNode}
       </Spin>

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -185,6 +185,8 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
   const [visible, setVisible] = React.useState(false);
   const inMeasureRow = React.useContext(TableMeasureRowContext);
 
+  const flattenedKeys = React.useMemo(() => flattenKeys(column.filters), [column.filters]);
+
   const filtered: boolean = !!(
     filterState &&
     (filterState.filteredKeys?.length || filterState.forceFiltered)
@@ -344,7 +346,7 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
 
   const onCheckAll = (e: CheckboxChangeEvent) => {
     if (e.target.checked) {
-      const allFilterKeys = flattenKeys(column?.filters).map<string>(String);
+      const allFilterKeys = flattenedKeys.map<string>(String);
       setFilteredKeysSync(allFilterKeys);
     } else {
       setFilteredKeysSync([]);
@@ -424,10 +426,9 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
             <div className={`${tablePrefixCls}-filter-dropdown-tree`}>
               {filterMultiple ? (
                 <Checkbox
-                  checked={selectedKeys.length === flattenKeys(column.filters).length}
+                  checked={selectedKeys.length === flattenedKeys.length}
                   indeterminate={
-                    selectedKeys.length > 0 &&
-                    selectedKeys.length < flattenKeys(column.filters).length
+                    selectedKeys.length > 0 && selectedKeys.length < flattenedKeys.length
                   }
                   className={`${tablePrefixCls}-filter-dropdown-checkall`}
                   onChange={onCheckAll}

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -326,18 +326,29 @@ const useFilter = <RecordType extends AnyObject = AnyObject>(
     onFilterChange(generateFilterInfo<RecordType>(newFilterStates), newFilterStates);
   };
 
-  const transformColumns = (innerColumns: ColumnsType<RecordType>) =>
-    injectFilter(
+  const transformColumns = React.useCallback(
+    (innerColumns: ColumnsType<RecordType>) =>
+      injectFilter(
+        prefixCls,
+        dropdownPrefixCls,
+        innerColumns,
+        mergedFilterStates,
+        tableLocale,
+        triggerFilter,
+        getPopupContainer,
+        undefined,
+        rootClassName,
+      ),
+    [
       prefixCls,
       dropdownPrefixCls,
-      innerColumns,
       mergedFilterStates,
       tableLocale,
       triggerFilter,
       getPopupContainer,
-      undefined,
       rootClassName,
-    );
+    ],
+  );
 
   return [transformColumns, mergedFilterStates, filters] as const;
 };

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -579,7 +579,9 @@ const useSelection = <RecordType extends AnyObject = AnyObject>(
                   const { nativeEvent } = event;
                   const { shiftKey } = nativeEvent;
                   const currentSelectedIndex = recordKeys.indexOf(key);
-                  const isMultiple = derivedSelectedKeys.some((item) => recordKeys.includes(item));
+                  const isMultiple =
+                    derivedSelectedKeySet.size > 0 &&
+                    recordKeys.some((key) => derivedSelectedKeySet.has(key));
 
                   if (shiftKey && checkStrictly && isMultiple) {
                     const changedKeys = multipleSelect(currentSelectedIndex, recordKeys, keySet);

--- a/components/table/hooks/useSorter.tsx
+++ b/components/table/hooks/useSorter.tsx
@@ -500,18 +500,29 @@ const useFilterSorter = <RecordType extends AnyObject = AnyObject>(
     onSorterChange(generateSorterInfo(newSorterStates), newSorterStates);
   };
 
-  const transformColumns = (innerColumns: ColumnsType<RecordType>) =>
-    injectSorter(
+  const transformColumns = React.useCallback(
+    (innerColumns: ColumnsType<RecordType>) =>
+      injectSorter(
+        prefixCls,
+        innerColumns,
+        mergedSorterStates,
+        triggerSorter,
+        sortDirections,
+        tableLocale,
+        showSorterTooltip,
+        undefined,
+        globalLocale,
+      ),
+    [
       prefixCls,
-      innerColumns,
       mergedSorterStates,
       triggerSorter,
       sortDirections,
       tableLocale,
       showSorterTooltip,
-      undefined,
       globalLocale,
-    );
+    ],
+  );
 
   const getSorters = () => generateSorterInfo(mergedSorterStates);
 

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -145,9 +145,9 @@ const InternalTabs = React.forwardRef<TabsRef, TabsProps>((props, ref) => {
     nativeElement: tabsRef.current,
   }));
 
-  let editable: EditableConfig | undefined;
-  if (type === 'editable-card') {
-    editable = {
+  const editable = React.useMemo<EditableConfig | undefined>(() => {
+    if (type !== 'editable-card') return undefined;
+    return {
       onEdit: (editType, { key, event }) => {
         onEdit?.(editType === 'add' ? event : key!, editType);
       },
@@ -155,7 +155,7 @@ const InternalTabs = React.forwardRef<TabsRef, TabsProps>((props, ref) => {
       addIcon: (addIcon ?? tabs?.addIcon) || <PlusOutlined />,
       showAdd: hideAdd !== true,
     };
-  }
+  }, [type, onEdit, removeIcon, tabs?.removeIcon, addIcon, tabs?.addIcon, hideAdd]);
   const rootPrefixCls = getPrefixCls();
 
   if (process.env.NODE_ENV !== 'production') {

--- a/components/tour/index.tsx
+++ b/components/tour/index.tsx
@@ -74,14 +74,17 @@ const Tour: React.FC<TourProps> & { _InternalPanelDoNotUseOrYouWillBeFired: type
     },
   );
 
-  const builtinPlacements: TourProps['builtinPlacements'] = (config) =>
-    getPlacements({
-      arrowPointAtCenter: config?.arrowPointAtCenter ?? true,
-      autoAdjustOverflow: true,
-      offset: token.marginXXS,
-      arrowWidth: token.sizePopupArrow,
-      borderRadius: token.borderRadius,
-    });
+  const builtinPlacements: TourProps['builtinPlacements'] = React.useCallback(
+    (config) =>
+      getPlacements({
+        arrowPointAtCenter: config?.arrowPointAtCenter ?? true,
+        autoAdjustOverflow: true,
+        offset: token.marginXXS,
+        arrowWidth: token.sizePopupArrow,
+        borderRadius: token.borderRadius,
+      }),
+    [token],
+  );
 
   const mergedRootClassName = clsx(
     { [`${prefixCls}-rtl`]: direction === 'rtl' },

--- a/components/transfer/ListBody.tsx
+++ b/components/transfer/ListBody.tsx
@@ -74,22 +74,28 @@ const TransferListBody: React.ForwardRefRenderFunction<
     }
   }, [filteredRenderItems, mergedPagination, pageSize]);
 
-  const onInternalClick = (item: KeyWiseTransferItem, e: React.MouseEvent<Element, MouseEvent>) => {
-    onItemSelect(item.key, !selectedKeys.includes(item.key), e);
-  };
+  const onInternalClick = React.useCallback(
+    (item: KeyWiseTransferItem, e: React.MouseEvent<Element, MouseEvent>) => {
+      onItemSelect(item.key, !selectedKeys.includes(item.key), e);
+    },
+    [onItemSelect, selectedKeys],
+  );
 
-  const onRemove = (item: KeyWiseTransferItem) => {
-    onItemRemove?.([item.key]);
-  };
+  const onRemove = React.useCallback(
+    (item: KeyWiseTransferItem) => {
+      onItemRemove?.([item.key]);
+    },
+    [onItemRemove],
+  );
 
-  const onPageChange = (cur: number) => {
+  const onPageChange = React.useCallback((cur: number) => {
     setCurrent(cur);
-  };
+  }, []);
 
-  const onSizeChange = (cur: number, size: number) => {
+  const onSizeChange = React.useCallback((cur: number, size: number) => {
     setCurrent(cur);
     setPageSize(size);
-  };
+  }, []);
 
   const memoizedItems = React.useMemo<RenderedItem<RecordType>[]>(() => {
     const displayItems = mergedPagination

--- a/components/transfer/ListBody.tsx
+++ b/components/transfer/ListBody.tsx
@@ -74,11 +74,13 @@ const TransferListBody: React.ForwardRefRenderFunction<
     }
   }, [filteredRenderItems, mergedPagination, pageSize]);
 
+  const selectedKeySet = React.useMemo(() => new Set(selectedKeys), [selectedKeys]);
+
   const onInternalClick = React.useCallback(
     (item: KeyWiseTransferItem, e: React.MouseEvent<Element, MouseEvent>) => {
-      onItemSelect(item.key, !selectedKeys.includes(item.key), e);
+      onItemSelect(item.key, !selectedKeySet.has(item.key), e);
     },
-    [onItemSelect, selectedKeys],
+    [onItemSelect, selectedKeySet],
   );
 
   const onRemove = React.useCallback(

--- a/components/transfer/Section.tsx
+++ b/components/transfer/Section.tsx
@@ -231,11 +231,18 @@ const TransferSection = <RecordType extends KeyWiseTransferItem>(
       filterRenderItems.push(renderedItem);
     });
     return [filterItems, filterRenderItems] as const;
-  }, [dataSource, filterValue]);
+  }, [dataSource, filterValue, filterOption, direction]);
+
+  const checkedKeySet = useMemo(() => new Set(checkedKeys), [checkedKeys]);
 
   const checkedActiveItems = useMemo<RecordType[]>(() => {
-    return filteredItems.filter((item) => checkedKeys.includes(item.key) && !item.disabled);
-  }, [checkedKeys, filteredItems]);
+    return filteredItems.filter((item) => checkedKeySet.has(item.key) && !item.disabled);
+  }, [checkedKeySet, filteredItems]);
+
+  const enabledItemKeys = useMemo(
+    () => filteredItems.filter((item) => !item.disabled).map(({ key }) => key),
+    [filteredItems],
+  );
 
   const checkStatus = useMemo<string>(() => {
     if (checkedActiveItems.length === 0) {
@@ -299,16 +306,13 @@ const TransferSection = <RecordType extends KeyWiseTransferItem>(
 
   const checkBox = (
     <Checkbox
-      disabled={dataSource.filter((d) => !d.disabled).length === 0 || disabled}
+      disabled={enabledItemKeys.length === 0 || disabled}
       checked={checkStatus === 'all'}
       indeterminate={checkStatus === 'part'}
       className={`${listPrefixCls}-checkbox`}
       onChange={() => {
         // Only select enabled items
-        onItemSelectAll?.(
-          filteredItems.filter((item) => !item.disabled).map(({ key }) => key),
-          checkStatus !== 'all',
-        );
+        onItemSelectAll?.(enabledItemKeys, checkStatus !== 'all');
       }}
     />
   );

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -496,13 +496,22 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
   const mergedStatus = getMergedStatus(status, customStatus);
   const mergedPagination = !children && pagination;
 
-  const leftActive =
-    rightDataSource.filter((d) => targetSelectedKeys.includes(d.key as TransferKey) && !d.disabled)
-      .length > 0;
+  const targetSelectedKeySet = React.useMemo(
+    () => new Set(targetSelectedKeys),
+    [targetSelectedKeys],
+  );
+  const sourceSelectedKeySet = React.useMemo(
+    () => new Set(sourceSelectedKeys),
+    [sourceSelectedKeys],
+  );
 
-  const rightActive =
-    leftDataSource.filter((d) => sourceSelectedKeys.includes(d.key as TransferKey) && !d.disabled)
-      .length > 0;
+  const leftActive = rightDataSource.some(
+    (d) => targetSelectedKeySet.has(d.key as TransferKey) && !d.disabled,
+  );
+
+  const rightActive = leftDataSource.some(
+    (d) => sourceSelectedKeySet.has(d.key as TransferKey) && !d.disabled,
+  );
 
   // ====================== Styles ======================
   const [mergedClassNames, mergedStyles] = useMergeSemantic(

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -410,6 +410,11 @@ const InternalTreeSelect: InternalTreeSelectRef = (props, ref) => {
   // ============================ zIndex ============================
   const [zIndex] = useZIndex('SelectLike', mergedStyles.popup?.root?.zIndex as number);
 
+  const computedBuiltinPlacements = React.useMemo(
+    () => mergedBuiltinPlacements(builtinPlacements, popupOverflow),
+    [builtinPlacements, popupOverflow],
+  );
+
   return (
     <RcTreeSelect
       classNames={mergedClassNames}
@@ -418,7 +423,7 @@ const InternalTreeSelect: InternalTreeSelectRef = (props, ref) => {
       disabled={mergedDisabled}
       {...selectProps}
       popupMatchSelectWidth={mergedPopupMatchSelectWidth}
-      builtinPlacements={mergedBuiltinPlacements(builtinPlacements, popupOverflow)}
+      builtinPlacements={computedBuiltinPlacements}
       ref={ref}
       prefixCls={prefixCls}
       className={mergedClassName}

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -287,14 +287,17 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
     return mergedDraggable;
   }, [draggable]);
 
-  const renderSwitcherIcon = (nodeProps: AntTreeNodeProps) => (
-    <SwitcherIconCom
-      prefixCls={prefixCls}
-      switcherIcon={switcherIcon}
-      switcherLoadingIcon={switcherLoadingIcon}
-      treeNodeProps={nodeProps}
-      showLine={showLine}
-    />
+  const renderSwitcherIcon = React.useCallback(
+    (nodeProps: AntTreeNodeProps) => (
+      <SwitcherIconCom
+        prefixCls={prefixCls}
+        switcherIcon={switcherIcon}
+        switcherLoadingIcon={switcherLoadingIcon}
+        treeNodeProps={nodeProps}
+        showLine={showLine}
+      />
+    ),
+    [prefixCls, switcherIcon, switcherLoadingIcon, showLine],
   );
   return (
     <RcTree


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [x] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> N/A

### 💡 Background and Solution

对 `components/` 下 12 个组件进行运行时性能优化，在不改变任何公开 API 和功能行为的前提下，通过 `useMemo`、`useCallback` 等手段减少不必要的对象/函数重建和子组件重渲染。

主要改动：

| 组件 | 优化内容 |
|------|---------|
| **Button** | `useEffect`（两中文字符检查）缺少依赖数组，每次渲染都执行 DOM 读取；补充依赖并使用 `setState` 函数式更新避免多余 setState |
| **Table** | `mergedExpandable` 从渲染期创建+变异改为 `useMemo`；`tableLocale` 改为 `useMemo`；`internalRowClassName` 改为 `useCallback`；`measureRowRender` 及其内联 `getPopupContainer` 改为 `useCallback`；`internalRef` 改为 `useMemo` |
| **Tree** | `renderSwitcherIcon` 改为 `useCallback`，避免所有树节点在父组件渲染时全部重渲染 |
| **Dropdown** | `builtinPlacements` 改为 `useMemo`（对齐 Tooltip 已有的正确做法） |
| **Select** | `mergedBuiltinPlacements()` 调用改为 `useMemo` 缓存 |
| **Cascader** | `mergedBuiltinPlacements()` 调用改为 `useMemo` 缓存 |
| **TreeSelect** | `mergedBuiltinPlacements()` 调用改为 `useMemo` 缓存 |
| **Tour** | `builtinPlacements` 工厂函数改为 `useCallback` |
| **Tabs** | `editable-card` 模式下的 `editable` 配置改为 `useMemo` |
| **Modal** | `handleCancel`/`handleOk` 改为 `useCallback`；`mergedModalRender` 改为 `useMemo` |
| **Transfer** | `ListBody` 中 `onInternalClick`/`onRemove`/`onPageChange`/`onSizeChange` 改为 `useCallback`，配合 `ListItem` 的 `React.memo` 生效 |
| **Card** | `tabList.map()` 转换改为 `useMemo`，避免每次渲染创建新数组导致 Tabs 重渲染 |

所有改动均为纯 refactoring，不修改任何公开 API、类型或行为。

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | ⚡️ Optimize runtime performance: memoize callbacks and computed values in Button, Table, Tree, Dropdown, Select, Cascader, TreeSelect, Tour, Tabs, Modal, Transfer, and Card to reduce unnecessary re-renders. |
| 🇨🇳 Chinese | ⚡️ 优化运行时性能：对 Button、Table、Tree、Dropdown、Select、Cascader、TreeSelect、Tour、Tabs、Modal、Transfer、Card 组件进行 useCallback/useMemo 优化，减少不必要的重渲染。 |