### PR TITLE
docs: add Mentions option value

### DIFF
--- a/components/mentions/index.en-US.md
+++ b/components/mentions/index.en-US.md
@@ -78,6 +78,7 @@ Common props ref：[Common props](/docs/react/common-props)
 <!-- prettier-ignore -->
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
+| value | Value inserted when selected | string | - |
 | label | Title of the option | React.ReactNode | - |
 | key | The key value of the option | string | - |
 | disabled | Optional | boolean | - |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Mentions 英文文档的 Option API 表缺少 `value` 字段，但该字段已在类型定义中支持，并且中文文档中已有对应说明。

本 PR 在英文 Option API 表中补充 `value`，使中英文文档保持一致。

验证：
- `git diff --check upstream/master...HEAD`
- `npx prettier --check components/mentions/index.en-US.md`
- `node_modules/.bin/remark components/mentions/index.en-US.md -q >/dev/null`

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |
