### PR TITLE
fix(checkbox): Unexpected checkbox hover border style on mobile device

### DIFF
--- a/components/checkbox/style/index.ts
+++ b/components/checkbox/style/index.ts
@@ -207,7 +207,7 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
 
           [hoverMediaQuery]: {
             // https://github.com/ant-design/ant-design/issues/50074
-            '&:hover': {
+            [`&:not(${checkboxCls}-disabled):hover`]: {
               backgroundColor: token.colorBgContainer,
               borderColor: token.colorPrimary,
             },

--- a/components/checkbox/style/index.ts
+++ b/components/checkbox/style/index.ts
@@ -29,6 +29,7 @@ interface CheckboxToken extends FullToken<'Checkbox'> {
 export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
   const { checkboxCls, checkboxSize, lineWidth } = token;
   const wrapperCls = `${checkboxCls}-wrapper`;
+  const hoverMediaQuery = '@media (hover: hover) and (pointer: fine)';
 
   return [
     // ===================== Basic =====================
@@ -141,20 +142,22 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
 
     // ===================== Hover =====================
     {
-      // Wrapper & Wrapper > Checkbox
-      [`
-        ${wrapperCls}:not(${wrapperCls}-disabled),
-        ${checkboxCls}:not(${checkboxCls}-disabled)
-      `]: {
-        [`&:hover ${checkboxCls}`]: {
-          borderColor: token.colorPrimary,
+      [hoverMediaQuery]: {
+        // Wrapper & Wrapper > Checkbox
+        [`
+          ${wrapperCls}:not(${wrapperCls}-disabled),
+          ${checkboxCls}:not(${checkboxCls}-disabled)
+        `]: {
+          [`&:hover ${checkboxCls}`]: {
+            borderColor: token.colorPrimary,
+          },
         },
-      },
 
-      [`${wrapperCls}:not(${wrapperCls}-disabled)`]: {
-        [`&:hover ${checkboxCls}-checked:not(${checkboxCls}-disabled)`]: {
-          backgroundColor: token.colorPrimaryHover,
-          borderColor: 'transparent',
+        [`${wrapperCls}:not(${wrapperCls}-disabled)`]: {
+          [`&:hover ${checkboxCls}-checked:not(${checkboxCls}-disabled)`]: {
+            backgroundColor: token.colorPrimaryHover,
+            borderColor: 'transparent',
+          },
         },
       },
     },
@@ -173,10 +176,12 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
           ...genNoMotionStyle(),
         },
 
-        // Hover on checked checkbox directly
-        [`&:not(${checkboxCls}-disabled):hover`]: {
-          backgroundColor: token.colorPrimaryHover,
-          borderColor: 'transparent',
+        [hoverMediaQuery]: {
+          // Hover on checked checkbox directly
+          [`&:not(${checkboxCls}-disabled):hover`]: {
+            backgroundColor: token.colorPrimaryHover,
+            borderColor: 'transparent',
+          },
         },
       },
     },
@@ -200,10 +205,12 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
             content: '""',
           },
 
-          // https://github.com/ant-design/ant-design/issues/50074
-          '&:hover': {
-            backgroundColor: token.colorBgContainer,
-            borderColor: token.colorPrimary,
+          [hoverMediaQuery]: {
+            // https://github.com/ant-design/ant-design/issues/50074
+            '&:hover': {
+              backgroundColor: token.colorBgContainer,
+              borderColor: token.colorPrimary,
+            },
           },
         },
       },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ✅] 🐞 Bug fix


### 💡 Background and Solution

when touch checkbox on mobile device, it will keep some unexpected hover style, add media query to void this situation.

<img width="592" height="1280" alt="image" src="https://github.com/user-attachments/assets/07ebafe6-49d0-400a-81b5-a59c7fe01c68" />
<img width="592" height="1280" alt="image" src="https://github.com/user-attachments/assets/75df5365-3530-4a29-9d90-ec2e44d922ff" />



### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix checkbox hover style on mobile device   |
| 🇨🇳 Chinese |     修复 checkbox 在移动端设备上点击时残留 hover 样式      |
