### PR TITLE
fix(Splitter): improve SplitBar accessibility

### DIFF
--- a/components/splitter/SplitBar.tsx
+++ b/components/splitter/SplitBar.tsx
@@ -137,6 +137,13 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
     onOffsetEnd(true);
   });
 
+  const onCollapseKeyDown = (e: React.KeyboardEvent<HTMLDivElement>, type: 'start' | 'end') => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onCollapse(index, type);
+    }
+  };
+
   const getVisibilityClass = (mode: ShowCollapsibleIconMode): string => {
     switch (mode) {
       case true:
@@ -237,13 +244,7 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
   }, [collapsibleIcon, vertical]);
 
   return (
-    <div
-      className={splitBarPrefixCls}
-      role="separator"
-      aria-valuenow={getValidNumber(ariaNow)}
-      aria-valuemin={getValidNumber(ariaMin)}
-      aria-valuemax={getValidNumber(ariaMax)}
-    >
+    <div className={splitBarPrefixCls}>
       {lazy && (
         <div
           className={clsx(`${splitBarPrefixCls}-preview`, {
@@ -268,6 +269,12 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
         onMouseDown={onMouseDown}
         onTouchStart={onTouchStart}
         onDoubleClick={() => onDraggerDoubleClick?.(index)}
+        role="separator"
+        aria-disabled={!resizable}
+        aria-orientation={vertical ? 'horizontal' : 'vertical'}
+        aria-valuenow={getValidNumber(ariaNow)}
+        aria-valuemin={getValidNumber(ariaMin)}
+        aria-valuemax={getValidNumber(ariaMax)}
       >
         {draggerIcon !== undefined ? (
           <div className={clsx(`${splitBarPrefixCls}-dragger-icon`)}>{draggerIcon}</div>
@@ -285,7 +292,11 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
             },
             getVisibilityClass(showStartCollapsibleIcon),
           )}
+          role="button"
+          tabIndex={0}
+          aria-label="Toggle start panel"
           onClick={() => onCollapse(index, 'start')}
+          onKeyDown={(e) => onCollapseKeyDown(e, 'start')}
         >
           <span
             className={clsx(
@@ -309,7 +320,11 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
             },
             getVisibilityClass(showEndCollapsibleIcon),
           )}
+          role="button"
+          tabIndex={0}
+          aria-label="Toggle end panel"
           onClick={() => onCollapse(index, 'end')}
+          onKeyDown={(e) => onCollapseKeyDown(e, 'end')}
         >
           <span
             className={clsx(

--- a/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -53,14 +53,16 @@ exports[`renders components/splitter/demo/collapsible.tsx extend context correct
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="50"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="50"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -101,14 +103,16 @@ exports[`renders components/splitter/demo/collapsible.tsx extend context correct
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="50"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="horizontal"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="50"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -230,14 +234,16 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx extend context cor
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="33"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="33"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -257,14 +263,16 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx extend context cor
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="67"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="false"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="67"
         class="ant-splitter-bar-dragger"
+        role="separator"
       />
     </div>
     <div
@@ -314,14 +322,16 @@ exports[`renders components/splitter/demo/control.tsx extend context correctly 1
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="50"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="false"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="50"
         class="ant-splitter-bar-dragger"
+        role="separator"
       />
     </div>
     <div
@@ -405,14 +415,16 @@ Array [
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="40"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="40"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled ant-splitter-bar-dragger-customize"
+        role="separator"
       >
         <div
           class="ant-splitter-bar-dragger-icon"
@@ -456,14 +468,16 @@ Array [
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="70"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="70"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled ant-splitter-bar-dragger-customize"
+        role="separator"
       >
         <div
           class="ant-splitter-bar-dragger-icon"
@@ -532,14 +546,16 @@ Array [
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="40"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="horizontal"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="40"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled ant-splitter-bar-dragger-customize acss-13lz4mh"
+        role="separator"
       >
         <div
           class="ant-splitter-bar-dragger-icon"
@@ -598,14 +614,16 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="0"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="false"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="0"
         class="ant-splitter-bar-dragger"
+        role="separator"
       />
     </div>
     <div
@@ -625,14 +643,16 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="0"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="0"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -678,14 +698,16 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="0"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="0"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -705,14 +727,16 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="0"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="false"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="0"
         class="ant-splitter-bar-dragger"
+        role="separator"
       />
     </div>
     <div
@@ -758,14 +782,16 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="0"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="false"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="0"
         class="ant-splitter-bar-dragger"
+        role="separator"
       />
     </div>
     <div
@@ -811,14 +837,16 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="50"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="50"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -865,14 +893,16 @@ exports[`renders components/splitter/demo/group.tsx extend context correctly 1`]
     </div>
   </div>
   <div
-    aria-valuemax="0"
-    aria-valuemin="0"
-    aria-valuenow="50"
     class="ant-splitter-bar"
-    role="separator"
   >
     <div
+      aria-disabled="false"
+      aria-orientation="vertical"
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="50"
       class="ant-splitter-bar-dragger"
+      role="separator"
     />
   </div>
   <div
@@ -899,14 +929,16 @@ exports[`renders components/splitter/demo/group.tsx extend context correctly 1`]
         </div>
       </div>
       <div
-        aria-valuemax="0"
-        aria-valuemin="0"
-        aria-valuenow="50"
         class="ant-splitter-bar"
-        role="separator"
       >
         <div
+          aria-disabled="false"
+          aria-orientation="horizontal"
+          aria-valuemax="0"
+          aria-valuemin="0"
+          aria-valuenow="50"
           class="ant-splitter-bar-dragger"
+          role="separator"
         />
       </div>
       <div
@@ -961,18 +993,20 @@ exports[`renders components/splitter/demo/lazy.tsx extend context correctly 1`] 
         </div>
       </div>
       <div
-        aria-valuemax="0"
-        aria-valuemin="0"
-        aria-valuenow="40"
         class="ant-splitter-bar"
-        role="separator"
       >
         <div
           class="ant-splitter-bar-preview"
           style="--ant-splitter-bar-preview-offset: 0px;"
         />
         <div
+          aria-disabled="true"
+          aria-orientation="vertical"
+          aria-valuemax="0"
+          aria-valuemin="0"
+          aria-valuenow="40"
           class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+          role="separator"
         />
       </div>
       <div
@@ -1017,18 +1051,20 @@ exports[`renders components/splitter/demo/lazy.tsx extend context correctly 1`] 
         </div>
       </div>
       <div
-        aria-valuemax="0"
-        aria-valuemin="0"
-        aria-valuenow="40"
         class="ant-splitter-bar"
-        role="separator"
       >
         <div
           class="ant-splitter-bar-preview"
           style="--ant-splitter-bar-preview-offset: 0px;"
         />
         <div
+          aria-disabled="true"
+          aria-orientation="horizontal"
+          aria-valuemax="0"
+          aria-valuemin="0"
+          aria-valuenow="40"
           class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+          role="separator"
         />
       </div>
       <div
@@ -1076,14 +1112,16 @@ exports[`renders components/splitter/demo/multiple.tsx extend context correctly 
     </div>
   </div>
   <div
-    aria-valuemax="0"
-    aria-valuemin="0"
-    aria-valuenow="33"
     class="ant-splitter-bar"
-    role="separator"
   >
     <div
+      aria-disabled="false"
+      aria-orientation="vertical"
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="33"
       class="ant-splitter-bar-dragger"
+      role="separator"
     />
   </div>
   <div
@@ -1103,14 +1141,16 @@ exports[`renders components/splitter/demo/multiple.tsx extend context correctly 
     </div>
   </div>
   <div
-    aria-valuemax="0"
-    aria-valuemin="0"
-    aria-valuenow="67"
     class="ant-splitter-bar"
-    role="separator"
   >
     <div
+      aria-disabled="false"
+      aria-orientation="vertical"
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="67"
       class="ant-splitter-bar-dragger"
+      role="separator"
     />
   </div>
   <div
@@ -1281,14 +1321,16 @@ exports[`renders components/splitter/demo/reset.tsx extend context correctly 1`]
     </div>
   </div>
   <div
-    aria-valuemax="0"
-    aria-valuemin="0"
-    aria-valuenow="30"
     class="ant-splitter-bar"
-    role="separator"
   >
     <div
+      aria-disabled="false"
+      aria-orientation="vertical"
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="30"
       class="ant-splitter-bar-dragger"
+      role="separator"
     />
   </div>
   <div
@@ -1308,14 +1350,16 @@ exports[`renders components/splitter/demo/reset.tsx extend context correctly 1`]
     </div>
   </div>
   <div
-    aria-valuemax="0"
-    aria-valuemin="0"
-    aria-valuenow="70"
     class="ant-splitter-bar"
-    role="separator"
   >
     <div
+      aria-disabled="false"
+      aria-orientation="vertical"
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="70"
       class="ant-splitter-bar-dragger"
+      role="separator"
     />
   </div>
   <div
@@ -1361,14 +1405,16 @@ exports[`renders components/splitter/demo/size.tsx extend context correctly 1`] 
     </div>
   </div>
   <div
-    aria-valuemax="0"
-    aria-valuemin="0"
-    aria-valuenow="40"
     class="ant-splitter-bar"
-    role="separator"
   >
     <div
+      aria-disabled="true"
+      aria-orientation="vertical"
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="40"
       class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+      role="separator"
     />
   </div>
   <div
@@ -1460,14 +1506,16 @@ Array [
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="0"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="0"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -1487,14 +1535,16 @@ Array [
       </div>
     </div>
     <div
-      aria-valuemax="9980"
-      aria-valuemin="0"
-      aria-valuenow="0"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="9980"
+        aria-valuemin="0"
+        aria-valuenow="0"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -1544,14 +1594,16 @@ exports[`renders components/splitter/demo/style-class.tsx extend context correct
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="50"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="false"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="50"
         class="ant-splitter-bar-dragger"
+        role="separator"
         style="background-color: rgba(194, 223, 252, 0.4);"
       />
     </div>
@@ -1592,14 +1644,16 @@ exports[`renders components/splitter/demo/style-class.tsx extend context correct
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="50"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="false"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="50"
         class="ant-splitter-bar-dragger"
+        role="separator"
       />
     </div>
     <div
@@ -1645,14 +1699,16 @@ exports[`renders components/splitter/demo/vertical.tsx extend context correctly 
     </div>
   </div>
   <div
-    aria-valuemax="0"
-    aria-valuemin="0"
-    aria-valuenow="50"
     class="ant-splitter-bar"
-    role="separator"
   >
     <div
+      aria-disabled="false"
+      aria-orientation="horizontal"
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="50"
       class="ant-splitter-bar-dragger"
+      role="separator"
     />
   </div>
   <div

--- a/components/splitter/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/splitter/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -31,14 +31,16 @@ exports[`renders components/splitter/demo/_semantic.tsx correctly 1`] = `
           </div>
         </div>
         <div
-          aria-valuemax="0"
-          aria-valuemin="0"
-          aria-valuenow="50"
           class="ant-splitter-bar"
-          role="separator"
         >
           <div
+            aria-disabled="false"
+            aria-orientation="vertical"
+            aria-valuemax="0"
+            aria-valuemin="0"
+            aria-valuenow="50"
             class="ant-splitter-bar-dragger semantic-mark-dragger"
+            role="separator"
           />
         </div>
         <div

--- a/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
@@ -53,14 +53,16 @@ exports[`renders components/splitter/demo/collapsible.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="50"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="50"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -101,14 +103,16 @@ exports[`renders components/splitter/demo/collapsible.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="50"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="horizontal"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="50"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -228,14 +232,16 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="33"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="33"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -255,14 +261,16 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="67"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="false"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="67"
         class="ant-splitter-bar-dragger"
+        role="separator"
       />
     </div>
     <div
@@ -310,14 +318,16 @@ exports[`renders components/splitter/demo/control.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="50"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="false"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="50"
         class="ant-splitter-bar-dragger"
+        role="separator"
       />
     </div>
     <div
@@ -399,14 +409,16 @@ Array [
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="40"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="40"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled ant-splitter-bar-dragger-customize"
+        role="separator"
       >
         <div
           class="ant-splitter-bar-dragger-icon"
@@ -450,14 +462,16 @@ Array [
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="70"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="70"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled ant-splitter-bar-dragger-customize"
+        role="separator"
       >
         <div
           class="ant-splitter-bar-dragger-icon"
@@ -526,14 +540,16 @@ Array [
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="40"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="horizontal"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="40"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled ant-splitter-bar-dragger-customize acss-13lz4mh"
+        role="separator"
       >
         <div
           class="ant-splitter-bar-dragger-icon"
@@ -592,14 +608,16 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="0"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="false"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="0"
         class="ant-splitter-bar-dragger"
+        role="separator"
       />
     </div>
     <div
@@ -621,14 +639,16 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="0"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="0"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -678,14 +698,16 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="0"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="0"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -707,14 +729,16 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="0"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="false"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="0"
         class="ant-splitter-bar-dragger"
+        role="separator"
       />
     </div>
     <div
@@ -764,14 +788,16 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="0"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="false"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="0"
         class="ant-splitter-bar-dragger"
+        role="separator"
       />
     </div>
     <div
@@ -821,14 +847,16 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="50"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="50"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -875,14 +903,16 @@ exports[`renders components/splitter/demo/group.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    aria-valuemax="0"
-    aria-valuemin="0"
-    aria-valuenow="50"
     class="ant-splitter-bar"
-    role="separator"
   >
     <div
+      aria-disabled="false"
+      aria-orientation="vertical"
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="50"
       class="ant-splitter-bar-dragger"
+      role="separator"
     />
   </div>
   <div
@@ -909,14 +939,16 @@ exports[`renders components/splitter/demo/group.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        aria-valuemax="0"
-        aria-valuemin="0"
-        aria-valuenow="50"
         class="ant-splitter-bar"
-        role="separator"
       >
         <div
+          aria-disabled="false"
+          aria-orientation="horizontal"
+          aria-valuemax="0"
+          aria-valuemin="0"
+          aria-valuenow="50"
           class="ant-splitter-bar-dragger"
+          role="separator"
         />
       </div>
       <div
@@ -969,18 +1001,20 @@ exports[`renders components/splitter/demo/lazy.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        aria-valuemax="0"
-        aria-valuemin="0"
-        aria-valuenow="40"
         class="ant-splitter-bar"
-        role="separator"
       >
         <div
           class="ant-splitter-bar-preview"
           style="--ant-splitter-bar-preview-offset:0px"
         />
         <div
+          aria-disabled="true"
+          aria-orientation="vertical"
+          aria-valuemax="0"
+          aria-valuemin="0"
+          aria-valuenow="40"
           class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+          role="separator"
         />
       </div>
       <div
@@ -1025,18 +1059,20 @@ exports[`renders components/splitter/demo/lazy.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        aria-valuemax="0"
-        aria-valuemin="0"
-        aria-valuenow="40"
         class="ant-splitter-bar"
-        role="separator"
       >
         <div
           class="ant-splitter-bar-preview"
           style="--ant-splitter-bar-preview-offset:0px"
         />
         <div
+          aria-disabled="true"
+          aria-orientation="horizontal"
+          aria-valuemax="0"
+          aria-valuemin="0"
+          aria-valuenow="40"
           class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+          role="separator"
         />
       </div>
       <div
@@ -1084,14 +1120,16 @@ exports[`renders components/splitter/demo/multiple.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    aria-valuemax="0"
-    aria-valuemin="0"
-    aria-valuenow="33"
     class="ant-splitter-bar"
-    role="separator"
   >
     <div
+      aria-disabled="false"
+      aria-orientation="vertical"
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="33"
       class="ant-splitter-bar-dragger"
+      role="separator"
     />
   </div>
   <div
@@ -1113,14 +1151,16 @@ exports[`renders components/splitter/demo/multiple.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    aria-valuemax="0"
-    aria-valuemin="0"
-    aria-valuenow="67"
     class="ant-splitter-bar"
-    role="separator"
   >
     <div
+      aria-disabled="false"
+      aria-orientation="vertical"
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="67"
       class="ant-splitter-bar-dragger"
+      role="separator"
     />
   </div>
   <div
@@ -1268,14 +1308,16 @@ exports[`renders components/splitter/demo/reset.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    aria-valuemax="0"
-    aria-valuemin="0"
-    aria-valuenow="30"
     class="ant-splitter-bar"
-    role="separator"
   >
     <div
+      aria-disabled="false"
+      aria-orientation="vertical"
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="30"
       class="ant-splitter-bar-dragger"
+      role="separator"
     />
   </div>
   <div
@@ -1297,14 +1339,16 @@ exports[`renders components/splitter/demo/reset.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    aria-valuemax="0"
-    aria-valuemin="0"
-    aria-valuenow="70"
     class="ant-splitter-bar"
-    role="separator"
   >
     <div
+      aria-disabled="false"
+      aria-orientation="vertical"
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="70"
       class="ant-splitter-bar-dragger"
+      role="separator"
     />
   </div>
   <div
@@ -1350,14 +1394,16 @@ exports[`renders components/splitter/demo/size.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    aria-valuemax="0"
-    aria-valuemin="0"
-    aria-valuenow="40"
     class="ant-splitter-bar"
-    role="separator"
   >
     <div
+      aria-disabled="true"
+      aria-orientation="vertical"
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="40"
       class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+      role="separator"
     />
   </div>
   <div
@@ -1447,14 +1493,16 @@ Array [
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="0"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="0"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -1474,14 +1522,16 @@ Array [
       </div>
     </div>
     <div
-      aria-valuemax="9980"
-      aria-valuemin="0"
-      aria-valuenow="0"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="true"
+        aria-orientation="vertical"
+        aria-valuemax="9980"
+        aria-valuemin="0"
+        aria-valuenow="0"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"
+        role="separator"
       />
     </div>
     <div
@@ -1529,14 +1579,16 @@ exports[`renders components/splitter/demo/style-class.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="50"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="false"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="50"
         class="ant-splitter-bar-dragger"
+        role="separator"
         style="background-color:rgba(194,223,252,0.4)"
       />
     </div>
@@ -1577,14 +1629,16 @@ exports[`renders components/splitter/demo/style-class.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      aria-valuemax="0"
-      aria-valuemin="0"
-      aria-valuenow="50"
       class="ant-splitter-bar"
-      role="separator"
     >
       <div
+        aria-disabled="false"
+        aria-orientation="vertical"
+        aria-valuemax="0"
+        aria-valuemin="0"
+        aria-valuenow="50"
         class="ant-splitter-bar-dragger"
+        role="separator"
       />
     </div>
     <div
@@ -1628,14 +1682,16 @@ exports[`renders components/splitter/demo/vertical.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    aria-valuemax="0"
-    aria-valuemin="0"
-    aria-valuenow="50"
     class="ant-splitter-bar"
-    role="separator"
   >
     <div
+      aria-disabled="false"
+      aria-orientation="horizontal"
+      aria-valuemax="0"
+      aria-valuemin="0"
+      aria-valuenow="50"
       class="ant-splitter-bar-dragger"
+      role="separator"
     />
   </div>
   <div

--- a/components/splitter/__tests__/index.test.tsx
+++ b/components/splitter/__tests__/index.test.tsx
@@ -1010,6 +1010,30 @@ describe('Splitter', () => {
       expect(onCollapse).toHaveBeenCalledWith([false, false], [50, 50]);
     });
 
+    it('should trigger onCollapse when collapse button keydown', async () => {
+      const onCollapse = jest.fn();
+      const { container } = render(
+        <SplitterDemo
+          items={[{ collapsible: true }, { collapsible: true }]}
+          onCollapse={onCollapse}
+        />,
+      );
+
+      await resizeSplitter();
+
+      fireEvent.keyDown(container.querySelector('.ant-splitter-bar-collapse-start')!, {
+        key: 'Enter',
+      });
+      expect(onCollapse).toHaveBeenCalledTimes(1);
+      expect(onCollapse).toHaveBeenCalledWith([true, false], [0, 100]);
+
+      fireEvent.keyDown(container.querySelector('.ant-splitter-bar-collapse-end')!, {
+        key: ' ',
+      });
+      expect(onCollapse).toHaveBeenCalledTimes(2);
+      expect(onCollapse).toHaveBeenCalledWith([false, false], [50, 50]);
+    });
+
     it('should apply transition when motion is true', async () => {
       const { container } = render(
         <SplitterDemo

--- a/components/splitter/style/index.ts
+++ b/components/splitter/style/index.ts
@@ -198,7 +198,7 @@ const genSplitterStyle: GenerateStyle<SplitterToken, CSSObject> = (token) => {
           background: 'transparent',
         },
 
-        '&:hover, &:active': {
+        '&:hover, &:active, &:focus-within': {
           [`${splitBarCls}-collapse-bar-hover-only`]: {
             opacity: 1,
           },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🐞 Bug fix


### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

master代码中下面三处是绑定了onclick事件的，但是没有设置a11y相关的`role`、`tabIndex`和`aria-label`属性
components/splitter/SplitBar.tsx:256
components/splitter/SplitBar.tsx:279
components/splitter/SplitBar.tsx:303

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      improve SplitBar accessibility      |
| 🇨🇳 Chinese |      改进SplitBar的可访问性     |
