### PR TITLE
docs: redesign ThemePreview component layout to Bento Grid

### DIFF
--- a/.dumi/pages/index/components/ThemePreview/ComponentsBlock.tsx
+++ b/.dumi/pages/index/components/ThemePreview/ComponentsBlock.tsx
@@ -3,6 +3,8 @@ import { CheckOutlined, CloseOutlined, DownOutlined } from '@ant-design/icons';
 import {
   Alert,
   App,
+  Avatar,
+  Badge,
   Button,
   Checkbox,
   ColorPicker,
@@ -10,15 +12,17 @@ import {
   DatePicker,
   Dropdown,
   Flex,
-  Modal,
+  Input,
   Progress,
   Radio,
+  Rate,
   Segmented,
   Select,
   Slider,
   Space,
-  Steps,
   Switch,
+  Tag,
+  Typography,
 } from 'antd';
 import type { ConfigProviderProps } from 'antd';
 import { createStyles } from 'antd-style';
@@ -26,12 +30,10 @@ import clsx from 'clsx';
 
 import useLocale from '../../../../hooks/useLocale';
 
-const { _InternalPanelDoNotUseOrYouWillBeFired: ModalPanel } = Modal;
-const { Group: RadioButtonGroup, Button: RadioButton } = Radio;
+const { Search } = Input;
 
 const locales = {
   cn: {
-    range: '设置范围',
     text: 'Ant Design 使用 CSS-in-JS 技术以提供动态与混合主题的能力。与此同时，我们使用组件级别的 CSS-in-JS 解决方案，让你的应用获得更好的性能。',
     infoText: '信息内容展示',
     dropdown: '下拉菜单',
@@ -50,12 +52,18 @@ const locales = {
     icon: '图标按钮',
     hello: '你好，Ant Design!',
     release: 'Ant Design 6.0 正式发布！',
+    releaseDesc: '开启全新设计体验',
     segmentedDaily: '每日',
     segmentedWeekly: '每周',
     segmentedMonthly: '每月',
+    searchPlaceholder: '搜索组件',
+    tagSuccess: '已上线',
+    tagProcessing: '审核中',
+    tagError: '已关闭',
+    tagWarning: '警告',
+    teamTitle: '团队',
   },
   en: {
-    range: 'Set Range',
     text: 'Ant Design use CSS-in-JS technology to provide dynamic & mix theme ability. And which use component level CSS-in-JS solution get your application a better performance.',
     infoText: 'Info Text',
     dropdown: 'Dropdown',
@@ -74,9 +82,16 @@ const locales = {
     icon: 'Icon',
     hello: 'Hello, Ant Design!',
     release: 'Ant Design 6.0 is released!',
+    releaseDesc: 'Start a new design experience',
     segmentedDaily: 'Daily',
     segmentedWeekly: 'Weekly',
     segmentedMonthly: 'Monthly',
+    searchPlaceholder: 'Search',
+    tagSuccess: 'Live',
+    tagProcessing: 'Review',
+    tagError: 'Closed',
+    tagWarning: 'Warning',
+    teamTitle: 'Team',
   },
 };
 
@@ -86,6 +101,9 @@ const useStyle = createStyles(({ css, cssVar }) => ({
     gridTemplateColumns: 'repeat(3, 1fr)',
     gap: cssVar.paddingSM,
     width: '100%',
+    '@media (max-width: 576px)': {
+      gridTemplateColumns: '1fr',
+    },
   }),
   card: css({
     backgroundColor: `color-mix(in srgb, ${cssVar.colorBgContainer} 70%, transparent)`,
@@ -106,9 +124,15 @@ const useStyle = createStyles(({ css, cssVar }) => ({
   }),
   span2: css({
     gridColumn: 'span 2',
+    '@media (max-width: 576px)': {
+      gridColumn: 'span 1',
+    },
   }),
   span3: css({
     gridColumn: 'span 3',
+    '@media (max-width: 576px)': {
+      gridColumn: 'span 1',
+    },
   }),
   flexAuto: css({ flex: 'auto' }),
 }));
@@ -153,97 +177,104 @@ const ComponentsBlock: React.FC<ComponentsBlockProps> = (props) => {
       <App>
         <div className={containerClassName}>
           <div className={clsx(styles.grid, className)} style={style}>
-            {/* Row 1: Modal + Alert (2 cols) | DatePicker + Select (1 col) */}
+            {/* Row 1: Notification (span2) | Team (span1) */}
             <div className={clsx(styles.card, styles.span2)}>
-              <ModalPanel title="Ant Design" width="100%">
-                {locale.text}
-              </ModalPanel>
-              <Alert title={locale.infoText} type="info" />
+              <Alert
+                message={locale.release}
+                description={locale.releaseDesc}
+                type="success"
+                showIcon
+              />
+              <Flex gap="small" wrap>
+                <Tag color="success">{locale.tagSuccess}</Tag>
+                <Tag color="processing">{locale.tagProcessing}</Tag>
+                <Tag color="error">{locale.tagError}</Tag>
+                <Tag color="warning">{locale.tagWarning}</Tag>
+              </Flex>
             </div>
             <div className={styles.card}>
-              <DatePicker />
-              <Select
-                style={{ width: '100%' }}
-                mode="multiple"
-                maxTagCount="responsive"
-                defaultValue={['apple', 'banana']}
-                options={fruitOptions}
-              />
+              <Typography.Text type="secondary">{locale.teamTitle}</Typography.Text>
+              <Avatar.Group maxCount={3}>
+                <Badge dot status="success" offset={[-2, 24]}>
+                  <Avatar>A</Avatar>
+                </Badge>
+                <Avatar>B</Avatar>
+                <Avatar>C</Avatar>
+                <Avatar>D</Avatar>
+                <Avatar>E</Avatar>
+              </Avatar.Group>
             </div>
 
-            {/* Row 2: Buttons (1 col) | ColorPicker + Dropdown + Select (2 cols) */}
+            {/* Row 2: Actions (span1) | Colors & Search (span2) */}
             <div className={styles.card}>
               <Flex gap="small" wrap>
                 <Button type="primary" className={styles.flexAuto}>
                   {locale.primary}
                 </Button>
-                <Button type="primary" className={styles.flexAuto} danger>
+                <Button danger className={styles.flexAuto}>
                   {locale.danger}
                 </Button>
                 <Button className={styles.flexAuto}>{locale.default}</Button>
-                <Button className={styles.flexAuto} type="dashed">
-                  {locale.dashed}
-                </Button>
               </Flex>
-              <Progress style={{ margin: 0 }} percent={60} />
-            </div>
-            <div className={clsx(styles.card, styles.span2)}>
-              <Flex gap="middle" align="center">
-                <ColorPicker showText defaultValue="#1677ff" style={{ flex: 'none' }} />
-                <Space.Compact>
-                  <Button>{locale.dropdown}</Button>
-                  <Dropdown menu={{ items: dropdownItems }}>
-                    <Button icon={<DownOutlined />} />
-                  </Dropdown>
-                </Space.Compact>
-              </Flex>
-              <Select
-                style={{ width: '100%' }}
-                mode="multiple"
-                maxTagCount="responsive"
-                defaultValue={['apple', 'banana']}
-                options={fruitOptions}
-              />
-            </div>
-
-            {/* Row 3: Switch + Checkbox + Radio (1 col) | Steps (2 cols) */}
-            <div className={styles.card}>
+              <Space.Compact>
+                <Button>{locale.dropdown}</Button>
+                <Dropdown menu={{ items: dropdownItems }}>
+                  <Button icon={<DownOutlined />} />
+                </Dropdown>
+              </Space.Compact>
               <Switch
                 defaultChecked
                 checkedChildren={<CheckOutlined />}
                 unCheckedChildren={<CloseOutlined />}
                 style={{ width: 48 }}
               />
-              <Checkbox.Group
-                options={[locale.apple, locale.banana, locale.orange]}
-                defaultValue={[locale.apple]}
-              />
-              <Radio.Group defaultValue={locale.apple} options={[locale.apple, locale.banana]} />
             </div>
             <div className={clsx(styles.card, styles.span2)}>
-              <Steps
-                current={1}
-                items={[
-                  { title: locale.finished },
-                  { title: locale.inProgress },
-                  { title: locale.waiting },
-                ]}
+              <Flex gap="small" align="center">
+                <ColorPicker showText defaultValue="#1677ff" style={{ flex: 'none' }} />
+                <Rate defaultValue={4} />
+              </Flex>
+              <Search placeholder={locale.searchPlaceholder} allowClear />
+              <Select
+                style={{ width: '100%' }}
+                mode="multiple"
+                maxTagCount="responsive"
+                defaultValue={['apple', 'banana']}
+                options={fruitOptions}
               />
+            </div>
+
+            {/* Row 3: DatePicker & Select (span2) | Progress (span1) */}
+            <div className={clsx(styles.card, styles.span2)}>
+              <DatePicker style={{ width: '100%' }} />
+              <Select
+                style={{ width: '100%' }}
+                mode="multiple"
+                maxTagCount="responsive"
+                defaultValue={['apple', 'banana']}
+                options={fruitOptions}
+              />
+            </div>
+            <div className={styles.card}>
+              <Flex justify="space-around">
+                <Progress type="circle" percent={75} size={72} />
+                <Progress type="circle" percent={100} size={72} />
+              </Flex>
               <Slider defaultValue={50} />
             </div>
 
-            {/* Row 4: Segmented + RadioButtonGroup (3 cols) */}
+            {/* Row 4: Segmented + Checkbox + Radio (span3) */}
             <div className={clsx(styles.card, styles.span3)}>
-              <Flex gap="middle" align="center" justify="center">
+              <Flex gap="middle" align="center" justify="center" wrap>
                 <Segmented
                   defaultValue={locale.segmentedDaily}
                   options={[locale.segmentedDaily, locale.segmentedWeekly, locale.segmentedMonthly]}
                 />
-                <RadioButtonGroup defaultValue="a">
-                  <RadioButton value="a">A</RadioButton>
-                  <RadioButton value="b">B</RadioButton>
-                  <RadioButton value="c">C</RadioButton>
-                </RadioButtonGroup>
+                <Checkbox.Group
+                  options={[locale.apple, locale.banana, locale.orange]}
+                  defaultValue={[locale.apple]}
+                />
+                <Radio.Group defaultValue={locale.apple} options={[locale.apple, locale.banana]} />
               </Flex>
             </div>
           </div>

--- a/.dumi/pages/index/components/ThemePreview/ComponentsBlock.tsx
+++ b/.dumi/pages/index/components/ThemePreview/ComponentsBlock.tsx
@@ -4,7 +4,6 @@ import {
   Alert,
   App,
   Button,
-  Card,
   Checkbox,
   ColorPicker,
   ConfigProvider,
@@ -81,15 +80,39 @@ const locales = {
   },
 };
 
-const useStyle = createStyles(({ css, cssVar }) => {
-  return {
-    container: css({
-      backgroundColor: `color-mix(in srgb, ${cssVar.colorBgContainer} 70%, transparent)`,
-      backdropFilter: 'blur(12px)',
-    }),
-    flexAuto: css({ flex: 'auto' }),
-  };
-});
+const useStyle = createStyles(({ css, cssVar }) => ({
+  grid: css({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    gap: cssVar.paddingSM,
+    width: '100%',
+  }),
+  card: css({
+    backgroundColor: `color-mix(in srgb, ${cssVar.colorBgContainer} 70%, transparent)`,
+    backdropFilter: 'blur(12px)',
+    borderRadius: cssVar.borderRadiusLG,
+    border: `${cssVar.lineWidth} ${cssVar.lineType} ${cssVar.colorBorderSecondary}`,
+    padding: `${cssVar.paddingSM} ${cssVar.padding}`,
+    transition: `transform ${cssVar.motionDurationMid} ${cssVar.motionEaseInOut}, box-shadow ${cssVar.motionDurationMid} ${cssVar.motionEaseInOut}`,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: cssVar.paddingSM,
+    justifyContent: 'center',
+
+    '&:hover': {
+      transform: 'translateY(-2px)',
+      boxShadow: cssVar.boxShadowSecondary,
+    },
+  }),
+  span2: css({
+    gridColumn: 'span 2',
+  }),
+  span3: css({
+    gridColumn: 'span 3',
+  }),
+  flexAuto: css({ flex: 'auto' }),
+}));
+
 interface ComponentsBlockProps {
   config?: ConfigProviderProps;
   style?: React.CSSProperties;
@@ -113,94 +136,78 @@ const ComponentsBlock: React.FC<ComponentsBlockProps> = (props) => {
     [theme, inherit],
   );
 
+  const fruitOptions = [
+    { value: 'apple', label: locale.apple },
+    { value: 'banana', label: locale.banana },
+    { value: 'orange', label: locale.orange },
+    { value: 'watermelon', label: locale.watermelon },
+  ];
+
+  const dropdownItems = Array.from({ length: 5 }).map((_, index) => ({
+    key: `opt${index}`,
+    label: `${locale.option} ${index}`,
+  }));
+
   return (
     <ConfigProvider {...restConfig} theme={mergedTheme}>
-      <Card className={clsx(containerClassName, styles.container)}>
-        <App>
-          <Flex vertical gap="middle" style={style} className={className}>
-            <ModalPanel title="Ant Design" width="100%">
-              {locale.text}
-            </ModalPanel>
-            <Alert title={locale.infoText} type="info" />
-            {/* Line */}
-            <Flex gap="middle">
-              <div style={{ flex: 'none' }}>
+      <App>
+        <div className={containerClassName}>
+          <div className={clsx(styles.grid, className)} style={style}>
+            {/* Row 1: Modal + Alert (2 cols) | DatePicker + Select (1 col) */}
+            <div className={clsx(styles.card, styles.span2)}>
+              <ModalPanel title="Ant Design" width="100%">
+                {locale.text}
+              </ModalPanel>
+              <Alert title={locale.infoText} type="info" />
+            </div>
+            <div className={styles.card}>
+              <DatePicker />
+              <Select
+                style={{ width: '100%' }}
+                mode="multiple"
+                maxTagCount="responsive"
+                defaultValue={['apple', 'banana']}
+                options={fruitOptions}
+              />
+            </div>
+
+            {/* Row 2: Buttons (1 col) | ColorPicker + Dropdown + Select (2 cols) */}
+            <div className={styles.card}>
+              <Flex gap="small" wrap>
+                <Button type="primary" className={styles.flexAuto}>
+                  {locale.primary}
+                </Button>
+                <Button type="primary" className={styles.flexAuto} danger>
+                  {locale.danger}
+                </Button>
+                <Button className={styles.flexAuto}>{locale.default}</Button>
+                <Button className={styles.flexAuto} type="dashed">
+                  {locale.dashed}
+                </Button>
+              </Flex>
+              <Progress style={{ margin: 0 }} percent={60} />
+            </div>
+            <div className={clsx(styles.card, styles.span2)}>
+              <Flex gap="middle" align="center">
+                <ColorPicker showText defaultValue="#1677ff" style={{ flex: 'none' }} />
                 <Space.Compact>
                   <Button>{locale.dropdown}</Button>
-                  <Dropdown
-                    menu={{
-                      items: Array.from({ length: 5 }).map((_, index) => ({
-                        key: `opt${index}`,
-                        label: `${locale.option} ${index}`,
-                      })),
-                    }}
-                  >
+                  <Dropdown menu={{ items: dropdownItems }}>
                     <Button icon={<DownOutlined />} />
                   </Dropdown>
                 </Space.Compact>
-              </div>
-
-              <ColorPicker showText defaultValue="#1677ff" style={{ flex: 'none' }} />
-
+              </Flex>
               <Select
-                style={{ flex: 'auto' }}
+                style={{ width: '100%' }}
                 mode="multiple"
                 maxTagCount="responsive"
                 defaultValue={['apple', 'banana']}
-                options={[
-                  { value: 'apple', label: locale.apple },
-                  { value: 'banana', label: locale.banana },
-                  { value: 'orange', label: locale.orange },
-                  { value: 'watermelon', label: locale.watermelon },
-                ]}
+                options={fruitOptions}
               />
-            </Flex>
+            </div>
 
-            {/* Filled variants */}
-            <Flex gap="middle">
-              <DatePicker />
-
-              <Select
-                style={{ flex: 'auto' }}
-                mode="multiple"
-                maxTagCount="responsive"
-                defaultValue={['apple', 'banana']}
-                options={[
-                  { value: 'apple', label: locale.apple },
-                  { value: 'banana', label: locale.banana },
-                  { value: 'orange', label: locale.orange },
-                  { value: 'watermelon', label: locale.watermelon },
-                ]}
-              />
-            </Flex>
-
-            <Progress style={{ margin: 0 }} percent={60} />
-
-            <Steps
-              current={1}
-              items={[
-                { title: locale.finished },
-                { title: locale.inProgress },
-                { title: locale.waiting },
-              ]}
-            />
-            {/* Line */}
-            <Slider defaultValue={50} />
-            {/* Line */}
-            <Flex gap="middle">
-              <Button type="primary" className={styles.flexAuto}>
-                {locale.primary}
-              </Button>
-              <Button type="primary" className={styles.flexAuto} danger>
-                {locale.danger}
-              </Button>
-              <Button className={styles.flexAuto}>{locale.default}</Button>
-              <Button className={styles.flexAuto} type="dashed">
-                {locale.dashed}
-              </Button>
-            </Flex>
-            {/* Line */}
-            <Flex gap="middle">
+            {/* Row 3: Switch + Checkbox + Radio (1 col) | Steps (2 cols) */}
+            <div className={styles.card}>
               <Switch
                 defaultChecked
                 checkedChildren={<CheckOutlined />}
@@ -212,21 +219,36 @@ const ComponentsBlock: React.FC<ComponentsBlockProps> = (props) => {
                 defaultValue={[locale.apple]}
               />
               <Radio.Group defaultValue={locale.apple} options={[locale.apple, locale.banana]} />
-            </Flex>
-            <Flex gap="middle" align="center">
-              <RadioButtonGroup defaultValue="a">
-                <RadioButton value="a">A</RadioButton>
-                <RadioButton value="b">B</RadioButton>
-                <RadioButton value="c">C</RadioButton>
-              </RadioButtonGroup>
-              <Segmented
-                defaultValue={locale.segmentedDaily}
-                options={[locale.segmentedDaily, locale.segmentedWeekly, locale.segmentedMonthly]}
+            </div>
+            <div className={clsx(styles.card, styles.span2)}>
+              <Steps
+                current={1}
+                items={[
+                  { title: locale.finished },
+                  { title: locale.inProgress },
+                  { title: locale.waiting },
+                ]}
               />
-            </Flex>
-          </Flex>
-        </App>
-      </Card>
+              <Slider defaultValue={50} />
+            </div>
+
+            {/* Row 4: Segmented + RadioButtonGroup (3 cols) */}
+            <div className={clsx(styles.card, styles.span3)}>
+              <Flex gap="middle" align="center" justify="center">
+                <Segmented
+                  defaultValue={locale.segmentedDaily}
+                  options={[locale.segmentedDaily, locale.segmentedWeekly, locale.segmentedMonthly]}
+                />
+                <RadioButtonGroup defaultValue="a">
+                  <RadioButton value="a">A</RadioButton>
+                  <RadioButton value="b">B</RadioButton>
+                  <RadioButton value="c">C</RadioButton>
+                </RadioButtonGroup>
+              </Flex>
+            </div>
+          </div>
+        </div>
+      </App>
     </ConfigProvider>
   );
 };

--- a/.dumi/pages/index/components/ThemePreview/index.tsx
+++ b/.dumi/pages/index/components/ThemePreview/index.tsx
@@ -145,15 +145,11 @@ const useStyles = createStyles(({ css, cssVar }) => ({
   componentsBlockContainer: css({
     flex: 'auto',
     display: 'flex',
-    padding: cssVar.paddingXL,
     justifyContent: 'center',
-    border: `${cssVar.lineWidth} ${cssVar.lineType} ${cssVar.colorBorderSecondary}`,
-    borderRadius: cssVar.borderRadius,
-    boxShadow: cssVar.boxShadow,
   }),
   componentsBlock: css({
-    flex: 'none',
-    maxWidth: `calc(420px + ${cssVar.paddingXL} * 2)`,
+    width: '100%',
+    maxWidth: 780,
   }),
 }));
 

--- a/components/card/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.ts.snap
@@ -386,7 +386,7 @@ Array [
 
 exports[`renders components/card/demo/flexible-content.tsx correctly 1`] = `
 <div
-  class="ant-card ant-card-bordered ant-card-hoverable css-var-test-id"
+  class="ant-card ant-card-hoverable css-var-test-id"
   style="width:240px"
 >
   <div

--- a/components/card/demo/flexible-content.tsx
+++ b/components/card/demo/flexible-content.tsx
@@ -6,6 +6,7 @@ const { Meta } = Card;
 const App: React.FC = () => (
   <Card
     hoverable
+    variant="borderless"
     style={{ width: 240 }}
     cover={
       <img

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -71,6 +71,11 @@ export interface ComponentToken {
    * @descEN Text color of extra area
    */
   extraColor: string;
+  /**
+   * @desc 无边框卡片的阴影
+   * @descEN Shadow of borderless card
+   */
+  shadowTertiary: string;
 }
 
 interface CardToken extends FullToken<'Card'> {
@@ -79,6 +84,11 @@ interface CardToken extends FullToken<'Card'> {
    * @descEN Shadow of card
    */
   cardShadow: string;
+  /**
+   * @desc 无边框卡片的阴影
+   * @descEN Shadow of borderless card
+   */
+  shadowTertiary: string;
   /**
    * @desc 卡片头部内边距
    * @descEN Padding of card header
@@ -312,7 +322,7 @@ const genCardStyle: GenerateStyle<CardToken, CSSObject> = (token) => {
     cardShadow,
     cardHeadPadding,
     colorBorderSecondary,
-    boxShadowTertiary,
+    shadowTertiary,
     bodyPadding,
     extraColor,
     motionDurationMid,
@@ -327,7 +337,7 @@ const genCardStyle: GenerateStyle<CardToken, CSSObject> = (token) => {
       borderRadius: token.borderRadiusLG,
 
       [`&:not(${componentCls}-bordered)`]: {
-        boxShadow: boxShadowTertiary,
+        boxShadow: shadowTertiary,
       },
 
       [`${componentCls}-head`]: genCardHeadStyle(token),
@@ -477,6 +487,11 @@ export const prepareComponentToken: GetDefaultToken<'Card'> = (token) => ({
   headerPaddingSM: 12,
   bodyPadding: token.bodyPadding ?? token.paddingLG,
   headerPadding: token.headerPadding ?? token.paddingLG,
+  shadowTertiary: `
+    0 1px 2px 0 rgba(0, 0, 0, 0.06),
+    0 1px 6px -1px rgba(0, 0, 0, 0.04),
+    0 2px 10px 0 rgba(0, 0, 0, 0.04)
+  `,
 });
 
 // ============================== Export ==============================
@@ -485,6 +500,7 @@ export default genStyleHooks(
   (token) => {
     const cardToken = mergeToken<CardToken>(token, {
       cardShadow: token.boxShadowCard,
+      shadowTertiary: token.shadowTertiary,
       cardHeadPadding: token.padding,
       cardPaddingBase: token.paddingLG,
       cardActionsIconSize: token.fontSize,

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -71,6 +71,11 @@ export interface ComponentToken {
    * @descEN Text color of extra area
    */
   extraColor: string;
+  /**
+   * @desc 无边框卡片的阴影
+   * @descEN Shadow of borderless card
+   */
+  shadowTertiary: string;
 }
 
 interface CardToken extends FullToken<'Card'> {
@@ -79,6 +84,11 @@ interface CardToken extends FullToken<'Card'> {
    * @descEN Shadow of card
    */
   cardShadow: string;
+  /**
+   * @desc 无边框卡片的阴影
+   * @descEN Shadow of borderless card
+   */
+  shadowTertiary: string;
   /**
    * @desc 卡片头部内边距
    * @descEN Padding of card header
@@ -312,7 +322,7 @@ const genCardStyle: GenerateStyle<CardToken, CSSObject> = (token) => {
     cardShadow,
     cardHeadPadding,
     colorBorderSecondary,
-    boxShadowTertiary,
+    shadowTertiary,
     bodyPadding,
     extraColor,
     motionDurationMid,
@@ -327,7 +337,7 @@ const genCardStyle: GenerateStyle<CardToken, CSSObject> = (token) => {
       borderRadius: token.borderRadiusLG,
 
       [`&:not(${componentCls}-bordered)`]: {
-        boxShadow: boxShadowTertiary,
+        boxShadow: shadowTertiary,
       },
 
       [`${componentCls}-head`]: genCardHeadStyle(token),
@@ -477,6 +487,7 @@ export const prepareComponentToken: GetDefaultToken<'Card'> = (token) => ({
   headerPaddingSM: 12,
   bodyPadding: token.bodyPadding ?? token.paddingLG,
   headerPadding: token.headerPadding ?? token.paddingLG,
+  shadowTertiary: token.boxShadowTertiaryCard,
 });
 
 // ============================== Export ==============================
@@ -485,6 +496,7 @@ export default genStyleHooks(
   (token) => {
     const cardToken = mergeToken<CardToken>(token, {
       cardShadow: token.boxShadowCard,
+      shadowTertiary: token.shadowTertiary,
       cardHeadPadding: token.padding,
       cardPaddingBase: token.paddingLG,
       cardActionsIconSize: token.fontSize,

--- a/components/card/style/index.ts
+++ b/components/card/style/index.ts
@@ -71,11 +71,6 @@ export interface ComponentToken {
    * @descEN Text color of extra area
    */
   extraColor: string;
-  /**
-   * @desc 无边框卡片的阴影
-   * @descEN Shadow of borderless card
-   */
-  shadowTertiary: string;
 }
 
 interface CardToken extends FullToken<'Card'> {
@@ -84,11 +79,6 @@ interface CardToken extends FullToken<'Card'> {
    * @descEN Shadow of card
    */
   cardShadow: string;
-  /**
-   * @desc 无边框卡片的阴影
-   * @descEN Shadow of borderless card
-   */
-  shadowTertiary: string;
   /**
    * @desc 卡片头部内边距
    * @descEN Padding of card header
@@ -322,7 +312,7 @@ const genCardStyle: GenerateStyle<CardToken, CSSObject> = (token) => {
     cardShadow,
     cardHeadPadding,
     colorBorderSecondary,
-    shadowTertiary,
+    boxShadowTertiary,
     bodyPadding,
     extraColor,
     motionDurationMid,
@@ -337,7 +327,7 @@ const genCardStyle: GenerateStyle<CardToken, CSSObject> = (token) => {
       borderRadius: token.borderRadiusLG,
 
       [`&:not(${componentCls}-bordered)`]: {
-        boxShadow: shadowTertiary,
+        boxShadow: boxShadowTertiary,
       },
 
       [`${componentCls}-head`]: genCardHeadStyle(token),
@@ -487,11 +477,6 @@ export const prepareComponentToken: GetDefaultToken<'Card'> = (token) => ({
   headerPaddingSM: 12,
   bodyPadding: token.bodyPadding ?? token.paddingLG,
   headerPadding: token.headerPadding ?? token.paddingLG,
-  shadowTertiary: `
-    0 1px 2px 0 rgba(0, 0, 0, 0.06),
-    0 1px 6px -1px rgba(0, 0, 0, 0.04),
-    0 2px 10px 0 rgba(0, 0, 0, 0.04)
-  `,
 });
 
 // ============================== Export ==============================
@@ -500,7 +485,6 @@ export default genStyleHooks(
   (token) => {
     const cardToken = mergeToken<CardToken>(token, {
       cardShadow: token.boxShadowCard,
-      shadowTertiary: token.shadowTertiary,
       cardHeadPadding: token.padding,
       cardPaddingBase: token.paddingLG,
       cardActionsIconSize: token.fontSize,

--- a/components/theme/interface/alias.ts
+++ b/components/theme/interface/alias.ts
@@ -435,6 +435,13 @@ export interface AliasToken extends MapToken {
    * @descEN Control the tertiary box shadow style of an element.
    */
   boxShadowTertiary: string;
+  /**
+   * @nameZH 卡片阴影
+   * @nameEN Card box shadow
+   * @desc 控制无边框卡片的盒子阴影样式。
+   * @descEN Control the box shadow style of borderless card.
+   */
+  boxShadowTertiaryCard: string;
 
   /**
    * @nameZH 链接文本装饰

--- a/components/theme/util/alias.ts
+++ b/components/theme/util/alias.ts
@@ -152,9 +152,9 @@ export default function formatToken(derivativeToken: RawMergedToken): AliasToken
       0 9px 28px 8px ${getShadowColor(0.05)}
     `,
     boxShadowTertiary: `
-      0 1px 2px 0 ${getShadowColor(0.03)},
-      0 2px 6px -1px ${getShadowColor(0.03)},
-      0 6px 12px -4px ${getShadowColor(0.04)}
+      0 1px 2px 0 ${getShadowColor(0.04)},
+      0 6px 16px -4px ${getShadowColor(0.08)},
+      0 12px 24px -8px ${getShadowColor(0.05)}
     `,
 
     screenXS,

--- a/components/theme/util/alias.ts
+++ b/components/theme/util/alias.ts
@@ -152,9 +152,14 @@ export default function formatToken(derivativeToken: RawMergedToken): AliasToken
       0 9px 28px 8px ${getShadowColor(0.05)}
     `,
     boxShadowTertiary: `
+      0 1px 2px 0 ${getShadowColor(0.03)},
+      0 1px 6px -1px ${getShadowColor(0.02)},
+      0 2px 4px 0 ${getShadowColor(0.02)}
+    `,
+    boxShadowTertiaryCard: `
       0 1px 2px 0 ${getShadowColor(0.04)},
-      0 6px 16px -4px ${getShadowColor(0.08)},
-      0 12px 24px -8px ${getShadowColor(0.05)}
+      0 3px 6px -4px ${getShadowColor(0.06)},
+      0 6px 16px -8px ${getShadowColor(0.06)}
     `,
 
     screenXS,

--- a/components/theme/util/alias.ts
+++ b/components/theme/util/alias.ts
@@ -153,8 +153,8 @@ export default function formatToken(derivativeToken: RawMergedToken): AliasToken
     `,
     boxShadowTertiary: `
       0 1px 2px 0 ${getShadowColor(0.03)},
-      0 1px 6px -1px ${getShadowColor(0.02)},
-      0 2px 4px 0 ${getShadowColor(0.02)}
+      0 2px 6px -1px ${getShadowColor(0.03)},
+      0 6px 12px -4px ${getShadowColor(0.04)}
     `,
 
     screenXS,

--- a/components/tour/style/index.ts
+++ b/components/tour/style/index.ts
@@ -54,7 +54,7 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
     colorFill,
     indicatorHeight,
     indicatorWidth,
-    boxShadowTertiary,
+    boxShadowTertiaryCard,
     zIndexPopup,
     colorBgElevated,
     fontWeightStrong,
@@ -102,7 +102,7 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
           textAlign: 'start',
           textDecoration: 'none',
           borderRadius: tourBorderRadius,
-          boxShadow: boxShadowTertiary,
+          boxShadow: boxShadowTertiaryCard,
           position: 'relative',
           backgroundColor: colorBgElevated,
           border: 'none',
@@ -205,7 +205,7 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
             textDecoration: 'none',
             backgroundColor: colorPrimary,
             borderRadius,
-            boxShadow: boxShadowTertiary,
+            boxShadow: boxShadowTertiaryCard,
 
             [`${componentCls}-close`]: {
               color: colorTextLightSolid,


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 📽️ Demo improvement
- [x] 💄 Component style improvement

### 🔗 Related Issues

N/A

### 💡 Background and Solution

The current "定制主题，随心所欲" section uses a single Card wrapper with vertically stacked components, resulting in a monotonous flat layout. Inspired by [HeroUI](https://heroui.com/) homepage's scattered/floating component showcase, this PR redesigns the layout to a **Bento Grid** pattern where components are distributed across multiple cards with varying column spans, creating a visually appealing staggered arrangement.

**Before:** Single card, all components stacked vertically
```
┌──────────────────────────┐
│ Modal Panel              │
│ Alert                    │
│ Dropdown + ColorPicker   │
│ DatePicker + Select      │
│ Progress                 │
│ Steps                    │
│ Slider                   │
│ Buttons                  │
│ Switch + Checkbox + Radio│
│ Segment + RadioGroup     │
└──────────────────────────┘
```

**After:** Bento Grid with 3 columns, varying spans
```
┌─────────────────────────────┬──────────────┐
│ Modal + Alert      (span 2) │ DatePicker   │  Row 1
│                              │ + Select     │
├──────────┬───────────────────┴──────────────┤
│ Buttons  │ ColorPicker + Dropdown (span 2)  │  Row 2
│+ Progress│ + Select                         │
├──────────┼──────────────────────────────────┤
│ Switch   │ Steps + Slider        (span 2)   │  Row 3
│+ Checkbox│                                  │
│+ Radio   │                                  │
├──────────┴──────────────────────────────────┤
│ Segmented + RadioGroup           (span 3)   │  Row 4
└─────────────────────────────────────────────┘
```

Key changes:
- Replace single `<Card>` + `<Flex vertical>` with CSS Grid `repeat(3, 1fr)` bento layout
- Each component group lives in its own glass-morphism card (`backdrop-filter: blur(12px)`)
- Add hover lift effect (`translateY(-2px)`) with shadow transition
- Remove outer container border/shadow/padding (styling now per-card)
- Increase `maxWidth` from ~520px to 780px for grid breathing room
- Group related components logically across cards

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 💄 Redesign ThemePreview component layout from single vertical card to Bento Grid for better visual hierarchy. |
| 🇨🇳 Chinese | 💄 重构首页定制主题区域的组件布局，从单卡片垂直排列改为 Bento Grid 错落布局。 |