### PR TITLE
fix(Tour): align default zIndex with design token instead of rc-tour fallback

### DIFF
--- a/components/tour/__tests__/index.test.tsx
+++ b/components/tour/__tests__/index.test.tsx
@@ -828,4 +828,14 @@ describe('Tour', () => {
       'Custom Close Button',
     );
   });
+
+  // https://github.com/ant-design/ant-design/issues/53536
+  it('should fall back to design token zIndexPopup instead of rc-tour default when zIndex is not provided', () => {
+    const { baseElement } = render(
+      <Tour open steps={[{ title: 'test', description: 'test' }]} />,
+    );
+    const mask = baseElement.querySelector<HTMLElement>('.ant-tour-mask');
+    // Default Tour token zIndexPopup = zIndexPopupBase (1000) + 70 = 1070
+    expect(mask?.style.zIndex).toBe('1070');
+  });
 });

--- a/components/tour/index.tsx
+++ b/components/tour/index.tsx
@@ -117,6 +117,9 @@ const Tour: React.FC<TourProps> & { _InternalPanelDoNotUseOrYouWillBeFired: type
 
   // ============================ zIndex ============================
   const [zIndex, contextZIndex] = useZIndex('Tour', restProps.zIndex);
+  // Align with design token `Tour.zIndexPopup` (zIndexPopupBase + 70) when not nested
+  // and no custom zIndex is provided, instead of relying on rc-tour's default (1001).
+  const mergedZIndex = zIndex ?? token.zIndexPopupBase + 70;
 
   return (
     <ZIndexContext.Provider value={contextZIndex}>
@@ -126,7 +129,7 @@ const Tour: React.FC<TourProps> & { _InternalPanelDoNotUseOrYouWillBeFired: type
         classNames={mergedClassNames}
         closeIcon={closeIcon ?? contextCloseIcon}
         keyboard={keyboard}
-        zIndex={zIndex}
+        zIndex={mergedZIndex}
         rootClassName={mergedRootClassName}
         prefixCls={prefixCls}
         animated


### PR DESCRIPTION
### This is a ...

- [x] Bug fix

### Related Issues

close #53536

### Background and Solution

When a `Tour` is rendered without an explicit `zIndex` prop and outside of any `ZIndexContext.Provider`, the antd wrapper passes `zIndex={undefined}` to `@rc-component/tour`, which then falls back to its own internal default of `1001`.

This causes the design token `Tour.zIndexPopup` (documented as `zIndexPopupBase + 70` = `1070`) to be ignored on the mask and other inline-styled tour elements. As a result, content that sits between `1001` and `1070` (for example, a button whose author used `z-index: 1060` based on the documented popup z-index) renders above the tour.

The Tour component already calls `useToken()`, so the fix is to merge the calculated `zIndex` with the documented design token value as a fallback:

```ts
const mergedZIndex = zIndex ?? token.zIndexPopupBase + 70;
```

This keeps the existing behavior intact whenever:

- the user passes an explicit `zIndex` prop, or
- the Tour sits inside a parent `ZIndexContext.Provider` (nested popup scenario).

It only changes the top-level no-prop case, bringing the runtime in line with what the design token already documents.

A regression test asserts that `.ant-tour-mask`'s inline `z-index` equals `1070` by default.

### Change Log

| Language   | Changelog |
| ---------- | --------- |
| English    | Fix Tour default `zIndex` not matching the design token `Tour.zIndexPopup` when no `zIndex` prop is provided. |
| Chinese    | 修复 Tour 在未设置 `zIndex` 时默认值不符合设计令牌 `Tour.zIndexPopup` 的问题。 |