### PR TITLE
docs(Drawer): add demo showing closable placement option

### DIFF
--- a/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
@@ -90,14 +90,70 @@ exports[`renders components/drawer/demo/basic-right.tsx extend context correctly
 
 exports[`renders components/drawer/demo/closable-placement.tsx extend context correctly 1`] = `
 Array [
-  <button
-    class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
-    type="button"
+  <div
+    class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"
   >
-    <span>
-      Open
-    </span>
-  </button>,
+    <div
+      class="ant-space-item"
+    >
+      <div
+        class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+        role="radiogroup"
+      >
+        <label
+          class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
+        >
+          <span
+            class="ant-radio ant-wave-target ant-radio-checked"
+          >
+            <input
+              checked=""
+              class="ant-radio-input"
+              name="test-id"
+              type="radio"
+              value="start"
+            />
+          </span>
+          <span
+            class="ant-radio-label"
+          >
+            start
+          </span>
+        </label>
+        <label
+          class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+        >
+          <span
+            class="ant-radio ant-wave-target"
+          >
+            <input
+              class="ant-radio-input"
+              name="test-id"
+              type="radio"
+              value="end"
+            />
+          </span>
+          <span
+            class="ant-radio-label"
+          >
+            end
+          </span>
+        </label>
+      </div>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+        type="button"
+      >
+        <span>
+          Open
+        </span>
+      </button>
+    </div>
+  </div>,
   <div
     class="ant-drawer ant-drawer-right css-var-test-id ant-drawer-open ant-drawer-inline"
     tabindex="-1"
@@ -121,6 +177,32 @@ Array [
           <div
             class="ant-drawer-header-title"
           >
+            <button
+              aria-label="Close"
+              class="ant-drawer-close"
+              type="button"
+            >
+              <span
+                aria-label="close"
+                class="anticon anticon-close"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="close"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                  />
+                </svg>
+              </span>
+            </button>
             <div
               class="ant-drawer-title"
               id="test-id"
@@ -128,32 +210,6 @@ Array [
               Drawer Closable Placement
             </div>
           </div>
-          <button
-            aria-label="Close"
-            class="ant-drawer-close ant-drawer-close-end"
-            type="button"
-          >
-            <span
-              aria-label="close"
-              class="anticon anticon-close"
-              role="img"
-            >
-              <svg
-                aria-hidden="true"
-                data-icon="close"
-                fill="currentColor"
-                fill-rule="evenodd"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
-                />
-              </svg>
-            </span>
-          </button>
         </div>
         <div
           class="ant-drawer-body"
@@ -165,7 +221,7 @@ Array [
             Some contents...
           </p>
           <p>
-            Take a look at the top-right corner...
+            Toggle the radio above to move the close icon between start and end.
           </p>
         </div>
       </div>

--- a/components/drawer/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/drawer/__tests__/__snapshots__/demo.test.ts.snap
@@ -12,14 +12,70 @@ exports[`renders components/drawer/demo/basic-right.tsx correctly 1`] = `
 `;
 
 exports[`renders components/drawer/demo/closable-placement.tsx correctly 1`] = `
-<button
-  class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
-  type="button"
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"
 >
-  <span>
-    Open
-  </span>
-</button>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+      role="radiogroup"
+    >
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="start"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          start
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="end"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          end
+        </span>
+      </label>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+      type="button"
+    >
+      <span>
+        Open
+      </span>
+    </button>
+  </div>
+</div>
 `;
 
 exports[`renders components/drawer/demo/component-token.tsx correctly 1`] = `

--- a/components/drawer/demo/closable-placement.md
+++ b/components/drawer/demo/closable-placement.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-自定义抽屉的关闭按钮位置，放到右侧，默认为左侧。
+通过 `closable.placement` 配置关闭按钮的位置，可选 `start`（默认）或 `end`。默认情况下关闭按钮位于抽屉头部的起始位置（开口侧），便于用户在内容较宽时也能就近关闭。
 
 ## en-US
 
-Drawer with closable placement, customize the close placement to the `end`, defaults to `start`.
+Use `closable.placement` to control the close icon position. Available values are `start` (default) and `end`. By default the close button sits at the start of the header (closer to the screen edge the Drawer opens from), making it easier to dismiss the Drawer when the content is wide.

--- a/components/drawer/demo/closable-placement.tsx
+++ b/components/drawer/demo/closable-placement.tsx
@@ -1,8 +1,12 @@
 import React, { useState } from 'react';
-import { Button, Drawer } from 'antd';
+import { Button, Drawer, Radio, Space } from 'antd';
+import type { RadioChangeEvent } from 'antd';
+
+type ClosePlacement = 'start' | 'end';
 
 const App: React.FC = () => {
   const [open, setOpen] = useState(false);
+  const [placement, setPlacement] = useState<ClosePlacement>('start');
 
   const showDrawer = () => {
     setOpen(true);
@@ -12,20 +16,30 @@ const App: React.FC = () => {
     setOpen(false);
   };
 
+  const onPlacementChange = (e: RadioChangeEvent) => {
+    setPlacement(e.target.value);
+  };
+
   return (
     <>
-      <Button type="primary" onClick={showDrawer}>
-        Open
-      </Button>
+      <Space>
+        <Radio.Group value={placement} onChange={onPlacementChange}>
+          <Radio value="start">start</Radio>
+          <Radio value="end">end</Radio>
+        </Radio.Group>
+        <Button type="primary" onClick={showDrawer}>
+          Open
+        </Button>
+      </Space>
       <Drawer
         title="Drawer Closable Placement"
-        closable={{ placement: 'end' }}
+        closable={{ placement }}
         onClose={onClose}
         open={open}
       >
         <p>Some contents...</p>
         <p>Some contents...</p>
-        <p>Take a look at the top-right corner...</p>
+        <p>Toggle the radio above to move the close icon between start and end.</p>
       </Drawer>
     </>
   );


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close #54877

### 💡 Background and Solution

In #54877 the reporter asked for a way to put the Drawer close button on the leading edge so it stays accessible when the Drawer content is wide. As noted on the issue, Drawer already supports this via `closable={{ placement: 'start' | 'end' }}` (introduced in `5.28.0`), and the maintainer's reply suggested adding a demo rather than introducing a new prop.

The existing `closable-placement` demo only hard-coded `placement: 'end'`, which meant the docs never visually demonstrated the default `start` placement — exactly the case the reporter was looking for.

This PR updates the existing `closable-placement` demo to expose both values through a `Radio.Group` toggle so visitors can see the close icon move between the start and end of the Drawer header. The matching demo description and snapshots are updated accordingly. No component source or props were touched.

Files changed:

- `components/drawer/demo/closable-placement.tsx` — demo now uses `useState` + `Radio.Group` to switch `closable.placement` between `start` (default) and `end`.
- `components/drawer/demo/closable-placement.md` — refreshed zh-CN / en-US descriptions to cover both values.
- `components/drawer/__tests__/__snapshots__/demo.test.ts.snap` and `demo-extend.test.tsx.snap` — regenerated via `npx jest --config .jest.js --testPathPatterns "components/drawer/__tests__/demo" -u`.

The API table already documents `closable.placement` in both `index.zh-CN.md` and `index.en-US.md`, so no API-table changes were needed.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 📝 Update Drawer `closable.placement` demo to show both `start` and `end` placements. |
| 🇨🇳 Chinese | 📝 更新 Drawer `closable.placement` 演示，展示 `start` 与 `end` 两种关闭按钮位置。 |