### PR TITLE
fix(Transfer): forward html attributes to root element

### DIFF
--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -107,6 +107,20 @@ describe('Transfer', () => {
     expect(wrapper.container.firstChild).toMatchSnapshot();
   });
 
+  it('should forward html attributes to root element', () => {
+    const { container } = render(
+      <Transfer {...listCommonProps} data-testid="transfer-testid" aria-label="transfer-label" />,
+    );
+    expect(container.querySelector('.ant-transfer')).toHaveAttribute(
+      'data-testid',
+      'transfer-testid',
+    );
+    expect(container.querySelector('.ant-transfer')).toHaveAttribute(
+      'aria-label',
+      'transfer-label',
+    );
+  });
+
   it('should move selected keys to corresponding list', () => {
     const handleChange = jest.fn();
     const { container } = render(<Transfer {...listCommonProps} onChange={handleChange} />);

--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -107,18 +107,21 @@ describe('Transfer', () => {
     expect(wrapper.container.firstChild).toMatchSnapshot();
   });
 
-  it('should forward html attributes to root element', () => {
+  it('should only forward data and aria attributes to root element', () => {
     const { container } = render(
-      <Transfer {...listCommonProps} data-testid="transfer-testid" aria-label="transfer-label" />,
+      <Transfer
+        {...listCommonProps}
+        data-testid="transfer-testid"
+        aria-label="transfer-label"
+        id="transfer-id"
+        title="transfer-title"
+      />,
     );
-    expect(container.querySelector('.ant-transfer')).toHaveAttribute(
-      'data-testid',
-      'transfer-testid',
-    );
-    expect(container.querySelector('.ant-transfer')).toHaveAttribute(
-      'aria-label',
-      'transfer-label',
-    );
+    const rootNode = container.querySelector('.ant-transfer');
+    expect(rootNode).toHaveAttribute('data-testid', 'transfer-testid');
+    expect(rootNode).toHaveAttribute('aria-label', 'transfer-label');
+    expect(rootNode).not.toHaveAttribute('id');
+    expect(rootNode).not.toHaveAttribute('title');
   });
 
   it('should move selected keys to corresponding list', () => {

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -1,6 +1,6 @@
 import type { ChangeEvent, CSSProperties } from 'react';
 import React, { useCallback, useContext } from 'react';
-import { omit } from '@rc-component/util';
+import { pickAttrs } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useMultipleSelect } from '../_util/hooks';
@@ -583,12 +583,10 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
   const targetSectionClassNames = getMergedSectionClassNames('target');
   const sourceSectionStyles = getMergedSectionStyles('source');
   const targetSectionStyles = getMergedSectionStyles('target');
-
-  const legacyOmittedProps = restProps as typeof restProps & {
-    body?: unknown;
-    onSearchChange?: unknown;
-  };
-  const divProps = omit(legacyOmittedProps, ['dir', 'body', 'onSearchChange']);
+  const rootProps = pickAttrs(restProps, {
+    aria: true,
+    data: true,
+  });
 
   // ===================== Warning ======================
   if (process.env.NODE_ENV !== 'production') {
@@ -607,7 +605,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
 
   // ====================== Render ======================
   return (
-    <div {...divProps} className={cls} style={{ ...contextStyle, ...mergedStyles.root, ...style }}>
+    <div {...rootProps} className={cls} style={{ ...contextStyle, ...mergedStyles.root, ...style }}>
       <Section<KeyWise<RecordType>>
         prefixCls={prefixCls}
         style={handleListStyle('left')}

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -140,7 +140,8 @@ export interface TransferSearchOption {
   defaultValue?: string;
 }
 
-export interface TransferProps<RecordType = any> {
+export interface TransferProps<RecordType = any>
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'onScroll' | 'children'> {
   prefixCls?: string;
   className?: string;
   rootClassName?: string;
@@ -226,6 +227,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
     onChange,
     onSearch,
     onSelectChange,
+    ...restProps
   } = props;
 
   const {
@@ -598,7 +600,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
 
   // ====================== Render ======================
   return (
-    <div className={cls} style={{ ...contextStyle, ...mergedStyles.root, ...style }}>
+    <div {...restProps} className={cls} style={{ ...contextStyle, ...mergedStyles.root, ...style }}>
       <Section<KeyWise<RecordType>>
         prefixCls={prefixCls}
         style={handleListStyle('left')}

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -583,7 +583,12 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
   const targetSectionClassNames = getMergedSectionClassNames('target');
   const sourceSectionStyles = getMergedSectionStyles('source');
   const targetSectionStyles = getMergedSectionStyles('target');
-  const divProps = omit(restProps, ['dir']);
+
+  const legacyOmittedProps = restProps as typeof restProps & {
+    body?: unknown;
+    onSearchChange?: unknown;
+  };
+  const divProps = omit(legacyOmittedProps, ['dir', 'body', 'onSearchChange']);
 
   // ===================== Warning ======================
   if (process.env.NODE_ENV !== 'production') {

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -1,5 +1,6 @@
 import type { ChangeEvent, CSSProperties } from 'react';
 import React, { useCallback, useContext } from 'react';
+import { omit } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useMultipleSelect } from '../_util/hooks';
@@ -141,7 +142,7 @@ export interface TransferSearchOption {
 }
 
 export interface TransferProps<RecordType = any>
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'onScroll' | 'children'> {
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'onScroll' | 'children' | 'dir'> {
   prefixCls?: string;
   className?: string;
   rootClassName?: string;
@@ -582,6 +583,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
   const targetSectionClassNames = getMergedSectionClassNames('target');
   const sourceSectionStyles = getMergedSectionStyles('source');
   const targetSectionStyles = getMergedSectionStyles('target');
+  const divProps = omit(restProps, ['dir']);
 
   // ===================== Warning ======================
   if (process.env.NODE_ENV !== 'production') {
@@ -600,7 +602,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
 
   // ====================== Render ======================
   return (
-    <div {...restProps} className={cls} style={{ ...contextStyle, ...mergedStyles.root, ...style }}>
+    <div {...divProps} className={cls} style={{ ...contextStyle, ...mergedStyles.root, ...style }}>
       <Section<KeyWise<RecordType>>
         prefixCls={prefixCls}
         style={handleListStyle('left')}

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -142,7 +142,7 @@ export interface TransferSearchOption {
 }
 
 export interface TransferProps<RecordType = any>
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'onScroll' | 'children' | 'dir'> {
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'onScroll' | 'children'> {
   prefixCls?: string;
   className?: string;
   rootClassName?: string;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #58161

### 💡 需求背景和解决方案

Transfer 组件未将透传属性挂到根节点，导致 `data-testid`/`aria-*` 等属性被静默丢弃，影响 Playwright/testing-library 的稳定选择器。

本次修复：
- 让 `TransferProps` 支持根 `div` 的 HTML attributes（排除与组件自定义定义冲突的 `onChange`、`onScroll`、`children`）。
- 在 Transfer 根节点透传 `...restProps`，使 `data-*`、`aria-*`、`id`、`role` 等属性生效。
- 新增回归测试，覆盖 `data-testid` 与 `aria-label` 在根节点的透传行为。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Transfer to forward HTML attributes (e.g. `data-testid` and `aria-*`) to the root element. |
| 🇨🇳 中文 | 🐞 修复 Transfer 未透传根节点 HTML 属性（如 `data-testid`、`aria-*`）的问题。 |
