### PR TITLE
fix(Slider): prevent text selection on adjacent content when dragging in safari

### DIFF
--- a/components/slider/style/index.ts
+++ b/components/slider/style/index.ts
@@ -143,6 +143,9 @@ const genBaseStyle: GenerateStyle<SliderToken, CSSObject> = (token) => {
       padding: 0,
       cursor: 'pointer',
       touchAction: 'none',
+      // https://github.com/ant-design/ant-design/issues/55686
+      // Prevent text selection on adjacent content when dragging the handle in Safari.
+      userSelect: 'none',
 
       '&-vertical': {
         margin: `${unit(marginFull)} ${unit(marginPart)}`,


### PR DESCRIPTION
Closes #55686

In Safari, starting a drag on the Slider handle and moving the cursor over surrounding text causes that text to be highlighted, because the slider root does not opt out of text selection. The handle and mark text already set `user-select: none`, but the slider root container did not, so Safari treats the initial pointer-down on the slider as a candidate text-selection drag that extends to nearby content.

Adding `user-select: none` to the Slider root mirrors how Splitter (`components/splitter/style/index.ts`) suppresses selection on its drag bar and resolves the regression in Safari. Other browsers were unaffected by the missing rule and remain unaffected by adding it.

A previous report (#25010) for the same Safari behavior was resolved earlier; #55686 is a regression that re-surfaced in v5.28.1.