### PR TITLE
fix(Descriptions): apply mobile-first cascade for responsive column prop

### DIFF
--- a/components/descriptions/__tests__/index.test.tsx
+++ b/components/descriptions/__tests__/index.test.tsx
@@ -6,6 +6,8 @@ import { resetWarned } from '../../_util/warning';
 import mountTest from '../../../tests/shared/mountTest';
 import { render } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
+import { matchScreen } from '../../_util/responsiveObserver';
+import DEFAULT_COLUMN_MAP from '../constant';
 
 describe('Descriptions', () => {
   mountTest(Descriptions);
@@ -145,6 +147,38 @@ describe('Descriptions', () => {
         .reduce((total, cur) => total + cur, 0),
     ).toBe(8);
     wrapper.unmount();
+  });
+
+  // Verify the mobile-first cascade fix: matchScreen(screens, userColumn) is tried
+  // before falling back to DEFAULT_COLUMN_MAP, so the highest explicitly-set
+  // user breakpoint wins over the library default for any unspecified higher breakpoint.
+  describe('column mobile-first cascade', () => {
+    it('cascades md:2 upward to lg viewport instead of DEFAULT_COLUMN_MAP.lg', () => {
+      // On an lg screen xs/sm/md/lg are all active (cumulative min-width semantics).
+      const lgScreens = { xs: true, sm: true, md: true, lg: true };
+      const column = { xs: 1, md: 2 };
+      const result =
+        matchScreen(lgScreens, column) ?? matchScreen(lgScreens, DEFAULT_COLUMN_MAP) ?? 3;
+      expect(result).toBe(2);
+    });
+
+    it('cascades xl:4 upward to xxl viewport', () => {
+      const xxlScreens = { xs: true, sm: true, md: true, lg: true, xl: true, xxl: true };
+      const column = { xs: 1, md: 2, xl: 4 };
+      const result =
+        matchScreen(xxlScreens, column) ?? matchScreen(xxlScreens, DEFAULT_COLUMN_MAP) ?? 3;
+      expect(result).toBe(4);
+    });
+
+    it('falls back to DEFAULT_COLUMN_MAP when no user-supplied key is active', () => {
+      // sm viewport; user only specified xl which is not yet active.
+      const smScreens = { xs: true, sm: true };
+      const column = { xl: 4 };
+      const result =
+        matchScreen(smScreens, column) ?? matchScreen(smScreens, DEFAULT_COLUMN_MAP) ?? 3;
+      // DEFAULT_COLUMN_MAP.sm = 2
+      expect(result).toBe(DEFAULT_COLUMN_MAP.sm);
+    });
   });
 
   it('warning if exceed the row span', () => {

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -139,12 +139,16 @@ const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) 
     });
   }
   // Column count
+  // Mobile-first cascade: try the user-supplied map first (scanning large→small
+  // over cumulative min-width screens, so a lower breakpoint like `md` is still
+  // "active" on an `lg` viewport).  Only fall back to DEFAULT_COLUMN_MAP when
+  // no user-supplied breakpoint is active at all.
   const mergedColumn = React.useMemo(() => {
     if (isNumber(column)) {
       return column;
     }
 
-    return matchScreen(screens, { ...DEFAULT_COLUMN_MAP, ...column }) ?? 3;
+    return matchScreen(screens, column) ?? matchScreen(screens, DEFAULT_COLUMN_MAP) ?? 3;
   }, [screens, column]);
 
   // Items with responsive


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

No related issue.

### 💡 Background and Solution

**Problem**

When `column` is passed as a partial responsive object (e.g. `{ xs: 1, md: 2 }`),
`Descriptions` merged it with `DEFAULT_COLUMN_MAP` before matching the active screen:

```ts
matchScreen(screens, { ...DEFAULT_COLUMN_MAP, ...column })
```

Because `DEFAULT_COLUMN_MAP` defines a value for every breakpoint (`lg: 3`, `xl: 3`,
`xxl: 3`, `xxxl: 4`), those defaults always filled the gaps the developer intentionally
left empty. On an `lg` viewport with `column={{ xs: 1, md: 2 }}`, the resolved column
count was `3` (from `DEFAULT_COLUMN_MAP.lg`) instead of the expected `2` (from `md`
cascading upward).

This is inconsistent with how `Masonry` handles its identical `columns` prop, which
already uses a correct mobile-first lookup.

**Root cause**

`matchScreen` scans breakpoints from largest to smallest and returns the first entry
where both the screen is active and the map has a defined value. Pre-filling every key
via `DEFAULT_COLUMN_MAP` guaranteed a hit at whatever the largest active breakpoint was,
before the user's lower value could be reached.

**Fix**

Try the user-supplied map first; fall back to `DEFAULT_COLUMN_MAP` only when no
user-specified key is active at all:

```ts
// Before
matchScreen(screens, { ...DEFAULT_COLUMN_MAP, ...column }) ?? 3

// After
matchScreen(screens, column) ?? matchScreen(screens, DEFAULT_COLUMN_MAP) ?? 3
```

Because Ant Design uses cumulative `min-width` media queries, on an `lg` screen the
`md` key is also active — so `matchScreen` finds `md: 2` naturally, matching
Tailwind-style mobile-first cascade semantics.

**Behaviour change**

| `column` prop | Viewport | Before | After |
|---|---|---|---|
| `{ xs:1, md:2 }` | `lg` | **3** (DEFAULT) | **2** ✓ |
| `{ xs:1, md:2, xl:4 }` | `xxl` | **3** (DEFAULT) | **4** ✓ |
| `{ xs:1, md:2 }` | `xs` | 1 | 1 ✓ unchanged |
| `{}` | `lg` | 3 (DEFAULT) | 3 (DEFAULT) ✓ unchanged |
| `{ xl:4 }` | `sm` | 2 (DEFAULT sm) | 2 (DEFAULT sm) ✓ unchanged |

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     :ladybug: Fix `Descriptions` `column` responsive object not cascading upward in mobile-first order; unspecified higher breakpoints now inherit the last user-defined lower-breakpoint value instead of falling back to internal defaults      |
| 🇨🇳 Chinese |           |
