### PR TITLE
ci: fix react-doctor workflow

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: millionco/react-doctor@main
         with:
+          node-version: 24
           fail-on: error
           diff: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          annotations: true


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [x] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

React Doctor workflow 直接使用 `millionco/react-doctor@main`，当前 action wrapper 会向 `react-doctor@0.1.6` CLI 传入不支持的 `--pr-comment` 参数，导致 CI 报错退出。

本次改为直接运行锁定版本的 `react-doctor@0.1.6` CLI，并保留 diff 扫描、error gate 和 GitHub annotations。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |
