### PR TITLE
test(DatePicker): cover explicit multiple={true|false} type inference

### DIFF
--- a/components/date-picker/__tests__/type.test.tsx
+++ b/components/date-picker/__tests__/type.test.tsx
@@ -78,6 +78,25 @@ describe('DatePicker.typescript', () => {
     expect(datePicker).toBeTruthy();
   });
 
+  // https://github.com/ant-design/ant-design/issues/49198
+  it('DatePicker should accept only single value if multiple is explicitly false', () => {
+    const mockSingleValue = dayjs();
+    const mockOnChange = jest.fn<void, [Dayjs | null, string | null]>();
+    const mockOnOk = jest.fn<void, [Dayjs | null]>();
+
+    const datePicker = (
+      <DatePicker
+        multiple={false}
+        defaultValue={mockSingleValue}
+        value={mockSingleValue}
+        onChange={mockOnChange}
+        onOk={mockOnOk}
+      />
+    );
+
+    expect(datePicker).toBeTruthy();
+  });
+
   it('DatePicker should accept only array value if multiple is true', () => {
     const mockMultiValue = [dayjs()];
     const mockOnChange = jest.fn<void, [Dayjs[] | null, string[] | null]>();
@@ -86,6 +105,24 @@ describe('DatePicker.typescript', () => {
     const datePicker = (
       <DatePicker
         multiple
+        defaultValue={mockMultiValue}
+        value={mockMultiValue}
+        onChange={mockOnChange}
+        onOk={mockOnOk}
+      />
+    );
+
+    expect(datePicker).toBeTruthy();
+  });
+
+  it('DatePicker should accept only array value if multiple is explicitly true', () => {
+    const mockMultiValue = [dayjs()];
+    const mockOnChange = jest.fn<void, [Dayjs[] | null, string[] | null]>();
+    const mockOnOk = jest.fn<void, [Dayjs[] | null]>();
+
+    const datePicker = (
+      <DatePicker
+        multiple={true}
         defaultValue={mockMultiValue}
         value={mockMultiValue}
         onChange={mockOnChange}


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Refs #49198 (the example from this issue is the case being covered).
Builds on #55826, which introduced the \`IsMultiple\` generic that drives the discrimination.

### 💡 Background and Solution

The existing TypeScript tests in \`components/date-picker/__tests__/type.test.tsx\` only cover the case where \`multiple\` is omitted (relying on the default) or set without a value (\`multiple\` as a JSX boolean shorthand). The case from issue #49198 — where users pass \`multiple={false}\` or \`multiple={true}\` as an explicit boolean literal — was never asserted by the type test suite.

\`PickerPropsWithMultiple\` already discriminates \`onChange\` / \`value\` / \`defaultValue\` / \`onOk\` based on the \`IsMultiple\` type parameter, so the explicit-literal cases work correctly today. This PR adds two regression tests so the behavior is locked in and any future regression in the discrimination logic will fail the type test:

- \`multiple={false}\` → \`onChange?: (date: Dayjs | null, dateString: string | null) => void\`
- \`multiple={true}\` → \`onChange?: (date: Dayjs[] | null, dateString: string[] | null) => void\`

No runtime or public type changes — tests only.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | N/A (test-only change) |
| 🇨🇳 Chinese | 无需更新日志（仅新增类型测试） |