### PR TITLE
fix: fix Descriptions table width inflated inside max-content Table

### DIFF
--- a/components/descriptions/style/index.ts
+++ b/components/descriptions/style/index.ts
@@ -154,7 +154,13 @@ const genDescriptionStyles: GenerateStyle<DescriptionsToken, CSSObject> = (token
         fontSize: token.fontSize,
       },
       [`${componentCls}-view`]: {
-        width: '100%',
+        // Use `min-width: 100%` together with `width: 0` instead of
+        // `width: 100%` so the view still fills its container in normal layout,
+        // but won't contribute an extreme intrinsic width when nested inside a
+        // `max-content` sized ancestor (e.g. Table with
+        // `scroll={{ x: 'max-content' }}`). See #54268.
+        width: 0,
+        minWidth: '100%',
         borderRadius: token.borderRadiusLG,
         table: {
           width: '100%',


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close #54268

### 💡 Background and Solution

When a `Descriptions` is nested inside a `Table` that uses `scroll={{ x: 'max-content' }}`, the inner Descriptions table is rendered with an extreme width (~500000px), breaking the layout.

**Root cause**: `.ant-descriptions-view table` was styled with `width: 100%` together with `table-layout: fixed`. Inside a `max-content` sized ancestor, the `100%` width has no resolved percentage base, so the browser's `max-content` measurement and the `100%` rule amplify each other and the table width explodes.

**Solution**: change the inner table to `width: auto` + `min-width: 100%`. `min-width: 100%` keeps the table filling its container in normal layout, while `width: auto` prevents it from being inflated under a `max-content` context.

Verified in the browser with a Table + nested Descriptions demo: the inner table width goes from ~500000px down to a normal value, while all other Descriptions instances (including the bordered variant and standalone usage) render identically.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Descriptions table width being inflated to an extreme value when nested inside a Table with `scroll={{ x: 'max-content' }}`. |
| 🇨🇳 Chinese | 修复 Descriptions 嵌套在设置了 `scroll={{ x: 'max-content' }}` 的 Table 内时表格宽度被异常撑大的问题。 |