### PR TITLE
docs(Modal): replace deprecated Tabs.TabPane with items in dark demo

### DIFF
--- a/components/modal/demo/dark.tsx
+++ b/components/modal/demo/dark.tsx
@@ -29,7 +29,6 @@ dayjs.extend(customParseFormat);
 
 const { Panel } = Collapse;
 const { TreeNode } = Tree;
-const { TabPane } = Tabs;
 const { Meta } = Card;
 const { Link } = Anchor;
 const { Text } = Typography;
@@ -430,17 +429,14 @@ const Demo: React.FC = () => {
             <Link href="#Link-Props" title="Link Props" />
           </Link>
         </Anchor>
-        <Tabs type="card">
-          <TabPane tab="Tab 1" key="1">
-            Content of Tab Pane 1
-          </TabPane>
-          <TabPane tab="Tab 2" key="2">
-            Content of Tab Pane 2
-          </TabPane>
-          <TabPane tab="Tab 3" key="3">
-            Content of Tab Pane 3
-          </TabPane>
-        </Tabs>
+        <Tabs
+          type="card"
+          items={[
+            { key: '1', label: 'Tab 1', children: 'Content of Tab Pane 1' },
+            { key: '2', label: 'Tab 2', children: 'Content of Tab Pane 2' },
+            { key: '3', label: 'Tab 3', children: 'Content of Tab Pane 3' },
+          ]}
+        />
         <Timeline>
           <Timeline.Item>Create a services site 2015-09-01</Timeline.Item>
           <Timeline.Item>Solve initial network problems 2015-09-01</Timeline.Item>


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> N/A

### 💡 Background and Solution

The Modal `dark` demo (`components/modal/demo/dark.tsx`) still used the deprecated `Tabs.TabPane` child API (`const { TabPane } = Tabs;` plus `<TabPane tab=... key=...>` children). `Tabs.TabPane` has been deprecated for a long time in favor of the `items` prop, and using it triggers a deprecation warning in the console.

This PR converts the `Tabs` usage in this demo to the modern `items` prop and removes the now-unused `TabPane` destructure. The rendered output (three card-type tabs with the same labels and content) is unchanged.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Replace deprecated `Tabs.TabPane` with the `items` prop in the Modal dark demo. |
| 🇨🇳 Chinese | 将 Modal 暗色 demo 中已废弃的 `Tabs.TabPane` 替换为 `items` 属性。 |