### PR TITLE
fix(locale): add missing Tour translations to km_KH

### DIFF
--- a/components/locale/km_KH.ts
+++ b/components/locale/km_KH.ts
@@ -35,6 +35,11 @@ const localeValues: Locale = {
     triggerAsc: 'ចុចដើម្បីរៀបតាមលំដាប់តូច​',
     cancelSort: 'ចុចដើម្បីបោះបង់',
   },
+  Tour: {
+    Next: 'បន្ទាប់',
+    Previous: 'មុន',
+    Finish: 'បញ្ចប់',
+  },
   Modal: {
     okText: 'យល់ព្រម',
     cancelText: 'បោះបង់',


### PR DESCRIPTION
@
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [x] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

No tracking issue. Proactive locale-consistency fix discovered by scanning `components/locale/*.ts` for keys present in `en_US.ts` but missing from other locales.

### 💡 Background and Solution

`components/locale/km_KH.ts` (Khmer) is missing the `Tour` block entirely. As a result, Khmer-locale users see the Tour component buttons in English ("Next" / "Previous" / "Finish") because `useLocale("Tour", defaultLocale.Tour)` in `components/tour/panelRender.tsx` falls back to the English defaults.

This PR adds the three missing strings using standard Khmer translations consistent with the existing vocabulary already used in `km_KH.ts` (e.g. `បញ្ចប់` matches the "end"/"finish" wording already used in `components/date-picker/locale/km_KH.ts` `rangeMonthPlaceholder`).

```ts
Tour: {
  Next: "បន្ទាប់",     // banṭăp — next
  Previous: "មុន",     // mŏn — previous
  Finish: "បញ្ចប់",    // bǎnchóp — finish/complete
},
```

The change is additive only — no existing keys are renamed or removed, and the `Tour` field on the `Locale` interface is already optional (`components/locale/index.tsx`), so no type changes are required. This mirrors prior precedent merges that added missing Tour translations for other locales (#40750 fr, #45166 pl, #49612 nl, #50058 fr-BE/nl-BE).

### 📝 Change Log

| Language   | Changelog                                                            |
| ---------- | -------------------------------------------------------------------- |
| 🇺🇸 English | 🇰🇭 Add missing Tour locale translations (Next / Previous / Finish) for `km_KH`. |
| 🇨🇳 Chinese | 🇰🇭 补全 `km_KH` 高棉语 Tour 组件的本地化文案（Next / Previous / Finish）。                |
@