### PR TITLE
docs(Tree): add missing className, motion and style props to zh-CN API table

### DIFF
--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -51,6 +51,7 @@ demo:
 | checkable | 节点前添加 Checkbox 复选框 | boolean | false |  |
 | checkedKeys | （受控）选中复选框的树节点（注意：父子节点有关联，如果传入父节点 key，则子节点自动选中；相应当子节点 key 都传入，父节点也自动选中。当设置 `checkable` 和 `checkStrictly`，它是一个有`checked`和`halfChecked`属性的对象，并且父子节点的选中与否不再关联 | string\[] \| {checked: string\[], halfChecked: string\[]} | \[] |  |
 | checkStrictly | checkable 状态下节点选择完全受控（父子节点选中状态不再关联） | boolean | false |  |
+| className | 添加在 Tree 上的额外 class | string | - |  |
 | classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | |
 | defaultCheckedKeys | 默认选中复选框的树节点 | string\[] | \[] |  |
 | defaultExpandAll | 默认展开所有树节点 | boolean | false |  |
@@ -66,12 +67,14 @@ demo:
 | icon | 在标题之前插入自定义图标。需要设置 `showIcon` 为 true | ReactNode \| (props) => ReactNode | - |  |
 | loadData | 异步加载数据 | function(node) | - |  |
 | loadedKeys | （受控）已经加载的节点，需要配合 `loadData` 使用 | string\[] | \[] |  |
+| motion | 自定义树的动画配置 | CSSMotionProps | - |  |
 | multiple | 支持点选多个节点（节点本身） | boolean | false |  |
 | rootStyle | 添加在 Tree 最外层的 style | CSSProperties | - | 4.20.0 |
 | selectable | 是否可选中 | boolean | true |  |
 | selectedKeys | （受控）设置选中的树节点，多选需设置 `multiple` 为 true | string\[] | - |  |
 | showIcon | 控制是否展示 `icon` 节点，没有默认样式 | boolean | false |  |
 | showLine | 是否展示连接线 | boolean \| { showLeafIcon: ReactNode \| ((props: AntTreeNodeProps) => ReactNode) } | false |  |
+| style | Tree 组件的样式 | CSSProperties | - |  |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | |
 | switcherIcon | 自定义树节点的展开/折叠图标（`showLine` 下不会自动 rotate） | ReactNode \| ((props: AntTreeNodeProps) => ReactNode) | - | renderProps: 4.20.0 |
 | switcherLoadingIcon | 自定义树节点的加载图标 | ReactNode | - | 5.20.0 |


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> N/A — EN ↔ CN documentation parity fix.

### 💡 Background and Solution

The English Tree API table (`components/tree/index.en-US.md`) documents the `className`, `motion`, and `style` props, but these three rows are missing from the Chinese API table (`components/tree/index.zh-CN.md`).

This PR mirrors the three rows into the zh-CN table, keeping them in the same alphabetical positions as the EN table:

- `className` — added in `Tree` 上的额外 class (`string`)
- `motion` — 自定义树的动画配置 (`CSSMotionProps`)
- `style` — Tree 组件的样式 (`CSSProperties`)

All three props exist in the component source (`motion` is wired through `Tree.tsx`; `className`/`style` are standard pass-through props), and the descriptions/types match their EN counterparts. No code, types, demos, locale, or styles are touched — docs only.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add missing `className`, `motion` and `style` props to Tree zh-CN API table to match the en-US docs. |
| 🇨🇳 Chinese | 补充 Tree 组件中文 API 表格中缺失的 `className`、`motion` 和 `style` 属性，使其与英文文档保持一致。 |
