### PR TITLE
docs: add copilot-instructions file to reduce AI hallucinations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,8 @@
 
 This is the Ant Design (antd) repository - a React component library with enterprise-class UI design language, widely used for building professional web applications.
 
+> For deeper, project-wide conventions (demo/test import rules, documentation format, changelog rules, PR templates, etc.), see [`CLAUDE.md`](../CLAUDE.md) at the repository root. This file is a concise, suggestion-time reference designed to keep AI tools from hallucinating non-existent components or APIs.
+
 ## Project Context
 
 - **Framework**: TypeScript + React (compatible with React 16-19)
@@ -9,6 +11,54 @@ This is the Ant Design (antd) repository - a React component library with enterp
 - **Purpose**: Enterprise-class UI components for React applications
 - **Design System**: Follows Ant Design specifications
 - **Internationalization**: Full i18n support
+
+## Authoritative Component List
+
+The following are the **only** top-level exports of `antd`. Do **not** invent components outside this list (e.g. `antd` does not export `Container`, `Stack`, `Heading`, `Box`, `Sidebar`, `Navbar`, `IconButton`, etc.).
+
+`Affix`, `Alert`, `Anchor`, `App`, `AutoComplete`, `Avatar`, `BackTop` (deprecated — use `FloatButton.BackTop`), `Badge`, `BorderBeam`, `Breadcrumb`, `Button`, `Calendar`, `Card`, `Carousel`, `Cascader`, `Checkbox`, `Col`, `Collapse`, `ColorPicker`, `ConfigProvider`, `DatePicker`, `Descriptions`, `Divider`, `Drawer`, `Dropdown`, `Empty`, `Flex`, `FloatButton`, `Form`, `Grid`, `Image`, `Input`, `InputNumber`, `Layout`, `List`, `Masonry`, `Mentions`, `Menu`, `Modal`, `Pagination`, `Popconfirm`, `Popover`, `Progress`, `QRCode`, `Radio`, `Rate`, `Result`, `Row`, `Segmented`, `Select`, `Skeleton`, `Slider`, `Space`, `Spin`, `Splitter`, `Statistic`, `Steps`, `Switch`, `Table`, `Tabs`, `Tag`, `TimePicker`, `Timeline`, `Tooltip`, `Tour`, `Transfer`, `Tree`, `TreeSelect`, `Typography`, `Upload`, `Watermark`.
+
+Function exports (lowercase): `message`, `notification`, `theme`, `version`, `unstableSetRender`.
+
+When in doubt, verify against `components/index.ts` (the source of truth for public exports). Icons live in a **separate** package: `@ant-design/icons` — never import icons from `antd`.
+
+## Import Patterns
+
+```tsx
+// Components and types
+import { Button, Form, Input, type FormProps } from 'antd';
+
+// Locales live under antd/locale (not from the main entry)
+import enUS from 'antd/locale/en_US';
+
+// Icons live in a separate package
+import { SearchOutlined } from '@ant-design/icons';
+
+// DatePicker / TimePicker / Calendar require a date library wrapper.
+// The default uses dayjs — moment is no longer the default since v5.
+import dayjs from 'dayjs';
+```
+
+## API Migration Notes (Do Not Hallucinate the Old Names)
+
+The current major version uses these renames. Use the **new** API in suggestions:
+
+| Component | Deprecated (do not suggest) | Use instead |
+| --- | --- | --- |
+| Modal, Drawer, Dropdown, Tooltip, Popover, Popconfirm, Cascader, Select, AutoComplete, TreeSelect, etc. | `visible`, `onVisibleChange` | `open`, `onOpenChange` |
+| Modal, Drawer, Tabs, etc. | `destroyOnClose` | `destroyOnHidden` |
+| Tabs | `<Tabs><Tabs.TabPane /></Tabs>` (children API) | `<Tabs items={[{ key, label, children }]} />` |
+| Menu | `<Menu><Menu.Item /></Menu>` (children API) | `<Menu items={[{ key, label }]} />` |
+| Breadcrumb | `routes`, `<Breadcrumb.Item />` (children API) | `items={[{ title }]}` |
+| Anchor | children-based `<Anchor.Link />` | `items={[{ key, href, title }]}` |
+| AutoComplete, Cascader, Select | `dropdownClassName`, `dropdownStyle`, `dropdownRender`, `dropdownMatchSelectWidth` | `classNames.popup.root`, `styles.popup.root`, `popupRender`, `popupMatchSelectWidth` |
+| AutoComplete, Cascader | `onDropdownVisibleChange` | `onOpenChange` |
+| Card | `bordered` | `variant` |
+| Avatar.Group | `maxCount`, `maxStyle`, `maxPopoverPlacement` | `max={{ count, style, popover }}` |
+| BackTop | top-level `BackTop` | `FloatButton.BackTop` |
+| Calendar | `dateCellRender`, `dateFullCellRender` | `cellRender`, `fullCellRender` |
+
+Internally these are flagged via `warning.deprecated(...)` and `@deprecated` JSDoc tags; check the component's `interface.ts` / `index.tsx` if unsure.
 
 ## Code Standards & Best Practices
 
@@ -62,8 +112,7 @@ This is the Ant Design (antd) repository - a React component library with enterp
 - Use `@ant-design/cssinjs` for all styling
 - Place component styles in `style/` directory
 - Generate styles with functions named `gen[ComponentName]Style`
-- Use design tokens from the Ant Design token system
-- Never hardcode colors, sizes, or spacing values
+- Use design tokens from the Ant Design token system (read tokens via the `theme.useToken()` hook, or `token` argument inside style functions) — never hardcode colors, sizes, or spacing values
 - Support both light and dark themes
 - Use CSS logical properties for RTL support (e.g., `margin-inline-start` instead of `margin-left`)
 - Respect `prefers-reduced-motion` for animations
@@ -82,15 +131,21 @@ This is the Ant Design (antd) repository - a React component library with enterp
 - Target 100% test coverage
 - Place tests in `__tests__` directory as `index.test.tsx` or `componentName.test.tsx`
 - Include snapshot tests for UI components
+- Inside `components/**/__tests__/` use **relative** paths (`../`, `../../_util/...`) — never `antd`, `antd/es/*`, or path aliases. See [`CLAUDE.md`](../CLAUDE.md) for the full rule.
 
 ### Demo & Documentation
 
 - Keep demo code concise and copy-pasteable
 - Focus each demo on a single feature
-- Provide both English and Chinese documentation
+- Provide both English and Chinese documentation (`index.en-US.md` and `index.zh-CN.md`)
+- Inside `components/**/demo/` use **absolute** imports (`antd`, `antd/es/*`, `antd/locale/*`) — never relative paths to component internals. The semantic demos (`_semantic*.tsx`) are an exception. See [`CLAUDE.md`](../CLAUDE.md) for the full rule.
 - Follow import order: React → dependencies → antd components → custom components → types → styles
 - Use 2-space indentation
 - Prefer antd built-in components over external dependencies
+
+### Type Checks (Utility)
+
+Prefer the helpers in `components/_util/is.ts` (`isNumber`, `isString`, `isPlainObject`, `isFunction`, `isThenable`, `isPrimitive`, `isNonNullable`) over inline `typeof` / `instanceof` checks when the helper covers the case.
 
 ### API Documentation Format
 
@@ -101,21 +156,21 @@ When documenting component APIs, use this table structure:
 - Number defaults as literal values: `0`, `100`
 - No default value: `-`
 - Descriptions start with capital letter, no ending period
-- Sort API properties alphabetically
+- Sort API properties alphabetically (ignoring common props like `className`, `style`; place event callbacks last)
 
 ### Internationalization
 
 - Locale configuration files use pattern: `locale_COUNTRY.ts` (e.g., `zh_CN.ts`)
 - Use `useLocale` hook from `components/locale/index.tsx`
-- When modifying locale strings, update ALL language files
+- When modifying locale strings, update ALL language files under `components/locale/`
 - Locale content should be plain strings with `${}` placeholders for variables
 
 ### File Organization
 
-- Components in `components/[component-name]/` directory
-- Demos in `components/[component-name]/demo/` as `.tsx` files
+- Components in `components/[component-name]/` directory (kebab-case directory name, PascalCase implementation file)
+- Demos in `components/[component-name]/demo/` as `.tsx` files paired with `.md` documentation
 - Use kebab-case for demo filenames: `basic.tsx`, `custom-filter.tsx`
-- Each component demo includes both `.md` documentation and `.tsx` code
+- Each component exports through `components/[component-name]/index.tsx`
 
 ## Development Commands
 


### PR DESCRIPTION
@
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close #54371

### 💡 Background and Solution

`.github/copilot-instructions.md` already exists (added in #55320) and covers general conventions. However, the original issue specifically asks for content that helps AI assistants avoid hallucinating non-existent components, props, and patterns when working with `antd`. The existing file did not include the most useful anti-hallucination signals: an authoritative component list, the v4 → v5 / current major renames, and the icon/locale import boundaries — all of which are exactly the things AI tools get wrong most often.

This PR adds the following sections to `.github/copilot-instructions.md`:

- **Authoritative Component List** — every top-level export of `antd`, sourced from `components/index.ts`, with an explicit "do not invent components outside this list" note and common examples of fabricated names to avoid.
- **Import Patterns** — clarifies that icons come from `@ant-design/icons` (not `antd`), that locales live under `antd/locale/*`, and that `DatePicker` / `TimePicker` / `Calendar` use `dayjs` by default (no longer `moment`).
- **API Migration Notes** — a table of the most common deprecated → current API renames currently enforced via `warning.deprecated(...)` and `@deprecated` JSDoc tags in the source (e.g. `visible` → `open`, `destroyOnClose` → `destroyOnHidden`, `Tabs.TabPane` children → `items`, `Menu.Item` children → `items`, `Breadcrumb.routes` → `items`, `BackTop` → `FloatButton.BackTop`, `Card.bordered` → `variant`, `dropdownRender` → `popupRender`, `dropdownClassName` → `classNames.popup.root`, `Avatar.Group.maxCount` → `max={{ count }}`, `dateCellRender` → `cellRender`, etc.). Every entry was verified against the source.
- **Link to `CLAUDE.md`** at the top, so deeper rules (demo absolute-imports, test relative-imports, doc format, changelog conventions, PR template) are one click away without bloating the suggestion-time context.
- Small polish to the existing sections (clarified token usage via `theme.useToken()`, mentioned `components/_util/is.ts` helpers, noted the demo/test import-direction rules from `CLAUDE.md`, and aligned the component-directory description with the actual structure).

The file is intentionally kept compact: GitHub Copilot loads this on every suggestion, so the goal is high signal-to-noise rather than exhaustive coverage.

### 📝 Change Log

| Language   | Changelog            |
| ---------- | -------------------- |
| 🇺🇸 English | No changelog required |
| 🇨🇳 Chinese | 无需更新日志          |
@