### PR TITLE
fix: align Input.Search button height with input token

### DIFF
--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 import { EditOutlined, UserOutlined } from '@ant-design/icons';
 import { fireEvent, render } from '@testing-library/react';
 
@@ -191,6 +192,48 @@ describe('Input.Search', () => {
   it('should support invalid addonAfter', () => {
     const { asFragment } = render(<Search addonAfter={[]} enterButton />);
     expect(asFragment().firstChild).toMatchSnapshot();
+  });
+
+  // https://github.com/ant-design/ant-design/issues/55494
+  it('should use Input controlHeight token for enter button in cssVar mode', () => {
+    const cache = createCache();
+
+    render(
+      <StyleProvider cache={cache}>
+        <ConfigProvider
+          theme={{
+            cssVar: {},
+            components: {
+              Input: {
+                controlHeight: 40,
+                controlHeightLG: 48,
+                controlHeightSM: 28,
+              },
+            },
+          }}
+        >
+          <Search enterButton="Search" />
+          <Search enterButton="Search" size="large" />
+          <Search enterButton="Search" size="small" />
+        </ConfigProvider>
+      </StyleProvider>,
+    );
+
+    const styleText = extractStyle(cache, { plain: true });
+
+    // Search button height should follow Input's control height tokens.
+    // In cssVar mode, the Input scope overrides `--ant-control-height` to 40px,
+    // so the search button picks up the customized Input control height.
+    expect(styleText).toContain('--ant-control-height:40px;');
+    expect(styleText).toContain(
+      '.ant-input-search .ant-input-search-btn{height:var(--ant-control-height);',
+    );
+    expect(styleText).toContain(
+      '.ant-input-search-large .ant-input-search-btn{height:var(--ant-control-height-lg);',
+    );
+    expect(styleText).toContain(
+      '.ant-input-search-small .ant-input-search-btn{height:var(--ant-control-height-sm);',
+    );
   });
 
   it('should prevent search button mousedown event', () => {

--- a/components/input/style/search.ts
+++ b/components/input/style/search.ts
@@ -14,6 +14,8 @@ const genSearchStyle: GenerateStyle<FullToken<'Input'>, CSSObject> = (token) => 
 
       // =========================== Button ===========================
       [btnCls]: {
+        height: token.controlHeight,
+
         '&-filled': {
           background: token.colorFillTertiary,
 
@@ -27,6 +29,14 @@ const genSearchStyle: GenerateStyle<FullToken<'Input'>, CSSObject> = (token) => 
             },
           },
         },
+      },
+
+      [`&-large ${btnCls}`]: {
+        height: token.controlHeightLG,
+      },
+
+      [`&-small ${btnCls}`]: {
+        height: token.controlHeightSM,
       },
     },
   };


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #55494

### 💡 需求背景和解决方案

在开启 `cssVar` 并通过 `components.Input.controlHeight` 自定义 Input 高度时，`Input.Search` 的输入框会跟随 Input token，但搜索按钮仍使用 Button 的高度，导致输入框和按钮高度不一致。

本 PR 将 `Input.Search` 的搜索按钮高度对齐到 Input 的 `controlHeight`、`controlHeightLG` 和 `controlHeightSM`，并补充 cssVar 模式下的回归测试。

测试命令：

```bash
npm test -- components/input/__tests__/Search.test.tsx
```

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Input.Search button height not following Input `controlHeight` token in cssVar mode. |
| 🇨🇳 中文 | 修复 Input.Search 在 cssVar 模式下搜索按钮高度不跟随 Input `controlHeight` token 的问题。 |
