### PR TITLE
docs(Popconfirm): correct default icon to ExclamationCircleFilled

### DIFF
--- a/components/popconfirm/index.en-US.md
+++ b/components/popconfirm/index.en-US.md
@@ -39,7 +39,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | cancelButtonProps | The cancel button props | [ButtonProps](/components/button/#api) | - |  |
 | cancelText | The text of the Cancel button | string | `Cancel` |  |
 | disabled | Whether show popconfirm when click its childrenNode | boolean | false |  |
-| icon | Customize icon of confirmation | ReactNode | &lt;ExclamationCircle /> |  |
+| icon | Customize icon of confirmation | ReactNode | &lt;ExclamationCircleFilled /> |  |
 | okButtonProps | The ok button props | [ButtonProps](/components/button/#api) | - |  |
 | okText | The text of the Confirm button | string | `OK` |  |
 | okType | Button `type` of the Confirm button | string | `primary` |  |

--- a/components/popconfirm/index.zh-CN.md
+++ b/components/popconfirm/index.zh-CN.md
@@ -40,7 +40,7 @@ demo:
 | cancelButtonProps | cancel 按钮 props | [ButtonProps](/components/button-cn#api) | - |  |
 | cancelText | 取消按钮文字 | string | `取消` |  |
 | disabled | 阻止点击 Popconfirm 子元素时弹出确认框 | boolean | false |  |
-| icon | 自定义弹出气泡 Icon 图标 | ReactNode | &lt;ExclamationCircle /> |  |
+| icon | 自定义弹出气泡 Icon 图标 | ReactNode | &lt;ExclamationCircleFilled /> |  |
 | okButtonProps | ok 按钮 props | [ButtonProps](/components/button-cn#api) | - |  |
 | okText | 确认按钮文字 | string | `确定` |  |
 | okType | 确认按钮类型 | string | `primary` |  |


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### What kind of changes does this PR introduce?

- [ ] Bugfix
- [x] Site / Documentation improvement
- [ ] Demo improvement
- [ ] Component style improvement
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Accessibility improvement
- [ ] Other (about what?)

### Related issues

N/A

### Background and solution

The Popconfirm API table previously listed the default `icon` as `<ExclamationCircle />`, but the component actually renders `<ExclamationCircleFilled />` (see `components/popconfirm/index.tsx`). Updated both the English and Chinese docs to match the implementation so the documented default no longer refers to a different icon glyph.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| English    | N/A       |
| Chinese    | N/A       |