### PR TITLE
fix(Dropdown): avoid React 19 element ref warning

### DIFF
--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -4,7 +4,7 @@ import RightOutlined from '@ant-design/icons/RightOutlined';
 import RcDropdown from '@rc-component/dropdown';
 import type { MenuProps as RcMenuProps } from '@rc-component/menu';
 import type { AlignType } from '@rc-component/trigger';
-import { omit, useComposeRef, useControlledState, useEvent } from '@rc-component/util';
+import { getNodeRef, omit, useComposeRef, useControlledState, useEvent } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useZIndex } from '../_util/hooks';
@@ -222,7 +222,7 @@ const Dropdown: CompoundedComponent = React.forwardRef<HTMLElement, DropdownProp
     isPrimitive(children) ? <span>{children}</span> : children,
   ) as React.ReactElement<{ className?: string; disabled?: boolean }>;
 
-  const composedRef = useComposeRef(ref, (child as any).ref);
+  const composedRef = useComposeRef(ref, getNodeRef(child));
 
   const popupTrigger = cloneElement(child, {
     className: clsx(


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #58054

### 💡 需求背景和解决方案

React 19 将 `ref` 作为普通 prop 处理，直接访问 `element.ref` 会触发废弃警告。

Dropdown 在合并自身 ref 和 trigger 子节点 ref 时直接读取了 `(child as any).ref`，导致子节点带有 `ref` 时会在 React 19 下出现 `Accessing element.ref was removed...` 警告。

本 PR 改为通过 `getNodeRef(child)` 获取子节点 ref，兼容 React 18/19 的 ref 读取方式，同时保留原有 ref 合并行为。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Dropdown triggering React 19 `element.ref` deprecation warning when the trigger node has a ref. |
| 🇨🇳 中文 | 修复 Dropdown 触发节点带有 `ref` 时在 React 19 下出现 `element.ref` 废弃警告的问题。 |
