### PR TITLE
demo(Image): use semantic styles for placeholder border radius

### DIFF
--- a/components/image/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/image/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -637,7 +637,7 @@ Array [
         aria-label="basic image"
         class="ant-image css-var-test-id ant-image-css-var"
         role="button"
-        style="width: 200px; height: 200px;"
+        style="width: 200px; height: 200px; border-radius: 8px;"
         tabindex="0"
       >
         <img
@@ -658,6 +658,7 @@ Array [
         </div>
         <div
           class="ant-image-cover ant-image-cover-center"
+          style="border-radius: 8px;"
         />
       </div>
     </div>

--- a/components/image/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/image/__tests__/__snapshots__/demo.test.ts.snap
@@ -626,7 +626,7 @@ Array [
         aria-label="basic image"
         class="ant-image css-var-test-id ant-image-css-var"
         role="button"
-        style="width:200px;height:200px"
+        style="width:200px;height:200px;border-radius:8px"
         tabindex="0"
       >
         <img
@@ -647,6 +647,7 @@ Array [
         </div>
         <div
           class="ant-image-cover ant-image-cover-center"
+          style="border-radius:8px"
         />
       </div>
     </div>

--- a/components/image/demo/placeholder.tsx
+++ b/components/image/demo/placeholder.tsx
@@ -1,9 +1,15 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Flex, Image } from 'antd';
+import { Button, Flex, Image, theme } from 'antd';
 
 const GeneratingProgress: React.FC = () => {
+  const { token } = theme.useToken();
   const [percent, setPercent] = useState(0);
   const [status, setStatus] = useState<'idle' | 'generating' | 'complete'>('idle');
+  const imageStyles = {
+    root: { borderRadius: token.borderRadiusLG },
+    image: { borderRadius: token.borderRadiusLG },
+    cover: { borderRadius: token.borderRadiusLG },
+  };
 
   useEffect(() => {
     if (status === 'generating' && percent < 100) {
@@ -29,14 +35,14 @@ const GeneratingProgress: React.FC = () => {
       <Image
         width={200}
         height={200}
-        style={{ borderRadius: 8 }}
+        styles={imageStyles}
         src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
       />
     ) : (
       <Image
         width={200}
         height={200}
-        style={{ borderRadius: 8 }}
+        styles={imageStyles}
         placeholder={{
           progress: {
             percent: Math.round(percent),
@@ -62,33 +68,34 @@ const GeneratingProgress: React.FC = () => {
 };
 
 const App: React.FC = () => {
+  const { token } = theme.useToken();
   const [random, setRandom] = useState<number>(() => Date.now());
+  const imageStyles = {
+    root: { borderRadius: token.borderRadiusLG },
+    image: { borderRadius: token.borderRadiusLG },
+    cover: { borderRadius: token.borderRadiusLG },
+  };
 
   return (
     <>
       <Flex gap={16} wrap>
+        <Image width={200} height={200} styles={imageStyles} placeholder={{ progress: true }} />
         <Image
           width={200}
           height={200}
-          style={{ borderRadius: 8 }}
-          placeholder={{ progress: true }}
-        />
-        <Image
-          width={200}
-          height={200}
-          style={{ borderRadius: 8 }}
+          styles={imageStyles}
           placeholder={{ progress: { render: () => 'loading...' } }}
         />
         <Image
           width={200}
           height={200}
-          style={{ borderRadius: 8 }}
+          styles={imageStyles}
           placeholder={{ progress: { percent: 50 } }}
         />
         <Image
           width={200}
           height={200}
-          style={{ borderRadius: 8 }}
+          styles={imageStyles}
           placeholder={{
             progress: {
               percent: 75,
@@ -116,7 +123,7 @@ const App: React.FC = () => {
             width={200}
             height={200}
             alt="basic image"
-            style={{ borderRadius: 8 }}
+            styles={imageStyles}
             src={`https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?${random}`}
             placeholder={
               <div
@@ -125,7 +132,7 @@ const App: React.FC = () => {
                   height: '100%',
                   background: 'rgba(255, 255, 255, 0.3)',
                   backdropFilter: 'blur(10px)',
-                  borderRadius: 8,
+                  borderRadius: token.borderRadiusLG,
                 }}
               />
             }


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/ant-design/ant-design/issues/58169

### 💡 需求背景和解决方案

Image placeholder demo 中存在硬编码圆角样式，且不同示例写法不一致。
本次改动统一使用语义化 styles 配置，并提取复用的圆角样式对象（包含 root、image、cover），同时改为使用 design token token.borderRadiusLG，使示例更符合组件语义化样式能力和 token 体系。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A (Demo-only change) |
| 🇨🇳 中文 | 无需更新日志（仅 Demo 调整） |