### PR TITLE
fix(table): prevent ellipsis from disappearing on cell click

### DIFF
--- a/components/table/style/ellipsis.ts
+++ b/components/table/style/ellipsis.ts
@@ -10,6 +10,7 @@ const genEllipsisStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
     [`${componentCls}-wrapper`]: {
       [`${componentCls}-cell-ellipsis`]: {
         ...textEllipsis,
+        overflow: 'clip',
         wordBreak: 'keep-all',
 
         // Fixed first or last should special process
@@ -20,6 +21,7 @@ const genEllipsisStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
           overflow: 'visible',
           [`${componentCls}-cell-content`]: {
             ...textEllipsis,
+            overflow: 'clip',
             display: 'block',
           },
         },


### PR DESCRIPTION
### 🤔 This is a ...

  - [x] 🐞 Bug fix

  ### 🔗 Related Issues

  close #58228

  ### 💡 Background and Solution

  **Problem:** When clicking on a Table cell with `ellipsis: true`, the browser places
  the text cursor in the hidden (truncated) portion of the text. This causes the
  browser to scroll to show the cursor position, making the ellipsis visually
  disappear.

  **Solution:** Changed `overflow: hidden` to `overflow: clip` on
  `.ant-table-cell-ellipsis`. Unlike `overflow: hidden`, `overflow: clip` does not
  create a scroll container, so the browser cannot scroll to show the cursor in the
  hidden area. This preserves the ellipsis while still allowing users to select and
  copy text.

  **Before:**
  Click on an ellipsis cell → ellipsis disappears

  **After:**
  Click on an ellipsis cell → ellipsis remains visible, text still selectable

  ### 📝 Change Log

  | Language   | Changelog |
  | ---------- | --------- |
  | 🇺🇸 English | 这条 PR 已被回滚，无需纳入 ChangeLog |
  | 🇨🇳 Chinese | 这条 PR 已被回滚，无需纳入 ChangeLog |