### PR TITLE
docs: correct Divider plain default value

### DIFF
--- a/components/divider/index.en-US.md
+++ b/components/divider/index.en-US.md
@@ -41,7 +41,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | dashed | Whether line is dashed | boolean | false |  |
 | orientation | Whether line is horizontal or vertical | `horizontal` \| `vertical` | `horizontal` | - |
 | ~~orientationMargin~~ | The margin-left/right between the title and its closest border, while the `titlePlacement` should not be `center`, If a numeric value of type `string` is provided without a unit, it is assumed to be in pixels (px) by default. | string \| number | - |  |
-| plain | Divider text show as plain style | boolean | true | 4.2.0 |
+| plain | Divider text show as plain style | boolean | false | 4.2.0 |
 | style | The style object of container | CSSProperties | - |  |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
 | size | The size of divider. Only valid for horizontal layout | `small` \| `medium` \| `large` | - | 5.25.0 |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Divider 英文 API 文档中 `plain` 的默认值写为 `true`，但中文文档和组件实现都表明默认值应为 `false`。

本 PR 将英文文档中的 `plain` 默认值修正为 `false`，使其与实际行为保持一致。

验证：
- `git diff --check upstream/master...HEAD`
- `npx prettier --check components/divider/index.en-US.md`
- `node_modules/.bin/remark components/divider/index.en-US.md -q >/dev/null`

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |
