### PR TITLE
fix(Result): skip rendering empty title element when title is not provided

### DIFF
--- a/components/result/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/result/__tests__/__snapshots__/index.test.tsx.snap
@@ -27,8 +27,5 @@ exports[`Result rtl render component should be rendered correctly in RTL directi
       </svg>
     </span>
   </div>
-  <div
-    class="ant-result-title"
-  />
 </div>
 `;

--- a/components/result/__tests__/index.test.tsx
+++ b/components/result/__tests__/index.test.tsx
@@ -71,6 +71,11 @@ describe('Result', () => {
     expect(container.querySelectorAll('.ant-result-extra')).toHaveLength(0);
   });
 
+  it('🙂  When title is undefined, the title dom is not rendered', () => {
+    const { container } = render(<Result status="404" />);
+    expect(container.querySelectorAll('.ant-result-title')).toHaveLength(0);
+  });
+
   it('🙂  result should support className', () => {
     const { container } = render(<Result status="404" title="404" className="my-result" />);
     expect(container.querySelectorAll('.ant-result.my-result')).toHaveLength(1);

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -225,9 +225,11 @@ const Result: ResultType = (props) => {
   return (
     <div {...restProps} className={rootClassNames} style={rootStyles}>
       <Icon className={iconClassNames} style={mergedStyles.icon} status={status} icon={icon} />
-      <div className={titleClassNames} style={mergedStyles.title}>
-        {title}
-      </div>
+      {title && (
+        <div className={titleClassNames} style={mergedStyles.title}>
+          {title}
+        </div>
+      )}
       {subTitle && (
         <div className={subTitleClassNames} style={mergedStyles.subTitle}>
           {subTitle}


### PR DESCRIPTION
### 🤔 What kind of change does this PR introduce?

- [x] 🐞 Bug fix

### 🔗 Related issues

N/A

### 💡 Background and solution

When `Result` is rendered without the optional `title` prop, an empty `<div class="ant-result-title" />` was still being placed in the output. This is inconsistent with the other optional slots (`subTitle`, `extra`, `body`), which are only rendered when their corresponding prop is truthy, and it adds an empty element whose styles (margin, line-height) introduce unwanted vertical space and complicate semantic-mark consumers.

This PR wraps the title `<div>` in a conditional render so the element is only emitted when `title` is provided. The existing RTL snapshot is updated to reflect the removed empty element, and a test case is added covering the `title === undefined` path.

### 📝 Changelog

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | 🐞 Fix Result rendering an empty `title` element when the `title` prop is not provided. |
| 🇨🇳 Chinese | 🐞 修复 Result 未传入 `title` 属性时仍会渲染空的标题元素的问题。 |
