### PR TITLE
fix: avoid deep rc component imports

### DIFF
--- a/components/mentions/demo/_semantic.tsx
+++ b/components/mentions/demo/_semantic.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { UnstableContext } from '@rc-component/mentions';
-import type { UnstableContextProps } from '@rc-component/mentions/lib/context';
 import type { MentionProps } from 'antd';
 import { Mentions } from 'antd';
 
@@ -25,7 +24,10 @@ const locales = {
 
 const Block: React.FC<MentionProps> = (props) => {
   const divRef = React.useRef<HTMLDivElement>(null);
-  const memoizedValue = React.useMemo<UnstableContextProps>(() => ({ open: true }), []);
+  const memoizedValue = React.useMemo<React.ContextType<typeof UnstableContext>>(
+    () => ({ open: true }),
+    [],
+  );
   return (
     <div ref={divRef} style={{ position: 'absolute', height: 200, overflow: 'hidden' }}>
       <UnstableContext.Provider value={memoizedValue}>

--- a/components/mentions/index.tsx
+++ b/components/mentions/index.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
 import RcMentions from '@rc-component/mentions';
-import type {
-  DataDrivenOptionProps as MentionsOptionProps,
-  MentionsProps as RcMentionsProps,
-  MentionsRef as RcMentionsRef,
-} from '@rc-component/mentions/lib/Mentions';
+import type { MentionsProps as RcMentionsProps } from '@rc-component/mentions';
 import { composeRef } from '@rc-component/util';
 import { clsx } from 'clsx';
 
@@ -37,7 +33,8 @@ function loadingFilterOption() {
 
 export type MentionPlacement = 'top' | 'bottom';
 
-export type { DataDrivenOptionProps as MentionsOptionProps } from '@rc-component/mentions/lib/Mentions';
+export type MentionsOptionProps = NonNullable<RcMentionsProps['options']>[number];
+type RcMentionsRef = React.ComponentRef<typeof RcMentions>;
 
 export interface OptionProps {
   value: string;

--- a/components/menu/interface.ts
+++ b/components/menu/interface.ts
@@ -1,9 +1,10 @@
-import type {
-  MenuDividerType as RcMenuDividerType,
-  MenuItemGroupType as RcMenuItemGroupType,
-  MenuItemType as RcMenuItemType,
-  SubMenuType as RcSubMenuType,
-} from '@rc-component/menu/lib/interface';
+import type { MenuProps as RcMenuProps } from '@rc-component/menu';
+
+type RcItemType = NonNullable<NonNullable<RcMenuProps['items']>[number]>;
+type RcMenuDividerType = Extract<RcItemType, { type: 'divider' }>;
+type RcMenuItemGroupType = Extract<RcItemType, { type: 'group' }>;
+type RcMenuItemType = Extract<RcItemType, { type?: 'item' }>;
+type RcSubMenuType = Extract<RcItemType, { type?: 'submenu' }>;
 
 export type DataAttributes = {
   [Key in `data-${string}`]: unknown;

--- a/components/modal/PurePanel.tsx
+++ b/components/modal/PurePanel.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Panel } from '@rc-component/dialog';
-import type { PanelProps } from '@rc-component/dialog/lib/Dialog/Content/Panel';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
@@ -12,6 +11,8 @@ import { ConfirmContent } from './ConfirmDialog';
 import type { ModalFuncProps, ModalSemanticAllType } from './interface';
 import { Footer, renderCloseIcon } from './shared';
 import useStyle from './style';
+
+type PanelProps = React.ComponentPropsWithoutRef<typeof Panel>;
 
 export interface PurePanelProps
   extends Omit<PanelProps, 'prefixCls' | 'footer' | 'classNames' | 'styles'>,

--- a/components/rate/index.tsx
+++ b/components/rate/index.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import StarFilled from '@ant-design/icons/StarFilled';
 import RcRate from '@rc-component/rate';
-import type { RateRef, RateProps as RcRateProps } from '@rc-component/rate/lib/Rate';
-import type { StarProps as RcStarProps } from '@rc-component/rate/lib/Star';
 import { clsx } from 'clsx';
 
 import { isPlainObject } from '../_util/is';
@@ -13,6 +11,10 @@ import type { SizeType } from '../config-provider/SizeContext';
 import Tooltip from '../tooltip';
 import type { TooltipProps } from '../tooltip';
 import useStyle from './style';
+
+type RateRef = React.ComponentRef<typeof RcRate>;
+type RcRateProps = React.ComponentPropsWithoutRef<typeof RcRate>;
+type RcCharacterRender = NonNullable<RcRateProps['characterRender']>;
 
 export interface RateProps extends RcRateProps {
   rootClassName?: string;
@@ -33,7 +35,7 @@ const Rate = React.forwardRef<RateRef, RateProps>((props, ref) => {
     ...rest
   } = props;
 
-  const characterRender: RcStarProps['characterRender'] = (node, { index }) => {
+  const characterRender: RcCharacterRender = (node, { index }) => {
     if (!tooltips) {
       return node;
     }

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -1,10 +1,5 @@
 import * as React from 'react';
 import RcTooltip from '@rc-component/tooltip';
-import type { placements as Placements } from '@rc-component/tooltip/lib/placements';
-import type {
-  TooltipProps as RcTooltipProps,
-  TooltipRef as RcTooltipRef,
-} from '@rc-component/tooltip/lib/Tooltip';
 import type { BuildInPlacements } from '@rc-component/trigger';
 import { useControlledState } from '@rc-component/util';
 import { clsx } from 'clsx';
@@ -32,6 +27,10 @@ import PurePanel from './PurePanel';
 import useStyle from './style';
 import UniqueProvider from './UniqueProvider';
 import { parseColor } from './util';
+
+type RcTooltipProps = React.ComponentPropsWithoutRef<typeof RcTooltip>;
+type RcTooltipRef = React.ComponentRef<typeof RcTooltip>;
+type Placements = NonNullable<RcTooltipProps['builtinPlacements']>;
 
 export type { AdjustOverflow, PlacementsConfig };
 
@@ -110,7 +109,7 @@ export interface AbstractTooltipProps extends LegacyTooltipProps {
   rootClassName?: string;
   color?: LiteralUnion<PresetColorType>;
   placement?: TooltipPlacement;
-  builtinPlacements?: typeof Placements;
+  builtinPlacements?: Placements;
   openClassName?: string;
   arrow?: boolean | { pointAtCenter?: boolean };
   autoAdjustOverflow?: boolean | AdjustOverflow;

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -7,7 +7,6 @@ import RcTreeSelect, {
   SHOW_PARENT,
   TreeNode,
 } from '@rc-component/tree-select';
-import type { DataNode } from '@rc-component/tree-select/lib/interface';
 import { omit } from '@rc-component/util';
 import { clsx } from 'clsx';
 
@@ -41,6 +40,8 @@ import type { AntTreeNodeProps, TreeProps } from '../tree';
 import type { SwitcherIcon } from '../tree/Tree';
 import SwitcherIconCom from '../tree/utils/iconUtil';
 import useStyle from './style';
+
+type DataNode = NonNullable<RcTreeSelectProps['treeData']>[number];
 
 type RawValue = string | number;
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [x] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [x] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

#58115

### 💡 需求背景和解决方案

移除部分组件中对 `@rc-component/*/lib` 内部路径的类型导入，改为从对应 rc 包的根入口导出内容推导类型，避免依赖底层包内部目录结构。

本次覆盖 `@rc-component/dialog`、`@rc-component/menu`、`@rc-component/mentions`、`@rc-component/rate`、`@rc-component/tooltip` 和 `@rc-component/tree-select`。无运行时逻辑变化。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |