### PR TITLE
fix: avoid disabled AutoComplete custom input background stacking

### DIFF
--- a/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1005,6 +1005,163 @@ Array [
 
 exports[`renders components/auto-complete/demo/custom.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/auto-complete/demo/disabled-custom-debug.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap"
+  style="gap: 12px;"
+>
+  <input
+    class="ant-input ant-input-disabled ant-input-outlined css-var-test-id ant-input-css-var"
+    disabled=""
+    placeholder="Regular Input"
+    type="text"
+    value=""
+  />
+  <div
+    class="ant-select ant-select-outlined ant-select-auto-complete ant-select-customize css-var-test-id ant-select-css-var ant-select-single ant-select-disabled ant-select-customize-input ant-select-show-search"
+  >
+    <div
+      class="ant-select-content"
+    >
+      <textarea
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="off"
+        class="ant-input ant-input-outlined css-var-test-id ant-input-css-var ant-select-input ant-input-disabled"
+        disabled=""
+        id="test-id"
+        role="combobox"
+        type="text"
+      />
+    </div>
+  </div>
+  <div
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-empty ant-select-dropdown-placement-bottomLeft"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+  >
+    <div>
+      <div
+        class="ant-select-item-empty"
+        id="test-id_list"
+        role="listbox"
+      />
+    </div>
+  </div>
+  <div
+    class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow ant-select-disabled"
+  >
+    <div
+      class="ant-select-content"
+    >
+      <div
+        class="ant-select-placeholder"
+        style="visibility: visible;"
+      />
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="off"
+        class="ant-select-input"
+        disabled=""
+        id="test-id"
+        readonly=""
+        role="combobox"
+        type="search"
+        value=""
+      />
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-empty ant-select-dropdown-placement-bottomLeft"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+  >
+    <div>
+      <div
+        class="ant-select-item-empty"
+        id="test-id_list"
+        role="listbox"
+      >
+        <div
+          class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
+        >
+          <div
+            class="ant-empty-image"
+          >
+            <svg
+              height="41"
+              viewBox="0 0 64 41"
+              width="64"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                No data
+              </title>
+              <g
+                fill="none"
+                fill-rule="evenodd"
+                transform="translate(0 1)"
+              >
+                <ellipse
+                  cx="32"
+                  cy="33"
+                  fill="#f5f5f5"
+                  rx="32"
+                  ry="7"
+                />
+                <g
+                  fill-rule="nonzero"
+                  stroke="#d9d9d9"
+                >
+                  <path
+                    d="M55 12.8 44.9 1.3Q44 0 42.9 0H21.1q-1.2 0-2 1.3L9 12.8V22h46z"
+                  />
+                  <path
+                    d="M41.6 16c0-1.7 1-3 2.2-3H55v18.1c0 2.2-1.3 3.9-3 3.9H12c-1.7 0-3-1.7-3-3.9V13h11.2c1.2 0 2.2 1.3 2.2 3s1 2.9 2.2 2.9h14.8c1.2 0 2.2-1.4 2.2-3"
+                    fill="#fafafa"
+                  />
+                </g>
+              </g>
+            </svg>
+          </div>
+          <div
+            class="ant-empty-description"
+          >
+            No data
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/auto-complete/demo/disabled-custom-debug.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/auto-complete/demo/form-debug.tsx extend context correctly 1`] = `
 <form
   class="ant-form ant-form-horizontal css-var-test-id ant-form-css-var"

--- a/components/auto-complete/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo.test.tsx.snap
@@ -419,6 +419,88 @@ exports[`renders components/auto-complete/demo/custom.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/auto-complete/demo/disabled-custom-debug.tsx correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap"
+  style="gap:12px"
+>
+  <input
+    class="ant-input ant-input-disabled ant-input-outlined css-var-test-id ant-input-css-var"
+    disabled=""
+    placeholder="Regular Input"
+    type="text"
+    value=""
+  />
+  <div
+    class="ant-select ant-select-outlined ant-select-auto-complete ant-select-customize css-var-test-id ant-select-css-var ant-select-single ant-select-disabled ant-select-customize-input ant-select-show-search"
+  >
+    <div
+      class="ant-select-content"
+    >
+      <textarea
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="off"
+        class="ant-input ant-input-outlined css-var-test-id ant-input-css-var ant-select-input ant-input-disabled"
+        disabled=""
+        id="test-id"
+        role="combobox"
+        type="text"
+      />
+    </div>
+  </div>
+  <div
+    class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow ant-select-disabled"
+  >
+    <div
+      class="ant-select-content"
+    >
+      <div
+        class="ant-select-placeholder"
+        style="visibility:visible"
+      />
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="off"
+        class="ant-select-input"
+        disabled=""
+        id="test-id"
+        readonly=""
+        role="combobox"
+        type="search"
+        value=""
+      />
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/auto-complete/demo/form-debug.tsx correctly 1`] = `
 <form
   class="ant-form ant-form-horizontal css-var-test-id ant-form-css-var"

--- a/components/auto-complete/demo/disabled-custom-debug.md
+++ b/components/auto-complete/demo/disabled-custom-debug.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+禁用自定义输入组件 Debug。
+
+## en-US
+
+Disabled custom input debug.

--- a/components/auto-complete/demo/disabled-custom-debug.tsx
+++ b/components/auto-complete/demo/disabled-custom-debug.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { AutoComplete, Flex, Input, Select } from 'antd';
+
+const App: React.FC = () => (
+  <Flex gap={12} wrap>
+    <Input disabled placeholder="Regular Input" />
+    <AutoComplete disabled>
+      <Input.TextArea disabled />
+    </AutoComplete>
+    <Select disabled options={[]} />
+  </Flex>
+);
+
+export default App;

--- a/components/auto-complete/index.en-US.md
+++ b/components/auto-complete/index.en-US.md
@@ -34,6 +34,7 @@ The differences with Select are:
 <code src="./demo/variant.tsx" version="5.13.0">Variants</code>
 <code src="./demo/allowClear.tsx">Customize clear button</code>
 <code src="./demo/style-class.tsx" version="6.0.0">Custom semantic dom styling</code>
+<code src="./demo/disabled-custom-debug.tsx" debug>Disabled custom input debug</code>
 <code src="./demo/form-debug.tsx" debug>Debug in Form</code>
 <code src="./demo/AutoComplete-and-Select.tsx" debug>AutoComplete and Select</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>

--- a/components/auto-complete/index.zh-CN.md
+++ b/components/auto-complete/index.zh-CN.md
@@ -35,6 +35,7 @@ demo:
 <code src="./demo/variant.tsx" version="5.13.0">多种形态</code>
 <code src="./demo/allowClear.tsx">自定义清除按钮</code>
 <code src="./demo/style-class.tsx" version="6.0.0">自定义语义结构的样式和类</code>
+<code src="./demo/disabled-custom-debug.tsx" debug>禁用自定义输入 Debug</code>
 <code src="./demo/form-debug.tsx" debug>在 Form 中 Debug</code>
 <code src="./demo/AutoComplete-and-Select.tsx" debug>AutoComplete 和 Select</code>
 <code src="./demo/render-panel.tsx" debug>\_InternalPanelDoNotUseOrYouWillBeFired</code>

--- a/components/select/style/select-input-customize.ts
+++ b/components/select/style/select-input-customize.ts
@@ -4,7 +4,18 @@ import type { GenerateStyle } from '../../theme/interface';
 import type { SelectToken } from './token';
 
 const genSelectInputCustomizeStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
-  const { componentCls } = token;
+  const { antCls, componentCls } = token;
+
+  const transparentBackground: CSSObject = {
+    background: 'transparent',
+  };
+  const disabledCustomizedInputSelector = [
+    '> input[disabled]',
+    '> textarea[disabled]',
+    `> ${componentCls}-input`,
+    `> ${antCls}-input-affix-wrapper-disabled`,
+    `> ${antCls}-input-search`,
+  ].join(', ');
 
   return {
     [`&${componentCls}-customize`]: {
@@ -24,6 +35,12 @@ const genSelectInputCustomizeStyle: GenerateStyle<SelectToken, CSSObject> = (tok
         '&-value': {
           display: 'none',
         },
+      },
+
+      [`&${componentCls}-disabled ${componentCls}-content`]: {
+        [disabledCustomizedInputSelector]: transparentBackground,
+
+        'input[disabled], textarea[disabled]': transparentBackground,
       },
     },
   };


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #58111

### 💡 需求背景和解决方案

AutoComplete 在禁用状态下使用自定义输入组件时，外层 Select 和内层 Input/TextArea 都会应用禁用背景色。由于 `colorBgContainerDisabled` 是半透明颜色，两层背景叠加会导致视觉上比普通禁用 Input 和 Select 更深。

本次调整在 disabled customize 模式下将内层自定义输入背景设为透明，保留外层 Select 的禁用背景，避免半透明背景重复叠加。同时新增 AutoComplete debug demo，对比 disabled Input、disabled AutoComplete + TextArea 和 disabled Select 的显示效果。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix AutoComplete custom input background being darker than other disabled controls when disabled. |
| 🇨🇳 中文 | 修复 AutoComplete 禁用自定义输入组件时背景色比其他禁用控件更深的问题。 |
