### PR TITLE
fix(modal): correct footer button alignment when confirmLoading is true

### DIFF
--- a/components/modal/style/index.ts
+++ b/components/modal/style/index.ts
@@ -340,16 +340,15 @@ const genModalStyle: GenerateStyle<ModalToken> = (token) => {
         },
 
         [`${componentCls}-footer`]: {
+          display: 'flex',
+          justifyContent: 'end',
+          alignItems: 'center',
           textAlign: 'end',
           background: token.footerBg,
           marginTop: token.footerMarginTop,
           padding: token.footerPadding,
           borderTop: token.footerBorderTop,
           borderRadius: token.footerBorderRadius,
-
-          [`> ${token.antCls}-btn`]: {
-            verticalAlign: 'middle',
-          },
 
           [`> ${token.antCls}-btn + ${token.antCls}-btn`]: {
             marginInlineStart: token.marginXS,

--- a/components/modal/style/index.ts
+++ b/components/modal/style/index.ts
@@ -340,14 +340,16 @@ const genModalStyle: GenerateStyle<ModalToken> = (token) => {
         },
 
         [`${componentCls}-footer`]: {
-          display: 'flex',
-          justifyContent: 'end',
-          alignItems: 'center',
+          textAlign: 'end',
           background: token.footerBg,
           marginTop: token.footerMarginTop,
           padding: token.footerPadding,
           borderTop: token.footerBorderTop,
           borderRadius: token.footerBorderRadius,
+
+          [`> ${token.antCls}-btn`]: {
+            verticalAlign: 'middle',
+          },
 
           [`> ${token.antCls}-btn + ${token.antCls}-btn`]: {
             marginInlineStart: token.marginXS,

--- a/components/modal/style/index.ts
+++ b/components/modal/style/index.ts
@@ -340,7 +340,9 @@ const genModalStyle: GenerateStyle<ModalToken> = (token) => {
         },
 
         [`${componentCls}-footer`]: {
-          textAlign: 'end',
+          display: 'flex',
+          justifyContent: 'end',
+          alignItems: 'center',
           background: token.footerBg,
           marginTop: token.footerMarginTop,
           padding: token.footerPadding,


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

close #58118

### 💡 需求背景和解决方案

Modal 在 `confirmLoading=true` 时，footer 中的按钮会出现垂直方向错位。原因是 Button 组件在 #55907 之后使用了 `display: inline-flex`，而 footer 仅依赖 `textAlign: end` 的 inline 流布局，导致加载态按钮与其它按钮在基线上对不齐。

修复方式：为 `.ant-modal-footer` 增加 `display: flex; justifyContent: end; alignItems: center;`，让按钮通过 flex 排列对齐；同时保留原有的 `textAlign: end`，避免对自定义 footer 内容（如纯文本、非按钮节点）的渲染产生 breaking change。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Modal footer button vertical misalignment when `confirmLoading` is `true`. |
| 🇨🇳 中文 | 修复 Modal 在 `confirmLoading` 为 `true` 时 footer 按钮垂直方向错位的问题。 |