### PR TITLE
fix(Layout): improve Sider trigger accessibility

### DIFF
--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -160,10 +160,13 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
   const rawWidth = collapsed ? collapsedWidth : width;
   // use "px" as fallback unit for width
   const siderWidth = isNumeric(rawWidth) ? `${rawWidth}px` : String(rawWidth);
+  const triggerLabel = collapsed ? 'Expand sidebar' : 'Collapse sidebar';
   // special trigger when collapsedWidth == 0
   const zeroWidthTrigger =
     Number.parseFloat(String(collapsedWidth || 0)) === 0 ? (
       <span
+        aria-expanded={!collapsed}
+        aria-label={triggerLabel}
         onClick={toggle}
         onKeyDown={handleTriggerKeyDown}
         role="button"
@@ -191,6 +194,8 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
     trigger !== null
       ? zeroWidthTrigger || (
           <div
+            aria-expanded={!collapsed}
+            aria-label={triggerLabel}
             className={`${prefixCls}-trigger`}
             onClick={toggle}
             onKeyDown={handleTriggerKeyDown}

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -149,6 +149,13 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
     handleSetCollapsed(!collapsed, 'clickTrigger');
   };
 
+  const handleTriggerKeyDown: React.KeyboardEventHandler<HTMLElement> = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggle();
+    }
+  };
+
   const divProps = omit(otherProps, ['collapsed']);
   const rawWidth = collapsed ? collapsedWidth : width;
   // use "px" as fallback unit for width
@@ -158,6 +165,9 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
     Number.parseFloat(String(collapsedWidth || 0)) === 0 ? (
       <span
         onClick={toggle}
+        onKeyDown={handleTriggerKeyDown}
+        role="button"
+        tabIndex={0}
         className={clsx(
           `${prefixCls}-zero-width-trigger`,
           `${prefixCls}-zero-width-trigger-${reverseArrow ? 'right' : 'left'}`,
@@ -180,7 +190,14 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
   const triggerDom =
     trigger !== null
       ? zeroWidthTrigger || (
-          <div className={`${prefixCls}-trigger`} onClick={toggle} style={{ width: siderWidth }}>
+          <div
+            className={`${prefixCls}-trigger`}
+            onClick={toggle}
+            onKeyDown={handleTriggerKeyDown}
+            role="button"
+            tabIndex={0}
+            style={{ width: siderWidth }}
+          >
             {trigger || defaultTrigger}
           </div>
         )

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -9,6 +9,7 @@ import { clsx } from 'clsx';
 import { isFunction } from '../_util/is';
 import type { Breakpoint } from '../_util/responsiveObserver';
 import { ConfigContext } from '../config-provider';
+import { useLocale } from '../locale';
 import { LayoutContext } from './context';
 import useStyle from './style/sider';
 
@@ -105,6 +106,7 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
 
   // =========================== Prefix ===========================
   const { getPrefixCls, direction } = useContext(ConfigContext);
+  const [siderLocale] = useLocale('Sider');
   const prefixCls = getPrefixCls('layout-sider', customizePrefixCls);
 
   const [hashId, cssVarCls] = useStyle(prefixCls);
@@ -160,7 +162,7 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
   const rawWidth = collapsed ? collapsedWidth : width;
   // use "px" as fallback unit for width
   const siderWidth = isNumeric(rawWidth) ? `${rawWidth}px` : String(rawWidth);
-  const triggerLabel = collapsed ? 'Expand sidebar' : 'Collapse sidebar';
+  const triggerLabel = collapsed ? siderLocale.expand : siderLocale.collapse;
   // special trigger when collapsedWidth == 0
   const zeroWidthTrigger =
     Number.parseFloat(String(collapsedWidth || 0)) === 0 ? (

--- a/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2312,6 +2312,8 @@ exports[`renders components/layout/demo/responsive.tsx extend context correctly 
       />
     </div>
     <span
+      aria-expanded="false"
+      aria-label="Expand sidebar"
       class="ant-layout-sider-zero-width-trigger ant-layout-sider-zero-width-trigger-left"
       role="button"
       tabindex="0"
@@ -2817,6 +2819,8 @@ exports[`renders components/layout/demo/side.tsx extend context correctly 1`] = 
       />
     </div>
     <div
+      aria-expanded="true"
+      aria-label="Collapse sidebar"
       class="ant-layout-sider-trigger"
       role="button"
       style="width: 200px;"

--- a/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2313,6 +2313,8 @@ exports[`renders components/layout/demo/responsive.tsx extend context correctly 
     </div>
     <span
       class="ant-layout-sider-zero-width-trigger ant-layout-sider-zero-width-trigger-left"
+      role="button"
+      tabindex="0"
     >
       <span
         aria-label="bars"
@@ -2816,7 +2818,9 @@ exports[`renders components/layout/demo/side.tsx extend context correctly 1`] = 
     </div>
     <div
       class="ant-layout-sider-trigger"
+      role="button"
       style="width: 200px;"
+      tabindex="0"
     >
       <span
         aria-label="left"

--- a/components/layout/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.ts.snap
@@ -1690,6 +1690,8 @@ exports[`renders components/layout/demo/side.tsx correctly 1`] = `
       />
     </div>
     <div
+      aria-expanded="true"
+      aria-label="Collapse sidebar"
       class="ant-layout-sider-trigger"
       role="button"
       style="width:200px"

--- a/components/layout/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.ts.snap
@@ -1691,7 +1691,9 @@ exports[`renders components/layout/demo/side.tsx correctly 1`] = `
     </div>
     <div
       class="ant-layout-sider-trigger"
+      role="button"
       style="width:200px"
+      tabindex="0"
     >
       <span
         aria-label="left"

--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -343,6 +343,52 @@ describe('Sider', () => {
     ).toEqual('rgb(255, 153, 102)');
   });
 
+  it('should support keyboard trigger on zero width trigger', () => {
+    const onCollapse = jest.fn();
+
+    const { container } = render(
+      <Sider collapsedWidth={0} collapsible onCollapse={onCollapse}>
+        Sider
+      </Sider>,
+    );
+
+    const trigger = container.querySelector<HTMLElement>('.ant-layout-sider-zero-width-trigger')!;
+    expect(trigger).toHaveAttribute('role', 'button');
+    expect(trigger).toHaveAttribute('tabindex', '0');
+
+    fireEvent.keyDown(trigger, { key: 'Escape' });
+    expect(onCollapse).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    expect(onCollapse).toHaveBeenCalledWith(true, 'clickTrigger');
+
+    fireEvent.keyDown(trigger, { key: ' ' });
+    expect(onCollapse).toHaveBeenCalledWith(false, 'clickTrigger');
+  });
+
+  it('should support keyboard trigger on default trigger', () => {
+    const onCollapse = jest.fn();
+
+    const { container } = render(
+      <Sider collapsible onCollapse={onCollapse}>
+        Sider
+      </Sider>,
+    );
+
+    const trigger = container.querySelector<HTMLElement>('.ant-layout-sider-trigger')!;
+    expect(trigger).toHaveAttribute('role', 'button');
+    expect(trigger).toHaveAttribute('tabindex', '0');
+
+    fireEvent.keyDown(trigger, { key: 'Tab' });
+    expect(onCollapse).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    expect(onCollapse).toHaveBeenCalledWith(true, 'clickTrigger');
+
+    fireEvent.keyDown(trigger, { key: ' ' });
+    expect(onCollapse).toHaveBeenCalledWith(false, 'clickTrigger');
+  });
+
   it('should be able to customize zero width trigger by trigger prop', () => {
     const { container } = render(
       <Sider collapsedWidth={0} collapsible trigger={<span className="my-trigger" />}>

--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -353,6 +353,8 @@ describe('Sider', () => {
     );
 
     const trigger = container.querySelector<HTMLElement>('.ant-layout-sider-zero-width-trigger')!;
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(trigger).toHaveAttribute('aria-label', 'Collapse sidebar');
     expect(trigger).toHaveAttribute('role', 'button');
     expect(trigger).toHaveAttribute('tabindex', '0');
 
@@ -361,6 +363,8 @@ describe('Sider', () => {
 
     fireEvent.keyDown(trigger, { key: 'Enter' });
     expect(onCollapse).toHaveBeenCalledWith(true, 'clickTrigger');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveAttribute('aria-label', 'Expand sidebar');
 
     fireEvent.keyDown(trigger, { key: ' ' });
     expect(onCollapse).toHaveBeenCalledWith(false, 'clickTrigger');
@@ -376,6 +380,8 @@ describe('Sider', () => {
     );
 
     const trigger = container.querySelector<HTMLElement>('.ant-layout-sider-trigger')!;
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(trigger).toHaveAttribute('aria-label', 'Collapse sidebar');
     expect(trigger).toHaveAttribute('role', 'button');
     expect(trigger).toHaveAttribute('tabindex', '0');
 
@@ -384,6 +390,8 @@ describe('Sider', () => {
 
     fireEvent.keyDown(trigger, { key: 'Enter' });
     expect(onCollapse).toHaveBeenCalledWith(true, 'clickTrigger');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveAttribute('aria-label', 'Expand sidebar');
 
     fireEvent.keyDown(trigger, { key: ' ' });
     expect(onCollapse).toHaveBeenCalledWith(false, 'clickTrigger');

--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -6,6 +6,8 @@ import Layout from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
+import zhCN from '../../locale/zh_CN';
 import Menu from '../../menu';
 
 const { Sider, Content, Footer, Header } = Layout;
@@ -395,6 +397,20 @@ describe('Sider', () => {
 
     fireEvent.keyDown(trigger, { key: ' ' });
     expect(onCollapse).toHaveBeenCalledWith(false, 'clickTrigger');
+  });
+
+  it('should localize trigger aria-label via locale config', () => {
+    const { container } = render(
+      <ConfigProvider locale={zhCN}>
+        <Sider collapsible>Sider</Sider>
+      </ConfigProvider>,
+    );
+
+    const trigger = container.querySelector<HTMLElement>('.ant-layout-sider-trigger')!;
+    expect(trigger).toHaveAttribute('aria-label', '收起侧边栏');
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-label', '展开侧边栏');
   });
 
   it('should be able to customize zero width trigger by trigger prop', () => {

--- a/components/locale/en_US.ts
+++ b/components/locale/en_US.ts
@@ -147,6 +147,10 @@ const localeValues: Locale = {
     singleColor: 'Single',
     gradientColor: 'Gradient',
   },
+  Sider: {
+    expand: 'Expand sidebar',
+    collapse: 'Collapse sidebar',
+  },
 };
 
 export default localeValues;

--- a/components/locale/index.tsx
+++ b/components/locale/index.tsx
@@ -62,6 +62,10 @@ export interface Locale {
     singleColor: string;
     gradientColor: string;
   };
+  Sider?: {
+    expand?: string;
+    collapse?: string;
+  };
 }
 
 export interface LocaleProviderProps {

--- a/components/locale/zh_CN.ts
+++ b/components/locale/zh_CN.ts
@@ -148,6 +148,10 @@ const localeValues: Locale = {
     singleColor: '单色',
     gradientColor: '渐变色',
   },
+  Sider: {
+    expand: '展开侧边栏',
+    collapse: '收起侧边栏',
+  },
 };
 
 export default localeValues;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

master 代码中下面两处是绑定了 onClick 事件的静态 HTML 元素，但是没有设置 a11y 相关的 `role` 属性：

components/layout/Sider.tsx:159
components/layout/Sider.tsx:183

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | improve Sider trigger accessibility |
| 🇨🇳 Chinese | 改进 Sider 触发器的可访问性 |
