### PR TITLE
test: fix flaky visual diff caused by unstable screenshot rendering

### DIFF
--- a/tests/shared/imageTest.tsx
+++ b/tests/shared/imageTest.tsx
@@ -239,24 +239,22 @@ export default function imageTest(
       // Wait for fonts to be ready and the layout to settle BEFORE measuring
       // the page size. Otherwise the rendered width/height may shift after the
       // screenshot is taken, making the visual diff flaky.
-      await page.waitForFunction(
-        () =>
-          Promise.race([
-            // timeout 1000ms as a safety net
-            new Promise((resolve) => setTimeout(() => resolve(true), 1000)),
-            // wait fonts ready then raf * 2 to settle the layout
-            (document.fonts?.ready ?? Promise.resolve()).then(
-              () =>
-                new Promise((resolve) => {
+      await page.evaluate(() =>
+        Promise.race([
+          // timeout 1000ms as a safety net
+          new Promise((resolve) => setTimeout(() => resolve(true), 1000)),
+          // wait fonts ready then raf * 2 to settle the layout
+          (document.fonts?.ready ?? Promise.resolve()).then(
+            () =>
+              new Promise((resolve) => {
+                requestAnimationFrame(() => {
                   requestAnimationFrame(() => {
-                    requestAnimationFrame(() => {
-                      resolve(true);
-                    });
+                    resolve(true);
                   });
-                }),
-            ),
-          ]),
-        { timeout: 5000 },
+                });
+              }),
+          ),
+        ]),
       );
 
       if (!options.onlyViewport) {

--- a/tests/shared/imageTest.tsx
+++ b/tests/shared/imageTest.tsx
@@ -155,7 +155,11 @@ export default function imageTest(
         waitUntil: 'domcontentloaded',
       });
       await page.addStyleTag({ path: `${process.cwd()}/components/style/reset.css` });
-      await page.addStyleTag({ content: '*{animation: none!important;}' });
+      // Disable animation & transition to avoid capturing intermediate frames,
+      // which makes the rendered width/content flaky across runs.
+      await page.addStyleTag({
+        content: '*{animation: none!important; transition: none!important;}',
+      });
 
       const cache = createCache();
 
@@ -232,6 +236,29 @@ export default function imageTest(
         openTriggerClassName || '',
       );
 
+      // Wait for fonts to be ready and the layout to settle BEFORE measuring
+      // the page size. Otherwise the rendered width/height may shift after the
+      // screenshot is taken, making the visual diff flaky.
+      await page.waitForFunction(
+        () =>
+          Promise.race([
+            // timeout 1000ms as a safety net
+            new Promise((resolve) => setTimeout(() => resolve(true), 1000)),
+            // wait fonts ready then raf * 2 to settle the layout
+            (document.fonts?.ready ?? Promise.resolve()).then(
+              () =>
+                new Promise((resolve) => {
+                  requestAnimationFrame(() => {
+                    requestAnimationFrame(() => {
+                      resolve(true);
+                    });
+                  });
+                }),
+            ),
+          ]),
+        { timeout: 5000 },
+      );
+
       if (!options.onlyViewport) {
         // Get scroll height of the rendered page and set viewport
         const bodyHeight = await page.evaluate(() => document.body.scrollHeight);
@@ -243,21 +270,6 @@ export default function imageTest(
         );
         await page.setViewport({ width: 800, height: bodyHeight, ...sharedViewportConfig });
       }
-
-      await page.waitForFunction(() =>
-        Promise.race([
-          // timeout 100ms
-          new Promise((resolve) => setTimeout(() => resolve(true), 100)),
-          // raf * 2
-          new Promise((resolve) => {
-            requestAnimationFrame(() => {
-              requestAnimationFrame(() => {
-                resolve(true);
-              });
-            });
-          }),
-        ]),
-      );
 
       const image = await page.screenshot({ fullPage: !options.onlyViewport });
       await fse.writeFile(path.join(snapshotPath, `${identifier}${suffix}.png`), image);

--- a/tests/shared/imageTest.tsx
+++ b/tests/shared/imageTest.tsx
@@ -155,10 +155,12 @@ export default function imageTest(
         waitUntil: 'domcontentloaded',
       });
       await page.addStyleTag({ path: `${process.cwd()}/components/style/reset.css` });
-      // Disable animation & transition to avoid capturing intermediate frames,
-      // which makes the rendered width/content flaky across runs.
+      // Disable animation & transition (including pseudo-elements like
+      // `::before`/`::after`, used by Menu/Tabs/Carousel active bars) to avoid
+      // capturing intermediate frames, which makes the rendered width/content
+      // flaky across runs.
       await page.addStyleTag({
-        content: '*{animation: none!important; transition: none!important;}',
+        content: '*,*::before,*::after{animation: none!important; transition: none!important;}',
       });
 
       const cache = createCache();
@@ -239,23 +241,23 @@ export default function imageTest(
       // Wait for fonts to be ready and the layout to settle BEFORE measuring
       // the page size. Otherwise the rendered width/height may shift after the
       // screenshot is taken, making the visual diff flaky.
-      await page.evaluate(() =>
-        Promise.race([
-          // timeout 1000ms as a safety net
-          new Promise((resolve) => setTimeout(() => resolve(true), 1000)),
-          // wait fonts ready then raf * 2 to settle the layout
-          (document.fonts?.ready ?? Promise.resolve()).then(
-            () =>
-              new Promise((resolve) => {
-                requestAnimationFrame(() => {
-                  requestAnimationFrame(() => {
-                    resolve(true);
-                  });
-                });
-              }),
-          ),
-        ]),
-      );
+      await page.evaluate(async () => {
+        // Wait fonts ready, but cap it at 1000ms as a safety net so a stuck
+        // font load can never hang the screenshot.
+        await Promise.race([
+          document.fonts?.ready ?? Promise.resolve(),
+          new Promise((resolve) => setTimeout(resolve, 1000)),
+        ]);
+        // Always settle the layout with raf * 2, regardless of which branch
+        // above resolved first.
+        await new Promise((resolve) => {
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              resolve(true);
+            });
+          });
+        });
+      });
 
       if (!options.onlyViewport) {
         // Get scroll height of the rendered page and set viewport


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> 起因：https://github.com/ant-design/ant-design/pull/58253#issuecomment-4645134649 中出现了与 PR 无关的偶发 visual diff。

### 💡 Background and Solution

#### 问题

Visual regression CI 经常产出**与 PR 改动无关**的偶发 diff，且在不同 run 之间反复横跳——截图内容有时变宽、有时变窄、有时高度多出一块空白，导致没有改动相关组件的 PR 也被 flag。

排查了所有 open PR 后发现，**同一张截图会横跨大量主题完全无关的 PR 反复 diff**，这只可能是 master 基线本身不稳定造成的，例如：

- `table-sticky.*` 出现在 **9 个**互不相关的 PR（涉及 Select、Menu、Slider、List、ColorPicker 等，根本没碰 Table）
- `list-vertical.dark` 出现在 **6 个**无关 PR
- `tooltip-destroy-on-close`、`select-component-token`、`auto-complete-basic`、`form-register`、`date-picker-allow-empty` 等各出现在多个无关 PR 中

#### 根因（共三类失败模式）

| 类型 | 现象 | 实例 | 根因 |
| --- | --- | --- | --- |
| ① 高度抖动 | base / current 内容相同，但画布高度不同、底部偶发多/少一块空白 | `list-vertical.dark` 717↔849、`form-layout-multiple` 267↔853 | `document.body.scrollHeight` 在布局 / 字体稳定**之前**被测量 |
| ② 文本宽度塌缩 | 文字容器宽度偶发收缩导致换行 | `tooltip-destroy-on-close`：base 显示「Dom will」折成两行，current 显示完整一行 | 截图时字体尚未加载、布局尚未稳定 |
| ③ 定位 / 中间帧 | sticky 列、动画位置偏移 | `table-sticky` 的「Fix Right」定位抖动、`carousel-dot-duration` 进度条 | 仅禁用了 `animation` 而未禁用 `transition`；且截图前的等待 `Promise.race([100ms, raf*2])` 实际只等了约 2 帧 |

#### 解决方案（`tests/shared/imageTest.tsx`）

1. **同时禁用 `animation` 和 `transition`**，避免截到过渡中间帧（修 ③ 的动画 / 过渡问题）。
2. **截图前等待 `document.fonts.ready` + 双 `requestAnimationFrame`**（1s 兜底、5s 硬超时），等字体加载、布局稳定后再截图（修 ②）。
3. 把上述等待逻辑**前移到测量页面高度之前**，使 `scrollHeight` 基于稳定布局测得，viewport 高度不再抖动（修 ①）。

#### 影响范围

当前约有 **60+ 个 open PR** 报了 visual diff 失败，其中绝大多数属于上述 ①②③ 三类偶发抖动。这些 PR 在合入本修复后的 master 上重新生成基线、重跑 visual diff，无关 diff 即会消失。少数集中在同组件系列 PR 的 diff（如 Tag、Alert token 系列）属于 PR 自身的预期改动，需作者正常确认，与本修复无关。

### 📝 Change Log

> 仅涉及内部测试基建，对用户无感知。

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | N/A       |
| 🇨🇳 Chinese | 无需更新日志 |
