### PR TITLE
fix(Upload): keep default progress style

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -83,7 +83,8 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
   const mergedDisabled = customDisabled ?? disabled;
 
   const customRequest = props.customRequest || config.customRequest;
-  const mergedProgress = { ...config.progress, ...customProgress };
+  const mergedProgress =
+    config.progress || customProgress ? { ...config.progress, ...customProgress } : undefined;
   const mergedAccept = fallbackProp(customAccept, config.accept, '');
 
   const [internalFileList, setMergedFileList] = useControlledState(defaultFileList, fileList);


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #58125

### 💡 需求背景和解决方案

#57283 为 Upload 增加了 ConfigProvider 的 `progress` 全局配置支持，但在没有传入 `upload.progress` 和组件 `progress` 时，也会把空对象 `{}` 传给 UploadList。

这会覆盖 UploadList 原本的默认进度条配置 `{ size: [-1, 2], showInfo: false }`，导致默认上传列表中的 Progress 回退到自身默认样式，进度条变粗并显示进度信息，从而在 Upload 默认文件列表中与文件名重叠。

本次修复仅在存在全局或组件级 `progress` 配置时才合并并传递配置；没有配置时保持 `undefined`，让 UploadList 继续使用原有默认进度条样式。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Upload progress bar becoming too thick when no `progress` config is provided. |
| 🇨🇳 中文 | 🐞 修复 Upload 未配置 `progress` 时进度条异常变粗的问题。 |