### PR TITLE
fix(Dropdown): prevent vertical menu from overflowing the viewport

### DIFF
--- a/components/dropdown/__tests__/index.test.tsx
+++ b/components/dropdown/__tests__/index.test.tsx
@@ -552,4 +552,26 @@ describe('Dropdown', () => {
     expect(itemContent).toHaveStyle(objectStyles.itemContent);
     expect(itemTitle).toHaveStyle(objectStyles.itemTitle);
   });
+
+  // https://github.com/ant-design/ant-design/issues/56044
+  it('vertical menu should keep viewport spacing instead of full 100vh', () => {
+    render(
+      <Dropdown menu={{ items }} open>
+        <button type="button">button</button>
+      </Dropdown>,
+    );
+
+    const cssText = Array.from(document.head.querySelectorAll('style'))
+      .map((style) => style.innerHTML)
+      .join('');
+    const verticalRule = cssText
+      .split('}')
+      .find(
+        (rule) => rule.includes('-dropdown-menu-vertical') && rule.includes('max-height'),
+      );
+
+    expect(verticalRule).toBeTruthy();
+    expect(verticalRule).toContain('calc(100vh');
+    expect(verticalRule).not.toMatch(/max-height:\s*100vh/);
+  });
 });

--- a/components/dropdown/style/index.ts
+++ b/components/dropdown/style/index.ts
@@ -72,6 +72,7 @@ const genBaseStyle: GenerateStyle<DropdownToken> = (token) => {
     fontSizeIcon,
     controlPaddingHorizontal,
     colorBgElevated,
+    controlHeightLG,
   } = token;
 
   return [
@@ -97,8 +98,10 @@ const genBaseStyle: GenerateStyle<DropdownToken> = (token) => {
         },
 
         // Makes vertical dropdowns have a scrollbar once they become taller than the viewport.
+        // Leave some viewport spacing so the menu stays on-screen when the trigger is centered.
+        // https://github.com/ant-design/ant-design/issues/56044
         '&-menu-vertical': {
-          maxHeight: '100vh',
+          maxHeight: `calc(100vh - ${unit(token.calc(controlHeightLG).mul(2.5).equal())})`,
           overflowY: 'auto',
         },
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

close #56044

### 💡 Background and Solution

The vertical dropdown menu uses `max-height: 100vh` (added in #51112 to add a scrollbar for tall menus). Because the value equals the full viewport height, when the trigger sits in the middle (or near the top) of the screen the popup can extend beyond the viewport, leaving the top-most items off-screen and unclickable. Submenus with many items hit the same problem.

Menu's own submenu already solves this by reserving a small viewport margin via `calc(100vh - controlHeightLG * 2.5)`. This PR aligns the Dropdown vertical menu with that approach so the menu stays within the viewport and becomes scrollable instead of overflowing.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Dropdown vertical menu overflowing the viewport when the trigger is centered, keeping all menu items reachable. |
| 🇨🇳 Chinese | 修复 Dropdown 纵向菜单在触发器位于屏幕中部时溢出视口、顶部菜单项无法点击的问题。 |