### PR TITLE
feat(locale): add missing QRCode and ColorPicker translations to pt_BR

### DIFF
--- a/components/locale/pt_BR.ts
+++ b/components/locale/pt_BR.ts
@@ -133,6 +133,17 @@ const localeValues: Locale = {
       },
     },
   },
+  QRCode: {
+    expired: 'Código QR expirado',
+    refresh: 'Atualizar',
+    scanned: 'Escaneado',
+  },
+  ColorPicker: {
+    presetEmpty: 'Vazio',
+    transparent: 'Transparente',
+    singleColor: 'Único',
+    gradientColor: 'Gradiente',
+  },
 };
 
 export default localeValues;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [x] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> N/A — proactive locale backfill.

The Brazilian Portuguese locale (`pt_BR`) was missing the `QRCode` and `ColorPicker` blocks that `en_US` (and the European Portuguese `pt_PT`) already provide. As a result, Brazilian Portuguese users see English fallback strings in the QRCode and ColorPicker components.

### 💡 Background and Solution

`components/locale/en_US.ts` defines `QRCode` and `ColorPicker` translation blocks. Several locales have already been backfilled with these blocks (e.g. `pt_PT`, `it_IT`, `zh_HK`/`zh_TW`), but `pt_BR` was never updated.

This PR adds native Brazilian Portuguese strings, additively (no existing keys renamed or removed), matching the key order in `en_US.ts`. Wording follows the existing European Portuguese (`pt_PT`) translations, adapted to Brazilian usage where it differs (e.g. `scanned` → `Escaneado` rather than the European `Digitalizado`).

```ts
QRCode: {
  expired: 'Código QR expirado',
  refresh: 'Atualizar',
  scanned: 'Escaneado',
},
ColorPicker: {
  presetEmpty: 'Vazio',
  transparent: 'Transparente',
  singleColor: 'Único',
  gradientColor: 'Gradiente',
},
```

This follows the same shape as previously merged locale-backfill PRs, e.g. #54842 (Italian QRCode & ColorPicker) and #53440 (zh_HK/zh_TW ColorPicker).

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🇧🇷 Add missing Brazilian Portuguese (pt_BR) translations for QRCode and ColorPicker. |
| 🇨🇳 Chinese | 🇧🇷 补充 QRCode 与 ColorPicker 组件缺失的巴西葡萄牙语（pt_BR）国际化文案。 |
