### PR TITLE
docs(Anchor, Avatar): document global config support

### DIFF
--- a/components/anchor/index.en-US.md
+++ b/components/anchor/index.en-US.md
@@ -40,45 +40,45 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### Anchor Props
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| affix | Fixed mode of Anchor | boolean \| Omit<AffixProps, 'offsetTop' \| 'target' \| 'children'> | true | object: 5.19.0 |
-| bounds | Bounding distance of anchor area | number | 5 |  |
-| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| getContainer | Scrolling container | () => HTMLElement | () => window |  |
-| getCurrentAnchor | Customize the anchor highlight | (activeLink: string) => string | - |  |
-| offsetTop | Pixels to offset from top when calculating position of scroll | number | 0 |  |
-| showInkInFixed | Whether show ink-square when `affix={false}` | boolean | false |  |
-| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
-| targetOffset | Anchor scroll offset, default as `offsetTop`, [example](#anchor-demo-targetoffset) | number | - |  |
-| onChange | Listening for anchor link change | (currentActiveLink: string) => void |  |  |
-| onClick | Set the handler to handle `click` event | (e: MouseEvent, link: object) => void | - |  |
-| items | Data configuration option content, support nesting through children | { key, href, title, target, children }\[] [see](#anchoritem) | - | 5.1.0 |
-| direction | Set Anchor direction | `vertical` \| `horizontal` | `vertical` | 5.2.0 |
-| replace | Replace items' href in browser history instead of pushing it | boolean | false | 5.7.0 |
+| Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| affix | Fixed mode of Anchor | boolean \| Omit<AffixProps, 'offsetTop' \| 'target' \| 'children'> | true | object: 5.19.0 | × |
+| bounds | Bounding distance of anchor area | number | 5 |  | × |
+| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
+| getContainer | Scrolling container | () => HTMLElement | () => window |  | × |
+| getCurrentAnchor | Customize the anchor highlight | (activeLink: string) => string | - |  | × |
+| offsetTop | Pixels to offset from top when calculating position of scroll | number | 0 |  | × |
+| showInkInFixed | Whether show ink-square when `affix={false}` | boolean | false |  | × |
+| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
+| targetOffset | Anchor scroll offset, default as `offsetTop`, [example](#anchor-demo-targetoffset) | number | - |  | × |
+| onChange | Listening for anchor link change | (currentActiveLink: string) => void |  |  | × |
+| onClick | Set the handler to handle `click` event | (e: MouseEvent, link: object) => void | - |  | × |
+| items | Data configuration option content, support nesting through children | { key, href, title, target, children }\[] [see](#anchoritem) | - | 5.1.0 | × |
+| direction | Set Anchor direction | `vertical` \| `horizontal` | `vertical` | 5.2.0 | × |
+| replace | Replace items' href in browser history instead of pushing it | boolean | false | 5.7.0 | × |
 
 ### AnchorItem
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| key | The unique identifier of the Anchor Link | string \| number | - |  |
-| href | The target of hyperlink | string |  |  |
-| target | Specifies where to display the linked URL | string |  |  |
-| title | The content of hyperlink | ReactNode |  |  |
-| children | Nested Anchor Link, `Attention: This attribute does not support horizontal orientation` | [AnchorItem](#anchoritem)\[] | - |  |
-| replace | Replace item href in browser history instead of pushing it | boolean | false | 5.7.0 |
-| targetOffset | Customize scroll offset for this anchor link. It takes precedence over the `targetOffset` prop of the Anchor component | number | - | 6.4.0 |
+| Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| key | The unique identifier of the Anchor Link | string \| number | - |  | × |
+| href | The target of hyperlink | string |  |  | × |
+| target | Specifies where to display the linked URL | string |  |  | × |
+| title | The content of hyperlink | ReactNode |  |  | × |
+| children | Nested Anchor Link, `Attention: This attribute does not support horizontal orientation` | [AnchorItem](#anchoritem)\[] | - |  | × |
+| replace | Replace item href in browser history instead of pushing it | boolean | false | 5.7.0 | × |
+| targetOffset | Customize scroll offset for this anchor link. It takes precedence over the `targetOffset` prop of the Anchor component | number | - | 6.4.0 | × |
 
 ### Link Props
 
 We recommend using the items form instead.
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| href | The target of hyperlink | string |  |  |
-| target | Specifies where to display the linked URL | string |  |  |
-| title | The content of hyperlink | ReactNode |  |  |
-| targetOffset | Customize scroll offset for this anchor link. It takes precedence over the `targetOffset` prop of the Anchor component | number | - | 6.4.0 |
+| Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| href | The target of hyperlink | string |  |  | × |
+| target | Specifies where to display the linked URL | string |  |  | × |
+| title | The content of hyperlink | ReactNode |  |  | × |
+| targetOffset | Customize scroll offset for this anchor link. It takes precedence over the `targetOffset` prop of the Anchor component | number | - | 6.4.0 | × |
 
 ## Semantic DOM
 

--- a/components/anchor/index.zh-CN.md
+++ b/components/anchor/index.zh-CN.md
@@ -41,45 +41,45 @@ group:
 
 ### Anchor Props
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| affix | 固定模式 | boolean \| Omit<AffixProps, 'offsetTop' \| 'target' \| 'children'> | true | object: 5.19.0 |
-| bounds | 锚点区域边界 | number | 5 |  |
-| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| getContainer | 指定滚动的容器 | () => HTMLElement | () => window |  |
-| getCurrentAnchor | 自定义高亮的锚点 | (activeLink: string) => string | - |  |
-| offsetTop | 距离窗口顶部达到指定偏移量后触发 | number |  |  |
-| showInkInFixed | `affix={false}` 时是否显示小方块 | boolean | false |  |
-| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
-| targetOffset | 锚点滚动偏移量，默认与 offsetTop 相同，[例子](#anchor-demo-targetoffset) | number | - |  |
-| onChange | 监听锚点链接改变 | (currentActiveLink: string) => void | - |  |
-| onClick | `click` 事件的 handler | (e: MouseEvent, link: object) => void | - |  |
-| items | 数据化配置选项内容，支持通过 children 嵌套 | { key, href, title, target, children }\[] [具体见](#anchoritem) | - | 5.1.0 |
-| direction | 设置导航方向 | `vertical` \| `horizontal` | `vertical` | 5.2.0 |
-| replace | 替换浏览器历史记录中项目的 href 而不是推送它 | boolean | false | 5.7.0 |
+| 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| affix | 固定模式 | boolean \| Omit<AffixProps, 'offsetTop' \| 'target' \| 'children'> | true | object: 5.19.0 | × |
+| bounds | 锚点区域边界 | number | 5 |  | × |
+| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
+| getContainer | 指定滚动的容器 | () => HTMLElement | () => window |  | × |
+| getCurrentAnchor | 自定义高亮的锚点 | (activeLink: string) => string | - |  | × |
+| offsetTop | 距离窗口顶部达到指定偏移量后触发 | number |  |  | × |
+| showInkInFixed | `affix={false}` 时是否显示小方块 | boolean | false |  | × |
+| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
+| targetOffset | 锚点滚动偏移量，默认与 offsetTop 相同，[例子](#anchor-demo-targetoffset) | number | - |  | × |
+| onChange | 监听锚点链接改变 | (currentActiveLink: string) => void | - |  | × |
+| onClick | `click` 事件的 handler | (e: MouseEvent, link: object) => void | - |  | × |
+| items | 数据化配置选项内容，支持通过 children 嵌套 | { key, href, title, target, children }\[] [具体见](#anchoritem) | - | 5.1.0 | × |
+| direction | 设置导航方向 | `vertical` \| `horizontal` | `vertical` | 5.2.0 | × |
+| replace | 替换浏览器历史记录中项目的 href 而不是推送它 | boolean | false | 5.7.0 | × |
 
 ### AnchorItem
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| key | 唯一标志 | string \| number | - |  |
-| href | 锚点链接 | string | - |  |
-| target | 该属性指定在何处显示链接的资源 | string | - |  |
-| title | 文字内容 | ReactNode | - |  |
-| children | 嵌套的 Anchor Link，`注意：水平方向该属性不支持` | [AnchorItem](#anchoritem)\[] | - |  |
-| replace | 替换浏览器历史记录中的项目 href 而不是推送它 | boolean | false | 5.7.0 |
-| targetOffset | 设置单个锚点的滚动偏移量，会覆盖 Anchor 组件的 targetOffset 属性 | number | - | 6.4.0 |
+| 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| key | 唯一标志 | string \| number | - |  | × |
+| href | 锚点链接 | string | - |  | × |
+| target | 该属性指定在何处显示链接的资源 | string | - |  | × |
+| title | 文字内容 | ReactNode | - |  | × |
+| children | 嵌套的 Anchor Link，`注意：水平方向该属性不支持` | [AnchorItem](#anchoritem)\[] | - |  | × |
+| replace | 替换浏览器历史记录中的项目 href 而不是推送它 | boolean | false | 5.7.0 | × |
+| targetOffset | 设置单个锚点的滚动偏移量，会覆盖 Anchor 组件的 targetOffset 属性 | number | - | 6.4.0 | × |
 
 ### Link Props
 
 建议使用 items 形式。
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| href | 锚点链接 | string | - |  |
-| target | 该属性指定在何处显示链接的资源 | string | - |  |
-| title | 文字内容 | ReactNode | - |  |
-| targetOffset | 设置单个锚点的滚动偏移量，会覆盖 Anchor 组件的 targetOffset 属性 | number | - | 6.4.0 |
+| 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| href | 锚点链接 | string | - |  | × |
+| target | 该属性指定在何处显示链接的资源 | string | - |  | × |
+| title | 文字内容 | ReactNode | - |  | × |
+| targetOffset | 设置单个锚点的滚动偏移量，会覆盖 Anchor 组件的 targetOffset 属性 | number | - | 6.4.0 | × |
 
 ## Semantic DOM
 

--- a/components/avatar/index.en-US.md
+++ b/components/avatar/index.en-US.md
@@ -30,32 +30,32 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### Avatar
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| alt | This attribute defines the alternative text describing the image | string | - |  |
-| gap | Letter type unit distance between left and right sides | number | 4 | 4.3.0 |
-| icon | Custom icon type for an icon avatar | ReactNode | - |  |
-| shape | The shape of avatar | `circle` \| `square` | `circle` |  |
-| size | The size of the avatar | number \| `large` \| `medium` \| `small` \| { xs: number, sm: number, ...} | `medium` | 4.7.0 |
-| src | The address of the image for an image avatar or image element | string \| ReactNode | - | ReactNode: 4.8.0 |
-| srcSet | A list of sources to use for different screen resolutions | string | - |  |
-| draggable | Whether the picture is allowed to be dragged | boolean \| `'true'` \| `'false'` | true |  |
-| crossOrigin | CORS settings attributes | `'anonymous'` \| `'use-credentials'` \| `''` | - | 4.17.0 |
-| onError | Handler when img load error, return false to prevent default fallback behavior | () => boolean | - |  |
+| Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| alt | This attribute defines the alternative text describing the image | string | - |  | × |
+| gap | Letter type unit distance between left and right sides | number | 4 | 4.3.0 | × |
+| icon | Custom icon type for an icon avatar | ReactNode | - |  | × |
+| shape | The shape of avatar | `circle` \| `square` | `circle` |  | × |
+| size | The size of the avatar | number \| `large` \| `medium` \| `small` \| { xs: number, sm: number, ...} | `medium` | 4.7.0 | × |
+| src | The address of the image for an image avatar or image element | string \| ReactNode | - | ReactNode: 4.8.0 | × |
+| srcSet | A list of sources to use for different screen resolutions | string | - |  | × |
+| draggable | Whether the picture is allowed to be dragged | boolean \| `'true'` \| `'false'` | true |  | × |
+| crossOrigin | CORS settings attributes | `'anonymous'` \| `'use-credentials'` \| `''` | - | 4.17.0 | × |
+| onError | Handler when img load error, return false to prevent default fallback behavior | () => boolean | - |  | × |
 
 > Tip: You can set `icon` or `children` as the fallback for image load error, with the priority of `icon` > `children`
 
 ### Avatar.Group <Badge>4.5.0+</Badge>
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| max | Set maximum display related configurations | `{ count?: number; style?: CSSProperties; popover?: PopoverProps }` | - | 5.18.0 |
-| ~~maxCount~~ | Deprecated, please use `max={{ count: number }}` | number | - |  |
-| ~~maxPopoverPlacement~~ | Deprecated, please use `max={{ popover: PopoverProps }}` | `top` \| `bottom` | `top` |  |
-| ~~maxPopoverTrigger~~ | Deprecated, please use `max={{ popover: PopoverProps }}` | `hover` \| `focus` \| `click` | `hover` |  |
-| ~~maxStyle~~ | Deprecated, please use `max={{ style: CSSProperties }}` | CSSProperties | - |  |
-| size | The size of the avatar | number \| `large` \| `medium` \| `small` \| { xs: number, sm: number, ...} | `medium` | 4.8.0 |
-| shape | The shape of the avatar | `circle` \| `square` | `circle` | 5.8.0 |
+| Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| max | Set maximum display related configurations | `{ count?: number; style?: CSSProperties; popover?: PopoverProps }` | - | 5.18.0 | × |
+| ~~maxCount~~ | Deprecated, please use `max={{ count: number }}` | number | - |  | × |
+| ~~maxPopoverPlacement~~ | Deprecated, please use `max={{ popover: PopoverProps }}` | `top` \| `bottom` | `top` |  | × |
+| ~~maxPopoverTrigger~~ | Deprecated, please use `max={{ popover: PopoverProps }}` | `hover` \| `focus` \| `click` | `hover` |  | × |
+| ~~maxStyle~~ | Deprecated, please use `max={{ style: CSSProperties }}` | CSSProperties | - |  | × |
+| size | The size of the avatar | number \| `large` \| `medium` \| `small` \| { xs: number, sm: number, ...} | `medium` | 4.8.0 | × |
+| shape | The shape of the avatar | `circle` \| `square` | `circle` | 5.8.0 | × |
 
 ## Design Token
 

--- a/components/avatar/index.zh-CN.md
+++ b/components/avatar/index.zh-CN.md
@@ -35,32 +35,32 @@ group:
 
 ### Avatar
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| alt | 图像无法显示时的替代文本 | string | - |  |
-| gap | 字符类型距离左右两侧边界单位像素 | number | 4 | 4.3.0 |
-| icon | 设置头像的自定义图标 | ReactNode | - |  |
-| shape | 指定头像的形状 | `circle` \| `square` | `circle` |  |
-| size | 设置头像的大小 | number \| `large` \| `medium` \| `small` \| { xs: number, sm: number, ...} | `medium` | 4.7.0 |
-| src | 图片类头像的资源地址或者图片元素 | string \| ReactNode | - | ReactNode: 4.8.0 |
-| srcSet | 设置图片类头像响应式资源地址 | string | - |  |
-| draggable | 图片是否允许拖动 | boolean \| `'true'` \| `'false'` | true |  |
-| crossOrigin | CORS 属性设置 | `'anonymous'` \| `'use-credentials'` \| `''` | - | 4.17.0 |
-| onError | 图片加载失败的事件，返回 false 会关闭组件默认的 fallback 行为 | () => boolean | - |  |
+| 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| alt | 图像无法显示时的替代文本 | string | - |  | × |
+| gap | 字符类型距离左右两侧边界单位像素 | number | 4 | 4.3.0 | × |
+| icon | 设置头像的自定义图标 | ReactNode | - |  | × |
+| shape | 指定头像的形状 | `circle` \| `square` | `circle` |  | × |
+| size | 设置头像的大小 | number \| `large` \| `medium` \| `small` \| { xs: number, sm: number, ...} | `medium` | 4.7.0 | × |
+| src | 图片类头像的资源地址或者图片元素 | string \| ReactNode | - | ReactNode: 4.8.0 | × |
+| srcSet | 设置图片类头像响应式资源地址 | string | - |  | × |
+| draggable | 图片是否允许拖动 | boolean \| `'true'` \| `'false'` | true |  | × |
+| crossOrigin | CORS 属性设置 | `'anonymous'` \| `'use-credentials'` \| `''` | - | 4.17.0 | × |
+| onError | 图片加载失败的事件，返回 false 会关闭组件默认的 fallback 行为 | () => boolean | - |  | × |
 
 > Tip：你可以设置 `icon` 或 `children` 作为图片加载失败的默认 fallback 行为，优先级为 `icon` > `children`
 
 ### Avatar.Group <Badge>4.5.0+</Badge>
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| max | 设置最多显示相关配置 | `{ count?: number; style?: CSSProperties; popover?: PopoverProps }` | - | 5.18.0 |
-| ~~maxCount~~ | 已废弃，请使用 `max={{ count: number }}` | number | - |  |
-| ~~maxPopoverPlacement~~ | 已废弃，请使用 `max={{ popover: PopoverProps }}` | `top` \| `bottom` | `top` |  |
-| ~~maxPopoverTrigger~~ | 已废弃，请使用 `max={{ popover: PopoverProps }}` | `hover` \| `focus` \| `click` | `hover` |  |
-| ~~maxStyle~~ | 已废弃，请使用 `max={{ style: CSSProperties }}` | CSSProperties | - |  |
-| size | 设置头像的大小 | number \| `large` \| `medium` \| `small` \| { xs: number, sm: number, ...} | `medium` | 4.8.0 |
-| shape | 设置头像的形状 | `circle` \| `square` | `circle` | 5.8.0 |
+| 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| max | 设置最多显示相关配置 | `{ count?: number; style?: CSSProperties; popover?: PopoverProps }` | - | 5.18.0 | × |
+| ~~maxCount~~ | 已废弃，请使用 `max={{ count: number }}` | number | - |  | × |
+| ~~maxPopoverPlacement~~ | 已废弃，请使用 `max={{ popover: PopoverProps }}` | `top` \| `bottom` | `top` |  | × |
+| ~~maxPopoverTrigger~~ | 已废弃，请使用 `max={{ popover: PopoverProps }}` | `hover` \| `focus` \| `click` | `hover` |  | × |
+| ~~maxStyle~~ | 已废弃，请使用 `max={{ style: CSSProperties }}` | CSSProperties | - |  | × |
+| size | 设置头像的大小 | number \| `large` \| `medium` \| `small` \| { xs: number, sm: number, ...} | `medium` | 4.8.0 | × |
+| shape | 设置头像的形状 | `circle` \| `square` | `circle` | 5.8.0 | × |
 
 ## 主题变量（Design Token）{#design-token}
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 📝 Site / documentation improvement

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

Anchor 和 Avatar 的 API 表格缺少全局配置支持信息。本次为相关属性表补充“全局配置”列，标明哪些属性支持通过 ConfigProvider 进行组件级配置，并同步更新中英文文档。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  Anchor, Avatar  document global config support       |
| 🇨🇳 Chinese |    Anchor, Avatar  全局配置支持文档     |
