### PR TITLE
fix: avoid rendering DOM wrappers for false React nodes

### DIFF
--- a/components/_util/ContextIsolator.tsx
+++ b/components/_util/ContextIsolator.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 
 import { NoFormStyle } from '../form/context';
 import { NoCompactStyle } from '../space/Compact';
-import { isNonNullable } from './is';
+import { isReactRenderable } from './is';
 
 const ContextIsolator: React.FC<
   Readonly<React.PropsWithChildren<Partial<Record<'space' | 'form', boolean>>>>
 > = (props) => {
   const { space, form, children } = props;
-  if (!isNonNullable(children)) {
+  if (!isReactRenderable(children)) {
     return null;
   }
   let result: React.ReactNode = children;

--- a/components/_util/__tests__/ContextIsolator.test.tsx
+++ b/components/_util/__tests__/ContextIsolator.test.tsx
@@ -4,8 +4,8 @@ import { render } from '../../../tests/utils';
 import ContextIsolator from '../ContextIsolator';
 
 describe('ContextIsolator component', () => {
-  it('ContextIsolator should work when Children is null', () => {
-    [undefined, null].forEach((item) => {
+  it('ContextIsolator should work when Children is empty', () => {
+    [undefined, null, false].forEach((item) => {
       expect(() => {
         render(<ContextIsolator>{item}</ContextIsolator>);
       }).not.toThrow();

--- a/components/_util/convertToTooltipProps.ts
+++ b/components/_util/convertToTooltipProps.ts
@@ -2,10 +2,10 @@ import type { ReactNode } from 'react';
 import { isValidElement } from 'react';
 
 import type { TooltipProps } from '../tooltip';
-import { isNonNullable, isPlainObject } from './is';
+import { isPlainObject, isReactRenderable } from './is';
 
 const convertToTooltipProps = <P extends TooltipProps>(tooltip: P | ReactNode, context?: P) => {
-  if (!isNonNullable(tooltip)) {
+  if (!isReactRenderable(tooltip)) {
     return null;
   }
 

--- a/components/_util/is.ts
+++ b/components/_util/is.ts
@@ -2,6 +2,10 @@ export const isNonNullable = <T>(val: T): val is NonNullable<T> => {
   return val !== undefined && val !== null;
 };
 
+export const isReactRenderable = <T>(val: T): val is Exclude<NonNullable<T>, false> => {
+  return isNonNullable(val) && val !== false;
+};
+
 export const isNumber = (val: any): val is number => {
   return typeof val === 'number' && !Number.isNaN(val);
 };

--- a/components/badge/Badge.tsx
+++ b/components/badge/Badge.tsx
@@ -7,7 +7,7 @@ import type { PresetStatusColorType } from '../_util/colors';
 import { isPresetColor } from '../_util/colors';
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isNonNullable, isNumber, isPlainObject } from '../_util/is';
+import { isNonNullable, isNumber, isPlainObject, isReactRenderable } from '../_util/is';
 import { cloneElement } from '../_util/reactNode';
 import type { LiteralUnion } from '../_util/type';
 import { devUseWarning } from '../_util/warning';
@@ -134,7 +134,8 @@ const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>((props, ref) => {
 
   const isHidden = useMemo(() => {
     const isEmpty =
-      (!isNonNullable(mergedCount) || mergedCount === '') && (!isNonNullable(text) || text === '');
+      (!isReactRenderable(mergedCount) || mergedCount === '') &&
+      (!isReactRenderable(text) || text === '');
     return (isEmpty || (isZero && !showZero)) && !showAsDot;
   }, [mergedCount, isZero, showZero, showAsDot, text]);
 

--- a/components/breadcrumb/useItemRender.tsx
+++ b/components/breadcrumb/useItemRender.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { pickAttrs } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { isNonNullable, isPlainObject } from '../_util/is';
+import { isPlainObject, isReactRenderable } from '../_util/is';
 import type { BreadcrumbProps, InternalRouteType, ItemType } from './Breadcrumb';
 
 type AddParameters<TFunction extends (...args: any) => any, TParameters extends [...args: any]> = (
@@ -13,7 +13,7 @@ type ItemRender = NonNullable<BreadcrumbProps['itemRender']>;
 type InternalItemRenderParams = AddParameters<ItemRender, [href?: string]>;
 
 function getBreadcrumbName(route: InternalRouteType, params: any) {
-  if (!isNonNullable(route.title)) {
+  if (!isReactRenderable(route.title)) {
     return null;
   }
   const paramsKeys = Object.keys(params).join('|');
@@ -31,7 +31,7 @@ export function renderItem(
   children: React.ReactNode,
   href?: string,
 ) {
-  if (!isNonNullable(children)) {
+  if (!isReactRenderable(children)) {
     return null;
   }
 

--- a/components/button/Button.tsx
+++ b/components/button/Button.tsx
@@ -4,7 +4,7 @@ import { clsx } from 'clsx';
 
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isNonNullable, isNumber, isPlainObject } from '../_util/is';
+import { isNumber, isPlainObject, isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import Wave from '../_util/wave';
 import { useComponentConfig } from '../config-provider/context';
@@ -442,7 +442,7 @@ const InternalCompoundedButton = React.forwardRef<
     iconNode = defaultLoadingIconElement;
   }
 
-  const contentNode = isNonNullable(children)
+  const contentNode = isReactRenderable(children)
     ? spaceChildren(
         children,
         needInserted && mergedInsertSpace,

--- a/components/button/buttonHelpers.tsx
+++ b/components/button/buttonHelpers.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { clsx } from 'clsx';
 
-import { isNonNullable, isNumber, isString } from '../_util/is';
+import { isNumber, isReactRenderable, isString } from '../_util/is';
 import { cloneElement, isFragment } from '../_util/reactNode';
 import { PresetColors } from '../theme/interface';
 import type { BaseButtonProps, LegacyButtonType } from './Button';
@@ -29,7 +29,7 @@ function splitCNCharsBySpace(
   style?: React.CSSProperties,
   className?: string,
 ) {
-  if (!isNonNullable(child) || child === '') {
+  if (!isReactRenderable(child) || child === '') {
     return;
   }
 

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -6,7 +6,7 @@ import { clsx } from 'clsx';
 
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isNonNullable } from '../_util/is';
+import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import Wave from '../_util/wave';
 import { TARGET_CLS } from '../_util/wave/interface';
@@ -246,7 +246,7 @@ const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProp
           ref={mergedRef}
           value={value}
         />
-        {isNonNullable(children) && (
+        {isReactRenderable(children) && (
           <span
             className={clsx(`${prefixCls}-label`, mergedClassNames.label)}
             style={mergedStyles.label}

--- a/components/descriptions/Cell.tsx
+++ b/components/descriptions/Cell.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
-import { isNonNullable } from '../_util/is';
+import { isReactRenderable } from '../_util/is';
 import type { CellSemanticType } from './DescriptionsContext';
 import DescriptionsContext from './DescriptionsContext';
 
@@ -70,8 +70,8 @@ const Cell: React.FC<CellProps> = (props) => {
           [mergedClassNames.content!]: mergedClassNames.content && type === 'content',
         })}
       >
-        {isNonNullable(label) && <span style={mergedLabelStyle}>{label}</span>}
-        {isNonNullable(content) && <span style={mergedContentStyle}>{content}</span>}
+        {isReactRenderable(label) && <span style={mergedLabelStyle}>{label}</span>}
+        {isReactRenderable(content) && <span style={mergedContentStyle}>{content}</span>}
       </Component>
     );
   }
@@ -79,7 +79,7 @@ const Cell: React.FC<CellProps> = (props) => {
   return (
     <Component className={clsx(`${itemPrefixCls}-item`, className)} style={style} colSpan={span}>
       <div className={`${itemPrefixCls}-item-container`}>
-        {isNonNullable(label) && (
+        {isReactRenderable(label) && (
           <span
             style={mergedLabelStyle}
             className={clsx(`${itemPrefixCls}-item-label`, mergedClassNames.label, {
@@ -89,7 +89,7 @@ const Cell: React.FC<CellProps> = (props) => {
             {label}
           </span>
         )}
-        {isNonNullable(content) && (
+        {isReactRenderable(content) && (
           <span
             style={mergedContentStyle}
             className={clsx(`${itemPrefixCls}-item-content`, mergedClassNames.content)}

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -3,7 +3,7 @@ import type { CSSMotionProps } from '@rc-component/motion';
 import CSSMotion, { CSSMotionList } from '@rc-component/motion';
 import { clsx } from 'clsx';
 
-import { isNonNullable } from '../_util/is';
+import { isReactRenderable } from '../_util/is';
 import initCollapseMotion from '../_util/motion';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import { FormContext, FormItemPrefixContext } from './context';
@@ -70,7 +70,7 @@ const ErrorList: React.FC<ErrorListProps> = ({
   const debounceWarnings = useDebounce(warnings);
 
   const fullKeyList = React.useMemo<ErrorEntity[]>(() => {
-    if (isNonNullable(help)) {
+    if (isReactRenderable(help)) {
       return [toErrorEntity(help, 'help', helpStatus)];
     }
     return [

--- a/components/form/FormItem/ItemHolder.tsx
+++ b/components/form/FormItem/ItemHolder.tsx
@@ -5,7 +5,7 @@ import isVisible from '@rc-component/util/lib/Dom/isVisible';
 import { clsx } from 'clsx';
 
 import type { FormItemProps } from '.';
-import { isNonNullable } from '../../_util/is';
+import { isReactRenderable } from '../../_util/is';
 import { Row } from '../../grid';
 import type { ReportMetaChange } from '../context';
 import { FormContext, NoStyleItemContext } from '../context';
@@ -62,7 +62,7 @@ export default function ItemHolder(props: ItemHolderProps) {
   const itemRef = React.useRef<HTMLDivElement>(null);
   const debounceErrors = useDebounce(errors);
   const debounceWarnings = useDebounce(warnings);
-  const hasHelp = isNonNullable(help);
+  const hasHelp = isReactRenderable(help);
   const hasError = !!(hasHelp || errors.length || warnings.length);
   const isOnScreen = !!itemRef.current && isVisible(itemRef.current);
   const [marginBottom, setMarginBottom] = React.useState<number | null>(null);

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -6,7 +6,7 @@ import InfoCircleFilled from '@ant-design/icons/InfoCircleFilled';
 import { clsx } from 'clsx';
 
 import { CONTAINER_MAX_OFFSET, normalizeMaskConfig } from '../_util/hooks';
-import { isFunction, isNonNullable, isPlainObject } from '../_util/is';
+import { isFunction, isPlainObject, isReactRenderable } from '../_util/is';
 import { getTransitionName } from '../_util/motion';
 import { devUseWarning } from '../_util/warning';
 import type { ThemeConfig } from '../config-provider';
@@ -141,8 +141,8 @@ export const ConfirmContent: React.FC<ConfirmDialogProps & { confirmPrefixCls: s
     </>
   );
 
-  const hasTitle = isNonNullable(props.title) && props.title !== '';
-  const hasIcon = isNonNullable(mergedIcon);
+  const hasTitle = isReactRenderable(props.title) && props.title !== '';
+  const hasIcon = isReactRenderable(mergedIcon);
 
   const bodyCls = `${confirmPrefixCls}-body`;
 

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -12,7 +12,7 @@ import { clsx } from 'clsx';
 import { pickClosable, useClosable } from '../_util/hooks';
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isNonNullable, isPlainObject } from '../_util/is';
+import { isPlainObject, isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import { useComponentConfig } from '../config-provider/context';
@@ -37,10 +37,11 @@ export function getCloseIcon(prefixCls: string, closeIcon?: React.ReactNode): Re
   return closeIcon || <CloseOutlined className={`${prefixCls}-close-icon`} />;
 }
 
-export interface PurePanelProps extends Omit<
-  RcNotificationProps,
-  'prefixCls' | 'classNames' | 'styles' | 'title' | 'description' | 'icon' | 'actions' | 'role'
-> {
+export interface PurePanelProps
+  extends Omit<
+    RcNotificationProps,
+    'prefixCls' | 'classNames' | 'styles' | 'title' | 'description' | 'icon' | 'actions' | 'role'
+  > {
   prefixCls?: string;
   icon?: React.ReactNode;
   /** @deprecated Please use `title` instead */
@@ -105,7 +106,7 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
     });
   }
   const mergedTitle = title ?? message;
-  const hasTitle = isNonNullable(mergedTitle) && mergedTitle !== false && mergedTitle !== '';
+  const hasTitle = isReactRenderable(mergedTitle) && mergedTitle !== '';
   const prefixCls = staticPrefixCls || getPrefixCls('notification');
   const noticePrefixCls = `${prefixCls}-notice`;
   const iconNode = icon || (type ? TypeIcon[type] : null);

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -4,6 +4,7 @@ import { composeRef } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import Wave from '../_util/wave';
 import { TARGET_CLS } from '../_util/wave/interface';
@@ -137,7 +138,7 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
           ref={mergedRef}
           onClick={onInputClick}
         />
-        {children !== undefined ? (
+        {isReactRenderable(children) ? (
           <span
             className={clsx(`${prefixCls}-label`, mergedClassNames.label)}
             style={mergedStyles.label}

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -9,7 +9,7 @@ import { clsx } from 'clsx';
 import type { HTMLAriaDataAttributes } from '../_util/aria-data-attrs';
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isNonNullable } from '../_util/is';
+import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import noFound from './noFound';
@@ -226,18 +226,18 @@ const Result: ResultType = (props) => {
   return (
     <div {...restProps} className={rootClassNames} style={rootStyles}>
       <Icon className={iconClassNames} style={mergedStyles.icon} status={status} icon={icon} />
-      {isNonNullable(title) && (
+      {isReactRenderable(title) && (
         <div className={titleClassNames} style={mergedStyles.title}>
           {title}
         </div>
       )}
-      {isNonNullable(subTitle) && (
+      {isReactRenderable(subTitle) && (
         <div className={subTitleClassNames} style={mergedStyles.subTitle}>
           {subTitle}
         </div>
       )}
       <Extra className={extraClassNames} extra={extra} style={mergedStyles.extra} />
-      {isNonNullable(children) && (
+      {isReactRenderable(children) && (
         <div className={bodyClassNames} style={mergedStyles.body}>
           {children}
         </div>

--- a/components/space/Item.tsx
+++ b/components/space/Item.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { clsx } from 'clsx';
 
 import type { SpaceSemanticAllType } from '.';
-import { isNonNullable } from '../_util/is';
+import { isReactRenderable } from '../_util/is';
 import { SpaceContext } from './context';
 import type { SpaceContextType } from './context';
 
@@ -22,7 +22,7 @@ const Item: React.FC<ItemProps> = (props) => {
 
   const { latestIndex } = React.useContext<SpaceContextType>(SpaceContext);
 
-  if (!isNonNullable(children)) {
+  if (!isReactRenderable(children)) {
     return null;
   }
 

--- a/components/space/index.tsx
+++ b/components/space/index.tsx
@@ -7,7 +7,7 @@ import { useOrientation } from '../_util/hooks';
 import type { Orientation } from '../_util/hooks';
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isNonNullable } from '../_util/is';
+import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import type { SizeType } from '../config-provider/SizeContext';
@@ -176,7 +176,7 @@ const InternalSpace = React.forwardRef<HTMLDivElement, SpaceProps>((props, ref) 
 
   const memoizedSpaceContext = React.useMemo<SpaceContextType>(() => {
     const calcLatestIndex = childNodes.reduce<number>(
-      (latest, child, i) => (isNonNullable(child) ? i : latest),
+      (latest, child, i) => (isReactRenderable(child) ? i : latest),
       0,
     );
     return { latestIndex: calcLatestIndex };

--- a/components/tour/panelRender.tsx
+++ b/components/tour/panelRender.tsx
@@ -4,7 +4,7 @@ import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import { pickAttrs } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { isNonNullable } from '../_util/is';
+import { isReactRenderable } from '../_util/is';
 import type { ButtonProps } from '../button/Button';
 import Button from '../button/Button';
 import { useLocale } from '../locale';
@@ -81,7 +81,7 @@ const TourPanel: React.FC<TourPanelProps> = (props) => {
     nextButtonProps?.onClick?.();
   };
 
-  const headerNode = isNonNullable(title) ? (
+  const headerNode = isReactRenderable(title) ? (
     <div className={clsx(`${prefixCls}-header`, classNames.header)} style={styles.header}>
       <div className={clsx(`${prefixCls}-title`, classNames.title)} style={styles.title}>
         {title}
@@ -89,7 +89,7 @@ const TourPanel: React.FC<TourPanelProps> = (props) => {
     </div>
   ) : null;
 
-  const descriptionNode = isNonNullable(description) ? (
+  const descriptionNode = isReactRenderable(description) ? (
     <div
       className={clsx(`${prefixCls}-description`, classNames.description)}
       style={styles.description}
@@ -98,7 +98,7 @@ const TourPanel: React.FC<TourPanelProps> = (props) => {
     </div>
   ) : null;
 
-  const coverNode = isNonNullable(cover) ? (
+  const coverNode = isReactRenderable(cover) ? (
     <div className={clsx(`${prefixCls}-cover`, classNames.cover)} style={styles.cover}>
       {cover}
     </div>

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -7,7 +7,7 @@ import { composeRef, omit, toArray, useControlledState, useLayoutEffect } from '
 import { clsx } from 'clsx';
 
 import type { GenerateSemantic } from '../../_util/hooks/useMergeSemantic/semanticType';
-import { isFunction, isNonNullable } from '../../_util/is';
+import { isFunction, isReactRenderable } from '../../_util/is';
 import { isStyleSupport } from '../../_util/styleChecker';
 import type { DirectionType } from '../../config-provider';
 import useLocale from '../../locale/useLocale';
@@ -104,9 +104,8 @@ export interface EllipsisConfig {
   tooltip?: React.ReactNode | TooltipProps;
 }
 
-export interface BlockProps<
-  C extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements,
-> extends TypographyProps<C> {
+export interface BlockProps<C extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements>
+  extends TypographyProps<C> {
   /**
    * @since 6.4.0
    */
@@ -477,7 +476,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
         locale={textLocale}
         onCopy={onCopyClick}
         loading={copyLoading}
-        iconOnly={!isNonNullable(children)}
+        iconOnly={!isReactRenderable(children)}
         className={mergedClassNames.action}
         style={mergedStyles.action}
       />


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

ReactNode 类型的属性或 children 为 `false` 时，React 不会渲染实际内容，但部分组件之前使用 `isNonNullable` 判断是否需要渲染外层 DOM，导致空的包装节点仍然被渲染出来。

本次新增 `isReactRenderable` 工具方法，用于区分“非 null/undefined”与“需要保留渲染结构”的判断；相关 DOM 展示判断改为过滤 `false`，同时保留 `true`、`0`、空字符串等已有语义。同步更新 `ContextIsolator` 相关测试覆盖 `false` children。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix components rendering empty wrapper DOM nodes when ReactNode content is `false`. |
| 🇨🇳 中文 | 修复多个组件在 ReactNode 内容为 `false` 时渲染空包装 DOM 节点的问题。 |