### PR TITLE
fix(date-picker): fall back to rangePlaceholder when locale lacks range-variant placeholder

### DIFF
--- a/components/date-picker/__tests__/RangePicker.test.tsx
+++ b/components/date-picker/__tests__/RangePicker.test.tsx
@@ -151,6 +151,30 @@ describe('RangePicker', () => {
     expect(container.querySelectorAll('input')[1]?.placeholder).toEqual('End quarter');
   });
 
+  it('should fall back to rangePlaceholder when locale omits range-variant placeholder', () => {
+    const partialLocale = {
+      ...enUS,
+      lang: {
+        ...enUS.lang,
+        rangePlaceholder: ['Fallback start', 'Fallback end'] as [string, string],
+        rangeYearPlaceholder: undefined,
+        rangeQuarterPlaceholder: undefined,
+        rangeMonthPlaceholder: undefined,
+        rangeWeekPlaceholder: undefined,
+      },
+    };
+
+    (['year', 'quarter', 'month', 'week'] as const).forEach((picker) => {
+      const { container, unmount } = render(
+        <RangePicker picker={picker} locale={partialLocale} />,
+      );
+      const inputs = container.querySelectorAll('input');
+      expect(inputs[0]?.placeholder).toEqual('Fallback start');
+      expect(inputs[inputs.length - 1]?.placeholder).toEqual('Fallback end');
+      unmount();
+    });
+  });
+
   it('legacy dropdownClassName & popupClassName', () => {
     resetWarned();
 

--- a/components/date-picker/util.ts
+++ b/components/date-picker/util.ts
@@ -40,19 +40,19 @@ export function getRangePlaceholder(
     return customizePlaceholder;
   }
 
-  if (picker === 'year' && locale.lang.yearPlaceholder) {
+  if (picker === 'year' && locale.lang.rangeYearPlaceholder) {
     return locale.lang.rangeYearPlaceholder;
   }
-  if (picker === 'quarter' && locale.lang.quarterPlaceholder) {
+  if (picker === 'quarter' && locale.lang.rangeQuarterPlaceholder) {
     return locale.lang.rangeQuarterPlaceholder;
   }
-  if (picker === 'month' && locale.lang.monthPlaceholder) {
+  if (picker === 'month' && locale.lang.rangeMonthPlaceholder) {
     return locale.lang.rangeMonthPlaceholder;
   }
-  if (picker === 'week' && locale.lang.weekPlaceholder) {
+  if (picker === 'week' && locale.lang.rangeWeekPlaceholder) {
     return locale.lang.rangeWeekPlaceholder;
   }
-  if (picker === 'time' && locale.timePickerLocale.placeholder) {
+  if (picker === 'time' && locale.timePickerLocale.rangePlaceholder) {
     return locale!.timePickerLocale.rangePlaceholder;
   }
   return locale.lang.rangePlaceholder;


### PR DESCRIPTION
### This is a

- [x] Bug fix

### Related Issues

Several locales (fr_FR, ru_RU, tr_TR, nl_NL, sv_SE, nb_NO, hr_HR, hi_IN, and ~14 others) ship a singular `quarterPlaceholder` / `yearPlaceholder` / `monthPlaceholder` / `weekPlaceholder` but no `range*Placeholder`. With those locales, `<DatePicker.RangePicker picker="quarter" />` (or year/month/week) renders inputs with no placeholder at all.

### Background and Solution

`getRangePlaceholder` in `components/date-picker/util.ts` gated each return on the singular field while returning the range field:

```ts
if (picker === 'quarter' && locale.lang.quarterPlaceholder) {
  return locale.lang.rangeQuarterPlaceholder; // undefined if locale never defined it
}
```

When a locale defines the singular but not the range variant, the function returns `undefined` instead of falling through to the generic `lang.rangePlaceholder`. The fix flips the guard to check the range-variant field itself, so any locale missing the range-specific translation transparently falls back to the locale's default `rangePlaceholder` ("Start date" / "End date" in the source locale).

Same issue applied to `time` picker (gated on `timePickerLocale.placeholder` while returning `timePickerLocale.rangePlaceholder`). Fixed consistently.

Backward compatible: every locale that already defines both fields keeps the exact same output. An added regression test (`RangePicker.test.tsx`) renders a locale stripped of all range-variant placeholders and asserts that all four picker modes fall back to `rangePlaceholder`.

### Change Log

| Language   | Changelog |
| ---------- | --------- |
| English | Fix DatePicker RangePicker showing empty placeholder when locale defines only the singular `*Placeholder` field (affected fr_FR, ru_RU, tr_TR, nl_NL, sv_SE and ~17 other locales). |
| Chinese | 修复 DatePicker RangePicker 在仅定义单数形式 `*Placeholder` 的语言包下占位符为空的问题（影响 fr_FR、ru_RU、tr_TR、nl_NL、sv_SE 等 20+ 语言）。|