### PR TITLE
docs: sync Notification and Table API docs

### DIFF
--- a/components/notification/index.en-US.md
+++ b/components/notification/index.en-US.md
@@ -55,6 +55,7 @@ The properties of config are as follows:
 | ~~btn~~ | Customized close button group, please use `actions` instead | ReactNode | - | - |
 | className | Customized CSS class | string | - | - |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
+| closable | Whether to show the close button | boolean \| [ClosableType](#closabletype) | true | - |
 | closeIcon | Custom close icon | ReactNode | true | 5.7.0: close button will be hidden when setting to null or false |
 | description | The content of notification box (required) | ReactNode | - | - |
 | duration | Time in seconds before Notification is closed. When set to `0` or `false`, it will never be closed automatically | number \| false | 4.5 | - |

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -284,6 +284,7 @@ Properties for row selection.
 | preserveSelectedRowKeys | Keep selection `key` even when it removed from `dataSource` | boolean | - | 4.4.0 |
 | renderCell | Renderer of the table cell. Same as `render` in column | (checked: boolean, record: T, index: number, originNode: ReactNode): ReactNode | - | 4.1.0 |
 | selectedRowKeys | Controlled selected row keys | string\[] \| number\[] | \[] |  |
+| defaultSelectedRowKeys | Default selected row keys | string\[] \| number\[] | \[] |  |
 | selections | Custom selection [config](#selection), only displays default selections when set to `true` | object\[] \| boolean | - |  |
 | type | `checkbox` or `radio` | `checkbox` \| `radio` | `checkbox` |  |
 | onCell | Set props on per cell. Same as `onCell` in column | function(record, rowIndex) | - | 5.5.0 |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

英文文档中 Notification config 表缺少已支持的 `closable` 配置项，Table `rowSelection` 表缺少已支持的 `defaultSelectedRowKeys` 配置项。

本 PR 补齐这两个英文 API 条目，并与 zh-CN 文档中的对应字段保持一致。

验证：
- `git diff --check upstream/master...HEAD`
- `npx prettier --check components/notification/index.en-US.md components/table/index.en-US.md`
- `node_modules/.bin/remark components/notification/index.en-US.md components/table/index.en-US.md -q`

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |
