### PR TITLE
type(Descriptions): support native HTML attributes on root element

### DIFF
--- a/components/descriptions/__tests__/type.test.tsx
+++ b/components/descriptions/__tests__/type.test.tsx
@@ -166,6 +166,35 @@ describe('Descriptions.Item span property types', () => {
     expect(items[3]).toHaveAttribute('colSpan', '3'); // 填充第二行剩余的列
   });
 
+  // 测试原生 HTML 属性的类型支持与透传
+  it('should accept and forward native HTML attributes to the root element', () => {
+    const handleClick = jest.fn();
+    const { container } = render(
+      <Descriptions
+        id="custom-id"
+        lang="en"
+        role="group"
+        data-testid="custom-descriptions"
+        aria-label="info"
+        tabIndex={0}
+        onClick={handleClick}
+        items={[{ key: '1', label: 'Label', children: 'Content' }]}
+      />,
+    );
+
+    const root = container.querySelector<HTMLDivElement>('.ant-descriptions');
+    expect(root).not.toBeNull();
+    expect(root).toHaveAttribute('id', 'custom-id');
+    expect(root).toHaveAttribute('lang', 'en');
+    expect(root).toHaveAttribute('role', 'group');
+    expect(root).toHaveAttribute('data-testid', 'custom-descriptions');
+    expect(root).toHaveAttribute('aria-label', 'info');
+    expect(root).toHaveAttribute('tabIndex', '0');
+
+    root!.click();
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
   // 测试所有响应式断点
   it('should support all responsive breakpoints', () => {
     const { container } = render(

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -60,11 +60,9 @@ export type DescriptionsSemanticAllType = GenerateSemantic<
   DescriptionsProps
 >;
 
-export interface DescriptionsProps {
+export interface DescriptionsProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
   prefixCls?: string;
-  className?: string;
   rootClassName?: string;
-  style?: React.CSSProperties;
   bordered?: boolean;
   /**
    * Note: `default` is deprecated and will be removed in v7, please use `medium` instead.
@@ -90,7 +88,6 @@ export interface DescriptionsProps {
   classNames?: DescriptionsSemanticAllType['classNamesAndFn'];
   styles?: DescriptionsSemanticAllType['stylesAndFn'];
   items?: DescriptionsItemType[];
-  id?: string;
 }
 
 const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) => {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - close #50599

### 💡 Background and Solution

**Problem**

`<Descriptions>` forwards every unrecognized prop to its root `<div>` via `{...restProps}`, but `DescriptionsProps` only declared a hand-picked `id?: string` (added in #46367) instead of the full set of native HTML attributes. As a result, valid attributes such as `lang`, `role`, `tabIndex`, `data-*`, `aria-*`, and DOM event handlers were forwarded correctly at runtime yet rejected by TypeScript:

```tsx
// Property 'lang' does not exist on type ... ts(2322)
<Descriptions lang="en" role="group" data-id="abc" />
```

**Solution**

`DescriptionsProps` now extends `React.HTMLAttributes<HTMLDivElement>`, with `title` omitted so it keeps its existing `React.ReactNode` type (the inherited `title` is `string`, which would otherwise conflict — see #17559). The redundant `id?: string`, `className?: string`, and `style?: React.CSSProperties` declarations are removed because they are now provided by `HTMLAttributes` with identical types.

This is a type-only change — no runtime behavior is modified. A test was added asserting that native HTML attributes are accepted by the type and forwarded to the root element.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🤖 Improve Descriptions type definition to support native HTML attributes (e.g. `lang`, `role`, `data-*`, `aria-*`) on the root element. |
| 🇨🇳 Chinese | 🤖 完善 Descriptions 类型定义，根元素支持原生 HTML 属性（如 `lang`、`role`、`data-*`、`aria-*`）。 |
