### PR TITLE
docs: fix component documentation anchors

### DIFF
--- a/components/skeleton/index.en-US.md
+++ b/components/skeleton/index.en-US.md
@@ -39,7 +39,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | active | Show animation effect | boolean | false |  |
-| avatar | Show avatar placeholder | boolean \| [SkeletonAvatarProps](#skeletonavatarprops) | false |  |
+| avatar | Show avatar placeholder | boolean \| [SkeletonAvatar](#skeletonavatar) | false |  |
 | loading | Display the skeleton when true | boolean | - |  |
 | paragraph | Show paragraph placeholder | boolean \| [SkeletonParagraphProps](#skeletonparagraphprops) | true |  |
 | round | Show paragraph and title radius when true | boolean | false |  |

--- a/components/timeline/index.en-US.md
+++ b/components/timeline/index.en-US.md
@@ -41,7 +41,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| items | Each node of timeline | [Items](#Items)[] | - |  |
+| items | Each node of timeline | [Items](#items)[] | - |  |
 | mode | By sending `alternate` the timeline will distribute the nodes to the left and right | `start` \| `alternate` \| `end` | `start` |  |
 | orientation | Set the direction of the timeline | `vertical` \| `horizontal` | `vertical` |  |
 | ~~pending~~ | Set the last ghost node's existence or its content. Use `item.loading` instead | ReactNode | false |  |

--- a/components/timeline/index.zh-CN.md
+++ b/components/timeline/index.zh-CN.md
@@ -42,7 +42,7 @@ demo:
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| items | 选项配置 | [Items](#Items)[] | - |  |
+| items | 选项配置 | [Items](#items)[] | - |  |
 | mode | 通过设置 `mode` 可以改变时间轴和内容的相对位置 | `start` \| `alternate` \| `end` | `start` |  |
 | orientation | 设置时间轴的方向 | `vertical` \| `horizontal` | `vertical` |  |
 | ~~pending~~ | 指定最后一个幽灵节点是否存在或内容，请使用 `item.loading` 代替 | ReactNode | false |  |

--- a/components/upload/demo/directory.md
+++ b/components/upload/demo/directory.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-支持上传一个文件夹里的所有文件。 [Safari 里仍然能选择文件?](#%E6%96%87%E4%BB%B6%E5%A4%B9%E4%B8%8A%E4%BC%A0%E5%9C%A8-safari-%E4%BB%8D%E7%84%B6%E5%8F%AF%E4%BB%A5%E9%80%89%E4%B8%AD%E6%96%87%E4%BB%B6)
+支持上传一个文件夹里的所有文件。 [Safari 里仍然能选择文件?](#faq-safari-folder-upload)
 
 ## en-US
 
-You can select and upload a whole directory. [Can still select files when uploading a folder in Safari?](#can-still-select-files-when-uploading-a-folder-in-safari)
+You can select and upload a whole directory. [Can still select files when uploading a folder in Safari?](#faq-safari-folder-upload)


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

修正文档中部分锚点链接不一致的问题：

- 修正 Timeline `items` API 类型链接，指向实际的 `#items` 锚点。
- 修正 Skeleton `avatar` API 类型链接，使其与 `Skeleton.Avatar` 小节锚点一致。
- 修正 Upload 文件夹上传 demo 中 Safari FAQ 链接，指向已有的 `#faq-safari-folder-upload` 锚点。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A      |
| 🇨🇳 中文 | N/A      |