### PR TITLE
chore: change dependabot github-actions schedule to weekly and group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,12 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - github-actions
       - dependencies


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] ⏩ 工作流程

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

将 Dependabot 对 GitHub Actions 的更新频率从每天（daily）调整为每周一次（weekly，每周一），并将所有 GitHub Actions 依赖归入同一 group，减少重复 PR。

### 📝 更新日志

无需更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A      |
| 🇨🇳 中文 | N/A      |