### PR TITLE
fix(Table): honor defaultSortOrder on responsive columns

### DIFF
--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -421,6 +421,11 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
   const [transformSorterColumns, sortStates, sorterTitleProps, getSorters] = useSorter<RecordType>({
     prefixCls,
     mergedColumns,
+    // Pass `baseColumns` (pre-responsive) so `defaultSortOrder` and controlled
+    // `sortOrder` on a `responsive` column are still honored when the column
+    // is hidden at the current breakpoint.
+    // See: https://github.com/ant-design/ant-design/issues/32847
+    baseColumns,
     onSorterChange,
     sortDirections: sortDirections || ['ascend', 'descend'],
     tableLocale,

--- a/components/table/__tests__/Table.sorter.test.tsx
+++ b/components/table/__tests__/Table.sorter.test.tsx
@@ -62,6 +62,32 @@ describe('Table.sorter', () => {
     expect(renderedNames(container)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
     expect(container.querySelector('th')?.getAttribute('aria-sort')).toEqual('descending');
   });
+
+  // https://github.com/ant-design/ant-design/issues/32847
+  it('defaultSortOrder still applies when column is hidden by responsive', () => {
+    // jsdom matchMedia mock only matches `max-width` queries (i.e. `xs`),
+    // so a column with `responsive: ['md']` is filtered out of `mergedColumns`.
+    // The default sort should still apply because base columns are used to
+    // collect default sort states.
+    const columns: ColumnType<any>[] = [
+      // Always-visible column we can read to assert row order.
+      { title: 'Name', dataIndex: 'name', key: 'name' },
+      {
+        title: 'NameSorted',
+        dataIndex: 'name',
+        key: 'name-sorted',
+        sorter: sorterFn,
+        defaultSortOrder: 'descend',
+        responsive: ['md'],
+      },
+    ];
+    const { container } = render(<Table columns={columns} dataSource={data} pagination={false} />);
+    // The responsive sorter column should not render a header.
+    expect(container.querySelectorAll('thead th')).toHaveLength(1);
+    // But the data should still be sorted by the hidden column's defaultSortOrder.
+    expect(renderedNames(container)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
+  });
+
   it('sort will work when column with children', () => {
     const onChange = jest.fn();
     const tableData = [

--- a/components/table/hooks/useSorter.tsx
+++ b/components/table/hooks/useSorter.tsx
@@ -380,6 +380,14 @@ export const getSortData = <RecordType extends AnyObject = AnyObject>(
 interface SorterConfig<RecordType = AnyObject> {
   prefixCls: string;
   mergedColumns: ColumnsType<RecordType>;
+  /**
+   * Columns before applying the responsive filter.
+   * Used to collect `defaultSortOrder` / controlled `sortOrder` for columns
+   * that are currently hidden by `column.responsive`, so the user's sort
+   * intent is preserved when the column appears at a different breakpoint.
+   * Falls back to `mergedColumns` when not provided.
+   */
+  baseColumns?: ColumnsType<RecordType>;
   onSorterChange: (
     sorterResult: SorterResult<RecordType> | SorterResult<RecordType>[],
     sortStates: SortState<RecordType>[],
@@ -401,6 +409,7 @@ const useFilterSorter = <RecordType extends AnyObject = AnyObject>(
   const {
     prefixCls,
     mergedColumns,
+    baseColumns,
     sortDirections,
     tableLocale,
     showSorterTooltip,
@@ -408,8 +417,14 @@ const useFilterSorter = <RecordType extends AnyObject = AnyObject>(
     globalLocale,
   } = props;
 
+  // Use base (pre-responsive) columns to seed sort states so that
+  // `defaultSortOrder` on a `responsive` column is honored even when the
+  // column is not visible at the current breakpoint.
+  // See: https://github.com/ant-design/ant-design/issues/32847
+  const collectColumns = baseColumns ?? mergedColumns;
+
   const [sortStates, setSortStates] = React.useState<SortState<RecordType>[]>(() =>
-    collectSortStates<RecordType>(mergedColumns, true),
+    collectSortStates<RecordType>(collectColumns, true),
   );
 
   const getColumnKeys = (columns: ColumnsType<RecordType>, pos?: string): Key[] => {
@@ -426,12 +441,15 @@ const useFilterSorter = <RecordType extends AnyObject = AnyObject>(
   };
   const mergedSorterStates = React.useMemo<SortState<RecordType>[]>(() => {
     let validate = true;
-    const collectedStates = collectSortStates<RecordType>(mergedColumns, false);
+    // Collect controlled `sortOrder` from the full (pre-responsive) column
+    // set so that a controlled `sortOrder` on a hidden responsive column
+    // still applies to the sorted data.
+    const collectedStates = collectSortStates<RecordType>(collectColumns, false);
 
     // Return if not controlled
     if (!collectedStates.length) {
-      const mergedColumnsKeys = getColumnKeys(mergedColumns);
-      return sortStates.filter(({ key }) => mergedColumnsKeys.includes(key));
+      const collectColumnsKeys = getColumnKeys(collectColumns);
+      return sortStates.filter(({ key }) => collectColumnsKeys.includes(key));
     }
 
     const validateStates: SortState<RecordType>[] = [];
@@ -468,7 +486,7 @@ const useFilterSorter = <RecordType extends AnyObject = AnyObject>(
     });
 
     return validateStates;
-  }, [mergedColumns, sortStates]);
+  }, [collectColumns, sortStates]);
 
   // Get render columns title required props
   const columnTitleSorterProps = React.useMemo<ColumnTitleProps<RecordType>>(() => {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

close #32847

### 💡 Background and Solution

**Problem.** When a `Table` column is declared with the `responsive` property and the active breakpoint excludes it, that column is filtered out of `mergedColumns` inside `InternalTable`. `useSorter` then seeds its initial sort state from this responsive-filtered column set, so a `defaultSortOrder` declared on a responsive-hidden column is silently dropped and never re-applied even after the column becomes visible at another breakpoint.

The same issue exists for a controlled `sortOrder` on a responsive-hidden column: it is omitted from the collected states because the column is missing from `mergedColumns`.

**Reproduction.** Original reproduction from the issue uses a column like:

```tsx
{
  title: 'Age',
  dataIndex: 'age',
  sorter: (a, b) => a.age - b.age,
  defaultSortOrder: 'descend',
  responsive: ['md'],
}
```

At any breakpoint not matching `md`, the table renders unsorted. When the viewport later widens to `md`, the column reappears but the data is still unsorted - the default order was lost on the first render.

**Fix.** `useSorter` now accepts a separate `baseColumns` prop (the pre-responsive column set) and uses it to:

1. Seed the initial `sortStates` via `collectSortStates(baseColumns, true)`, so `defaultSortOrder` on responsive columns is collected.
2. Detect controlled `sortOrder` via `collectSortStates(baseColumns, false)`, so a controlled order on a responsive-hidden column still applies.
3. Filter stale state via `getColumnKeys(baseColumns)`, so the sort state for a hidden column is preserved across breakpoint changes.

`mergedColumns` is still used by `injectSorter` for rendering header affordances - responsive-hidden columns do not show a sort icon. They only contribute their sort intent to the data.

When `baseColumns` is not supplied, the hook falls back to `mergedColumns` (current behavior preserved for any direct caller).

A regression test is added in `Table.sorter.test.tsx`: a column with `responsive: ['md']` and `defaultSortOrder: 'descend'` is rendered together with a visible non-sorter column; only one header `th` is rendered (the responsive sorter column is hidden) but the row order matches the default sort.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Table `defaultSortOrder` and controlled `sortOrder` being ignored when the column is hidden by `responsive` at the current breakpoint. |
| 🇨🇳 Chinese | 🐞 修复 Table 列设置 `responsive` 后，在未命中断点时 `defaultSortOrder` 与受控 `sortOrder` 不生效的问题。 |