### PR TITLE
fix(Modal): align footer buttons when loading

### DIFF
--- a/components/modal/style/confirm.ts
+++ b/components/modal/style/confirm.ts
@@ -99,6 +99,10 @@ const genModalConfirmStyle: GenerateStyle<ModalToken, CSSObject> = (token) => {
         textAlign: 'end',
         marginTop: token.confirmBtnsMarginTop,
 
+        [`> ${token.antCls}-btn`]: {
+          verticalAlign: 'middle',
+        },
+
         [`${token.antCls}-btn + ${token.antCls}-btn`]: {
           marginBottom: 0,
           marginInlineStart: token.marginXS,

--- a/components/modal/style/index.ts
+++ b/components/modal/style/index.ts
@@ -347,6 +347,10 @@ const genModalStyle: GenerateStyle<ModalToken> = (token) => {
           borderTop: token.footerBorderTop,
           borderRadius: token.footerBorderRadius,
 
+          [`> ${token.antCls}-btn`]: {
+            verticalAlign: 'middle',
+          },
+
           [`> ${token.antCls}-btn + ${token.antCls}-btn`]: {
             marginInlineStart: token.marginXS,
           },


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #58118

### 💡 需求背景和解决方案

Modal footer 使用文本流对齐按钮。当确认按钮开启 `confirmLoading` 后，Button loading icon 的 inline-flex 布局会影响按钮基线，导致 footer 中按钮出现垂直错位。

本次在 Modal 默认 footer 和 confirm footer 的直接子按钮上设置 `vertical-align: middle`，让 loading 按钮与普通按钮保持对齐，不改动 Button 的全局行为。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Modal footer buttons misaligned when `confirmLoading` is enabled. |
| 🇨🇳 中文 | 🐞 修复 Modal 在 `confirmLoading` 开启时底部按钮错位的问题。 |