### PR TITLE
fix(Modal): default focusable.autoFocusButton to null in confirm dialog

### DIFF
--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -105,10 +105,21 @@ export const ConfirmContent: React.FC<ConfirmDialogProps & { confirmPrefixCls: s
   // 默认为 true，保持向下兼容
   const mergedOkCancel = okCancel ?? type === 'confirm';
 
-  const mergedAutoFocusButton = React.useMemo(() => {
-    const base = focusable?.autoFocusButton || autoFocusButton;
-    return base || base === null ? base : 'ok';
-  }, [autoFocusButton, focusable?.autoFocusButton]);
+  // Default to `null` so the focus goes to the dialog container instead of
+  // auto-focusing the OK button. Auto-focusing a specific button is inconsistent
+  // across opens when the dialog is reused, and pulls focus away from the
+  // dialog content. See https://github.com/ant-design/ant-design/issues/56963
+  const focusableAutoFocusButton = focusable?.autoFocusButton;
+  const hasFocusableAutoFocusButton = !!focusable && 'autoFocusButton' in focusable;
+  const mergedAutoFocusButton = React.useMemo<null | 'ok' | 'cancel'>(() => {
+    if (hasFocusableAutoFocusButton) {
+      return focusableAutoFocusButton ?? null;
+    }
+    if (autoFocusButton !== undefined) {
+      return autoFocusButton;
+    }
+    return null;
+  }, [autoFocusButton, focusableAutoFocusButton, hasFocusableAutoFocusButton]);
 
   const [locale] = useLocale('Modal');
 

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -1013,6 +1013,21 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     );
   });
 
+  // https://github.com/ant-design/ant-design/issues/56963
+  it('should not autoFocus OK button by default', async () => {
+    Modal.confirm({
+      title: 'Test',
+      content: 'Test content',
+    });
+
+    await waitFakeTimer();
+
+    const okBtn = document.querySelector('.ant-modal-confirm-btns .ant-btn-primary');
+    const cancelBtn = document.querySelector('.ant-modal-confirm-btns .ant-btn-default');
+    expect(document.activeElement).not.toBe(okBtn);
+    expect(document.activeElement).not.toBe(cancelBtn);
+  });
+
   it('should support focusable global config in App.useApp modal.confirm', () => {
     const classNames = jest.fn(() => ({}));
 

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -103,7 +103,7 @@ The items listed above are all functions, expecting a settings object as paramet
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | afterClose | Specify a function that will be called when modal is closed completely | function | - | 4.9.0 |
-| ~~autoFocusButton~~ | Specify which button to autofocus. Please use `focusable.autoFocusButton` instead | null \| `ok` \| `cancel` | `ok` |  |
+| ~~autoFocusButton~~ | Specify which button to autofocus. Please use `focusable.autoFocusButton` instead | null \| `ok` \| `cancel` | null |  |
 | cancelButtonProps | The cancel button props | [ButtonProps](/components/button/#api) | - |  |
 | cancelText | Text of the Cancel button with Modal.confirm | string | `Cancel` |  |
 | centered | Centered Modal | boolean | false |  |
@@ -111,7 +111,7 @@ The items listed above are all functions, expecting a settings object as paramet
 | closable | Whether a close (x) button is visible on top right of the confirm dialog or not | boolean \| [ClosableType](#closabletype) | false | - |
 | closeIcon | Custom close icon | ReactNode | undefined | 4.9.0 |
 | content | Content | ReactNode | - |  |
-| focusable.autoFocusButton | Specify which button to autofocus | null \| `ok` \| `cancel` | `ok` | 6.2.0 |
+| focusable.autoFocusButton | Specify which button to autofocus | null \| `ok` \| `cancel` | null | 6.2.0 |
 | footer | Footer content, set as `footer: null` when you don't need default buttons | ReactNode \| (originNode: ReactNode, extra: { OkBtn: React.FC, CancelBtn: React.FC }) => ReactNode | - | renderFunction: 5.9.0 |
 | getContainer | Return the mount node for Modal | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
 | icon | Custom icon | ReactNode | &lt;ExclamationCircleFilled /> |  |

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -104,7 +104,7 @@ demo:
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | afterClose | Modal 完全关闭后的回调 | function | - | 4.9.0 |
-| ~~autoFocusButton~~ | 指定自动获得焦点的按钮。请使用 `focusable.autoFocusButton` 替代 | null \| `ok` \| `cancel` | `ok` |  |
+| ~~autoFocusButton~~ | 指定自动获得焦点的按钮。请使用 `focusable.autoFocusButton` 替代 | null \| `ok` \| `cancel` | null |  |
 | cancelButtonProps | cancel 按钮 props | [ButtonProps](/components/button-cn#api) | - |  |
 | cancelText | 设置 Modal.confirm 取消按钮文字 | string | `取消` |  |
 | centered | 垂直居中展示 Modal | boolean | false |  |
@@ -112,7 +112,7 @@ demo:
 | closable | 是否显示右上角的关闭按钮 | boolean \| [ClosableType](#closabletype) | false | - |
 | closeIcon | 自定义关闭图标 | ReactNode | undefined | 4.9.0 |
 | content | 内容 | ReactNode | - |  |
-| focusable.autoFocusButton | 指定自动获得焦点的按钮 | null \| `ok` \| `cancel` | `ok` | 6.2.0 |
+| focusable.autoFocusButton | 指定自动获得焦点的按钮 | null \| `ok` \| `cancel` | null | 6.2.0 |
 | footer | 底部内容，当不需要默认底部按钮时，可以设为 `footer: null` | ReactNode \| (originNode: ReactNode, extra: { OkBtn: React.FC, CancelBtn: React.FC }) => ReactNode | - | renderFunction: 5.9.0 |
 | getContainer | 指定 Modal 挂载的 HTML 节点，false 为挂载在当前 dom | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  |
 | icon | 自定义图标 | ReactNode | &lt;ExclamationCircleFilled /> |  |


### PR DESCRIPTION
### This is a ...

- [x] Bug fix

### Related Issues

close #56963

### Background and Solution

In `Modal.confirm` / `Modal.info` / etc., the OK button currently auto-focuses on the very first open because `focusable.autoFocusButton` defaults to `'ok'`. On subsequent opens the auto-focus does not fire again (the button DOM is not remounted when the dialog is just toggled), which makes the initial-focus behavior inconsistent between the first open and later opens.

Per the maintainer comment on the issue, the default focus should land on the dialog container itself rather than on the OK button. Defaulting `focusable.autoFocusButton` to `null` lets the dialog focus trap put focus on the modal container consistently on every open, while still allowing users to opt in to button auto-focus via `focusable.autoFocusButton: 'ok' | 'cancel'`.

Changes:
- `ConfirmDialog.tsx`: change default of `mergedAutoFocusButton` from `'ok'` to `null`. Also respect an explicit `focusable: { autoFocusButton: null }` (previously the falsy short-circuit fell through to the legacy `autoFocusButton` prop and then to `'ok'`).
- Documentation tables in `index.en-US.md` / `index.zh-CN.md` updated to reflect the new default.
- Added a regression test asserting that neither the OK nor the Cancel button gets focus by default.

### Change Log

| Language   | Changelog |
| ---------- | --------- |
| English    | Fix Modal default `focusable.autoFocusButton` value to `null` so focus lands on the dialog container instead of the OK button on every open. |
| Chinese    | 修复 Modal 的 `focusable.autoFocusButton` 默认值为 `null`，每次打开时焦点稳定落在对话框容器上而非确认按钮上。 |