### PR TITLE
docs(Tabs): remove stray semantic-dom link fragment from classNames type

### DIFF
--- a/components/tabs/index.en-US.md
+++ b/components/tabs/index.en-US.md
@@ -51,7 +51,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | addIcon | Customize add icon, only works with `type="editable-card"` | ReactNode | `<PlusOutlined />` | 4.4.0 |
 | animated | Whether to change tabs with animation. | boolean \| { inkBar: boolean, tabPane: boolean } | { inkBar: true, tabPane: false } |  |
 | centered | Centers tabs | boolean | false | 4.4.0 |
-| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string>(#semantic-dom) | - |  |
+| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
 | defaultActiveKey | Initial active TabPane's key, if `activeKey` is not set | string | `The key of first tab` |  |
 | hideAdd | Hide plus icon or not. Only works while `type="editable-card"` | boolean | false |  |
 | indicator | Customize `size` and `align` of indicator | { size?: number \| (origin: number) => number; align: `start` \| `center` \| `end`; } | - | 5.13.0 |


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 📝 Site / documentation improvement

### 🔗 Related Issues

N/A — small docs typo fix.

### 💡 Background and Solution

The English API docs for Tabs had a stray `(#semantic-dom)` fragment appended to the `classNames` type expression in `components/tabs/index.en-US.md`:

```
Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string>(#semantic-dom)
```

The trailing `(#semantic-dom)` is a leftover link target with no preceding `[label]`, so it renders as the literal text `(#semantic-dom)` at the end of the type column. The function-form return type should simply end with `Record<[SemanticDOM](#semantic-dom), string>`, which matches the `styles` row right below it (`Record<[SemanticDOM](#semantic-dom), CSSProperties>`) and the corresponding Chinese doc.

This PR removes the stray fragment. No code or behavior change.

### 📝 Change Log

| Language   | Changelog          |
| ---------- | ------------------ |
| 🇺🇸 English | No changelog required |
| 🇨🇳 Chinese | 无需更新日志       |
