### PR TITLE
perf(Transfer): combine enabled key iteration

### DIFF
--- a/components/transfer/Section.tsx
+++ b/components/transfer/Section.tsx
@@ -34,7 +34,12 @@ function isRenderResultPlainObject(result: RenderResult): result is RenderResult
 }
 
 function getEnabledItemKeys<RecordType extends KeyWiseTransferItem>(items: RecordType[]) {
-  return items.filter((data) => !data.disabled).map((data) => data.key);
+  return items.reduce<TransferKey[]>((keys, data) => {
+    if (!data.disabled) {
+      keys.push(data.key);
+    }
+    return keys;
+  }, []);
 }
 
 function getTextFromRenderResult<RecordType extends KeyWiseTransferItem>(
@@ -305,10 +310,7 @@ const TransferSection = <RecordType extends KeyWiseTransferItem>(
       className={`${listPrefixCls}-checkbox`}
       onChange={() => {
         // Only select enabled items
-        onItemSelectAll?.(
-          filteredItems.filter((item) => !item.disabled).map(({ key }) => key),
-          checkStatus !== 'all',
-        );
+        onItemSelectAll?.(getEnabledItemKeys(filteredItems), checkStatus !== 'all');
       }}
     />
   );


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] ⚡️ Performance optimization

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

修复 Transfer 中 `filter().map()` 带来的重复数组遍历问题。

将 `getEnabledItemKeys` 改为单次 `reduce` 收集可用项 key，并在全选逻辑中复用该 helper，避免相同逻辑再次通过链式遍历实现。

不涉及 API、UI 或交互变更。

### 📝 Change Log


| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Improve Transfer performance when collecting enabled item keys. |
| 🇨🇳 中文 | 优化 Transfer 收集可用项 key 时的遍历性能。 |
