### PR TITLE
docs: sync Slider deprecated APIs in zh-CN docs

### DIFF
--- a/components/slider/index.zh-CN.md
+++ b/components/slider/index.zh-CN.md
@@ -57,6 +57,10 @@ demo:
 | vertical | 值为 true 时，Slider 为垂直方向。与 `orientation` 同时存在，以 `orientation` 优先 | boolean | false |  |
 | onChangeComplete | 与 `mouseup` 和 `keyup` 触发时机一致，把当前值作为参数传入 | (value) => void | - |  |
 | onChange | 当 Slider 的值发生改变时，会触发 onChange 事件，并把改变后的值作为参数传入 | (value) => void | - |  |
+| ~~handleStyle~~ | 滑块手柄样式，请使用 `styles.handle` 替代 | CSSProperties | - | - |
+| ~~onAfterChange~~ | 与 `mouseup` 和 `keyup` 触发时机一致，请使用 `onChangeComplete` 替代 | (value) => void | - | - |
+| ~~railStyle~~ | 滑轨样式，请使用 `styles.rail` 替代 | CSSProperties | - | - |
+| ~~trackStyle~~ | 已选轨道样式，请使用 `styles.track` 替代 | CSSProperties | - | - |
 
 ### range
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Slider 英文文档中包含 `handleStyle`、`onAfterChange`、`railStyle`、`trackStyle` 这几个废弃 API 的说明，但中文文档缺失。

本次补齐中文 API 表中的对应废弃项，并指向推荐替代用法：`styles.handle`、`onChangeComplete`、`styles.rail` 和 `styles.track`。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |