### PR TITLE
docs(Tooltip): correct overlayInnerStyle deprecation pointer to styles.container

### DIFF
--- a/components/tooltip/shared/sharedProps.en-US.md
+++ b/components/tooltip/shared/sharedProps.en-US.md
@@ -17,7 +17,7 @@
 | mouseLeaveDelay | Delay in seconds, before tooltip is hidden on mouse leave | number | 0.1 |  |
 | ~~overlayClassName~~ | Class name of the tooltip card, please use `classNames.root` instead | string | - |  |
 | ~~overlayStyle~~ | Style of the tooltip card, please use `styles.root` | React.CSSProperties | - |  |
-| ~~overlayInnerStyle~~ | Style of the tooltip inner content, please use `styles.body` | React.CSSProperties | - |  |
+| ~~overlayInnerStyle~~ | Style of the tooltip inner content, please use `styles.container` instead | React.CSSProperties | - |  |
 | placement | The position of the tooltip relative to the target, which can be one of `top` `left` `right` `bottom` `topLeft` `topRight` `bottomLeft` `bottomRight` `leftTop` `leftBottom` `rightTop` `rightBottom` | string | `top` |  |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | |
 | trigger | Tooltip trigger mode. Could be multiple by passing an array | `hover` \| `focus` \| `click` \| `contextMenu` \| Array&lt;string> | `hover` |  |

--- a/components/tooltip/shared/sharedProps.zh-CN.md
+++ b/components/tooltip/shared/sharedProps.zh-CN.md
@@ -17,7 +17,7 @@
 | mouseLeaveDelay | 鼠标移出后延时多少才隐藏 Tooltip，单位：秒 | number | 0.1 |  |
 | ~~overlayClassName~~ | 卡片类名, 请使用 `classNames.root` 替换 | string | - |  |
 | ~~overlayStyle~~ | 卡片样式, 请使用 `styles.root` 替换| React.CSSProperties | - |  |
-| ~~overlayInnerStyle~~ | 卡片内容区域的样式对象, 请使用 `styles.body` 替换 | React.CSSProperties | - |  |
+| ~~overlayInnerStyle~~ | 卡片内容区域的样式对象, 请使用 `styles.container` 替换 | React.CSSProperties | - |  |
 | placement | 气泡框位置，可选 `top` `left` `right` `bottom` `topLeft` `topRight` `bottomLeft` `bottomRight` `leftTop` `leftBottom` `rightTop` `rightBottom` | string | `top` |  |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | |
 | trigger | 触发行为，可选 `hover` \| `focus` \| `click` \| `contextMenu`，可使用数组设置多个触发行为 | string \| string\[] | `hover` |  |


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 📝 Site / documentation improvement

### 🔗 Related Issues

N/A — surfaced while reading the shared Tooltip/Popover/Popconfirm API docs alongside the deprecation warning in code.

### 💡 Background and Solution

The shared API table (consumed by Tooltip, Popover, and Popconfirm via embed) advised users to migrate the deprecated `overlayInnerStyle` prop to `styles.body`:

```md
| ~~overlayInnerStyle~~ | Style of the tooltip inner content, please use `styles.body` | ...
```

However, the inner card of these components is exposed via the semantic key `container`, not `body`. Both the runtime deprecation warning and the `@deprecated` JSDoc on `AbstractTooltipProps` already point to `styles.container`:

- `components/tooltip/index.tsx:131` — `/** @deprecated Please use `styles.container` instead */`
- `components/tooltip/index.tsx:237` — `['overlayInnerStyle', 'styles.container']`
- `components/tooltip/demo/_semantic.tsx` — only `root`, `container`, `arrow` are defined; no `body`

The doc mismatch was sending users to a semantic key that does not exist for these three components. This PR aligns the en-US and zh-CN shared docs with the actual semantic key.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 📖 Correct Tooltip / Popover / Popconfirm shared docs to migrate deprecated `overlayInnerStyle` to `styles.container` instead of the non-existent `styles.body`. |
| 🇨🇳 Chinese | 📖 修正 Tooltip / Popover / Popconfirm 共享文档，将已废弃的 `overlayInnerStyle` 指引到正确的 `styles.container`，原文档错指向不存在的 `styles.body`。 |