### PR TITLE
ci: prevent compile jobs from running out of memory

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Build
         run: ut build
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
 
       # ========== Prepare examples ==========
       - name: Clear examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,6 +162,8 @@ jobs:
 
       - name: compile
         run: ut compile
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
 
       - name: cache dist
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -225,6 +227,8 @@ jobs:
         # lib only run in master branch not in pull request
         if: ${{ github.event_name != 'pull_request' || matrix.module != 'lib' }}
         run: ut compile
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
 
       - name: test
         # lib only run in master branch not in pull request


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [x] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

参考 ant-design/ant-design#58209 的 CI 失败，以及 master 最新 push 在 `compile` 阶段的同类 OOM 失败。

### 💡 需求背景和解决方案

当前 master 及基于 master 的 PR 在 `ut compile` / `ut build` 流程中会进入 `antd-tools run compile`，该步骤在 CI 默认 Node heap 限制下可能触发 `JavaScript heap out of memory`，导致 `✅ test` 与 `Publish Any Commit` workflow 失败。

本次只在受影响的 CI 编译步骤中设置 `NODE_OPTIONS=--max_old_space_size=4096`，与已有站点、dist 等构建步骤的内存配置保持一致，避免改动本地 npm scripts 的语义。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |
