### PR TITLE
fix: Input.OTP duplicate characters with CJK input methods

### DIFF
--- a/components/input/OTP/OTPInput.tsx
+++ b/components/input/OTP/OTPInput.tsx
@@ -71,6 +71,13 @@ const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
     }
     composedValueRef.current = nextValue;
     onChange(index, nextValue);
+    // The trailing `input` (if any) arrives synchronously right after
+    // `compositionend`. Clear the ref in the next tick so a browser that
+    // never fires that trailing `input` can not leave a stale value behind
+    // and block typing the same character again later.
+    raf(() => {
+      composedValueRef.current = null;
+    });
   };
 
   // ========================= Focus ==========================

--- a/components/input/OTP/OTPInput.tsx
+++ b/components/input/OTP/OTPInput.tsx
@@ -26,9 +26,51 @@ const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
 
   React.useImperativeHandle(ref, () => inputRef.current!);
 
+  // ====================== Composition =======================
+  // Track IME composition so that the intermediate value of CJK input methods
+  // is not written into the cell on every `input` event (see #52093).
+  const compositionRef = React.useRef(false);
+  // The value committed on `compositionend`. Some browsers fire an extra
+  // `input` right after `compositionend`, so we use this to avoid committing
+  // the same value twice.
+  const composedValueRef = React.useRef<string | null>(null);
+
   // ========================= Input ==========================
   const onInternalChange: React.InputEventHandler<HTMLInputElement> = (e) => {
-    onChange(index, (e.target as HTMLInputElement).value);
+    // Skip the intermediate values while composing. The final value is
+    // submitted on `compositionend`, which keeps every IME working.
+    if (compositionRef.current) {
+      return;
+    }
+    const nextValue = (e.target as HTMLInputElement).value;
+    // De-dupe the trailing `input` that some browsers emit right after
+    // `compositionend` with the already-committed value.
+    if (composedValueRef.current !== null) {
+      const composedValue = composedValueRef.current;
+      composedValueRef.current = null;
+      if (nextValue === composedValue) {
+        return;
+      }
+    }
+    onChange(index, nextValue);
+  };
+
+  const onInternalCompositionStart: React.CompositionEventHandler<HTMLInputElement> = () => {
+    compositionRef.current = true;
+    composedValueRef.current = null;
+  };
+
+  const onInternalCompositionEnd: React.CompositionEventHandler<HTMLInputElement> = (e) => {
+    compositionRef.current = false;
+    const nextValue = (e.target as HTMLInputElement).value;
+    // Composition can end without a real change (e.g. cancelled by `Esc` or
+    // blur). Skip in that case so we don't emit a redundant `onChange`.
+    if (nextValue === value) {
+      composedValueRef.current = null;
+      return;
+    }
+    composedValueRef.current = nextValue;
+    onChange(index, nextValue);
   };
 
   // ========================= Focus ==========================
@@ -80,6 +122,8 @@ const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
         ref={inputRef}
         value={value}
         onInput={onInternalChange}
+        onCompositionStart={onInternalCompositionStart}
+        onCompositionEnd={onInternalCompositionEnd}
         onFocus={onInternalFocus}
         onKeyDown={onInternalKeyDown}
         onMouseDown={syncSelection}

--- a/components/input/__tests__/otp.test.tsx
+++ b/components/input/__tests__/otp.test.tsx
@@ -324,4 +324,77 @@ describe('Input.OTP', () => {
     expect(input).toHaveStyle('color: rgb(255, 0, 0)');
     expect(separator).toHaveStyle('color: rgb(0, 0, 255)');
   });
+
+  // https://github.com/ant-design/ant-design/issues/52093
+  it('should ignore intermediate value while composing with IME', () => {
+    const onChange = jest.fn();
+    const { container } = render(<OTP length={1} onChange={onChange} />);
+    const input = container.querySelector('input')!;
+
+    // Composition keeps firing `input` with the intermediate pinyin, which
+    // should not be written into the cell.
+    fireEvent.compositionStart(input);
+    fireEvent.input(input, { target: { value: 'wo' } });
+    expect(onChange).not.toHaveBeenCalled();
+
+    // The final value is committed only when composition ends, so every IME
+    // can input exactly one character.
+    fireEvent.compositionEnd(input, { target: { value: '我' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('我');
+  });
+
+  it('should still trigger change for normal input after composing', () => {
+    const onChange = jest.fn();
+    const { container } = render(<OTP length={1} onChange={onChange} />);
+    const input = container.querySelector('input')!;
+
+    fireEvent.compositionStart(input);
+    fireEvent.compositionEnd(input, { target: { value: '我' } });
+    expect(onChange).toHaveBeenCalledWith('我');
+
+    // Latin input without composition keeps working as before.
+    fireEvent.input(input, { target: { value: 'a' } });
+    expect(onChange).toHaveBeenLastCalledWith('a');
+  });
+
+  it('should not commit twice when an extra input fires right after compositionend', () => {
+    const onInput = jest.fn();
+    const { container } = render(<OTP length={1} onInput={onInput} />);
+    const input = container.querySelector('input')!;
+
+    fireEvent.compositionStart(input);
+    fireEvent.compositionEnd(input, { target: { value: '我' } });
+    // Some browsers (e.g. Safari) emit a trailing `input` with the value that
+    // was already committed by `compositionend`; it should be ignored.
+    fireEvent.input(input, { target: { value: '我' } });
+
+    expect(onInput).toHaveBeenCalledTimes(1);
+    expect(onInput).toHaveBeenLastCalledWith(['我']);
+  });
+
+  it('should fill multiple cells when composition commits multiple characters', () => {
+    const onChange = jest.fn();
+    const { container } = render(<OTP length={2} onChange={onChange} />);
+    const input = container.querySelector('input')!;
+
+    fireEvent.compositionStart(input);
+    fireEvent.compositionEnd(input, { target: { value: '你好' } });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('你好');
+    expect(getText(container)).toBe('你好');
+  });
+
+  it('should not trigger callback when composition is cancelled without change', () => {
+    const onInput = jest.fn();
+    const { container } = render(<OTP length={1} onInput={onInput} />);
+    const input = container.querySelector('input')!;
+
+    // Composition cancelled (e.g. by `Esc`) restores the original empty value.
+    fireEvent.compositionStart(input);
+    fireEvent.compositionEnd(input, { target: { value: '' } });
+
+    expect(onInput).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

close #52093

### 💡 Background and Solution

`Input.OTP` listens to the native `input` event to report changes. During an IME (CJK) composition session, the `input` event keeps firing with the intermediate value (e.g. the pinyin `wo` before committing `我`), so every intermediate keystroke was written into the cell, resulting in duplicated/extra characters when typing Chinese with the Microsoft IME and similar input methods.

A previous attempt (#54851) only skipped `onChange` when `e.nativeEvent.isComposing` was true, but that broke other IMEs (QQ / Sogou) where no reliable non-composing `input` event follows to commit the final value, leaving the user unable to type anything at all.

This PR tracks the composition state explicitly:

- On `compositionstart`, mark composing and ignore the intermediate `input` values.
- On `compositionend`, commit the final value once, so every IME works regardless of the `input` / `compositionend` ordering.
- De-dupe the trailing `input` that some browsers (e.g. Safari) emit right after `compositionend` with the already-committed value.
- Skip reporting when a composition ends without a real change (cancelled by `Esc` / blur).

Tests cover: intermediate value ignored while composing, normal input after composing, trailing `input` de-dup, multi-character commit across cells, and cancelled composition.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `Input.OTP` typing duplicate characters with CJK (IME) input methods. |
| 🇨🇳 Chinese | 修复 `Input.OTP` 使用中文等输入法时会重复输入字符的问题。 |