### PR TITLE
fix: avoid deep @rc-component tree imports

### DIFF
--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -3,10 +3,8 @@ import { useCallback, useMemo } from 'react';
 import DownOutlined from '@ant-design/icons/DownOutlined';
 import { INTERNAL_COL_DEFINE } from '@rc-component/table';
 import type { FixedType } from '@rc-component/table/lib/interface';
-import type { DataNode, GetCheckDisabled } from '@rc-component/tree/lib/interface';
-import { arrAdd, arrDel } from '@rc-component/tree/lib/util';
-import { conductCheck } from '@rc-component/tree/lib/utils/conductUtil';
-import { convertDataToEntities } from '@rc-component/tree/lib/utils/treeUtil';
+import { arrAdd, arrDel, conductCheck, convertDataToEntities } from '@rc-component/tree';
+import type { DataNode } from '@rc-component/tree';
 import { useControlledState } from '@rc-component/util';
 import { clsx } from 'clsx';
 
@@ -198,8 +196,8 @@ const useSelection = <RecordType extends AnyObject = AnyObject>(
     return map;
   }, [flattedData, getRowKey, getCheckboxProps]);
 
-  const isCheckboxDisabled: GetCheckDisabled<RecordType> = useCallback(
-    (r: RecordType) => {
+  const isCheckboxDisabled = useCallback(
+    (r: RecordType): boolean => {
       const rowKey = getRowKey(r);
       let checkboxProps: Partial<CheckboxProps> | undefined;
       if (checkboxPropsMap.has(rowKey)) {

--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -2,11 +2,9 @@ import * as React from 'react';
 import FileOutlined from '@ant-design/icons/FileOutlined';
 import FolderOpenOutlined from '@ant-design/icons/FolderOpenOutlined';
 import FolderOutlined from '@ant-design/icons/FolderOutlined';
+import { conductExpandParent, convertDataToEntities, convertTreeToData } from '@rc-component/tree';
 import type RcTree from '@rc-component/tree';
-import type { BasicDataNode } from '@rc-component/tree';
-import type { DataNode, EventDataNode, Key } from '@rc-component/tree/lib/interface';
-import { conductExpandParent } from '@rc-component/tree/lib/util';
-import { convertDataToEntities, convertTreeToData } from '@rc-component/tree/lib/utils/treeUtil';
+import type { BasicDataNode, DataNode, EventDataNode } from '@rc-component/tree';
 import { clsx } from 'clsx';
 
 import { ConfigContext } from '../config-provider';
@@ -26,8 +24,8 @@ type DirectoryTreeCompoundedComponent = (<T extends BasicDataNode | DataNode = D
   Pick<React.FC, 'displayName'>;
 
 export interface DirectoryTreeState {
-  expandedKeys?: Key[];
-  selectedKeys?: Key[];
+  expandedKeys?: React.Key[];
+  selectedKeys?: React.Key[];
 }
 
 function getIcon(props: AntdTreeNodeAttribute): React.ReactNode {
@@ -46,16 +44,16 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
   const { defaultExpandAll, defaultExpandParent, defaultExpandedKeys, ...props } = oriProps;
 
   // Shift click usage
-  const lastSelectedKeyRef = React.useRef<Key>(null);
+  const lastSelectedKeyRef = React.useRef<React.Key>(null);
 
-  const cachedSelectedKeysRef = React.useRef<Key[]>(null);
+  const cachedSelectedKeysRef = React.useRef<React.Key[]>(null);
 
   const getInitExpandedKeys = () => {
     const { keyEntities } = convertDataToEntities(getTreeData(props), {
       fieldNames: props.fieldNames,
     });
 
-    let initExpandedKeys: Key[];
+    let initExpandedKeys: React.Key[];
     const mergedExpandedKeys = props.expandedKeys || defaultExpandedKeys || [];
 
     // Expanded keys
@@ -88,7 +86,7 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
   }, [props.expandedKeys]);
 
   const onExpand = (
-    keys: Key[],
+    keys: React.Key[],
     info: {
       node: EventDataNode<any>;
       expanded: boolean;
@@ -103,7 +101,7 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
   };
 
   const onSelect = (
-    keys: Key[],
+    keys: React.Key[],
     event: {
       event: 'select';
       selected: boolean;
@@ -129,7 +127,7 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
     const shiftPick: boolean = nativeEvent?.shiftKey;
 
     // Generate new selected keys
-    let newSelectedKeys: Key[];
+    let newSelectedKeys: React.Key[];
     if (multiple && ctrlPick) {
       // Control click
       newSelectedKeys = keys;

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -2,9 +2,8 @@ import type { Component } from 'react';
 import React from 'react';
 import HolderOutlined from '@ant-design/icons/HolderOutlined';
 import type { CSSMotionProps } from '@rc-component/motion';
-import type { BasicDataNode, TreeProps as RcTreeProps } from '@rc-component/tree';
+import type { BasicDataNode, DataNode, TreeProps as RcTreeProps } from '@rc-component/tree';
 import RcTree from '@rc-component/tree';
-import type { DataNode, Key } from '@rc-component/tree/lib/interface';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
@@ -48,8 +47,8 @@ export interface AntTreeNodeProps {
   disabled?: boolean;
   disableCheckbox?: boolean;
   title?: React.ReactNode | ((data: DataNode) => React.ReactNode);
-  key?: Key;
-  eventKey?: Key;
+  key?: React.Key;
+  eventKey?: React.Key;
   isLeaf?: boolean;
   checked?: boolean;
   expanded?: boolean;
@@ -90,13 +89,13 @@ export interface AntTreeNodeMouseEvent {
 }
 
 export interface AntTreeNodeDragEnterEvent extends AntTreeNodeMouseEvent {
-  expandedKeys: Key[];
+  expandedKeys: React.Key[];
 }
 
 export interface AntTreeNodeDropEvent {
   node: AntTreeNode;
   dragNode: AntTreeNode;
-  dragNodesKeys: Key[];
+  dragNodesKeys: React.Key[];
   dropPosition: number;
   dropToGap?: boolean;
   event: React.MouseEvent<HTMLElement>;
@@ -162,21 +161,21 @@ export interface TreeProps<T extends BasicDataNode = DataNode>
   /** Expand the corresponding tree node by default */
   defaultExpandParent?: boolean;
   /** Expand the specified tree node by default */
-  defaultExpandedKeys?: Key[];
+  defaultExpandedKeys?: React.Key[];
   /** (Controlled) Expand the specified tree node */
-  expandedKeys?: Key[];
+  expandedKeys?: React.Key[];
   /** (Controlled) Tree node with checked checkbox */
-  checkedKeys?: Key[] | { checked: Key[]; halfChecked: Key[] };
+  checkedKeys?: React.Key[] | { checked: React.Key[]; halfChecked: React.Key[] };
   /** Tree node with checkbox checked by default */
-  defaultCheckedKeys?: Key[];
+  defaultCheckedKeys?: React.Key[];
   /** (Controlled) Set the selected tree node */
-  selectedKeys?: Key[];
+  selectedKeys?: React.Key[];
   /** Tree node selected by default */
-  defaultSelectedKeys?: Key[];
+  defaultSelectedKeys?: React.Key[];
   selectable?: boolean;
   /** Click on the tree node to trigger */
   filterAntTreeNode?: (node: AntTreeNode) => boolean;
-  loadedKeys?: Key[];
+  loadedKeys?: React.Key[];
   /** Set the node to be draggable (IE>8) */
   draggable?: DraggableFn | boolean | DraggableConfig;
   style?: React.CSSProperties;

--- a/components/tree/__tests__/directory.test.tsx
+++ b/components/tree/__tests__/directory.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import type RcTree from '@rc-component/tree';
-import type { Key } from '@rc-component/tree/lib/interface';
 import debounce from 'lodash/debounce';
 
 import type { TreeProps } from '..';
@@ -91,7 +90,7 @@ describe('Directory Tree', () => {
 
     describe('with state control', () => {
       const StateDirTree: React.FC<TreeProps> = (props) => {
-        const [expandedKeys, setExpandedKeys] = React.useState<Key[]>([]);
+        const [expandedKeys, setExpandedKeys] = React.useState<React.Key[]>([]);
         return (
           <DirectoryTree expandedKeys={expandedKeys} onExpand={setExpandedKeys} {...props}>
             <TreeNode key="0-0" title="parent">

--- a/components/tree/index.tsx
+++ b/components/tree/index.tsx
@@ -1,7 +1,6 @@
 import type RcTree from '@rc-component/tree';
-import type { BasicDataNode } from '@rc-component/tree';
+import type { BasicDataNode, DataNode, EventDataNode } from '@rc-component/tree';
 import { TreeNode } from '@rc-component/tree';
-import type { DataNode } from '@rc-component/tree/lib/interface';
 
 import DirectoryTree from './DirectoryTree';
 import type { TreeProps } from './Tree';
@@ -23,9 +22,7 @@ export type {
   TreeProps,
 } from './Tree';
 
-export type { EventDataNode } from '@rc-component/tree/lib/interface';
-
-export type { BasicDataNode, DataNode };
+export type { BasicDataNode, DataNode, EventDataNode };
 
 type CompoundedComponent = (<T extends BasicDataNode | DataNode = DataNode>(
   props: React.PropsWithChildren<TreeProps<T>> & React.RefAttributes<RcTree>,

--- a/components/tree/utils/dictUtil.ts
+++ b/components/tree/utils/dictUtil.ts
@@ -1,5 +1,6 @@
-import type { DataNode, Key } from '@rc-component/tree/lib/interface';
-import { fillFieldNames } from '@rc-component/tree/lib/utils/treeUtil';
+import { fillFieldNames } from '@rc-component/tree';
+import type { DataNode } from '@rc-component/tree';
+import type React from 'react';
 
 import type { TreeProps } from '../Tree';
 
@@ -13,7 +14,7 @@ type FieldNames = TreeProps['fieldNames'];
 
 function traverseNodesKey(
   treeData: DataNode[],
-  callback: (key: Key | number | null, node: DataNode) => boolean,
+  callback: (key: React.Key | number | null, node: DataNode) => boolean,
   fieldNames: Required<NonNullable<FieldNames>>,
 ) {
   const { key: fieldKey, children: fieldChildren } = fieldNames;
@@ -38,12 +39,12 @@ export function calcRangeKeys({
   fieldNames,
 }: {
   treeData: DataNode[];
-  expandedKeys: Key[];
-  startKey?: Key;
-  endKey?: Key;
+  expandedKeys: React.Key[];
+  startKey?: React.Key;
+  endKey?: React.Key;
   fieldNames?: FieldNames;
-}): Key[] {
-  const keys: Key[] = [];
+}): React.Key[] {
+  const keys: React.Key[] = [];
   let record: Record = RECORD_NONE;
 
   if (startKey && startKey === endKey) {
@@ -53,7 +54,7 @@ export function calcRangeKeys({
     return [];
   }
 
-  function matchKey(key: Key) {
+  function matchKey(key: React.Key) {
     return key === startKey || key === endKey;
   }
 
@@ -88,10 +89,10 @@ export function calcRangeKeys({
 
 export function convertDirectoryKeysToNodes(
   treeData: DataNode[],
-  keys: Key[],
+  keys: React.Key[],
   fieldNames?: FieldNames,
 ) {
-  const restKeys: Key[] = [...keys];
+  const restKeys: React.Key[] = [...keys];
   const nodes: DataNode[] = [];
   traverseNodesKey(
     treeData,

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@rc-component/tabs": "~1.9.0",
     "@rc-component/tooltip": "~1.4.0",
     "@rc-component/tour": "~2.4.0",
-    "@rc-component/tree": "~1.3.1",
+    "@rc-component/tree": "~1.3.2",
     "@rc-component/tree-select": "~1.10.0",
     "@rc-component/trigger": "^3.9.0",
     "@rc-component/upload": "~1.1.0",


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [x] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

移除 antd 中对 `@rc-component/tree/lib/*` 的深度导入，统一改为从 `@rc-component/tree` 根入口导入类型和工具方法。

同时升级 `@rc-component/tree` 到 `~1.3.2`，使用其新增的根入口导出，并将原先依赖 rc tree `Key` 类型的地方改为直接使用 `React.Key`。

无 UI 和公开 API 行为变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |