### PR TITLE
fix: keep icon spin animation working with multiple icon prefixes

### DIFF
--- a/components/config-provider/__tests__/index.test.tsx
+++ b/components/config-provider/__tests__/index.test.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { SmileOutlined } from '@ant-design/icons';
+import { LoadingOutlined, SmileOutlined } from '@ant-design/icons';
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 
 import type { ConfigConsumerProps, RenderEmptyHandler } from '..';
 import ConfigProvider, { ConfigContext } from '..';
@@ -96,6 +97,29 @@ describe('ConfigProvider', () => {
 
     expect(container.querySelector('[role="img"]')).toHaveClass('bamboo');
     expect(container.querySelector('[role="img"]')).toHaveClass('bamboo-smile');
+  });
+
+  // https://github.com/ant-design/ant-design/issues/52412
+  it('should keep spin animation styles when multiple icon prefixes coexist', () => {
+    const cache = createCache();
+
+    render(
+      <StyleProvider cache={cache}>
+        <>
+          <ConfigProvider>
+            <LoadingOutlined spin />
+          </ConfigProvider>
+          <ConfigProvider iconPrefixCls="customicon">
+            <LoadingOutlined spin />
+          </ConfigProvider>
+        </>
+      </StyleProvider>,
+    );
+
+    const styleText = extractStyle(cache, { plain: true });
+
+    expect(styleText).toContain('.anticon-spin{animation-name:loadingCircle;');
+    expect(styleText).toContain('.customicon-spin{animation-name:loadingCircle;');
   });
 
   it('input autoComplete', () => {

--- a/components/style/index.tsx
+++ b/components/style/index.tsx
@@ -1,4 +1,4 @@
-import { unit } from '@ant-design/cssinjs';
+import { Keyframes, unit } from '@ant-design/cssinjs';
 import type { CSSObject } from '@ant-design/cssinjs';
 
 import type { AliasToken, GenerateStyle } from '../theme/internal';
@@ -42,6 +42,12 @@ export const resetIcon = (): CSSObject => ({
 
   svg: {
     display: 'inline-block',
+  },
+});
+
+const loadingCircle = new Keyframes('loadingCircle', {
+  '100%': {
+    transform: 'rotate(360deg)',
   },
 });
 
@@ -150,6 +156,13 @@ export const genIconStyle = (iconPrefixCls: string): CSSObject => ({
     [`.${iconPrefixCls} .${iconPrefixCls}-icon`]: {
       display: 'block',
     },
+  },
+
+  [`.${iconPrefixCls}-spin`]: {
+    animationName: loadingCircle,
+    animationDuration: '1s',
+    animationIterationCount: 'infinite',
+    animationTimingFunction: 'linear',
   },
 });
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

fix #52412

### 💡 需求背景和解决方案

`@ant-design/icons` 使用固定的样式 key（`@ant-design-icons`）注入 `.anticon-spin` 旋转动画，注入时会把 `anticon` 前缀替换为当前的 `iconPrefixCls`。当页面上存在多个不同 `iconPrefixCls` 的 `ConfigProvider` 共存时（例如 `Modal.confirm`、`message` 内部各自创建带独立 `iconPrefixCls` 的 `ConfigProvider`），后注入的样式会覆盖前者，导致部分 loading 图标的旋转动画失效。

解决方案：在 antd 自身的 `genIconStyle(iconPrefixCls)` 中，为每个 icon 前缀注册独立的 `.${iconPrefixCls}-spin` 关键帧动画作为兜底。该函数会在每个组件样式作用域内按对应前缀调用，因此各前缀的 spin 动画相互独立、不再互相覆盖。无 API 与 UI 变化。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix icon spin animation stopping when multiple \`iconPrefixCls\` coexist (e.g. with \`Modal.confirm\` or \`message\`). |
| 🇨🇳 中文 | 🐞 修复存在多个 \`iconPrefixCls\` 时（如配合 \`Modal.confirm\` 或 \`message\`）图标旋转动画停止的问题。 |