### PR TITLE
docs(Statistic): fix typos and clarify Timer API descriptions

### DIFF
--- a/components/statistic/index.en-US.md
+++ b/components/statistic/index.en-US.md
@@ -66,14 +66,14 @@ Common props ref：[Common props](/docs/react/common-props)
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| type | time counter down or up | `countdown` `countup` | - |  |
+| type | Timer direction, count down or count up | `countdown` \| `countup` | - |  |
 | format | Format as [dayjs](https://day.js.org/) | string | `HH:mm:ss` |  |
 | prefix | The prefix node of value | ReactNode | - |  |
 | suffix | The suffix node of value | ReactNode | - |  |
 | title | Display title | ReactNode | - |  |
-| value | Set target countdown time | number | - |  |
+| value | Target time for `countdown`, or start time for `countup` (timestamp in ms) | number | - |  |
 | valueStyle | Set value section style | CSSProperties | - |  |
-| onFinish | Trigger when time's up, only to be called when type is `countdown` | () => void | - |  |
+| onFinish | Trigger when time's up, only called when type is `countdown` | () => void | - |  |
 | onChange | Trigger when time's changing | (value: number) => void | - |  |
 
 ## Semantic DOM

--- a/components/statistic/index.zh-CN.md
+++ b/components/statistic/index.zh-CN.md
@@ -67,14 +67,14 @@ demo:
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
-| type | 计时类型，正计时或者倒计时 | `countdown` `countup` | - |  |
+| type | 计时类型，倒计时或者正计时 | `countdown` \| `countup` | - |  |
 | format | 格式化倒计时展示，参考 [dayjs](https://day.js.org/) | string | `HH:mm:ss` |  |
 | prefix | 设置数值的前缀 | ReactNode | - |  |
 | suffix | 设置数值的后缀 | ReactNode | - |  |
 | title | 数值的标题 | ReactNode | - |  |
-| value | 数值内容 | number | - |  |
+| value | `countdown` 模式下为目标时间，`countup` 模式下为起始时间（毫秒时间戳） | number | - |  |
 | valueStyle | 设置数值区域的样式 | CSSProperties | - |  |
-| onFinish | 倒计时完成时触发, 指定为 `countup` 此属性不生效 | () => void | - |  |
+| onFinish | 倒计时完成时触发，指定为 `countup` 时此属性不生效 | () => void | - |  |
 | onChange | 倒计时时间变化时触发 | (value: number) => void | - |  |
 
 ## Semantic DOM


### PR DESCRIPTION
### This is a ...

- [x] Site / documentation improvement

### Related Issues

No related issues.

### Background and Solution

The `Statistic.Timer` API table in both English and Chinese docs had several inaccuracies and typos:

- The `type` column listed `` `countdown` `countup` `` without the `\|` separator required by the API table convention, and the description `time counter down or up` was awkward English.
- The `value` description (`Set target countdown time`) only covered the `countdown` mode; the same field is the start time when `type` is `countup`.
- The Chinese `type` description (`正计时或者倒计时`) listed the values in the opposite order to the actual type union (`countdown | countup`).
- The Chinese `onFinish` row used a half-width comma and was missing a `时` for natural phrasing.

Changes:

- English `type` description rewritten to `Timer direction, count down or count up`; type union now `` `countdown` \| `countup` ``.
- English `value` description rewritten to cover both modes: `Target time for \`countdown\`, or start time for \`countup\` (timestamp in ms)`.
- English `onFinish` description simplified from `only to be called when type is \`countdown\`` to `only called when type is \`countdown\``.
- Chinese `type` description reordered to match the type union (`倒计时或者正计时`); type union now `` `countdown` \| `countup` ``.
- Chinese `value` description rewritten to cover both modes.
- Chinese `onFinish` description normalized to full-width comma and added `时` for natural phrasing.

### Change Log

No changelog required.

| Language | Changelog |
| --- | --- |
| English | No changelog required |
| Chinese | 无需更新日志 |