### PR TITLE
ci: pin third-party actions to SHA and add visual diff approval permission check

### DIFF
--- a/.github/workflows/issue-inactivity-reminder.yml
+++ b/.github/workflows/issue-inactivity-reminder.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Send reminders for inactive issues
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const daysBeforeReminder = 14;

--- a/.github/workflows/issue-schedule.yml
+++ b/.github/workflows/issue-schedule.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Send Unconfirmed Issues to DingTalk
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         env:
             DINGDING_BOT_TOKEN: ${{ secrets.DINGDING_BOT_COLLABORATOR_TOKEN }}
             actionTitle: 近 7 天未确认的 issue

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -47,7 +47,7 @@ jobs:
       build-failure: ${{ steps.prep-summary.outputs.build-failure }}
     steps:
       - name: summary jobs status
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         id: prep-summary
         with:
           script: |
@@ -89,7 +89,7 @@ jobs:
     steps:
       # We need get PR id first
       - name: download pr artifact
-        uses: dawidd6/action-download-artifact@v14 # Do not upgrade.
+        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # Do not upgrade.
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           run_id: ${{ github.event.workflow_run.id }}
@@ -109,7 +109,7 @@ jobs:
       # Download site artifact
       - name: download site artifact
         if: ${{ fromJSON(needs.upstream-workflow-summary.outputs.build-success) }}
-        uses: dawidd6/action-download-artifact@v14 # Do not upgrade.
+        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # Do not upgrade.
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
-      - uses: millionco/react-doctor@main
+      - uses: millionco/react-doctor@19afa9ba3ba673e3df682ee919423a21cdf14313
         with:
           node-version: 24
           fail-on: error

--- a/.github/workflows/visual-regression-diff-approver.yml
+++ b/.github/workflows/visual-regression-diff-approver.yml
@@ -29,7 +29,7 @@ jobs:
     # Return type: `success` or `failed` or `waiting`
     - name: Statistic Visual Diff Approval
       id: check_approval
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -66,9 +66,12 @@ jobs:
 
             // https://regex101.com/r/kLjudz/1
             const RE = /(?<=\>\s\[!IMPORTANT\].*?- \[ \])/s;
+            const trustedRoles = ['MEMBER', 'OWNER', 'COLLABORATOR'];
+            const isTrustedAuthor = trustedRoles.includes(comment.author_association);
             if (
               comment.body.includes('- [x] Visual diff is acceptable') &&
-              comment.body.match(RE) == null /** 检查 IMPORTANT 是否存在未勾选的 */
+              comment.body.match(RE) == null /** 检查 IMPORTANT 是否存在未勾选的 */ &&
+              isTrustedAuthor
             ) {
               hasMemberApprove = true;
             }

--- a/.github/workflows/visual-regression-diff-finish.yml
+++ b/.github/workflows/visual-regression-diff-finish.yml
@@ -47,7 +47,7 @@ jobs:
       build-status: ${{ steps.visual_diff_build_job_status.outputs.build-status }}
     steps:
       - name: summary jobs status
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         id: visual_diff_build_job_status
         with:
           script: |
@@ -98,7 +98,7 @@ jobs:
 
       # We need get persist-index first
       - name: download image snapshot artifact
-        uses: dawidd6/action-download-artifact@v14 # Do not upgrade.
+        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # Do not upgrade.
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           run_id: ${{ github.event.workflow_run.id }}
@@ -120,7 +120,7 @@ jobs:
       - name: download report artifact
         id: download_report
         if: ${{ needs.upstream-workflow-summary.outputs.build-status == 'success' || needs.upstream-workflow-summary.outputs.build-status == 'failure' }}
-        uses: dawidd6/action-download-artifact@v14 # Do not upgrade.
+        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # Do not upgrade.
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           run_id: ${{ github.event.workflow_run.id }}
@@ -182,7 +182,7 @@ jobs:
 
       # Resync commit status. This will be also reset by `visual-regression-diff-approver`
       - name: Reset Commit Status
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         if: ${{ steps.report.outcome == 'success' }}
         env:
           PR_ID: ${{ steps.pr.outputs.id }}

--- a/.github/workflows/visual-regression-persist-finish.yml
+++ b/.github/workflows/visual-regression-persist-finish.yml
@@ -50,7 +50,7 @@ jobs:
       build-failure: ${{ steps.persist_start_job_status.outputs.build-failure }}
     steps:
       - name: summary jobs status
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         id: persist_start_job_status
         with:
           script: |
@@ -98,7 +98,7 @@ jobs:
 
       # We need get persist key first
       - name: Download Visual Regression Ref
-        uses: dawidd6/action-download-artifact@v14 # Do not upgrade.
+        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # Do not upgrade.
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           run_id: ${{ github.event.workflow_run.id }}
@@ -112,7 +112,7 @@ jobs:
 
       - name: Download Visual-Regression Artifact
         if: ${{ fromJSON(needs.upstream-workflow-summary.outputs.build-success) }}
-        uses: dawidd6/action-download-artifact@v14 # Do not upgrade.
+        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05 # Do not upgrade.
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           run_id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] ⏩ 工作流程

### 🔗 相关 Issue

基于近期 AntV 和 TanStack 供应链攻击事件（Mini Shai-Hulud）的安全审查。参考：
- https://socket.dev/blog/antv-packages-compromised
- https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack
- https://tanstack.com/blog/npm-supply-chain-compromise-postmortem

### 💡 需求背景和解决方案

近期发生的 Mini Shai-Hulud 供应链攻击通过劫持 npm 维护者凭据、滥用 GitHub Actions `pull_request_target` + 缓存投毒 + OIDC 窃取链等方式，对 @antv（323 个包）和 @tanstack（42 个包）生态造成了大规模恶意代码注入。攻击者还利用第三方 Action 的 tag 可变性来注入恶意代码。

本次 PR 针对这些攻击手法，对项目 CI 工作流进行安全加固：

1. **SHA 固定第三方 Action 引用** — 防止 tag/branch 被劫持后恶意代码在可信 CI 上下文中执行
   - `millionco/react-doctor@main` → 固定到 commit SHA（风险最高：branch 引用 + 第三方 + 写权限）
   - `dawidd6/action-download-artifact@v14` → 固定到 commit SHA（3 个工作流文件中共 6 处引用）
   - `actions/github-script@v9` → 固定到 commit SHA（7 处引用）

2. **视觉回归审批添加权限校验** — `visual-regression-diff-approver.yml` 中，原来任何用户在 PR 评论区勾选"Visual diff is acceptable"都可以让视觉差异审批通过。现在增加 `author_association` 校验，仅限 MEMBER/OWNER/COLLABORATOR 角色的评论才能批准。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |