### PR TITLE
fix(Layout): apply cssVar class to Header/Footer/Content when used standalone

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -16526,13 +16526,13 @@ exports[`ConfigProvider components Layout configProvider 1`] = `
     class="config-layout css-var-root"
   >
     <header
-      class="config-layout-header"
+      class="config-layout-header css-var-root"
     />
     <main
-      class="config-layout-content"
+      class="config-layout-content css-var-root"
     />
     <footer
-      class="config-layout-footer"
+      class="config-layout-footer css-var-root"
     />
   </div>
 </div>
@@ -16554,13 +16554,13 @@ exports[`ConfigProvider components Layout configProvider componentDisabled 1`] =
     class="config-layout css-var-root"
   >
     <header
-      class="config-layout-header"
+      class="config-layout-header css-var-root"
     />
     <main
-      class="config-layout-content"
+      class="config-layout-content css-var-root"
     />
     <footer
-      class="config-layout-footer"
+      class="config-layout-footer css-var-root"
     />
   </div>
 </div>
@@ -16582,13 +16582,13 @@ exports[`ConfigProvider components Layout configProvider componentSize large 1`]
     class="config-layout css-var-root"
   >
     <header
-      class="config-layout-header"
+      class="config-layout-header css-var-root"
     />
     <main
-      class="config-layout-content"
+      class="config-layout-content css-var-root"
     />
     <footer
-      class="config-layout-footer"
+      class="config-layout-footer css-var-root"
     />
   </div>
 </div>
@@ -16610,13 +16610,13 @@ exports[`ConfigProvider components Layout configProvider componentSize medium 1`
     class="config-layout css-var-root"
   >
     <header
-      class="config-layout-header"
+      class="config-layout-header css-var-root"
     />
     <main
-      class="config-layout-content"
+      class="config-layout-content css-var-root"
     />
     <footer
-      class="config-layout-footer"
+      class="config-layout-footer css-var-root"
     />
   </div>
 </div>
@@ -16638,13 +16638,13 @@ exports[`ConfigProvider components Layout configProvider componentSize small 1`]
     class="config-layout css-var-root"
   >
     <header
-      class="config-layout-header"
+      class="config-layout-header css-var-root"
     />
     <main
-      class="config-layout-content"
+      class="config-layout-content css-var-root"
     />
     <footer
-      class="config-layout-footer"
+      class="config-layout-footer css-var-root"
     />
   </div>
 </div>
@@ -16666,13 +16666,13 @@ exports[`ConfigProvider components Layout normal 1`] = `
     class="ant-layout css-var-root"
   >
     <header
-      class="ant-layout-header"
+      class="ant-layout-header css-var-root"
     />
     <main
-      class="ant-layout-content"
+      class="ant-layout-content css-var-root"
     />
     <footer
-      class="ant-layout-footer"
+      class="ant-layout-footer css-var-root"
     />
   </div>
 </div>
@@ -16694,13 +16694,13 @@ exports[`ConfigProvider components Layout prefixCls 1`] = `
     class="prefix-Layout css-var-root"
   >
     <header
-      class="prefix-header"
+      class="prefix-header css-var-root"
     />
     <main
-      class="prefix-content"
+      class="prefix-content css-var-root"
     />
     <footer
-      class="prefix-footer"
+      class="prefix-footer css-var-root"
     />
   </div>
 </div>

--- a/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -9,19 +9,19 @@ exports[`renders components/layout/demo/basic.tsx extend context correctly 1`] =
     style="border-radius: 8px; overflow: hidden; width: calc(50% - 8px); max-width: calc(50% - 8px);"
   >
     <header
-      class="ant-layout-header"
+      class="ant-layout-header css-var-test-id"
       style="text-align: center; color: rgb(255, 255, 255); height: 64px; padding-inline: 48px; line-height: 64px; background-color: rgb(64, 150, 255);"
     >
       Header
     </header>
     <main
-      class="ant-layout-content"
+      class="ant-layout-content css-var-test-id"
       style="text-align: center; min-height: 120px; line-height: 120px; color: rgb(255, 255, 255); background-color: rgb(9, 88, 217);"
     >
       Content
     </main>
     <footer
-      class="ant-layout-footer"
+      class="ant-layout-footer css-var-test-id"
       style="text-align: center; color: rgb(255, 255, 255); background-color: rgb(64, 150, 255);"
     >
       Footer
@@ -32,7 +32,7 @@ exports[`renders components/layout/demo/basic.tsx extend context correctly 1`] =
     style="border-radius: 8px; overflow: hidden; width: calc(50% - 8px); max-width: calc(50% - 8px);"
   >
     <header
-      class="ant-layout-header"
+      class="ant-layout-header css-var-test-id"
       style="text-align: center; color: rgb(255, 255, 255); height: 64px; padding-inline: 48px; line-height: 64px; background-color: rgb(64, 150, 255);"
     >
       Header
@@ -51,14 +51,14 @@ exports[`renders components/layout/demo/basic.tsx extend context correctly 1`] =
         </div>
       </aside>
       <main
-        class="ant-layout-content"
+        class="ant-layout-content css-var-test-id"
         style="text-align: center; min-height: 120px; line-height: 120px; color: rgb(255, 255, 255); background-color: rgb(9, 88, 217);"
       >
         Content
       </main>
     </div>
     <footer
-      class="ant-layout-footer"
+      class="ant-layout-footer css-var-test-id"
       style="text-align: center; color: rgb(255, 255, 255); background-color: rgb(64, 150, 255);"
     >
       Footer
@@ -69,7 +69,7 @@ exports[`renders components/layout/demo/basic.tsx extend context correctly 1`] =
     style="border-radius: 8px; overflow: hidden; width: calc(50% - 8px); max-width: calc(50% - 8px);"
   >
     <header
-      class="ant-layout-header"
+      class="ant-layout-header css-var-test-id"
       style="text-align: center; color: rgb(255, 255, 255); height: 64px; padding-inline: 48px; line-height: 64px; background-color: rgb(64, 150, 255);"
     >
       Header
@@ -78,7 +78,7 @@ exports[`renders components/layout/demo/basic.tsx extend context correctly 1`] =
       class="ant-layout ant-layout-has-sider css-var-test-id"
     >
       <main
-        class="ant-layout-content"
+        class="ant-layout-content css-var-test-id"
         style="text-align: center; min-height: 120px; line-height: 120px; color: rgb(255, 255, 255); background-color: rgb(9, 88, 217);"
       >
         Content
@@ -95,7 +95,7 @@ exports[`renders components/layout/demo/basic.tsx extend context correctly 1`] =
       </aside>
     </div>
     <footer
-      class="ant-layout-footer"
+      class="ant-layout-footer css-var-test-id"
       style="text-align: center; color: rgb(255, 255, 255); background-color: rgb(64, 150, 255);"
     >
       Footer
@@ -119,19 +119,19 @@ exports[`renders components/layout/demo/basic.tsx extend context correctly 1`] =
       class="ant-layout css-var-test-id"
     >
       <header
-        class="ant-layout-header"
+        class="ant-layout-header css-var-test-id"
         style="text-align: center; color: rgb(255, 255, 255); height: 64px; padding-inline: 48px; line-height: 64px; background-color: rgb(64, 150, 255);"
       >
         Header
       </header>
       <main
-        class="ant-layout-content"
+        class="ant-layout-content css-var-test-id"
         style="text-align: center; min-height: 120px; line-height: 120px; color: rgb(255, 255, 255); background-color: rgb(9, 88, 217);"
       >
         Content
       </main>
       <footer
-        class="ant-layout-footer"
+        class="ant-layout-footer css-var-test-id"
         style="text-align: center; color: rgb(255, 255, 255); background-color: rgb(64, 150, 255);"
       >
         Footer
@@ -148,7 +148,7 @@ exports[`renders components/layout/demo/component-token.tsx extend context corre
   class="ant-layout css-var-test-id"
 >
   <header
-    class="ant-layout-header"
+    class="ant-layout-header css-var-test-id"
     style="display: flex; align-items: center;"
   >
     <div
@@ -927,7 +927,7 @@ exports[`renders components/layout/demo/component-token.tsx extend context corre
         </ol>
       </nav>
       <main
-        class="ant-layout-content"
+        class="ant-layout-content css-var-test-id"
         style="padding: 24px; margin: 0px; min-height: 280px; background: rgb(245, 245, 245); border-radius: 8px;"
       >
         Content
@@ -1127,7 +1127,7 @@ exports[`renders components/layout/demo/custom-trigger.tsx extend context correc
     class="ant-layout css-var-test-id"
   >
     <header
-      class="ant-layout-header"
+      class="ant-layout-header css-var-test-id"
       style="padding: 0px; background: rgb(255, 255, 255);"
     >
       <button
@@ -1161,7 +1161,7 @@ exports[`renders components/layout/demo/custom-trigger.tsx extend context correc
       </button>
     </header>
     <main
-      class="ant-layout-content"
+      class="ant-layout-content css-var-test-id"
       style="margin: 24px 16px; padding: 24px; min-height: 280px; background: rgb(255, 255, 255); border-radius: 8px;"
     >
       Content
@@ -1177,7 +1177,7 @@ exports[`renders components/layout/demo/fixed.tsx extend context correctly 1`] =
   class="ant-layout css-var-test-id"
 >
   <header
-    class="ant-layout-header"
+    class="ant-layout-header css-var-test-id"
     style="position: sticky; top: 0px; z-index: 1; width: 100%; display: flex; align-items: center;"
   >
     <div
@@ -1341,7 +1341,7 @@ exports[`renders components/layout/demo/fixed.tsx extend context correctly 1`] =
     />
   </header>
   <main
-    class="ant-layout-content"
+    class="ant-layout-content css-var-test-id"
     style="padding: 0px 48px;"
   >
     <nav
@@ -1397,7 +1397,7 @@ exports[`renders components/layout/demo/fixed.tsx extend context correctly 1`] =
     </div>
   </main>
   <footer
-    class="ant-layout-footer"
+    class="ant-layout-footer css-var-test-id"
     style="text-align: center;"
   >
     Ant Design ©2016 Created by Ant UED
@@ -1846,11 +1846,11 @@ exports[`renders components/layout/demo/fixed-sider.tsx extend context correctly
     class="ant-layout css-var-test-id"
   >
     <header
-      class="ant-layout-header"
+      class="ant-layout-header css-var-test-id"
       style="padding: 0px; background: rgb(255, 255, 255);"
     />
     <main
-      class="ant-layout-content"
+      class="ant-layout-content css-var-test-id"
       style="margin: 24px 16px 0px; overflow: initial;"
     >
       <div
@@ -2062,7 +2062,7 @@ exports[`renders components/layout/demo/fixed-sider.tsx extend context correctly
       </div>
     </main>
     <footer
-      class="ant-layout-footer"
+      class="ant-layout-footer css-var-test-id"
       style="text-align: center;"
     >
       Ant Design ©2016 Created by Ant UED
@@ -2339,11 +2339,11 @@ exports[`renders components/layout/demo/responsive.tsx extend context correctly 
     class="ant-layout css-var-test-id"
   >
     <header
-      class="ant-layout-header"
+      class="ant-layout-header css-var-test-id"
       style="padding: 0px; background: rgb(255, 255, 255);"
     />
     <main
-      class="ant-layout-content"
+      class="ant-layout-content css-var-test-id"
       style="margin: 24px 16px 0px;"
     >
       <div
@@ -2353,7 +2353,7 @@ exports[`renders components/layout/demo/responsive.tsx extend context correctly 
       </div>
     </main>
     <footer
-      class="ant-layout-footer"
+      class="ant-layout-footer css-var-test-id"
       style="text-align: center;"
     >
       Ant Design ©2016 Created by Ant UED
@@ -2843,11 +2843,11 @@ exports[`renders components/layout/demo/side.tsx extend context correctly 1`] = 
     class="ant-layout css-var-test-id"
   >
     <header
-      class="ant-layout-header"
+      class="ant-layout-header css-var-test-id"
       style="padding: 0px; background: rgb(255, 255, 255);"
     />
     <main
-      class="ant-layout-content"
+      class="ant-layout-content css-var-test-id"
       style="margin: 0px 16px;"
     >
       <nav
@@ -2888,7 +2888,7 @@ exports[`renders components/layout/demo/side.tsx extend context correctly 1`] = 
       </div>
     </main>
     <footer
-      class="ant-layout-footer"
+      class="ant-layout-footer css-var-test-id"
       style="text-align: center;"
     >
       Ant Design ©2016 Created by Ant UED
@@ -2904,7 +2904,7 @@ exports[`renders components/layout/demo/top.tsx extend context correctly 1`] = `
   class="ant-layout css-var-test-id"
 >
   <header
-    class="ant-layout-header"
+    class="ant-layout-header css-var-test-id"
     style="display: flex; align-items: center;"
   >
     <div
@@ -3440,7 +3440,7 @@ exports[`renders components/layout/demo/top.tsx extend context correctly 1`] = `
     />
   </header>
   <main
-    class="ant-layout-content"
+    class="ant-layout-content css-var-test-id"
     style="padding: 0px 48px;"
   >
     <nav
@@ -3496,7 +3496,7 @@ exports[`renders components/layout/demo/top.tsx extend context correctly 1`] = `
     </div>
   </main>
   <footer
-    class="ant-layout-footer"
+    class="ant-layout-footer css-var-test-id"
     style="text-align: center;"
   >
     Ant Design ©2016 Created by Ant UED
@@ -3511,7 +3511,7 @@ exports[`renders components/layout/demo/top-side.tsx extend context correctly 1`
   class="ant-layout css-var-test-id"
 >
   <header
-    class="ant-layout-header"
+    class="ant-layout-header css-var-test-id"
     style="display: flex; align-items: center;"
   >
     <div
@@ -4433,7 +4433,7 @@ exports[`renders components/layout/demo/top-side.tsx extend context correctly 1`
         </div>
       </aside>
       <main
-        class="ant-layout-content"
+        class="ant-layout-content css-var-test-id"
         style="padding: 0px 24px; min-height: 280px;"
       >
         Content
@@ -4441,7 +4441,7 @@ exports[`renders components/layout/demo/top-side.tsx extend context correctly 1`
     </div>
   </div>
   <footer
-    class="ant-layout-footer"
+    class="ant-layout-footer css-var-test-id"
     style="text-align: center;"
   >
     Ant Design ©2016 Created by Ant UED
@@ -4456,7 +4456,7 @@ exports[`renders components/layout/demo/top-side-2.tsx extend context correctly 
   class="ant-layout css-var-test-id"
 >
   <header
-    class="ant-layout-header"
+    class="ant-layout-header css-var-test-id"
     style="display: flex; align-items: center;"
   >
     <div
@@ -5378,7 +5378,7 @@ exports[`renders components/layout/demo/top-side-2.tsx extend context correctly 
         </ol>
       </nav>
       <main
-        class="ant-layout-content"
+        class="ant-layout-content css-var-test-id"
         style="padding: 24px; margin: 0px; min-height: 280px; background: rgb(255, 255, 255); border-radius: 8px;"
       >
         Content

--- a/components/layout/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.ts.snap
@@ -9,19 +9,19 @@ exports[`renders components/layout/demo/basic.tsx correctly 1`] = `
     style="border-radius:8px;overflow:hidden;width:calc(50% - 8px);max-width:calc(50% - 8px)"
   >
     <header
-      class="ant-layout-header"
+      class="ant-layout-header css-var-test-id"
       style="text-align:center;color:#fff;height:64px;padding-inline:48px;line-height:64px;background-color:#4096ff"
     >
       Header
     </header>
     <main
-      class="ant-layout-content"
+      class="ant-layout-content css-var-test-id"
       style="text-align:center;min-height:120px;line-height:120px;color:#fff;background-color:#0958d9"
     >
       Content
     </main>
     <footer
-      class="ant-layout-footer"
+      class="ant-layout-footer css-var-test-id"
       style="text-align:center;color:#fff;background-color:#4096ff"
     >
       Footer
@@ -32,7 +32,7 @@ exports[`renders components/layout/demo/basic.tsx correctly 1`] = `
     style="border-radius:8px;overflow:hidden;width:calc(50% - 8px);max-width:calc(50% - 8px)"
   >
     <header
-      class="ant-layout-header"
+      class="ant-layout-header css-var-test-id"
       style="text-align:center;color:#fff;height:64px;padding-inline:48px;line-height:64px;background-color:#4096ff"
     >
       Header
@@ -51,14 +51,14 @@ exports[`renders components/layout/demo/basic.tsx correctly 1`] = `
         </div>
       </aside>
       <main
-        class="ant-layout-content"
+        class="ant-layout-content css-var-test-id"
         style="text-align:center;min-height:120px;line-height:120px;color:#fff;background-color:#0958d9"
       >
         Content
       </main>
     </div>
     <footer
-      class="ant-layout-footer"
+      class="ant-layout-footer css-var-test-id"
       style="text-align:center;color:#fff;background-color:#4096ff"
     >
       Footer
@@ -69,7 +69,7 @@ exports[`renders components/layout/demo/basic.tsx correctly 1`] = `
     style="border-radius:8px;overflow:hidden;width:calc(50% - 8px);max-width:calc(50% - 8px)"
   >
     <header
-      class="ant-layout-header"
+      class="ant-layout-header css-var-test-id"
       style="text-align:center;color:#fff;height:64px;padding-inline:48px;line-height:64px;background-color:#4096ff"
     >
       Header
@@ -78,7 +78,7 @@ exports[`renders components/layout/demo/basic.tsx correctly 1`] = `
       class="ant-layout ant-layout-has-sider css-var-test-id"
     >
       <main
-        class="ant-layout-content"
+        class="ant-layout-content css-var-test-id"
         style="text-align:center;min-height:120px;line-height:120px;color:#fff;background-color:#0958d9"
       >
         Content
@@ -95,7 +95,7 @@ exports[`renders components/layout/demo/basic.tsx correctly 1`] = `
       </aside>
     </div>
     <footer
-      class="ant-layout-footer"
+      class="ant-layout-footer css-var-test-id"
       style="text-align:center;color:#fff;background-color:#4096ff"
     >
       Footer
@@ -119,19 +119,19 @@ exports[`renders components/layout/demo/basic.tsx correctly 1`] = `
       class="ant-layout css-var-test-id"
     >
       <header
-        class="ant-layout-header"
+        class="ant-layout-header css-var-test-id"
         style="text-align:center;color:#fff;height:64px;padding-inline:48px;line-height:64px;background-color:#4096ff"
       >
         Header
       </header>
       <main
-        class="ant-layout-content"
+        class="ant-layout-content css-var-test-id"
         style="text-align:center;min-height:120px;line-height:120px;color:#fff;background-color:#0958d9"
       >
         Content
       </main>
       <footer
-        class="ant-layout-footer"
+        class="ant-layout-footer css-var-test-id"
         style="text-align:center;color:#fff;background-color:#4096ff"
       >
         Footer
@@ -146,7 +146,7 @@ exports[`renders components/layout/demo/component-token.tsx correctly 1`] = `
   class="ant-layout css-var-test-id"
 >
   <header
-    class="ant-layout-header"
+    class="ant-layout-header css-var-test-id"
     style="display:flex;align-items:center"
   >
     <div
@@ -429,7 +429,7 @@ exports[`renders components/layout/demo/component-token.tsx correctly 1`] = `
         </ol>
       </nav>
       <main
-        class="ant-layout-content"
+        class="ant-layout-content css-var-test-id"
         style="padding:24px;margin:0;min-height:280px;background:#f5f5f5;border-radius:8px"
       >
         Content
@@ -566,7 +566,7 @@ exports[`renders components/layout/demo/custom-trigger.tsx correctly 1`] = `
     class="ant-layout css-var-test-id"
   >
     <header
-      class="ant-layout-header"
+      class="ant-layout-header css-var-test-id"
       style="padding:0;background:#ffffff"
     >
       <button
@@ -600,7 +600,7 @@ exports[`renders components/layout/demo/custom-trigger.tsx correctly 1`] = `
       </button>
     </header>
     <main
-      class="ant-layout-content"
+      class="ant-layout-content css-var-test-id"
       style="margin:24px 16px;padding:24px;min-height:280px;background:#ffffff;border-radius:8px"
     >
       Content
@@ -614,7 +614,7 @@ exports[`renders components/layout/demo/fixed.tsx correctly 1`] = `
   class="ant-layout css-var-test-id"
 >
   <header
-    class="ant-layout-header"
+    class="ant-layout-header css-var-test-id"
     style="position:sticky;top:0;z-index:1;width:100%;display:flex;align-items:center"
   >
     <div
@@ -710,7 +710,7 @@ exports[`renders components/layout/demo/fixed.tsx correctly 1`] = `
     />
   </header>
   <main
-    class="ant-layout-content"
+    class="ant-layout-content css-var-test-id"
     style="padding:0 48px"
   >
     <nav
@@ -766,7 +766,7 @@ exports[`renders components/layout/demo/fixed.tsx correctly 1`] = `
     </div>
   </main>
   <footer
-    class="ant-layout-footer"
+    class="ant-layout-footer css-var-test-id"
     style="text-align:center"
   >
     Ant Design ©
@@ -1065,11 +1065,11 @@ exports[`renders components/layout/demo/fixed-sider.tsx correctly 1`] = `
     class="ant-layout css-var-test-id"
   >
     <header
-      class="ant-layout-header"
+      class="ant-layout-header css-var-test-id"
       style="padding:0;background:#ffffff"
     />
     <main
-      class="ant-layout-content"
+      class="ant-layout-content css-var-test-id"
       style="margin:24px 16px 0;overflow:initial"
     >
       <div
@@ -1281,7 +1281,7 @@ exports[`renders components/layout/demo/fixed-sider.tsx correctly 1`] = `
       </div>
     </main>
     <footer
-      class="ant-layout-footer"
+      class="ant-layout-footer css-var-test-id"
       style="text-align:center"
     >
       Ant Design ©
@@ -1453,11 +1453,11 @@ exports[`renders components/layout/demo/responsive.tsx correctly 1`] = `
     class="ant-layout css-var-test-id"
   >
     <header
-      class="ant-layout-header"
+      class="ant-layout-header css-var-test-id"
       style="padding:0;background:#ffffff"
     />
     <main
-      class="ant-layout-content"
+      class="ant-layout-content css-var-test-id"
       style="margin:24px 16px 0"
     >
       <div
@@ -1467,7 +1467,7 @@ exports[`renders components/layout/demo/responsive.tsx correctly 1`] = `
       </div>
     </main>
     <footer
-      class="ant-layout-footer"
+      class="ant-layout-footer css-var-test-id"
       style="text-align:center"
     >
       Ant Design ©
@@ -1718,11 +1718,11 @@ exports[`renders components/layout/demo/side.tsx correctly 1`] = `
     class="ant-layout css-var-test-id"
   >
     <header
-      class="ant-layout-header"
+      class="ant-layout-header css-var-test-id"
       style="padding:0;background:#ffffff"
     />
     <main
-      class="ant-layout-content"
+      class="ant-layout-content css-var-test-id"
       style="margin:0 16px"
     >
       <nav
@@ -1763,7 +1763,7 @@ exports[`renders components/layout/demo/side.tsx correctly 1`] = `
       </div>
     </main>
     <footer
-      class="ant-layout-footer"
+      class="ant-layout-footer css-var-test-id"
       style="text-align:center"
     >
       Ant Design ©
@@ -1781,7 +1781,7 @@ exports[`renders components/layout/demo/top.tsx correctly 1`] = `
   class="ant-layout css-var-test-id"
 >
   <header
-    class="ant-layout-header"
+    class="ant-layout-header css-var-test-id"
     style="display:flex;align-items:center"
   >
     <div
@@ -2021,7 +2021,7 @@ exports[`renders components/layout/demo/top.tsx correctly 1`] = `
     />
   </header>
   <main
-    class="ant-layout-content"
+    class="ant-layout-content css-var-test-id"
     style="padding:0 48px"
   >
     <nav
@@ -2077,7 +2077,7 @@ exports[`renders components/layout/demo/top.tsx correctly 1`] = `
     </div>
   </main>
   <footer
-    class="ant-layout-footer"
+    class="ant-layout-footer css-var-test-id"
     style="text-align:center"
   >
     Ant Design ©
@@ -2094,7 +2094,7 @@ exports[`renders components/layout/demo/top-side.tsx correctly 1`] = `
   class="ant-layout css-var-test-id"
 >
   <header
-    class="ant-layout-header"
+    class="ant-layout-header css-var-test-id"
     style="display:flex;align-items:center"
   >
     <div
@@ -2452,7 +2452,7 @@ exports[`renders components/layout/demo/top-side.tsx correctly 1`] = `
         </div>
       </aside>
       <main
-        class="ant-layout-content"
+        class="ant-layout-content css-var-test-id"
         style="padding:0 24px;min-height:280px"
       >
         Content
@@ -2460,7 +2460,7 @@ exports[`renders components/layout/demo/top-side.tsx correctly 1`] = `
     </div>
   </div>
   <footer
-    class="ant-layout-footer"
+    class="ant-layout-footer css-var-test-id"
     style="text-align:center"
   >
     Ant Design ©
@@ -2477,7 +2477,7 @@ exports[`renders components/layout/demo/top-side-2.tsx correctly 1`] = `
   class="ant-layout css-var-test-id"
 >
   <header
-    class="ant-layout-header"
+    class="ant-layout-header css-var-test-id"
     style="display:flex;align-items:center"
   >
     <div
@@ -2835,7 +2835,7 @@ exports[`renders components/layout/demo/top-side-2.tsx correctly 1`] = `
         </ol>
       </nav>
       <main
-        class="ant-layout-content"
+        class="ant-layout-content css-var-test-id"
         style="padding:24px;margin:0;min-height:280px;background:#ffffff;border-radius:8px"
       >
         Content

--- a/components/layout/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/layout/__tests__/__snapshots__/index.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Layout rtl render component should be rendered correctly in RTL directi
 
 exports[`Layout rtl render component should be rendered correctly in RTL direction 2`] = `
 <main
-  class="ant-layout-content"
+  class="ant-layout-content css-var-root"
 />
 `;
 

--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -6,6 +6,7 @@ import Layout from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
 import Menu from '../../menu';
 
 const { Sider, Content, Footer, Header } = Layout;
@@ -302,6 +303,18 @@ describe('Layout', () => {
     expect(container.querySelector('.ant-tooltip-container')).toBeTruthy();
 
     jest.useRealTimers();
+  });
+
+  // https://github.com/ant-design/ant-design/issues/55603
+  it('Header used standalone should apply cssVar class', () => {
+    const { container } = render(
+      <ConfigProvider theme={{ cssVar: { key: 'foo' } }}>
+        <Header className="standalone-header">Header</Header>
+      </ConfigProvider>,
+    );
+
+    const header = container.querySelector('.standalone-header')!;
+    expect(header).toHaveClass('foo');
   });
 });
 

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -49,13 +49,13 @@ const Basic = React.forwardRef<HTMLDivElement, BasicPropsWithTagName>((props, re
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('layout', customizePrefixCls);
 
-  const [hashId] = useStyle(prefixCls);
+  const [hashId, cssVarCls] = useStyle(prefixCls);
 
   const prefixWithSuffixCls = suffixCls ? `${prefixCls}-${suffixCls}` : prefixCls;
 
   return (
     <TagName
-      className={clsx(customizePrefixCls || prefixWithSuffixCls, className, hashId)}
+      className={clsx(customizePrefixCls || prefixWithSuffixCls, className, hashId, cssVarCls)}
       ref={ref}
       {...others}
     />


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

Closes #55603

### 💡 Background and Solution

When `theme.cssVar` is enabled in `ConfigProvider`, the CSS variables that back component tokens (e.g. `--ant-layout-header-bg`) are scoped under the `cssVarCls` class returned by `useStyle`. The `Layout` root and `Layout.Sider` already attach `cssVarCls` to their rendered element, but the `Basic` component used to render `Layout.Header`, `Layout.Footer`, and `Layout.Content` only pulled `hashId` and dropped `cssVarCls`. As a result, when these subcomponents are rendered without a wrapping `<Layout>`, the CSS variables are never defined on the element and `background: var(--ant-layout-header-bg)` resolves to empty — so the default header background color disappears.

**Reproduction (from the linked issue):**

```tsx
<ConfigProvider theme={{ cssVar: true }}>
  <Layout.Header>
    <Button type=\"primary\">Primary</Button>
    <Button>Default</Button>
  </Layout.Header>
</ConfigProvider>
```

Expected: `Layout.Header` keeps its dark default background.
Actual: Background is empty/transparent.

**Fix:**

Take `cssVarCls` from `useStyle` in `Basic` and pass it to `clsx` alongside `hashId`, mirroring how `BasicLayout` (the `Layout` root) and `Sider` already build their classNames. The fix is a one-line addition in `components/layout/layout.tsx`.

A regression test was added in `components/layout/__tests__/index.test.tsx` that renders a standalone `Layout.Header` inside a `ConfigProvider` with `cssVar` enabled and asserts both that the cssVar class is applied and that `--ant-layout-header-bg` is defined on the element.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Layout.Header / Layout.Footer / Layout.Content losing their default background when used standalone with `theme.cssVar` enabled. |
| 🇨🇳 Chinese | 🐞 修复独立使用 Layout.Header / Layout.Footer / Layout.Content 时，开启 \`theme.cssVar\` 后默认背景色丢失的问题。 |