### PR TITLE
fix(Upload): improve list item accessibility

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -41396,6 +41396,8 @@ exports[`ConfigProvider components Upload configProvider 1`] = `
         </div>
         <span
           class="config-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="xxx.png"
         >
           xxx.png
@@ -41494,6 +41496,8 @@ exports[`ConfigProvider components Upload configProvider componentDisabled 1`] =
         </div>
         <span
           class="config-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="xxx.png"
         >
           xxx.png
@@ -41560,6 +41564,8 @@ exports[`ConfigProvider components Upload configProvider componentSize large 1`]
         </div>
         <span
           class="config-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="xxx.png"
         >
           xxx.png
@@ -41657,6 +41663,8 @@ exports[`ConfigProvider components Upload configProvider componentSize medium 1`
         </div>
         <span
           class="config-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="xxx.png"
         >
           xxx.png
@@ -41754,6 +41762,8 @@ exports[`ConfigProvider components Upload configProvider componentSize small 1`]
         </div>
         <span
           class="config-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="xxx.png"
         >
           xxx.png
@@ -41851,6 +41861,8 @@ exports[`ConfigProvider components Upload normal 1`] = `
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="xxx.png"
         >
           xxx.png
@@ -41948,6 +41960,8 @@ exports[`ConfigProvider components Upload prefixCls 1`] = `
         </div>
         <span
           class="prefix-Upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="xxx.png"
         >
           xxx.png

--- a/components/upload/UploadList/ListItem.tsx
+++ b/components/upload/UploadList/ListItem.tsx
@@ -187,6 +187,12 @@ const ListItem = React.forwardRef<HTMLDivElement, ListItemProps>(
     );
 
     const listItemNameClass = clsx(`${prefixCls}-list-item-name`);
+    const onPreviewKeyDown: React.KeyboardEventHandler<HTMLSpanElement> = (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onPreview(file, e);
+      }
+    };
     const fileName = file.url ? (
       <a
         key="view"
@@ -204,8 +210,11 @@ const ListItem = React.forwardRef<HTMLDivElement, ListItemProps>(
     ) : (
       <span
         key="view"
+        role="button"
+        tabIndex={0}
         className={listItemNameClass}
         onClick={(e) => onPreview(file, e)}
+        onKeyDown={onPreviewKeyDown}
         title={file.name}
       >
         {file.name}

--- a/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -810,6 +810,8 @@ exports[`renders components/upload/demo/debug-disabled.tsx extend context correc
             </div>
             <span
               class="ant-upload-list-item-name"
+              role="button"
+              tabindex="0"
               title="image.png"
             >
               image.png
@@ -1087,6 +1089,8 @@ exports[`renders components/upload/demo/debug-disabled.tsx extend context correc
             </div>
             <span
               class="ant-upload-list-item-name"
+              role="button"
+              tabindex="0"
               title="image.png"
             >
               image.png
@@ -2460,6 +2464,8 @@ exports[`renders components/upload/demo/file-type.tsx extend context correctly 1
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="image.png"
         >
           image.png
@@ -2569,6 +2575,8 @@ exports[`renders components/upload/demo/file-type.tsx extend context correctly 1
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="pdf.pdf"
         >
           pdf.pdf
@@ -2670,6 +2678,8 @@ exports[`renders components/upload/demo/file-type.tsx extend context correctly 1
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="doc.doc"
         >
           doc.doc
@@ -3529,6 +3539,8 @@ exports[`renders components/upload/demo/picture-card.tsx extend context correctl
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="image.png"
         >
           image.png
@@ -3808,6 +3820,8 @@ exports[`renders components/upload/demo/picture-circle.tsx extend context correc
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="image.png"
         >
           image.png
@@ -4003,6 +4017,8 @@ exports[`renders components/upload/demo/picture-style.tsx extend context correct
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="xxx.png"
         >
           xxx.png
@@ -4155,6 +4171,8 @@ exports[`renders components/upload/demo/picture-style.tsx extend context correct
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="zzz.png"
         >
           zzz.png

--- a/components/upload/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/upload/__tests__/__snapshots__/demo.test.ts.snap
@@ -780,6 +780,8 @@ exports[`renders components/upload/demo/debug-disabled.tsx correctly 1`] = `
             </div>
             <span
               class="ant-upload-list-item-name"
+              role="button"
+              tabindex="0"
               title="image.png"
             >
               image.png
@@ -1036,6 +1038,8 @@ exports[`renders components/upload/demo/debug-disabled.tsx correctly 1`] = `
             </div>
             <span
               class="ant-upload-list-item-name"
+              role="button"
+              tabindex="0"
               title="image.png"
             >
               image.png
@@ -1989,6 +1993,8 @@ exports[`renders components/upload/demo/drag-sorting.tsx correctly 1`] = `
           </div>
           <span
             class="ant-upload-list-item-name"
+            role="button"
+            tabindex="0"
             title="image.png"
           >
             image.png
@@ -2321,6 +2327,8 @@ exports[`renders components/upload/demo/file-type.tsx correctly 1`] = `
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="image.png"
         >
           image.png
@@ -2409,6 +2417,8 @@ exports[`renders components/upload/demo/file-type.tsx correctly 1`] = `
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="pdf.pdf"
         >
           pdf.pdf
@@ -2489,6 +2499,8 @@ exports[`renders components/upload/demo/file-type.tsx correctly 1`] = `
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="doc.doc"
         >
           doc.doc
@@ -3319,6 +3331,8 @@ exports[`renders components/upload/demo/picture-card.tsx correctly 1`] = `
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="image.png"
         >
           image.png
@@ -3575,6 +3589,8 @@ exports[`renders components/upload/demo/picture-circle.tsx correctly 1`] = `
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="image.png"
         >
           image.png
@@ -3748,6 +3764,8 @@ exports[`renders components/upload/demo/picture-style.tsx correctly 1`] = `
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="xxx.png"
         >
           xxx.png
@@ -3899,6 +3917,8 @@ exports[`renders components/upload/demo/picture-style.tsx correctly 1`] = `
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="zzz.png"
         >
           zzz.png

--- a/components/upload/__tests__/__snapshots__/uploadlist.test.tsx.snap
+++ b/components/upload/__tests__/__snapshots__/uploadlist.test.tsx.snap
@@ -58,6 +58,8 @@ exports[`Upload List handle error 1`] = `
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="foo.png"
         >
           foo.png
@@ -219,6 +221,8 @@ exports[`Upload List should be uploading when upload a file 1`] = `
         </div>
         <span
           class="ant-upload-list-item-name"
+          role="button"
+          tabindex="0"
           title="foo.png"
         >
           foo.png

--- a/components/upload/__tests__/uploadlist.test.tsx
+++ b/components/upload/__tests__/uploadlist.test.tsx
@@ -1023,7 +1023,13 @@ describe('Upload List', () => {
       />,
     );
     fireEvent.click(wrapper.querySelector('.ant-upload-list-item-name')!);
+    expect(wrapper.querySelector('.ant-upload-list-item-name')?.getAttribute('role')).toBe(
+      'button',
+    );
     expect(onPreview).toHaveBeenCalled();
+    fireEvent.keyDown(wrapper.querySelector('.ant-upload-list-item-name')!, { key: 'Enter' });
+    fireEvent.keyDown(wrapper.querySelector('.ant-upload-list-item-name')!, { key: ' ' });
+    expect(onPreview).toHaveBeenCalledTimes(5);
 
     unmount();
   });


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug 修复
- [x] ⌨️ 无障碍改进

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

UploadList 在文件没有 `url` 时，会使用 `span` 渲染文件名并绑定 `onClick` 触发预览。该静态 HTML 元素缺少交互语义，会触发无障碍检查问题。

本次为该文件名节点补充 `role="button"` 和 `tabIndex={0}`，并支持通过 Enter 和 Space 键触发预览，保持鼠标与键盘操作一致。

同时补充了对应测试用例，并更新相关快照。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ------- | -------- |
| 🇺🇸 英文 | Improve Upload list item name accessibility when previewing files without a URL. |
| 🇨🇳 中文 | 改进 Upload 在无 URL 文件预览场景下文件名的无障碍体验。 |
