### PR TITLE
docs(Collapse): fix grammar in expandIcon description

### DIFF
--- a/components/collapse/index.en-US.md
+++ b/components/collapse/index.en-US.md
@@ -44,7 +44,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | defaultActiveKey | Key of the initial active panel | string\[] \| string <br/> number\[] \| number | - |  |
 | ~~destroyInactivePanel~~ | Destroy Inactive Panel | boolean | false |  |
 | destroyOnHidden | Destroy Inactive Panel | boolean | false | 5.25.0 |
-| expandIcon | Allow to customize collapse icon | (panelProps) => ReactNode | - |  |
+| expandIcon | Customize the collapse expand icon | (panelProps) => ReactNode | - |  |
 | expandIconPlacement | Set expand icon placement | `start` \| `end` | `start` | - |
 | ~~expandIconPosition~~ | Set expand icon position, Please use `expandIconPlacement` instead | `start` \| `end` | - | 4.21.0 |
 | ghost | Make the collapse borderless and its background transparent | boolean | false | 4.4.0 |


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> Documentation grammar fix, no related issue.

### 💡 Background and Solution

The English API table for `Collapse` described the `expandIcon` prop as **"Allow to customize collapse icon"**, which is grammatically incorrect ("Allow to" needs an object such as "Allow you to ...").

This PR rewrites it to **"Customize the collapse expand icon"**, matching the phrasing already used by other components for the same prop (e.g. `Cascader`: "Customize the current item expand icon", `Table`: "Customize row expand Icon") and aligning with the Chinese doc ("自定义切换图标").

Only the English `components/collapse/index.en-US.md` prose is touched; no code, types, or behavior change.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | No changelog required |
| 🇨🇳 Chinese | 无需更新日志 |
