### PR TITLE
fix(Dropdown): apply menu theme dark when using `menu={{ theme: 'dark' }}`

### DIFF
--- a/components/dropdown/__tests__/index.test.tsx
+++ b/components/dropdown/__tests__/index.test.tsx
@@ -552,4 +552,15 @@ describe('Dropdown', () => {
     expect(itemContent).toHaveStyle(objectStyles.itemContent);
     expect(itemTitle).toHaveStyle(objectStyles.itemTitle);
   });
+
+  // https://github.com/ant-design/ant-design/issues/45549
+  it('should apply dark theme class when menu.theme is dark', () => {
+    const { container } = render(
+      <Dropdown menu={{ items, theme: 'dark' }} open>
+        <button type="button">button</button>
+      </Dropdown>,
+    );
+    const menu = container.querySelector('.ant-dropdown-menu');
+    expect(menu).toHaveClass('ant-dropdown-menu-dark');
+  });
 });

--- a/components/dropdown/style/index.ts
+++ b/components/dropdown/style/index.ts
@@ -1,5 +1,6 @@
 import type { CSSProperties } from 'react';
 import { unit } from '@ant-design/cssinjs';
+import { FastColor } from '@ant-design/fast-color';
 
 import { genFocusStyle, resetComponent } from '../../style';
 import {
@@ -373,6 +374,75 @@ const genBaseStyle: GenerateStyle<DropdownToken> = (token) => {
   ];
 };
 
+// ============================== Dark Theme ==============================
+// https://github.com/ant-design/ant-design/issues/45549
+// Menu's own dark theme styles are skipped when rendered inside Dropdown
+// (Menu uses injectStyle=false because Dropdown handles menu style itself).
+// We provide a minimal dark theme variant here so `<Dropdown menu={{ theme: 'dark' }} />`
+// applies the expected dark colors. Values mirror Menu's dark token defaults.
+const genDarkStyle: GenerateStyle<DropdownToken> = (token) => {
+  const { menuCls, colorTextLightSolid, colorPrimary, colorError, colorErrorHover } = token;
+  const darkMenuCls = `${menuCls}-dark`;
+  const darkItemColor = new FastColor(colorTextLightSolid).setA(0.65).toRgbString();
+  const darkItemDisabledColor = new FastColor(colorTextLightSolid).setA(0.25).toRgbString();
+  const darkItemBg = '#001529';
+  const darkItemSelectedBg = colorPrimary;
+  const darkItemHoverBg = new FastColor(colorTextLightSolid).setA(0.08).toRgbString();
+
+  return {
+    [darkMenuCls]: {
+      backgroundColor: darkItemBg,
+
+      [`${menuCls}-item, ${menuCls}-submenu-title`]: {
+        color: darkItemColor,
+
+        '&:hover, &-active': {
+          color: colorTextLightSolid,
+          backgroundColor: darkItemHoverBg,
+        },
+
+        '&-selected': {
+          color: colorTextLightSolid,
+          backgroundColor: darkItemSelectedBg,
+
+          '&:hover, &-active': {
+            backgroundColor: darkItemSelectedBg,
+          },
+        },
+
+        '&-disabled': {
+          color: `${darkItemDisabledColor} !important`,
+
+          '&:hover': {
+            color: `${darkItemDisabledColor} !important`,
+            backgroundColor: 'transparent',
+          },
+        },
+
+        // Danger
+        '&-danger': {
+          color: colorError,
+
+          '&:hover': {
+            color: colorErrorHover,
+          },
+        },
+      },
+
+      [`${menuCls}-item-group-title`]: {
+        color: darkItemColor,
+      },
+
+      // Submenu expand icon arrow
+      [`${menuCls}-submenu-title`]: {
+        [`${menuCls}-submenu-arrow-icon`]: {
+          color: darkItemColor,
+        },
+      },
+    },
+  };
+};
+
 // ============================== Export ==============================
 export const prepareComponentToken: GetDefaultToken<'Dropdown'> = (token) => ({
   zIndexPopup: token.zIndexPopupBase + 50,
@@ -394,7 +464,11 @@ export default genStyleHooks(
       dropdownArrowDistance: token.calc(sizePopupArrow).div(2).add(marginXXS).equal(),
       dropdownEdgeChildPadding: paddingXXS,
     });
-    return [genBaseStyle(dropdownToken), genStatusStyle(dropdownToken)];
+    return [
+      genBaseStyle(dropdownToken),
+      genDarkStyle(dropdownToken),
+      genStatusStyle(dropdownToken),
+    ];
   },
   prepareComponentToken,
   { resetStyle: false },


### PR DESCRIPTION
### What kind of changes does this PR introduce?

- 🐞 Bug fix

### Description

Menu's own dark theme styles are skipped when rendered inside a Dropdown because Menu opts out of style injection (Dropdown handles menu styling itself, see the `injectStyle` flag in `components/menu/style/index.ts`). As a result, passing `theme: 'dark'` to the dropdown's menu adds the `ant-dropdown-menu-dark` class to the DOM but has no visual effect.

This PR adds a minimal dark theme variant in Dropdown's stylesheet so that the `-dark` class actually applies dark background, item text, hover, selected, disabled, and danger styles to the dropdown menu and its submenu popups. The values mirror Menu's existing dark token defaults so visuals stay consistent with a top-level `<Menu theme="dark" />`.

Closes #45549

### Reproduction

```tsx
<Dropdown menu={{ items, theme: 'dark' }}>
  <Button>Open</Button>
</Dropdown>
```

Before this fix the dropdown menu rendered with light styling; with this fix it renders dark.

### Change log

- 🐞 Fix Dropdown not applying dark colors when `menu={{ theme: 'dark' }}` is passed.
- 🐞 修复 Dropdown 在传入 `menu={{ theme: 'dark' }}` 时未应用暗色样式的问题。
