### PR TITLE
fix: avoid deep @rc-component form imports

### DIFF
--- a/components/config-provider/__tests__/form.test.tsx
+++ b/components/config-provider/__tests__/form.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ValidateMessages } from '@rc-component/form/lib/interface';
+import type { ValidateMessages } from '@rc-component/form';
 import scrollIntoView from 'scroll-into-view-if-needed';
 
 import ConfigProvider from '..';

--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import FieldForm, { List, useWatch } from '@rc-component/form';
-import type { FormProps as RcFormProps } from '@rc-component/form/lib/Form';
 import type {
   FormRef,
   InternalNamePath,
+  FormProps as RcFormProps,
   ValidateErrorEntity,
-} from '@rc-component/form/lib/interface';
+} from '@rc-component/form';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';

--- a/components/form/FormItem/ItemHolder.tsx
+++ b/components/form/FormItem/ItemHolder.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { Meta } from '@rc-component/form/lib/interface';
+import type { Meta } from '@rc-component/form';
 import { isVisible, omit, useLayoutEffect } from '@rc-component/util';
 import { clsx } from 'clsx';
 

--- a/components/form/FormItem/StatusProvider.tsx
+++ b/components/form/FormItem/StatusProvider.tsx
@@ -3,7 +3,7 @@ import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
 import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
 import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
-import type { Meta, NamePath } from '@rc-component/form/lib/interface';
+import type { Meta, NamePath } from '@rc-component/form';
 import { clsx } from 'clsx';
 
 import type { FeedbackIcons, ValidateStatus } from '.';

--- a/components/form/FormItem/index.tsx
+++ b/components/form/FormItem/index.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import type { JSX } from 'react';
 import { Field, FieldContext, ListContext } from '@rc-component/form';
-import type { FieldProps } from '@rc-component/form/lib/Field';
-import type { InternalNamePath, Meta, RuleObject } from '@rc-component/form/lib/interface';
+import type { FieldProps, InternalNamePath, Meta, RuleObject } from '@rc-component/form';
 import { supportRef, useState } from '@rc-component/util';
 import { clsx } from 'clsx';
 
@@ -77,7 +76,9 @@ const MemoInput = React.memo<React.PropsWithChildren<MemoInputProps>>(
 );
 
 export interface FormItemProps<Values = any>
-  extends Omit<FormItemLabelProps, 'requiredMark'>, FormItemInputProps, RcFieldProps<Values> {
+  extends Omit<FormItemLabelProps, 'requiredMark'>,
+    FormItemInputProps,
+    RcFieldProps<Values> {
   prefixCls?: string;
   noStyle?: boolean;
   style?: React.CSSProperties;

--- a/components/form/FormList.tsx
+++ b/components/form/FormList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { List } from '@rc-component/form';
-import type { StoreValue, ValidatorRule } from '@rc-component/form/lib/interface';
+import type { StoreValue, ValidatorRule } from '@rc-component/form';
 
 import { isNumber } from '../_util/is';
 import { devUseWarning } from '../_util/warning';

--- a/components/form/__tests__/ref.test.tsx
+++ b/components/form/__tests__/ref.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { FormRef } from '@rc-component/form/lib/interface';
+import type { FormRef } from '@rc-component/form';
 
 import Form from '..';
 import type { FormInstance } from '..';

--- a/components/form/context.tsx
+++ b/components/form/context.tsx
@@ -1,8 +1,7 @@
 import type { PropsWithChildren, ReactNode } from 'react';
 import * as React from 'react';
 import { FormProvider as RcFormProvider } from '@rc-component/form';
-import type { FormProviderProps as RcFormProviderProps } from '@rc-component/form/lib/FormContext';
-import type { Meta } from '@rc-component/form/lib/interface';
+import type { Meta, FormProviderProps as RcFormProviderProps } from '@rc-component/form';
 import { omit } from '@rc-component/util';
 
 import type { Variant } from '../config-provider';

--- a/components/form/index.tsx
+++ b/components/form/index.tsx
@@ -1,4 +1,4 @@
-import type { Rule, RuleObject, RuleRender } from '@rc-component/form/lib/interface';
+import type { Rule, RuleObject, RuleRender } from '@rc-component/form';
 
 import { FormProvider } from './context';
 import ErrorList from './ErrorList';

--- a/components/form/interface.ts
+++ b/components/form/interface.ts
@@ -4,7 +4,7 @@ export type {
   NamePath,
   Store,
   StoreValue,
-} from '@rc-component/form/lib/interface';
+} from '@rc-component/form';
 
 export type ScrollFocusOptions = Options & {
   focus?: boolean;

--- a/components/form/util.ts
+++ b/components/form/util.ts
@@ -1,4 +1,4 @@
-import type { Meta } from '@rc-component/form/lib/interface';
+import type { Meta } from '@rc-component/form';
 
 import type { ValidateStatus } from './FormItem';
 import type { InternalNamePath } from './interface';

--- a/components/form/validateMessagesContext.tsx
+++ b/components/form/validateMessagesContext.tsx
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import type { ValidateMessages } from '@rc-component/form/lib/interface';
+import type { ValidateMessages } from '@rc-component/form';
 
 // ZombieJ: We export single file here since
 // ConfigProvider use this which will make loop deps

--- a/components/locale/index.tsx
+++ b/components/locale/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { ValidateMessages } from '@rc-component/form/lib/interface';
+import type { ValidateMessages } from '@rc-component/form';
 
 import { devUseWarning } from '../_util/warning';
 import type { PickerLocale as DatePickerLocale } from '../date-picker/generatePicker';

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@rc-component/dialog": "~1.9.0",
     "@rc-component/drawer": "~1.4.2",
     "@rc-component/dropdown": "~1.0.2",
-    "@rc-component/form": "~1.8.1",
+    "@rc-component/form": "~1.8.2",
     "@rc-component/image": "~1.9.0",
     "@rc-component/input": "~1.3.1",
     "@rc-component/input-number": "~1.6.2",


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] 🤖 TypeScript 定义更新

### 🔗 相关 Issue

https://github.com/ant-design/ant-design/issues/58115

### 💡 需求背景和解决方案

移除 antd 中对 `@rc-component/form` 构建产物内部路径的直接引用，统一改为从 `@rc-component/form` 公开入口导入类型。

同时升级 `@rc-component/form` 到已发布的 `~1.8.2`，使用其新增的 root type exports，避免继续依赖 `lib` 内部路径。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Form internal rc package deep imports. |
| 🇨🇳 中文 | 🐞 修复 Form 对 rc 包内部构建产物路径的引用。 |
