### PR TITLE
fix: resolve @ant-design/icons alias on Windows

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -92,7 +92,7 @@ export default defineConfig({
     'antd/locale': path.join(__dirname, 'components/locale'),
     antd: path.join(__dirname, 'components'),
     // https://github.com/ant-design/ant-design/issues/46628
-    '@ant-design/icons$': '@ant-design/icons/lib',
+    '@ant-design/icons$': '@ant-design/icons/lib/index',
   },
   extraRehypePlugins: [rehypeAntd, rehypeChangelog],
   extraRemarkPlugins: [remarkAntd, remarkAnchor],


### PR DESCRIPTION
## Summary

Fix `Can't resolve '@ant-design/icons'` error on Windows when running the dev server.

On Windows, dumi falls back to webpack (mako is disabled per `.dumirc.ts` L71), which strictly follows the Node.js `exports` field in `package.json`. The current alias `'@ant-design/icons$': '@ant-design/icons/lib'` doesn't match any entry in `@ant-design/icons` exports — only `./lib/*` wildcard exists, no bare `./lib` entry. Changing to `'@ant-design/icons/lib/index'` correctly matches the `./lib/*` wildcard pattern.

Close #58158

## Test Plan

- [ ] On Windows: run `npm start` and verify no `Module not found` error for `@ant-design/icons`
- [ ] On macOS/Linux: run `npm start` and verify icons still load correctly (mako resolver is lenient, so this change should be transparent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)