### PR TITLE
fix: treat empty string as non-renderable content

### DIFF
--- a/components/_util/__tests__/ContextIsolator.test.tsx
+++ b/components/_util/__tests__/ContextIsolator.test.tsx
@@ -5,7 +5,7 @@ import ContextIsolator from '../ContextIsolator';
 
 describe('ContextIsolator component', () => {
   it('ContextIsolator should work when Children is empty', () => {
-    [undefined, null, false].forEach((item) => {
+    [undefined, null, false, ''].forEach((item) => {
       expect(() => {
         render(<ContextIsolator>{item}</ContextIsolator>);
       }).not.toThrow();

--- a/components/_util/is.ts
+++ b/components/_util/is.ts
@@ -2,8 +2,8 @@ export const isNonNullable = <T>(val: T): val is NonNullable<T> => {
   return val !== undefined && val !== null;
 };
 
-export const isReactRenderable = <T>(val: T): val is Exclude<NonNullable<T>, false> => {
-  return isNonNullable(val) && val !== false;
+export const isReactRenderable = <T>(val: T): val is Exclude<NonNullable<T>, false | ''> => {
+  return isNonNullable(val) && val !== false && val !== '';
 };
 
 export const isNumber = (val: any): val is number => {

--- a/components/badge/Badge.tsx
+++ b/components/badge/Badge.tsx
@@ -133,9 +133,7 @@ const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>((props, ref) => {
   const mergedCount = showAsDot ? '' : numberedDisplayCount;
 
   const isHidden = useMemo(() => {
-    const isEmpty =
-      (!isReactRenderable(mergedCount) || mergedCount === '') &&
-      (!isReactRenderable(text) || text === '');
+    const isEmpty = !isReactRenderable(mergedCount) && !isReactRenderable(text);
     return (isEmpty || (isZero && !showZero)) && !showAsDot;
   }, [mergedCount, isZero, showZero, showAsDot, text]);
 

--- a/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -183,14 +183,6 @@ exports[`Breadcrumb should render a menu 1`] = `
     >
       /
     </li>
-    <li
-      class="ant-breadcrumb-item"
-    >
-      <a
-        class="ant-breadcrumb-link"
-        href="#/index/first/second/third"
-      />
-    </li>
   </ol>
 </nav>
 `;

--- a/components/button/buttonHelpers.tsx
+++ b/components/button/buttonHelpers.tsx
@@ -29,7 +29,7 @@ function splitCNCharsBySpace(
   style?: React.CSSProperties,
   className?: string,
 ) {
-  if (!isReactRenderable(child) || child === '') {
+  if (!isReactRenderable(child)) {
     return;
   }
 

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -3,7 +3,7 @@ import type { CSSMotionProps } from '@rc-component/motion';
 import CSSMotion, { CSSMotionList } from '@rc-component/motion';
 import { clsx } from 'clsx';
 
-import { isReactRenderable } from '../_util/is';
+import { isNonNullable } from '../_util/is';
 import initCollapseMotion from '../_util/motion';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import { FormContext, FormItemPrefixContext } from './context';
@@ -68,9 +68,10 @@ const ErrorList: React.FC<ErrorListProps> = ({
   // ref: https://github.com/ant-design/ant-design/issues/36336
   const debounceErrors = useDebounce(errors);
   const debounceWarnings = useDebounce(warnings);
+  const hasHelp = isNonNullable(help) && help !== false;
 
   const fullKeyList = React.useMemo<ErrorEntity[]>(() => {
-    if (isReactRenderable(help)) {
+    if (hasHelp) {
       return [toErrorEntity(help, 'help', helpStatus)];
     }
     return [
@@ -79,7 +80,7 @@ const ErrorList: React.FC<ErrorListProps> = ({
         toErrorEntity(warning, 'warning', 'warning', index),
       ),
     ];
-  }, [help, helpStatus, debounceErrors, debounceWarnings]);
+  }, [help, helpStatus, hasHelp, debounceErrors, debounceWarnings]);
 
   const filledKeyFullKeyList = React.useMemo<ErrorEntity[]>(() => {
     const keysCount: Record<string, number> = {};

--- a/components/form/FormItem/ItemHolder.tsx
+++ b/components/form/FormItem/ItemHolder.tsx
@@ -4,7 +4,7 @@ import { isVisible, omit, useLayoutEffect } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { FormItemProps } from '.';
-import { isReactRenderable } from '../../_util/is';
+import { isNonNullable } from '../../_util/is';
 import { Row } from '../../grid';
 import type { ReportMetaChange } from '../context';
 import { FormContext, NoStyleItemContext } from '../context';
@@ -61,7 +61,7 @@ export default function ItemHolder(props: ItemHolderProps) {
   const itemRef = React.useRef<HTMLDivElement>(null);
   const debounceErrors = useDebounce(errors);
   const debounceWarnings = useDebounce(warnings);
-  const hasHelp = isReactRenderable(help);
+  const hasHelp = isNonNullable(help) && help !== false;
   const hasError = !!(hasHelp || errors.length || warnings.length);
   const isOnScreen = !!itemRef.current && isVisible(itemRef.current);
   const [marginBottom, setMarginBottom] = React.useState<number | null>(null);

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -141,7 +141,7 @@ export const ConfirmContent: React.FC<ConfirmDialogProps & { confirmPrefixCls: s
     </>
   );
 
-  const hasTitle = isReactRenderable(props.title) && props.title !== '';
+  const hasTitle = isReactRenderable(props.title);
   const hasIcon = isReactRenderable(mergedIcon);
 
   const bodyCls = `${confirmPrefixCls}-body`;

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -106,7 +106,7 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
     });
   }
   const mergedTitle = title ?? message;
-  const hasTitle = isReactRenderable(mergedTitle) && mergedTitle !== '';
+  const hasTitle = isReactRenderable(mergedTitle);
   const prefixCls = staticPrefixCls || getPrefixCls('notification');
   const noticePrefixCls = `${prefixCls}-notice`;
   const iconNode = icon || (type ? TypeIcon[type] : null);

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -191,7 +191,7 @@ export function useInternalNotification(
         });
       }
       const mergedTitle = title ?? message;
-      const hasTitle = isReactRenderable(mergedTitle) && mergedTitle !== '';
+      const hasTitle = isReactRenderable(mergedTitle);
       const mergedActions = actions ?? btn;
 
       const realCloseIcon = getCloseIcon(


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Follow-up to the review discussion in #58096.

### 💡 需求背景和解决方案

`isReactRenderable` 目前会把空字符串判断为可渲染内容，导致部分组件还需要额外维护 `value !== ''` 判断。

本次将 `''` 纳入 `isReactRenderable` 的不可渲染范围，并移除 Badge、Button、Modal、Notification 中重复的空字符串判断。Form 的 `help=""` 是显式占位语义，保留原有渲染行为。Breadcrumb 对空标题不再渲染空链接，并更新对应快照。

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | 🐞 Fix empty string being treated as renderable content in shared render checks. |
| 🇨🇳 中文 | 🐞 修复共享渲染判断中空字符串被视为可渲染内容的问题。 |
