### PR TITLE
docs(Skeleton): add missing active prop to zh-CN API tables

### DIFF
--- a/components/skeleton/index.zh-CN.md
+++ b/components/skeleton/index.zh-CN.md
@@ -39,6 +39,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*VcjGQLSrYdcAAA
 
 | 属性 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
+| active | 是否展示动画效果 | boolean | false |  |
 | avatar | 是否显示头像占位图 | boolean \| [SkeletonAvatar](#skeletonavatar) | false |  |
 | loading | 为 true 时，显示占位图。反之则直接展示子组件 | boolean | - |  |
 | paragraph | 是否显示段落占位图 | boolean \| [SkeletonParagraphProps](#skeletonparagraphprops) | true |  |
@@ -60,24 +61,27 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*VcjGQLSrYdcAAA
 
 ### Skeleton.Avatar
 
-| 属性  | 说明                 | 类型                                     | 默认值   |
-| ----- | -------------------- | ---------------------------------------- | -------- |
-| shape | 指定头像的形状       | `circle` \| `square`                     | `circle` |
-| size  | 设置头像占位图的大小 | number \| `large` \| `medium` \| `small` | `medium` |
+| 属性   | 说明                                       | 类型                                     | 默认值   |
+| ------ | ------------------------------------------ | ---------------------------------------- | -------- |
+| active | 是否展示动画效果，只在独立使用头像时有效   | boolean                                  | false    |
+| shape  | 指定头像的形状                             | `circle` \| `square`                     | `circle` |
+| size   | 设置头像占位图的大小                       | number \| `large` \| `medium` \| `small` | `medium` |
 
 ### Skeleton.Button
 
 | 属性 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
+| active | 是否展示动画效果 | boolean | false |  |
 | block | 将按钮宽度调整为其父宽度的选项 | boolean | false | 4.17.0 |
 | shape | 指定按钮的形状 | `circle` \| `round` \| `square` \| `default` | - |  |
 | size | 设置按钮的大小 | `large` \| `medium` \| `small` | `medium` |  |
 
 ### Skeleton.Input
 
-| 属性 | 说明             | 类型                           | 默认值   |
-| ---- | ---------------- | ------------------------------ | -------- |
-| size | 设置输入框的大小 | `large` \| `medium` \| `small` | `medium` |
+| 属性   | 说明             | 类型                           | 默认值   |
+| ------ | ---------------- | ------------------------------ | -------- |
+| active | 是否展示动画效果 | boolean                        | false    |
+| size   | 设置输入框的大小 | `large` \| `medium` \| `small` | `medium` |
 
 ## Semantic DOM
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

N/A

### 💡 Background and Solution

The English Skeleton documentation lists the `active` prop on `Skeleton`, `Skeleton.Avatar`, `Skeleton.Button`, and `Skeleton.Input`, but the Chinese documentation was missing this prop on `Skeleton`, `Skeleton.Avatar`, `Skeleton.Button`, and `Skeleton.Input` API tables. The prop is fully implemented in the source code (`components/skeleton/Skeleton.tsx`, `Avatar.tsx`, `Button.tsx`, `Input.tsx`) — it's only the zh-CN docs that were out of sync.

This PR adds the missing `active` rows to bring the zh-CN docs in line with the en-US docs, keeping parameters in alphabetical order per the project's API table conventions.

No code or component behavior is changed.

### 📝 Change Log

| Language   | Changelog       |
| ---------- | --------------- |
| 🇺🇸 English | N/A             |
| 🇨🇳 Chinese | N/A             |