### PR TITLE
docs: fix Vite links and collaborator command typo

### DIFF
--- a/docs/blog/to-be-collaborator.zh-CN.md
+++ b/docs/blog/to-be-collaborator.zh-CN.md
@@ -147,7 +147,7 @@ git push origin fix-branch
 
 ```
 npm run install-react-16
-npm run test componet/XXX
+npm run test component/XXX
 ```
 
 ## 十. 成为 Collaborator

--- a/docs/react/getting-started.en-US.md
+++ b/docs/react/getting-started.en-US.md
@@ -112,6 +112,6 @@ Jest does not support `esm` modules, and Ant Design uses them. In order to test 
 
 ## Customize your Workflow
 
-If you want to customize your workflow, we recommend using [webpack](https://webpack.js.org) or [vite](https://vitejs.dev/) to build and debug code. You can try out plenty of [boilerplates](https://github.com/enaqx/awesome-react#react-tools) available in the React ecosystem.
+If you want to customize your workflow, we recommend using [webpack](https://webpack.js.org) or [vite](https://vite.dev/) to build and debug code. You can try out plenty of [boilerplates](https://github.com/enaqx/awesome-react#react-tools) available in the React ecosystem.
 
 There are also some [scaffolds](https://scaffold.ant.design/) which have already been integrated into antd, so you can try and start with one of these and even contribute.

--- a/docs/react/use-with-vite.en-US.md
+++ b/docs/react/use-with-vite.en-US.md
@@ -5,7 +5,7 @@ order: 2
 title: Usage with Vite
 ---
 
-[Vite](https://vitejs.dev/) is one of the best React application development tools. Let's use `antd` within it.
+[Vite](https://vite.dev/) is one of the best React application development tools. Let's use `antd` within it.
 
 ## Install and Initialization
 
@@ -64,6 +64,6 @@ const App = () => (
 export default App;
 ```
 
-OK, you should now see a blue primary button displayed on the page. Next you can choose any components of `antd` to develop your application. Visit other workflows of `Vite` at its [User Guide](https://vitejs.dev/).
+OK, you should now see a blue primary button displayed on the page. Next you can choose any components of `antd` to develop your application. Visit other workflows of `Vite` at its [User Guide](https://vite.dev/).
 
 We are successfully running antd components now, go build your own application!


### PR DESCRIPTION
## Summary

- update English Vite documentation links from the legacy `vitejs.dev` domain to `vite.dev`
- fix the collaborator guide example command from `componet/XXX` to `component/XXX`

## Verification

- checked the changed files with `rg -n "componet|https://vitejs\\.dev/"`