### PR TITLE
fix: respect icons package exports in site build

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -91,8 +91,6 @@ export default defineConfig({
     'antd/es': path.join(__dirname, 'components'),
     'antd/locale': path.join(__dirname, 'components/locale'),
     antd: path.join(__dirname, 'components'),
-    // https://github.com/ant-design/ant-design/issues/46628
-    '@ant-design/icons$': '@ant-design/icons/lib',
   },
   extraRehypePlugins: [rehypeAntd, rehypeChangelog],
   extraRemarkPlugins: [remarkAntd, remarkAnchor],


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [x] 📽️ 演示代码改进

### 🔗 相关 Issue

https://ant.design/components/layout-cn#layout-demo-side

### 💡 需求背景和解决方案

Layout 侧边栏示例中，`icon` 和 `title` 的间距丢失。根因不是 Layout/Menu 组件样式本身，而是站点构建配置里把 `@ant-design/icons` 的 root import 强制 alias 到 `@ant-design/icons/lib`。

这个 alias 会绕过 `@ant-design/icons` package.json 里的 `exports` 条件映射，使站点里一部分 icons 代码走 `lib`，而 Ant Design 内部通过 subpath 解析到的 icons context 在当前构建环境下会走 `es`。两边拿到的 `IconContext` 不是同一个实例后，icons 注入样式时读不到 ConfigProvider 提供的 `layer` 信息，导致 icon 相关样式没有进入预期的 `antd` cascade layer，进而影响 demo 页面里 Tailwind/base reset 与 antd layer 的优先级关系，最终表现为 Layout demo 的 menu icon/title 间距被重置。

`@ant-design/icons` 新版本已经通过 package exports 处理 root import 的 ESM/CJS 兼容，不再需要在 dumi 配置里强制把 `@ant-design/icons` 指到 `lib`。因此这里移除该 alias，让构建工具按 package exports 正常解析，保证 icons root import 与内部 context 使用一致的条件映射。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Layout side demo icon spacing on the website. |
| 🇨🇳 中文 | 修复官网 Layout 侧边栏示例图标与标题间距异常的问题。 |