### PR TITLE
fix(DatePicker, TimePicker): clear button accessibility

### DIFF
--- a/components/date-picker/style/index.ts
+++ b/components/date-picker/style/index.ts
@@ -2,7 +2,7 @@ import type { CSSObject } from '@ant-design/cssinjs';
 import { unit } from '@ant-design/cssinjs';
 
 import { genPlaceholderStyle, initInputToken } from '../../input/style';
-import { resetComponent, textEllipsis } from '../../style';
+import { genFocusOutline, resetComponent, textEllipsis } from '../../style';
 import { genCompactItemStyle } from '../../style/compact-item';
 import {
   initMoveMotion,
@@ -210,6 +210,7 @@ const genPickerStyle: GenerateStyle<PickerToken> = (token) => {
           transform: 'translateY(-50%)',
           cursor: 'pointer',
           opacity: 0,
+          pointerEvents: 'none',
           transition: ['opacity', 'color'].map((prop) => `${prop} ${motionDurationMid}`).join(', '),
 
           '> *': {
@@ -219,11 +220,18 @@ const genPickerStyle: GenerateStyle<PickerToken> = (token) => {
           '&:hover': {
             color: colorIcon,
           },
+
+          '&:focus-visible': {
+            color: token.colorIcon,
+            borderRadius: token.borderRadiusSM,
+            ...genFocusOutline(token),
+          },
         },
 
-        '&:hover': {
+        '&:hover, &:focus-within': {
           [`${componentCls}-clear`]: {
             opacity: 1,
+            pointerEvents: 'auto',
           },
           // Should use the following selector, but since `:has` has poor compatibility,
           // we use `:not(:last-child)` instead, which may cause some problems in some cases.


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] ⌨️ Accessibility improvement

### 🔗 Related Issues

Closes https://github.com/ant-design/ant-design/issues/57933

### 💡 Background and Solution

This PR adds several accessibility improvements to the clear button:
- displaying clear button not only on hover, but also on focus
- adding focus styles to the clear button
- adding corresponding `pointer-events` to the default and active states
 
**NOTE**: This PR should be merged after https://github.com/react-component/picker/pull/971 release and snapshots should be updated. 

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(DatePicker, TimePicker): clear button accessibility |
| 🇨🇳 Chinese | fix(DatePicker, TimePicker): 清除按钮辅助功能 |
