### PR TITLE
fix: Typography ellipsis tooltip false positive with small line-height

### DIFF
--- a/components/typography/Base/util.ts
+++ b/components/typography/Base/util.ts
@@ -33,9 +33,15 @@ export function isEleEllipsis(ele: HTMLElement): boolean {
   // overflow even though the text is not clamped. Collapsing it to a zero
   // sized inline-block keeps the horizontal detection (see #50143 / #50414)
   // while avoiding the vertical false positive (see #56347).
+  // `margin`, `padding` and `border-width` are also reset so that global
+  // stylesheets targeting `em` (resets or custom styles) can not re-introduce
+  // any size and bring back the false positive.
   childDiv.style.display = 'inline-block';
   childDiv.style.width = '0';
   childDiv.style.height = '0';
+  childDiv.style.margin = '0';
+  childDiv.style.padding = '0';
+  childDiv.style.borderWidth = '0';
   ele.appendChild(childDiv);
 
   // For test case

--- a/components/typography/Base/util.ts
+++ b/components/typography/Base/util.ts
@@ -21,8 +21,21 @@ export function getNode(dom: React.ReactNode, defaultNode: React.ReactNode, need
  * - https://github.com/ant-design/ant-design/issues/50414
  */
 export function isEleEllipsis(ele: HTMLElement): boolean {
-  // Create a new div to get the size
+  // Create a new node to probe the layout box.
   const childDiv = document.createElement('em');
+
+  // The probe is only used to detect whether the content overflows the
+  // container, so it must not contribute any size of its own. As an inline
+  // element, its `getBoundingClientRect` height comes from the font box
+  // (ascent + descent) regardless of `line-height`. When `line-height` is
+  // smaller than the font box (e.g. a 14px font with an 18px line on some
+  // font families), the probe would stick out vertically and report a false
+  // overflow even though the text is not clamped. Collapsing it to a zero
+  // sized inline-block keeps the horizontal detection (see #50143 / #50414)
+  // while avoiding the vertical false positive (see #56347).
+  childDiv.style.display = 'inline-block';
+  childDiv.style.width = '0';
+  childDiv.style.height = '0';
   ele.appendChild(childDiv);
 
   // For test case

--- a/components/typography/__tests__/ellipsis.test.tsx
+++ b/components/typography/__tests__/ellipsis.test.tsx
@@ -807,4 +807,27 @@ describe('Typography.Ellipsis', () => {
     fireEvent.mouseLeave(typographyEl);
     fireEvent.mouseLeave(operationsWrapper!);
   });
+
+  // https://github.com/ant-design/ant-design/issues/56347
+  describe('isEleEllipsis probe', () => {
+    it('should collapse the probe so a short line-height does not report a false overflow', () => {
+      const ele = document.createElement('div');
+      document.body.appendChild(ele);
+
+      const appendSpy = jest.spyOn(ele, 'appendChild');
+
+      baseUtil.isEleEllipsis(ele);
+
+      const probe = appendSpy.mock.calls[0][0] as HTMLElement;
+      // The probe must not contribute its own size, otherwise an inline
+      // element's font box (taller than a small `line-height`) would stick
+      // out vertically and be mistaken for an overflow.
+      expect(probe.style.display).toBe('inline-block');
+      expect(probe.style.width).toBe('0px');
+      expect(probe.style.height).toBe('0px');
+
+      appendSpy.mockRestore();
+      document.body.removeChild(ele);
+    });
+  });
 });

--- a/components/typography/__tests__/ellipsis.test.tsx
+++ b/components/typography/__tests__/ellipsis.test.tsx
@@ -825,6 +825,10 @@ describe('Typography.Ellipsis', () => {
       expect(probe.style.display).toBe('inline-block');
       expect(probe.style.width).toBe('0px');
       expect(probe.style.height).toBe('0px');
+      // Reset box model so global styles targeting `em` can not add size back.
+      expect(probe.style.margin).toBe('0px');
+      expect(probe.style.padding).toBe('0px');
+      expect(probe.style.borderWidth).toBe('0px');
 
       appendSpy.mockRestore();
       document.body.removeChild(ele);


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

fix #56347

### 💡 Background and Solution

When `Typography` enables `ellipsis` with a `tooltip`, it detects native (CSS) ellipsis by injecting an `<em>` probe at the end of the content and checking whether the probe's `getBoundingClientRect` exceeds the container's rect.

The problem: an `<em>` is an inline element, so its measured height comes from the **font box** (ascent + descent), which is independent of `line-height`. When `line-height` is smaller than the font's natural box (e.g. a 14px font with an 18px line on font families such as Poppins), the probe sticks out vertically above and below the line box. `isEleEllipsis` then reads `childRect.bottom > rect.bottom` as an overflow and shows a tooltip **even though the text is not actually clamped**.

**Solution:** collapse the probe to a zero-sized `inline-block` (`display: inline-block; width: 0; height: 0`) so it no longer contributes any size of its own. This removes the spurious vertical overflow while keeping the horizontal overflow detection that was introduced for #50143 / #50414 intact (verified in a real browser: short text no longer triggers the tooltip, while genuinely truncated single-line and multi-line text still do).

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Typography that incorrectly shows the ellipsis tooltip when the text is not truncated under a small `line-height`. |
| 🇨🇳 Chinese | 修复 Typography 在较小 `line-height` 下文本未被省略时仍错误展示省略 tooltip 的问题。 |