### PR TITLE
fix: add bodyStyle to Layout.Sider

### DIFF
--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -71,7 +71,7 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
     className,
     trigger,
     children,
-    bodyStyle = {},
+    bodyStyle,
     defaultCollapsed = false,
     theme = 'dark',
     style = {},

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -40,7 +40,12 @@ export interface SiderProps extends React.HTMLAttributes<HTMLDivElement> {
   collapsible?: boolean;
   collapsed?: boolean;
   defaultCollapsed?: boolean;
-  bodyStyle?: React.CSSProperties;
+  classNames?: {
+    body?: string;
+  };
+  styles?: {
+    body?: React.CSSProperties;
+  };
   reverseArrow?: boolean;
   onCollapse?: (collapsed: boolean, type: CollapseType) => void;
   zeroWidthTriggerStyle?: React.CSSProperties;
@@ -69,9 +74,10 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
     className,
+    classNames,
     trigger,
     children,
-    bodyStyle,
+    styles,
     defaultCollapsed = false,
     theme = 'dark',
     style = {},
@@ -218,7 +224,7 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
   return (
     <SiderContext.Provider value={contextValue}>
       <aside className={siderCls} {...divProps} style={divStyle} ref={ref}>
-        <div className={`${prefixCls}-children`} style={bodyStyle}>
+        <div className={clsx(`${prefixCls}-children`, classNames?.body)} style={styles?.body}>
           {children}
         </div>
         {collapsible || (below && zeroWidthTrigger) ? triggerDom : null}

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -40,6 +40,7 @@ export interface SiderProps extends React.HTMLAttributes<HTMLDivElement> {
   collapsible?: boolean;
   collapsed?: boolean;
   defaultCollapsed?: boolean;
+  bodyStyle?: React.CSSProperties;
   reverseArrow?: boolean;
   onCollapse?: (collapsed: boolean, type: CollapseType) => void;
   zeroWidthTriggerStyle?: React.CSSProperties;
@@ -70,6 +71,7 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
     className,
     trigger,
     children,
+    bodyStyle = {},
     defaultCollapsed = false,
     theme = 'dark',
     style = {},
@@ -216,7 +218,9 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
   return (
     <SiderContext.Provider value={contextValue}>
       <aside className={siderCls} {...divProps} style={divStyle} ref={ref}>
-        <div className={`${prefixCls}-children`}>{children}</div>
+        <div className={`${prefixCls}-children`} style={bodyStyle}>
+          {children}
+        </div>
         {collapsible || (below && zeroWidthTrigger) ? triggerDom : null}
       </aside>
     </SiderContext.Provider>

--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -343,6 +343,32 @@ describe('Sider', () => {
     ).toEqual('rgb(255, 153, 102)');
   });
 
+  it('bodyStyle should work', () => {
+    const { container } = render(
+      <Sider
+        bodyStyle={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          justifyContent: 'space-evenly',
+        }}
+      >
+        <Menu theme="dark" mode="inline" defaultSelectedKeys={['1']}>
+          <Menu.Item key="1">
+            <UserOutlined />
+            <span>nav 1</span>
+          </Menu.Item>
+        </Menu>
+      </Sider>,
+    );
+    expect(container.querySelector<HTMLElement>('.ant-layout-sider-children')).toHaveStyle({
+      display: 'flex',
+      flexDirection: 'column',
+      height: '100%',
+      justifyContent: 'space-evenly',
+    });
+  });
+
   it('should be able to customize zero width trigger by trigger prop', () => {
     const { container } = render(
       <Sider collapsedWidth={0} collapsible trigger={<span className="my-trigger" />}>

--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -343,14 +343,17 @@ describe('Sider', () => {
     ).toEqual('rgb(255, 153, 102)');
   });
 
-  it('bodyStyle should work', () => {
+  it('semantic classNames and styles should work', () => {
     const { container } = render(
       <Sider
-        bodyStyle={{
-          display: 'flex',
-          flexDirection: 'column',
-          height: '100%',
-          justifyContent: 'space-evenly',
+        classNames={{ body: 'custom-body' }}
+        styles={{
+          body: {
+            display: 'flex',
+            flexDirection: 'column',
+            height: '100%',
+            justifyContent: 'space-evenly',
+          },
         }}
       >
         <Menu theme="dark" mode="inline" defaultSelectedKeys={['1']}>
@@ -361,7 +364,9 @@ describe('Sider', () => {
         </Menu>
       </Sider>,
     );
-    expect(container.querySelector<HTMLElement>('.ant-layout-sider-children')).toHaveStyle({
+    const body = container.querySelector<HTMLElement>('.ant-layout-sider-children');
+    expect(body).toHaveClass('custom-body');
+    expect(body).toHaveStyle({
       display: 'flex',
       flexDirection: 'column',
       height: '100%',

--- a/components/layout/demo/_semantic.tsx
+++ b/components/layout/demo/_semantic.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Layout } from 'antd';
+
+import useLocale from '../../../.dumi/hooks/useLocale';
+import SemanticPreview from '../../../.dumi/theme/common/SemanticPreview';
+
+const { Sider } = Layout;
+
+const locales = {
+  cn: {
+    body: '内部内容容器',
+  },
+  en: {
+    body: 'Inner content wrapper',
+  },
+};
+
+const SiderBlock: React.FC<React.ComponentProps<typeof Sider>> = (props) => (
+  <Layout style={{ width: '100%', height: 240 }}>
+    <Sider {...props}>Sider</Sider>
+    <Layout.Content style={{ padding: 24 }}>Content</Layout.Content>
+  </Layout>
+);
+
+const App: React.FC = () => {
+  const [locale] = useLocale(locales);
+
+  return (
+    <SemanticPreview
+      componentName="Layout.Sider"
+      height={240}
+      semantics={[{ name: 'body', desc: locale.body, version: '6.5.0' }]}
+    >
+      <SiderBlock />
+    </SemanticPreview>
+  );
+};
+
+export default App;

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -100,23 +100,24 @@ The wrapper.
 
 The sidebar.
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| breakpoint | [Breakpoints](/components/grid/#col) of the responsive layout | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` \| `xxxl` | - | xxxl: 6.3.0 |
-| className | Container className | string | - |  |
-| collapsed | To set the current status | boolean | - |  |
-| collapsedWidth | Width of the collapsed sidebar, by setting to 0 a special trigger will appear | number | 80 |  |
-| collapsible | Whether can be collapsed | boolean | false |  |
-| defaultCollapsed | To set the initial status | boolean | false |  |
-| bodyStyle | To customize the styles of the inner content wrapper | CSSProperties | - |  |
-| reverseArrow | Reverse direction of arrow, for a sider that expands from the right | boolean | false |  |
-| style | To customize the styles | CSSProperties | - |  |
-| theme | Color theme of the sidebar | `light` \| `dark` | `dark` |  |
-| trigger | Specify the customized trigger, set to null to hide the trigger | ReactNode | - |  |
-| width | Width of the sidebar | number \| string | 200 |  |
-| zeroWidthTriggerStyle | To customize the styles of the special trigger that appears when `collapsedWidth` is 0 | object | - |  |
-| onBreakpoint | The callback function, executed when [breakpoints](/components/grid/#api) changed | (broken) => {} | - |  |
-| onCollapse | The callback function, executed by clicking the trigger or activating the responsive layout | (collapsed, type) => {} | - |  |
+| Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| breakpoint | [Breakpoints](/components/grid/#col) of the responsive layout | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` \| `xxxl` | - | xxxl: 6.3.0 | × |
+| className | Container className | string | - |  | × |
+| classNames | Semantic DOM className | [`Record<body, string>`](#semantic-dom) | - | 6.5.0 | × |
+| collapsed | To set the current status | boolean | - |  | × |
+| collapsedWidth | Width of the collapsed sidebar, by setting to 0 a special trigger will appear | number | 80 |  | × |
+| collapsible | Whether can be collapsed | boolean | false |  | × |
+| defaultCollapsed | To set the initial status | boolean | false |  | × |
+| reverseArrow | Reverse direction of arrow, for a sider that expands from the right | boolean | false |  | × |
+| style | To customize the styles | CSSProperties | - |  | × |
+| styles | Semantic DOM style | [`Record<body, CSSProperties>`](#semantic-dom) | - | 6.5.0 | × |
+| theme | Color theme of the sidebar | `light` \| `dark` | `dark` |  | × |
+| trigger | Specify the customized trigger, set to null to hide the trigger | ReactNode | - |  | × |
+| width | Width of the sidebar | number \| string | 200 |  | × |
+| zeroWidthTriggerStyle | To customize the styles of the special trigger that appears when `collapsedWidth` is 0 | object | - |  | × |
+| onBreakpoint | The callback function, executed when [breakpoints](/components/grid/#api) changed | (broken) => {} | - |  | × |
+| onCollapse | The callback function, executed by clicking the trigger or activating the responsive layout | (collapsed, type) => {} | - |  | × |
 
 #### breakpoint width
 
@@ -131,6 +132,10 @@ The sidebar.
   xxxl: '1920px',
 }
 ```
+
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
 
 ## Design Token
 

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -116,20 +116,7 @@ The sidebar.
 | zeroWidthTriggerStyle | To customize the styles of the special trigger that appears when `collapsedWidth` is 0 | object | - |  | × |
 | onBreakpoint | The callback function, executed when [breakpoints](/components/grid/#api) changed | (broken) => {} | - |  | × |
 | onCollapse | The callback function, executed by clicking the trigger or activating the responsive layout | (collapsed, type) => {} | - |  | × |
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| breakpoint | [Breakpoints](/components/grid/#col) of the responsive layout | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` \| `xxxl` | - | xxxl: 6.3.0 |
-| collapsed | To set the current status | boolean | - |  |
-| collapsedWidth | Width of the collapsed sidebar, by setting to 0 a special trigger will appear | number | 80 |  |
-| collapsible | Whether can be collapsed | boolean | false |  |
-| defaultCollapsed | To set the initial status | boolean | false |  |
-| reverseArrow | Reverse direction of arrow, for a sider that expands from the right | boolean | false |  |
-| theme | Color theme of the sidebar | `light` \| `dark` | `dark` |  |
-| trigger | Specify the customized trigger, set to null to hide the trigger | ReactNode | - |  |
-| width | Width of the sidebar | number \| string | 200 |  |
-| zeroWidthTriggerStyle | To customize the styles of the special trigger that appears when `collapsedWidth` is 0 | object | - |  |
-| onBreakpoint | The callback function, executed when [breakpoints](/components/grid/#api) changed | (broken) => {} | - |  |
-| onCollapse | The callback function, executed by clicking the trigger or activating the responsive layout | (collapsed, type) => {} | - |  |
+
 
 #### breakpoint width
 

--- a/components/layout/index.en-US.md
+++ b/components/layout/index.en-US.md
@@ -108,6 +108,7 @@ The sidebar.
 | collapsedWidth | Width of the collapsed sidebar, by setting to 0 a special trigger will appear | number | 80 |  |
 | collapsible | Whether can be collapsed | boolean | false |  |
 | defaultCollapsed | To set the initial status | boolean | false |  |
+| bodyStyle | To customize the styles of the inner content wrapper | CSSProperties | - |  |
 | reverseArrow | Reverse direction of arrow, for a sider that expands from the right | boolean | false |  |
 | style | To customize the styles | CSSProperties | - |  |
 | theme | Color theme of the sidebar | `light` \| `dark` | `dark` |  |

--- a/components/layout/index.zh-CN.md
+++ b/components/layout/index.zh-CN.md
@@ -109,6 +109,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HdS6Q5vUCDcAAA
 | collapsedWidth | 收缩宽度，设置为 0 会出现特殊 trigger | number | 80 |  |
 | collapsible | 是否可收起 | boolean | false |  |
 | defaultCollapsed | 是否默认收起 | boolean | false |  |
+| bodyStyle | 指定内部内容容器的样式 | CSSProperties | - |  |
 | reverseArrow | 翻转折叠提示箭头的方向，当 Sider 在右边时可以使用 | boolean | false |  |
 | style | 指定样式 | CSSProperties | - |  |
 | theme | 主题颜色 | `light` \| `dark` | `dark` |  |

--- a/components/layout/index.zh-CN.md
+++ b/components/layout/index.zh-CN.md
@@ -105,13 +105,14 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HdS6Q5vUCDcAAA
 | --- | --- | --- | --- | --- |
 | breakpoint | 触发响应式布局的[断点](/components/grid-cn#col) | `xs` \| `sm` \| `md` \| `lg` \| `xl` \| `xxl` \| `xxxl` | - | xxxl: 6.3.0 |
 | className | 容器 className | string | - |  |
+| classNames | 语义化结构 className | [`Record<body, string>`](#semantic-dom) | - | 6.5.0 |
 | collapsed | 当前收起状态 | boolean | - |  |
 | collapsedWidth | 收缩宽度，设置为 0 会出现特殊 trigger | number | 80 |  |
 | collapsible | 是否可收起 | boolean | false |  |
 | defaultCollapsed | 是否默认收起 | boolean | false |  |
-| bodyStyle | 指定内部内容容器的样式 | CSSProperties | - |  |
 | reverseArrow | 翻转折叠提示箭头的方向，当 Sider 在右边时可以使用 | boolean | false |  |
 | style | 指定样式 | CSSProperties | - |  |
+| styles | 语义化结构 style | [`Record<body, CSSProperties>`](#semantic-dom) | - | 6.5.0 |
 | theme | 主题颜色 | `light` \| `dark` | `dark` |  |
 | trigger | 自定义 trigger，设置为 null 时隐藏 trigger | ReactNode | - |  |
 | width | 宽度 | number \| string | 200 |  |
@@ -132,6 +133,10 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HdS6Q5vUCDcAAA
   xxxl: '1920px',
 }
 ```
+
+## Semantic DOM
+
+<code src="./demo/_semantic.tsx" simplify="true"></code>
 
 ## 主题变量（Design Token）{#design-token}
 


### PR DESCRIPTION
Closes #13527\n\n/claim #13527\n\nAdds a bodyStyle prop to Layout.Sider so the inner wrapper can be styled directly, which makes flexbox layouts work without an extra wrapper div.\n\nValidation: bun run version; bun x jest --config .jest.js --runInBand components/layout/__tests__/index.test.tsx --no-cache; bun x biome check components/layout/Sider.tsx components/layout/__tests__/index.test.tsx components/layout/index.en-US.md components/layout/index.zh-CN.md; bun x prettier -c components/layout/index.en-US.md components/layout/index.zh-CN.md