### PR TITLE
fix: correct Space.Compact first/last class when child renders nul

### DIFF
--- a/components/input/__tests__/__snapshots__/Search.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/Search.test.tsx.snap
@@ -223,6 +223,7 @@ exports[`Input.Search should support addonAfter and suffix for loading 1`] = `
       </span>
     </span>
   </button>
+  addonAfter
 </div>
 `;
 
@@ -272,6 +273,7 @@ exports[`Input.Search should support addonAfter and suffix for loading 2`] = `
       </span>
     </span>
   </button>
+  addonAfter
 </div>
 `;
 

--- a/components/input/__tests__/__snapshots__/Search.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/Search.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`Input.Search should support addonAfter 1`] = `
     value=""
   />
   <button
-    class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-input-search-btn"
+    class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-last-item ant-input-search-btn"
     type="button"
   >
     <span
@@ -144,7 +144,7 @@ exports[`Input.Search should support addonAfter 2`] = `
     value=""
   />
   <button
-    class="ant-btn css-var-root ant-btn-default ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item ant-input-search-btn"
+    class="ant-btn css-var-root ant-btn-default ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item ant-btn-compact-last-item ant-input-search-btn"
     type="button"
   >
     <span
@@ -196,7 +196,7 @@ exports[`Input.Search should support addonAfter and suffix for loading 1`] = `
     </span>
   </span>
   <button
-    class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-loading ant-btn-compact-item ant-input-search-btn"
+    class="ant-btn css-var-root ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-loading ant-btn-compact-item ant-btn-compact-last-item ant-input-search-btn"
     type="button"
   >
     <span
@@ -223,7 +223,6 @@ exports[`Input.Search should support addonAfter and suffix for loading 1`] = `
       </span>
     </span>
   </button>
-  addonAfter
 </div>
 `;
 
@@ -246,7 +245,7 @@ exports[`Input.Search should support addonAfter and suffix for loading 2`] = `
     </span>
   </span>
   <button
-    class="ant-btn css-var-root ant-btn-default ant-btn-color-primary ant-btn-variant-solid ant-btn-loading ant-btn-compact-item ant-input-search-btn"
+    class="ant-btn css-var-root ant-btn-default ant-btn-color-primary ant-btn-variant-solid ant-btn-loading ant-btn-compact-item ant-btn-compact-last-item ant-input-search-btn"
     type="button"
   >
     <span
@@ -273,7 +272,6 @@ exports[`Input.Search should support addonAfter and suffix for loading 2`] = `
       </span>
     </span>
   </button>
-  addonAfter
 </div>
 `;
 
@@ -302,7 +300,7 @@ exports[`Input.Search should support custom button 1`] = `
   class="ant-space-compact ant-input-search css-var-root ant-input-search-with-button"
 >
   <input
-    class="ant-input ant-input-outlined css-var-root ant-input-css-var ant-input-compact-item ant-input-compact-first-item"
+    class="ant-input ant-input-outlined css-var-root ant-input-css-var ant-input-compact-item ant-input-compact-first-item ant-input-compact-last-item"
     type="search"
     value=""
   />

--- a/components/space/Compact.tsx
+++ b/components/space/Compact.tsx
@@ -141,8 +141,22 @@ const Compact: React.FC<SpaceCompactProps> = (props) => {
 
   const compactItemContext = React.useContext(SpaceCompactItemContext);
 
-  const childNodes = toArray(children).filter(React.isValidElement);
+  const childNodes = toArray(children);
   const [registeredItemKeys, setRegisteredItemKeys] = React.useState<React.Key[]>([]);
+  const registeredItemKeySet = React.useMemo(
+    () => new Set(registeredItemKeys),
+    [registeredItemKeys],
+  );
+
+  const childKeys = React.useMemo(
+    () => childNodes.map((child, index) => child?.key ?? `${prefixCls}-item-${index}`),
+    [childNodes, prefixCls],
+  );
+
+  const activeKeys = React.useMemo(
+    () => childKeys.filter((key) => registeredItemKeySet.has(key)),
+    [childKeys, registeredItemKeySet],
+  );
 
   const registerItem = React.useCallback((itemKey: React.Key) => {
     setRegisteredItemKeys((prevKeys) => {
@@ -157,13 +171,13 @@ const Compact: React.FC<SpaceCompactProps> = (props) => {
     setRegisteredItemKeys((prevKeys) => prevKeys.filter((key) => key !== itemKey));
   }, []);
 
-  const firstItemKey = registeredItemKeys[0];
-  const lastItemKey = registeredItemKeys[registeredItemKeys.length - 1];
+  const firstItemKey = activeKeys[0];
+  const lastItemKey = activeKeys[activeKeys.length - 1];
 
   const nodes = React.useMemo(
     () =>
       childNodes.map((child, i) => {
-        const key = child?.key ?? `${prefixCls}-item-${i}`;
+        const key = childKeys[i];
         const isFirstItem = firstItemKey !== undefined ? key === firstItemKey : i === 0;
         const isLastItem =
           lastItemKey !== undefined ? key === lastItemKey : i === childNodes.length - 1;
@@ -185,6 +199,7 @@ const Compact: React.FC<SpaceCompactProps> = (props) => {
       }),
     [
       childNodes,
+      childKeys,
       compactItemContext,
       deregisterItem,
       firstItemKey,

--- a/components/space/Compact.tsx
+++ b/components/space/Compact.tsx
@@ -140,6 +140,23 @@ const Compact: React.FC<SpaceCompactProps> = (props) => {
   );
 
   const compactItemContext = React.useContext(SpaceCompactItemContext);
+  const {
+    compactItemKey,
+    deregisterItem: deregisterCompactItem,
+    registerItem: registerCompactItem,
+  } = compactItemContext || {};
+
+  React.useEffect(() => {
+    if (compactItemKey === undefined || !registerCompactItem || !deregisterCompactItem) {
+      return;
+    }
+
+    registerCompactItem(compactItemKey);
+
+    return () => {
+      deregisterCompactItem(compactItemKey);
+    };
+  }, [compactItemKey, deregisterCompactItem, registerCompactItem]);
 
   const childNodes = toArray(children);
   const [registeredItemKeys, setRegisteredItemKeys] = React.useState<React.Key[]>([]);

--- a/components/space/Compact.tsx
+++ b/components/space/Compact.tsx
@@ -16,6 +16,9 @@ export interface SpaceCompactItemContextType {
   compactDirection?: 'horizontal' | 'vertical';
   isFirstItem?: boolean;
   isLastItem?: boolean;
+  compactItemKey?: React.Key;
+  registerItem?: (key: React.Key) => void;
+  deregisterItem?: (key: React.Key) => void;
 }
 
 export const SpaceCompactItemContext = React.createContext<SpaceCompactItemContextType | null>(
@@ -25,11 +28,33 @@ export const SpaceCompactItemContext = React.createContext<SpaceCompactItemConte
 export const useCompactItemContext = (prefixCls: string, direction: DirectionType) => {
   const compactItemContext = React.useContext(SpaceCompactItemContext);
 
+  const {
+    compactDirection,
+    compactItemKey,
+    compactSize,
+    deregisterItem,
+    isFirstItem,
+    isLastItem,
+    registerItem,
+  } = compactItemContext || {};
+
+  React.useEffect(() => {
+    if (compactItemKey === undefined || !registerItem || !deregisterItem) {
+      return;
+    }
+
+    registerItem(compactItemKey);
+
+    return () => {
+      deregisterItem(compactItemKey);
+    };
+  }, [compactItemKey, deregisterItem, registerItem]);
+
   const compactItemClassnames = React.useMemo<string>(() => {
     if (!compactItemContext) {
       return '';
     }
-    const { compactDirection, isFirstItem, isLastItem } = compactItemContext;
+
     const separator = compactDirection === 'vertical' ? '-vertical-' : '-';
 
     return clsx(`${prefixCls}-compact${separator}item`, {
@@ -37,11 +62,11 @@ export const useCompactItemContext = (prefixCls: string, direction: DirectionTyp
       [`${prefixCls}-compact${separator}last-item`]: isLastItem,
       [`${prefixCls}-compact${separator}item-rtl`]: direction === 'rtl',
     });
-  }, [prefixCls, direction, compactItemContext]);
+  }, [compactDirection, compactItemContext, direction, isFirstItem, isLastItem, prefixCls]);
 
   return {
-    compactSize: compactItemContext?.compactSize,
-    compactDirection: compactItemContext?.compactDirection,
+    compactSize,
+    compactDirection,
     compactItemClassnames,
   };
 };
@@ -116,27 +141,59 @@ const Compact: React.FC<SpaceCompactProps> = (props) => {
 
   const compactItemContext = React.useContext(SpaceCompactItemContext);
 
-  const childNodes = toArray(children);
+  const childNodes = toArray(children).filter(React.isValidElement);
+  const [registeredItemKeys, setRegisteredItemKeys] = React.useState<React.Key[]>([]);
+
+  const registerItem = React.useCallback((itemKey: React.Key) => {
+    setRegisteredItemKeys((prevKeys) => {
+      if (prevKeys.includes(itemKey)) {
+        return prevKeys;
+      }
+      return [...prevKeys, itemKey];
+    });
+  }, []);
+
+  const deregisterItem = React.useCallback((itemKey: React.Key) => {
+    setRegisteredItemKeys((prevKeys) => prevKeys.filter((key) => key !== itemKey));
+  }, []);
+
+  const firstItemKey = registeredItemKeys[0];
+  const lastItemKey = registeredItemKeys[registeredItemKeys.length - 1];
 
   const nodes = React.useMemo(
     () =>
       childNodes.map((child, i) => {
-        const key = child?.key || `${prefixCls}-item-${i}`;
+        const key = child?.key ?? `${prefixCls}-item-${i}`;
+        const isFirstItem = firstItemKey !== undefined ? key === firstItemKey : i === 0;
+        const isLastItem =
+          lastItemKey !== undefined ? key === lastItemKey : i === childNodes.length - 1;
+
         return (
           <CompactItem
             key={key}
             compactSize={mergedSize}
             compactDirection={mergedOrientation}
-            isFirstItem={i === 0 && (!compactItemContext || compactItemContext?.isFirstItem)}
-            isLastItem={
-              i === childNodes.length - 1 && (!compactItemContext || compactItemContext?.isLastItem)
-            }
+            isFirstItem={isFirstItem && (!compactItemContext || compactItemContext?.isFirstItem)}
+            isLastItem={isLastItem && (!compactItemContext || compactItemContext?.isLastItem)}
+            compactItemKey={key}
+            registerItem={registerItem}
+            deregisterItem={deregisterItem}
           >
             {child}
           </CompactItem>
         );
       }),
-    [childNodes, compactItemContext, mergedOrientation, mergedSize, prefixCls],
+    [
+      childNodes,
+      compactItemContext,
+      deregisterItem,
+      firstItemKey,
+      lastItemKey,
+      mergedOrientation,
+      mergedSize,
+      prefixCls,
+      registerItem,
+    ],
   );
 
   // =========================== Render ===========================

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -13989,7 +13989,7 @@ exports[`renders components/space/demo/compact-nested.tsx extend context correct
         class="ant-space-compact"
       >
         <input
-          class="ant-input ant-input-outlined css-var-test-id ant-input-css-var ant-input-compact-item ant-input-compact-first-item"
+          class="ant-input ant-input-outlined css-var-test-id ant-input-css-var ant-input-compact-item"
           placeholder="Typing..."
           style="width: 90px;"
           type="text"
@@ -14225,7 +14225,7 @@ exports[`renders components/space/demo/compact-nested.tsx extend context correct
       </div>
     </div>
     <button
-      class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item"
+      class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item"
       type="button"
     >
       <span>
@@ -14295,7 +14295,7 @@ exports[`renders components/space/demo/compact-nested.tsx extend context correct
           value="mysite"
         />
         <button
-          class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-last-item"
+          class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item"
           type="button"
         >
           <span
@@ -14332,7 +14332,7 @@ exports[`renders components/space/demo/compact-nested.tsx extend context correct
       class="ant-space-compact"
     >
       <div
-        class="ant-picker ant-picker-outlined ant-picker-compact-item ant-picker-compact-first-item css-var-test-id ant-picker-css-var"
+        class="ant-picker ant-picker-outlined ant-picker-compact-item css-var-test-id ant-picker-css-var"
       >
         <div
           class="ant-picker-input"
@@ -15899,7 +15899,7 @@ exports[`renders components/space/demo/compact-nested.tsx extend context correct
       </button>
     </div>
     <button
-      class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item"
+      class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item ant-btn-compact-first-item"
       type="button"
     >
       <span>
@@ -15907,7 +15907,7 @@ exports[`renders components/space/demo/compact-nested.tsx extend context correct
       </span>
     </button>
     <button
-      class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item"
+      class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item ant-btn-compact-last-item"
       type="button"
     >
       <span>
@@ -16055,7 +16055,7 @@ exports[`renders components/space/demo/compact-nested.tsx extend context correct
         </div>
       </div>
       <button
-        class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item ant-btn-compact-last-item"
+        class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item"
         type="button"
       >
         <span>

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -13989,7 +13989,7 @@ exports[`renders components/space/demo/compact-nested.tsx extend context correct
         class="ant-space-compact"
       >
         <input
-          class="ant-input ant-input-outlined css-var-test-id ant-input-css-var ant-input-compact-item"
+          class="ant-input ant-input-outlined css-var-test-id ant-input-css-var ant-input-compact-item ant-input-compact-first-item"
           placeholder="Typing..."
           style="width: 90px;"
           type="text"
@@ -14225,7 +14225,7 @@ exports[`renders components/space/demo/compact-nested.tsx extend context correct
       </div>
     </div>
     <button
-      class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item"
+      class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item"
       type="button"
     >
       <span>
@@ -14295,7 +14295,7 @@ exports[`renders components/space/demo/compact-nested.tsx extend context correct
           value="mysite"
         />
         <button
-          class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item"
+          class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-last-item"
           type="button"
         >
           <span
@@ -14332,7 +14332,7 @@ exports[`renders components/space/demo/compact-nested.tsx extend context correct
       class="ant-space-compact"
     >
       <div
-        class="ant-picker ant-picker-outlined ant-picker-compact-item css-var-test-id ant-picker-css-var"
+        class="ant-picker ant-picker-outlined ant-picker-compact-item ant-picker-compact-first-item css-var-test-id ant-picker-css-var"
       >
         <div
           class="ant-picker-input"
@@ -15899,7 +15899,7 @@ exports[`renders components/space/demo/compact-nested.tsx extend context correct
       </button>
     </div>
     <button
-      class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item ant-btn-compact-first-item"
+      class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item"
       type="button"
     >
       <span>
@@ -15907,7 +15907,7 @@ exports[`renders components/space/demo/compact-nested.tsx extend context correct
       </span>
     </button>
     <button
-      class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item ant-btn-compact-last-item"
+      class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item"
       type="button"
     >
       <span>
@@ -16055,7 +16055,7 @@ exports[`renders components/space/demo/compact-nested.tsx extend context correct
         </div>
       </div>
       <button
-        class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item"
+        class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-compact-item ant-btn-compact-last-item"
         type="button"
       >
         <span>

--- a/components/space/__tests__/space-compact.test.tsx
+++ b/components/space/__tests__/space-compact.test.tsx
@@ -83,6 +83,41 @@ describe('Space.Compact', () => {
     expect(container.querySelector('.test-single-button')).toHaveClass('ant-btn-compact-last-item');
   });
 
+  it('should include nested Compact in outer first and last calculation', () => {
+    const { container } = render(
+      <Space.Compact>
+        <Space.Compact>
+          <Input className="test-nested-left-input" />
+          <Button className="test-nested-left-button">Left</Button>
+        </Space.Compact>
+        <Button className="test-nested-middle-button">Middle</Button>
+        <Space.Compact>
+          <Input className="test-nested-right-input" />
+          <Button className="test-nested-right-button">Right</Button>
+        </Space.Compact>
+      </Space.Compact>,
+    );
+
+    expect(container.querySelector('.test-nested-left-input')).toHaveClass(
+      'ant-input-compact-first-item',
+    );
+    expect(container.querySelector('.test-nested-left-button')).not.toHaveClass(
+      'ant-btn-compact-last-item',
+    );
+    expect(container.querySelector('.test-nested-middle-button')).not.toHaveClass(
+      'ant-btn-compact-first-item',
+    );
+    expect(container.querySelector('.test-nested-middle-button')).not.toHaveClass(
+      'ant-btn-compact-last-item',
+    );
+    expect(container.querySelector('.test-nested-right-input')).not.toHaveClass(
+      'ant-input-compact-first-item',
+    );
+    expect(container.querySelector('.test-nested-right-button')).toHaveClass(
+      'ant-btn-compact-last-item',
+    );
+  });
+
   [
     {
       name: 'Button',

--- a/components/space/__tests__/space-compact.test.tsx
+++ b/components/space/__tests__/space-compact.test.tsx
@@ -66,6 +66,23 @@ describe('Space.Compact', () => {
     expect(container.querySelector('.test-button')).toHaveClass('ant-btn-compact-last-item');
   });
 
+  it('should keep first and last class when only one child is actually rendered', () => {
+    const ConditionalButton = ({ visible }: { visible: boolean }) =>
+      visible ? <Button>Conditional</Button> : null;
+
+    const { container } = render(
+      <Space.Compact>
+        <Button className="test-single-button">Always visible</Button>
+        <ConditionalButton visible={false} />
+      </Space.Compact>,
+    );
+
+    expect(container.querySelector('.test-single-button')).toHaveClass(
+      'ant-btn-compact-first-item',
+    );
+    expect(container.querySelector('.test-single-button')).toHaveClass('ant-btn-compact-last-item');
+  });
+
   [
     {
       name: 'Button',


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- fix https://github.com/ant-design/ant-design/issues/58191

### 💡 Background and Solution

Space.Compact previously calculated first and last item classes from children index only.  
When a child component exists in children but returns null internally, the visible item could miss the last-item class, causing incorrect border radius.

This PR updates Compact item boundary calculation to align with actually rendered compact items, so single visible items correctly receive both first-item and last-item classes.  
A regression test is included for the conditional-rendering-null scenario, and related snapshots are updated.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Space.Compact incorrect first/last class assignment when conditional children render null, ensuring single visible items get correct rounded styles. |
| 🇨🇳 Chinese | 🐞 修复 Space.Compact 在条件子项渲染为 null 时首尾样式类计算错误，确保仅有一个可见子项时圆角样式正确。 |