### PR TITLE
feat(Select): support passing native props to search input

### DIFF
--- a/components/auto-complete/AutoComplete.tsx
+++ b/components/auto-complete/AutoComplete.tsx
@@ -19,6 +19,8 @@ import type {
   SelectSemanticAllType,
 } from '../select';
 import Select from '../select';
+import { getInputPropsInput } from '../select/inputProps';
+import type { SelectInputComponent } from '../select/inputProps';
 
 export type AutoCompleteSemanticType = {
   classNames?: {
@@ -58,7 +60,15 @@ export interface AutoCompleteProps<
   OptionType extends BaseOptionType | DefaultOptionType = DefaultOptionType,
 > extends Omit<
     InternalSelectProps<ValueType, OptionType>,
-    'loading' | 'mode' | 'optionLabelProp' | 'labelInValue' | 'styles' | 'classNames' | 'showSearch' | 'optionFilterProp' | 'filterSort'
+    | 'loading'
+    | 'mode'
+    | 'optionLabelProp'
+    | 'labelInValue'
+    | 'styles'
+    | 'classNames'
+    | 'showSearch'
+    | 'optionFilterProp'
+    | 'filterSort'
   > {
   /** @deprecated Please use `options` instead */
   dataSource?: DataSourceItemType[];
@@ -80,7 +90,12 @@ export interface AutoCompleteProps<
   /** @deprecated Please use `onOpenChange` instead */
   onDropdownVisibleChange?: (visible: boolean) => void;
   onOpenChange?: (visible: boolean) => void;
-  showSearch?: boolean | Pick<SearchConfig<OptionType> & { searchIcon?: React.ReactNode }, 'filterOption' | 'onSearch' | 'searchIcon'>;
+  showSearch?:
+    | boolean
+    | Pick<
+        SearchConfig<OptionType> & { searchIcon?: React.ReactNode },
+        'filterOption' | 'onSearch' | 'searchIcon'
+      >;
 }
 
 function isSelectOptionOrSelectOptGroup(child: any): boolean {
@@ -109,6 +124,7 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
     classNames,
     popupMatchSelectWidth,
     dropdownMatchSelectWidth,
+    inputProps,
   } = props;
   const childNodes: React.ReactElement[] = toArray(children);
 
@@ -127,7 +143,21 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
     [customizeInput] = childNodes;
   }
 
-  const getInputElement = customizeInput ? (): React.ReactElement => customizeInput! : undefined;
+  const inputPropsRef = React.useRef(inputProps);
+  inputPropsRef.current = inputProps;
+
+  const inputComponentRef = React.useRef<SelectInputComponent>(customizeInput);
+  inputComponentRef.current = customizeInput;
+
+  const InputPropsInput = React.useMemo(
+    () => getInputPropsInput(inputComponentRef, inputPropsRef),
+    [],
+  );
+  const hasInputProps = Object.prototype.hasOwnProperty.call(props, 'inputProps');
+
+  const getInputElement = customizeInput
+    ? (): React.ReactElement => (hasInputProps ? <InputPropsInput /> : customizeInput!)
+    : undefined;
 
   // ============================ Options ============================
   let optionChildren: React.ReactNode;

--- a/components/auto-complete/__tests__/index.test.tsx
+++ b/components/auto-complete/__tests__/index.test.tsx
@@ -5,7 +5,7 @@ import AutoComplete from '..';
 import { resetWarned } from '../../_util/warning';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import { render, screen } from '../../../tests/utils';
+import { fireEvent, render, screen } from '../../../tests/utils';
 import Input from '../../input';
 
 describe('AutoComplete', () => {
@@ -96,6 +96,91 @@ describe('AutoComplete', () => {
       </AutoComplete>,
     );
     expect(screen.getByRole('combobox')).toHaveClass('custom');
+  });
+
+  it('should pass inputProps to custom input', () => {
+    render(
+      <AutoComplete
+        inputProps={{
+          autoComplete: 'new-password',
+          className: 'custom-input-props',
+        }}
+      >
+        <Input className="custom" />
+      </AutoComplete>,
+    );
+    const input = screen.getByRole('combobox');
+
+    expect(input).toHaveAttribute('autocomplete', 'new-password');
+    expect(input).toHaveClass('custom');
+    expect(input).toHaveClass('custom-input-props');
+  });
+
+  it('should preserve disabled custom input with inputProps', () => {
+    render(
+      <AutoComplete inputProps={{ autoComplete: 'off' }}>
+        <Input disabled />
+      </AutoComplete>,
+    );
+    const input = screen.getByRole('combobox');
+
+    expect(input).toBeDisabled();
+    expect(input).toHaveAttribute('autocomplete', 'off');
+  });
+
+  it('should keep custom input element stable when inputProps toggles', () => {
+    const { rerender } = render(
+      <AutoComplete inputProps={undefined} options={[{ label: '1', value: '1' }]}>
+        <Input />
+      </AutoComplete>,
+    );
+    const input = screen.getByRole('combobox');
+
+    input.focus();
+
+    rerender(
+      <AutoComplete
+        inputProps={{ autoComplete: 'new-password' }}
+        options={[{ label: '1', value: '1' }]}
+      >
+        <Input />
+      </AutoComplete>,
+    );
+
+    expect(screen.getByRole('combobox')).toBe(input);
+    expect(input).toHaveFocus();
+    expect(input).toHaveAttribute('autocomplete', 'new-password');
+  });
+
+  it('should compose custom inputProps event handlers after internal handlers', () => {
+    const handlerCalls: string[] = [];
+    const originOnChange = jest.fn(() => {
+      handlerCalls.push('origin');
+    });
+    const inputPropsOnChange = jest.fn(() => {
+      handlerCalls.push('inputProps');
+    });
+    const onSearch = jest.fn((searchValue: string) => {
+      handlerCalls.push(`internal:${searchValue}`);
+    });
+    render(
+      <AutoComplete
+        inputProps={{ onChange: inputPropsOnChange }}
+        onSearch={onSearch}
+        options={[{ label: '1', value: '1' }]}
+      >
+        <input onChange={originOnChange} />
+      </AutoComplete>,
+    );
+    const input = screen.getByRole('combobox');
+
+    fireEvent.change(input, { target: { value: '1' } });
+
+    expect(originOnChange).toHaveBeenCalledTimes(1);
+    expect(inputPropsOnChange).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch.mock.calls[0][0]).toBe('1');
+    expect(handlerCalls).toEqual(['internal:1', 'origin', 'inputProps']);
   });
 
   it('deprecated popupClassName', () => {

--- a/components/select/__tests__/index.test.tsx
+++ b/components/select/__tests__/index.test.tsx
@@ -96,6 +96,183 @@ describe('Select', () => {
     expect(container.querySelector('.anticon-search')).toBeTruthy();
   });
 
+  it('should pass inputProps to inner input', () => {
+    const { container } = render(
+      <Select inputProps={{ autoComplete: 'new-password' }} showSearch />,
+    );
+    const input = container.querySelector('input')!;
+
+    expect(container.querySelector('.ant-select')).not.toHaveAttribute('autocomplete');
+    expect(input).toHaveAttribute('autocomplete', 'new-password');
+  });
+
+  it('should merge inputProps className with inner input className', () => {
+    const { container } = render(
+      <Select
+        components={{
+          input: <input className="origin-input" />,
+        }}
+        inputProps={{
+          className: 'custom-input-props',
+        }}
+        showSearch
+      />,
+    );
+    const input = container.querySelector('input')!;
+
+    expect(input).toHaveClass('ant-select-input');
+    expect(input).toHaveClass('origin-input');
+    expect(input).toHaveClass('custom-input-props');
+  });
+
+  it('should compose inputProps event handlers with inner input handlers', () => {
+    const handlerCalls: string[] = [];
+    const originOnChange = jest.fn(() => {
+      handlerCalls.push('origin');
+    });
+    const inputPropsOnChange = jest.fn(() => {
+      handlerCalls.push('inputProps');
+    });
+    const onSearch = jest.fn((searchValue: string) => {
+      handlerCalls.push(`internal:${searchValue}`);
+    });
+    const { container } = render(
+      <Select
+        components={{
+          input: <input className="origin-input" onChange={originOnChange} />,
+        }}
+        inputProps={{
+          onChange: inputPropsOnChange,
+        }}
+        onSearch={onSearch}
+        options={[{ label: '1', value: '1' }]}
+        showSearch
+      />,
+    );
+    const input = container.querySelector('input')!;
+
+    fireEvent.change(input, { target: { value: '1' } });
+
+    expect(originOnChange).toHaveBeenCalledTimes(1);
+    expect(inputPropsOnChange).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch.mock.calls[0][0]).toBe('1');
+    expect(handlerCalls).toEqual(['internal:1', 'origin', 'inputProps']);
+  });
+
+  it('should ignore empty inputProps event handlers', () => {
+    const inputPropsOnChange = jest.fn();
+    const { container } = render(
+      <Select
+        inputProps={{ onFocus: undefined, onChange: inputPropsOnChange }}
+        options={[{ label: '1', value: '1' }]}
+        showSearch
+      />,
+    );
+    const input = container.querySelector('input')!;
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '1' } });
+
+    expect(input).toHaveClass('ant-select-input');
+    expect(inputPropsOnChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('should keep generated input accessibility props authoritative', () => {
+    const { container } = render(
+      <Select
+        inputProps={{ role: 'textbox', inputMode: 'numeric' }}
+        options={[{ label: '1', value: '1' }]}
+        showSearch
+      />,
+    );
+    const input = container.querySelector('input')!;
+
+    expect(input).toHaveAttribute('role', 'combobox');
+    expect(input).toHaveAttribute('inputmode', 'numeric');
+  });
+
+  it('should keep input element stable when inputProps toggles', () => {
+    const { container, rerender } = render(
+      <Select inputProps={undefined} options={[{ label: '1', value: '1' }]} showSearch />,
+    );
+    const input = container.querySelector('input')!;
+
+    input.focus();
+
+    rerender(
+      <Select
+        inputProps={{ autoComplete: 'new-password' }}
+        options={[{ label: '1', value: '1' }]}
+        showSearch
+      />,
+    );
+
+    expect(container.querySelector('input')).toBe(input);
+    expect(input).toHaveFocus();
+    expect(input).toHaveAttribute('autocomplete', 'new-password');
+  });
+
+  it('should preserve disabled state when inputProps disabled is false', () => {
+    const { container } = render(
+      <Select
+        disabled
+        inputProps={{ disabled: false }}
+        options={[{ label: '1', value: '1' }]}
+        showSearch
+      />,
+    );
+    const input = container.querySelector('input')!;
+
+    expect(container.querySelector('.ant-select-disabled')).toBeTruthy();
+    expect(input).toBeDisabled();
+  });
+
+  it('should preserve disabled state when inputProps disabled is true', () => {
+    const { container } = render(
+      <Select inputProps={{ disabled: true }} options={[{ label: '1', value: '1' }]} showSearch />,
+    );
+    const input = container.querySelector('input')!;
+
+    expect(input).toBeDisabled();
+  });
+
+  it('should preserve readOnly state when merging inputProps', () => {
+    const { container, rerender } = render(
+      <Select inputProps={{ readOnly: false }} options={[{ label: '1', value: '1' }]} />,
+    );
+    let input = container.querySelector('input')!;
+
+    expect(input).toHaveAttribute('readonly');
+
+    rerender(
+      <Select inputProps={{ readOnly: true }} options={[{ label: '1', value: '1' }]} showSearch />,
+    );
+    input = container.querySelector('input')!;
+
+    expect(input).toHaveAttribute('readonly');
+  });
+
+  it('should preserve control props from custom input element', () => {
+    const originOnChange = jest.fn();
+    const { container } = render(
+      <Select
+        components={{
+          input: <input disabled={false} value="origin" onChange={originOnChange} />,
+        }}
+        disabled
+        inputProps={{ autoComplete: 'new-password' }}
+        options={[{ label: '1', value: '1' }]}
+        showSearch
+      />,
+    );
+    const input = container.querySelector('input')!;
+
+    expect(input).toBeDisabled();
+    expect(input).not.toHaveValue('origin');
+    expect(input).toHaveAttribute('autocomplete', 'new-password');
+  });
+
   describe('Select Custom Icons', () => {
     it('should support customized icons', () => {
       const { rerender, asFragment } = render(

--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -80,6 +80,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | ~~filterOption~~ | If true, filter options by input, if function, filter options against it. The function will receive two arguments, `inputValue` and `option`, if the function returns `true`, the option will be included in the filtered set; Otherwise, it will be excluded | boolean \| function(inputValue, option) | true |  | × |
 | ~~filterSort~~ | Sort function for search options sorting, see [Array.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)'s compareFunction | (optionA: Option, optionB: Option, info: { searchValue: string }) => number | - | `searchValue`: 5.19.0 | × |
 | getPopupContainer | Parent Node which the selector should be rendered to. Default to `body`. When position issues happen, try to modify it into scrollable content and position it relative. [Example](https://codesandbox.io/s/4j168r7jw0) | function(triggerNode) | () => document.body |  | × |
+| inputProps | Native props of the internal search input | React.InputHTMLAttributes\<HTMLInputElement\> | - | 6.5.0 | × |
 | labelInValue | Whether to embed label in value, turn the format of value from `string` to { value: string, label: ReactNode } | boolean | false |  | × |
 | listHeight | Config popup height | number | 256 |  | × |
 | loading | Indicate loading state | boolean | false |  | × |

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -34,6 +34,8 @@ import { FormItemInputContext } from '../form/context';
 import useVariants from '../form/hooks/useVariants';
 import { useCompactItemContext } from '../space/Compact';
 import { useToken } from '../theme/internal';
+import { getInputPropsInput } from './inputProps';
+import type { SelectInputComponent } from './inputProps';
 import mergedBuiltinPlacements from './mergedBuiltinPlacements';
 import useStyle from './style';
 import useIcons from './useIcons';
@@ -42,7 +44,13 @@ import useShowArrow from './useShowArrow';
 
 type RawValue = string | number;
 
-export type { BaseOptionType, DefaultOptionType, OptionProps, BaseSelectRef as RefSelectProps, SearchConfig };
+export type {
+  BaseOptionType,
+  DefaultOptionType,
+  OptionProps,
+  BaseSelectRef as RefSelectProps,
+  SearchConfig,
+};
 
 export interface LabeledValue {
   key?: string;
@@ -117,6 +125,8 @@ export interface InternalSelectProps<
   styles?: SelectSemanticAllType['stylesAndFn'];
   loadingIcon?: React.ReactNode;
   showSearch?: boolean | (SearchConfig<OptionType> & { searchIcon?: React.ReactNode });
+  /** Pass native props to the internal search input. */
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
 export interface SelectProps<
@@ -199,6 +209,8 @@ const InternalSelect = <
     classNames,
     clearIcon,
     showSearch,
+    inputProps,
+    components,
     ...rest
   } = props;
 
@@ -315,6 +327,27 @@ const InternalSelect = <
   const mergedShowSearch = showSearch ?? contextShowSearch;
 
   const selectProps = omit(rest, ['suffixIcon', 'itemIcon' as any]);
+  const inputPropsRef = React.useRef(inputProps);
+  inputPropsRef.current = inputProps;
+
+  const inputComponentRef = React.useRef<SelectInputComponent>(components?.input);
+  inputComponentRef.current = components?.input;
+
+  const inputPropsInput = React.useMemo(
+    () => getInputPropsInput(inputComponentRef, inputPropsRef),
+    [],
+  );
+  const hasInputProps = Object.prototype.hasOwnProperty.call(props, 'inputProps');
+  const mergedComponents = React.useMemo(
+    () =>
+      !hasInputProps
+        ? components
+        : {
+            ...components,
+            input: inputPropsInput,
+          },
+    [hasInputProps, components, inputPropsInput],
+  );
 
   const mergedSize = useSize((ctx) => customizeSize ?? compactSize ?? ctx);
 
@@ -435,6 +468,7 @@ const InternalSelect = <
       styles={mergedStyles}
       showSearch={mergedShowSearch}
       {...selectProps}
+      components={mergedComponents}
       style={{ ...mergedStyles.root, ...contextStyle, ...style }}
       popupMatchSelectWidth={mergedPopupMatchSelectWidth}
       transitionName={getTransitionName(rootPrefixCls, 'slide-up', transitionName)}

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -81,6 +81,7 @@ demo:
 | ~~filterOption~~ | 是否根据输入项进行筛选。当其为一个函数时，会接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 true，反之则返回 false。[示例](#select-demo-search) | boolean \| function(inputValue, option) | true |  | × |
 | ~~filterSort~~ | 搜索时对筛选结果项的排序函数, 类似[Array.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)里的 compareFunction | (optionA: Option, optionB: Option, info: { searchValue: string }) => number | - | `searchValue`: 5.19.0 | × |
 | getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codesandbox.io/s/4j168r7jw0) | function(triggerNode) | () => document.body |  | × |
+| inputProps | 内部搜索输入框的原生属性 | React.InputHTMLAttributes\<HTMLInputElement\> | - | 6.5.0 | × |
 | labelInValue | 是否把每个选项的 label 包装到 value 中，会把 Select 的 value 类型从 `string` 变为 { value: string, label: ReactNode } 的格式 | boolean | false |  | × |
 | listHeight | 设置弹窗滚动高度 | number | 256 |  | × |
 | loading | 加载中状态 | boolean | false |  | × |

--- a/components/select/inputProps.tsx
+++ b/components/select/inputProps.tsx
@@ -1,0 +1,157 @@
+import * as React from 'react';
+import type { SelectProps as RcSelectProps } from '@rc-component/select';
+import { composeRef, getNodeRef } from '@rc-component/util';
+import { clsx } from 'clsx';
+
+type SelectComponents = NonNullable<RcSelectProps['components']>;
+export type SelectInputComponent = SelectComponents['input'];
+type InputComponentProps = React.InputHTMLAttributes<HTMLInputElement>;
+type InputComponentElementProps = InputComponentProps & React.RefAttributes<HTMLInputElement>;
+type InputEventHandler = (...args: unknown[]) => void;
+type InputPropsInputComponent = React.ForwardRefExoticComponent<
+  InputComponentProps & React.RefAttributes<HTMLInputElement>
+>;
+export type SelectInputComponentRef = React.MutableRefObject<SelectInputComponent>;
+export type InputPropsRef = React.MutableRefObject<InputComponentProps | undefined>;
+const INPUT_CONTROL_PROPS = ['value', 'defaultValue', 'disabled', 'readOnly'] as const;
+const INPUT_OVERRIDE_PROPS = ['autoComplete'] as const;
+type InputControlProp = (typeof INPUT_CONTROL_PROPS)[number];
+type InputOverrideProp = (typeof INPUT_OVERRIDE_PROPS)[number];
+
+const isEventHandlerProp = (propName: string) => /^on[A-Z]/.test(propName);
+
+const isInputControlProp = (propName: string): propName is InputControlProp =>
+  (INPUT_CONTROL_PROPS as readonly string[]).includes(propName);
+
+const isInputOverrideProp = (propName: string): propName is InputOverrideProp =>
+  (INPUT_OVERRIDE_PROPS as readonly string[]).includes(propName);
+
+const isMergedInputProp = (propName: string) =>
+  propName === 'className' ||
+  propName === 'style' ||
+  isInputControlProp(propName) ||
+  isEventHandlerProp(propName);
+
+const mergeInputRestProps = (
+  mergedProps: InputComponentProps,
+  props: InputComponentProps,
+  ...sources: InputComponentProps[]
+) => {
+  const mergedRecord = mergedProps as Record<string, unknown>;
+  const propsRecord = props as Record<string, unknown>;
+
+  sources.forEach((sourceProps) => {
+    const sourceRecord = sourceProps as Record<string, unknown>;
+
+    Object.keys(sourceProps).forEach((propName) => {
+      if (isMergedInputProp(propName)) {
+        return;
+      }
+
+      if (isInputOverrideProp(propName) || propsRecord[propName] === undefined) {
+        mergedRecord[propName] = sourceRecord[propName];
+      }
+    });
+  });
+};
+
+const composeInputHandlers = (...handlers: unknown[]) => {
+  const mergedHandlers = handlers.filter(
+    (handler, index): handler is InputEventHandler =>
+      typeof handler === 'function' && handlers.indexOf(handler) === index,
+  );
+
+  if (!mergedHandlers.length) {
+    return undefined;
+  }
+
+  return (...args: unknown[]) => {
+    mergedHandlers.forEach((handler) => {
+      handler(...args);
+    });
+  };
+};
+
+const mergeInputProps = (
+  props: InputComponentProps,
+  inputProps: InputComponentProps = {},
+  originProps: InputComponentProps = {},
+): InputComponentProps => {
+  const { className, style, ...restProps } = props;
+  const { className: originClassName, style: originStyle, ...restOriginProps } = originProps;
+  const { className: inputClassName, style: inputStyle, ...restInputProps } = inputProps;
+  const disabledValues = [props.disabled, originProps.disabled, inputProps.disabled];
+  const readOnlyValues = [props.readOnly, originProps.readOnly, inputProps.readOnly];
+
+  const mergedProps: InputComponentProps = {
+    ...restProps,
+    className: clsx(className, originClassName, inputClassName),
+    style: {
+      ...style,
+      ...originStyle,
+      ...inputStyle,
+    },
+  };
+  mergeInputRestProps(mergedProps, props, restOriginProps, restInputProps);
+
+  if (disabledValues.some((disabled) => disabled !== undefined)) {
+    mergedProps.disabled = disabledValues.some((disabled) => disabled);
+  }
+
+  if (readOnlyValues.some((readOnly) => readOnly !== undefined)) {
+    mergedProps.readOnly = readOnlyValues.some((readOnly) => readOnly);
+  }
+
+  const mergedRecord = mergedProps as Record<string, unknown>;
+  const propsRecord = props as Record<string, unknown>;
+  const originRecord = originProps as Record<string, unknown>;
+  const inputRecord = inputProps as Record<string, unknown>;
+
+  [...new Set([...Object.keys(originProps), ...Object.keys(inputProps)])].forEach((propName) => {
+    if (!isEventHandlerProp(propName)) {
+      return;
+    }
+
+    const handler = composeInputHandlers(
+      propsRecord[propName],
+      originRecord[propName],
+      inputRecord[propName],
+    );
+
+    if (handler) {
+      mergedRecord[propName] = handler;
+    }
+  });
+
+  return mergedProps;
+};
+
+export const getInputPropsInput = (
+  inputComponentRef: SelectInputComponentRef,
+  inputPropsRef: InputPropsRef,
+): InputPropsInputComponent => {
+  const Input = React.forwardRef<HTMLInputElement, InputComponentProps>((props, ref) => {
+    const inputComponent = inputComponentRef.current;
+    const inputProps = inputPropsRef.current;
+
+    if (React.isValidElement(inputComponent)) {
+      const originInput = inputComponent as React.ReactElement<InputComponentElementProps>;
+      const mergedProps = mergeInputProps(props, inputProps, originInput.props);
+      const mergedRef = composeRef(getNodeRef<HTMLInputElement>(originInput), ref);
+
+      return React.cloneElement(originInput, {
+        ...mergedProps,
+        ref: mergedRef,
+      });
+    }
+
+    const Component = (inputComponent || 'input') as React.ElementType;
+    const mergedProps = mergeInputProps(props, inputProps);
+
+    return <Component {...mergedProps} ref={ref} />;
+  });
+
+  Input.displayName = 'SelectInput';
+
+  return Input;
+};


### PR DESCRIPTION
### 🤔 This is 

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)


### 🔗 Related Issues

close #58109

### 💡 Background and Solution

When Select enables search, native attributes cannot be passed to the internal search input. For example, users cannot configure `autoComplete` on the actual input element.

This PR adds `inputProps` to pass native input attributes to Select's internal search input:

```tsx
<Select inputProps={{ autoComplete: 'new-password' }} showSearch />
```

It also updates the API documentation and adds a regression test to ensure inputProps.autoComplete is applied to the internal input instead of the outer .ant-select element.



### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| English | Add Select inputProps to pass native attributes to the internal search input. |
| Chinese | 新增 Select inputProps，用于向内部搜索输入框传递原生属性。 |