### PR TITLE
docs: correct Message duration default value

### DIFF
--- a/components/message/index.en-US.md
+++ b/components/message/index.en-US.md
@@ -45,7 +45,7 @@ This component provides some static methods, with usage and arguments as followi
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
 | content | The content of the message | ReactNode \| config | - |
-| duration | Time(seconds) before auto-dismiss, don't dismiss if set to 0 | number | 1.5 |
+| duration | Time(seconds) before auto-dismiss, don't dismiss if set to 0 | number | 3 |
 | onClose | Specify a function that will be called when the message is closed | function | - |
 
 `afterClose` can be called in thenable interface:


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Message 英文 API 文档中 duration 的默认值写为 1.5，但中文文档和组件实现都表明默认值应为 3。

本 PR 将英文文档中的 duration 默认值修正为 3，使其与实际行为保持一致。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     N/A     |
| 🇨🇳 中文 |     N/A     |