### PR TITLE
docs(Calendar, Card, Carousel, Cascader, Checkbox, Collapse, ColorPicker): document global config support

### DIFF
--- a/components/calendar/index.en-US.md
+++ b/components/calendar/index.en-US.md
@@ -39,25 +39,25 @@ Common props ref：[Common props](/docs/react/common-props)
 <Calendar cellRender={cellRender} onPanelChange={onPanelChange} onSelect={onSelect} />
 ```
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| cellRender | Customize cell content | function(current: dayjs, info: { prefixCls: string, originNode: React.ReactElement, today: dayjs, range?: 'start' \| 'end', type: PanelMode, locale?: Locale, subType?: 'hour' \| 'minute' \| 'second' \| 'meridiem' }) => React.ReactNode | - | 5.4.0 |
-| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| ~~dateFullCellRender~~ | Customize the display of the date cell, the returned content will override the cell. Please use `fullCellRender` instead in 5.4.0 and later | function(date: Dayjs): ReactNode | - | < 5.4.0 |
-| fullCellRender | Customize cell content | function(current: dayjs, info: { prefixCls: string, originNode: React.ReactElement, today: dayjs, range?: 'start' \| 'end', type: PanelMode, locale?: Locale, subType?: 'hour' \| 'minute' \| 'second' \| 'meridiem' }) => React.ReactNode | - | 5.4.0 |
-| defaultValue | The date selected by default | [dayjs](https://day.js.org/) | - |  |
-| disabledDate | Function that specifies the dates that cannot be selected, `currentDate` is same dayjs object as `value` prop which you shouldn't mutate it (https://github.com/ant-design/ant-design/issues/30987) | (currentDate: Dayjs) => boolean | - |  |
-| fullscreen | Whether to display in full-screen | boolean | true |  |
-| showWeek | Whether to display week number | boolean | false | 5.23.0 |
-| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
-| headerRender | Render custom header in panel | function(object:{value: Dayjs, type: 'year' \| 'month', onChange: f(), onTypeChange: f()}) | - |  |
-| locale | The calendar's locale | object | [(default)](https://github.com/ant-design/ant-design/blob/master/components/date-picker/locale/example.json) |  |
-| mode | The display mode of the calendar | `month` \| `year` | `month` |  |
-| validRange | To set valid range | \[[dayjs](https://day.js.org/), [dayjs](https://day.js.org/)] | - |  |
-| value | The current selected date | [dayjs](https://day.js.org/) | - |  |
-| onChange | Callback for when date changes | function(date: Dayjs) | - |  |
-| onPanelChange | Callback for when panel changes | function(date: Dayjs, mode: string) | - |  |
-| onSelect | Callback for when a date is selected, include source info | function(date: Dayjs, info: { source: 'year' \| 'month' \| 'date' \| 'customize' }) | - | `info`: 5.6.0 |
+| Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| cellRender | Customize cell content | function(current: dayjs, info: { prefixCls: string, originNode: React.ReactElement, today: dayjs, range?: 'start' \| 'end', type: PanelMode, locale?: Locale, subType?: 'hour' \| 'minute' \| 'second' \| 'meridiem' }) => React.ReactNode | - | 5.4.0 | × |
+| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
+| ~~dateFullCellRender~~ | Customize the display of the date cell, the returned content will override the cell. Please use `fullCellRender` instead in 5.4.0 and later | function(date: Dayjs): ReactNode | - | < 5.4.0 | × |
+| fullCellRender | Customize cell content | function(current: dayjs, info: { prefixCls: string, originNode: React.ReactElement, today: dayjs, range?: 'start' \| 'end', type: PanelMode, locale?: Locale, subType?: 'hour' \| 'minute' \| 'second' \| 'meridiem' }) => React.ReactNode | - | 5.4.0 | × |
+| defaultValue | The date selected by default | [dayjs](https://day.js.org/) | - |  | × |
+| disabledDate | Function that specifies the dates that cannot be selected, `currentDate` is same dayjs object as `value` prop which you shouldn't mutate it (https://github.com/ant-design/ant-design/issues/30987) | (currentDate: Dayjs) => boolean | - |  | × |
+| fullscreen | Whether to display in full-screen | boolean | true |  | × |
+| showWeek | Whether to display week number | boolean | false | 5.23.0 | × |
+| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
+| headerRender | Render custom header in panel | function(object:{value: Dayjs, type: 'year' \| 'month', onChange: f(), onTypeChange: f()}) | - |  | × |
+| locale | The calendar's locale | object | [(default)](https://github.com/ant-design/ant-design/blob/master/components/date-picker/locale/example.json) |  | × |
+| mode | The display mode of the calendar | `month` \| `year` | `month` |  | × |
+| validRange | To set valid range | \[[dayjs](https://day.js.org/), [dayjs](https://day.js.org/)] | - |  | × |
+| value | The current selected date | [dayjs](https://day.js.org/) | - |  | × |
+| onChange | Callback for when date changes | function(date: Dayjs) | - |  | × |
+| onPanelChange | Callback for when panel changes | function(date: Dayjs, mode: string) | - |  | × |
+| onSelect | Callback for when a date is selected, include source info | function(date: Dayjs, info: { source: 'year' \| 'month' \| 'date' \| 'customize' }) | - | `info`: 5.6.0 | × |
 
 ## Semantic DOM
 

--- a/components/calendar/index.zh-CN.md
+++ b/components/calendar/index.zh-CN.md
@@ -40,25 +40,25 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*-p-wQLik200AAA
 <Calendar cellRender={cellRender} onPanelChange={onPanelChange} onSelect={onSelect} />
 ```
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| cellRender | 自定义单元格的内容 | function(current: dayjs, info: { prefixCls: string, originNode: React.ReactElement, today: dayjs, range?: 'start' \| 'end', type: PanelMode, locale?: Locale, subType?: 'hour' \| 'minute' \| 'second' \| 'meridiem' }) => React.ReactNode | - | 5.4.0 |
-| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| ~~dateFullCellRender~~ | 自定义渲染日期单元格，返回内容覆盖单元格，>= 5.4.0 请用 `fullCellRender` | function(date: Dayjs): ReactNode | - | < 5.4.0 |
-| fullCellRender | 自定义单元格的内容 | function(current: dayjs, info: { prefixCls: string, originNode: React.ReactElement, today: dayjs, range?: 'start' \| 'end', type: PanelMode, locale?: Locale, subType?: 'hour' \| 'minute' \| 'second' \| 'meridiem' }) => React.ReactNode | - | 5.4.0 |
-| defaultValue | 默认展示的日期 | [dayjs](https://day.js.org/) | - |  |
-| disabledDate | 不可选择的日期，参数为当前 `value`，注意使用时[不要直接修改](https://github.com/ant-design/ant-design/issues/30987) | (currentDate: Dayjs) => boolean | - |  |
-| fullscreen | 是否全屏显示 | boolean | true |  |
-| showWeek | 是否显示周数列 | boolean | false | 5.23.0 |
-| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
-| headerRender | 自定义头部内容 | function(object:{value: Dayjs, type: 'year' \| 'month', onChange: f(), onTypeChange: f()}) | - |  |
-| locale | 国际化配置 | object | [(默认配置)](https://github.com/ant-design/ant-design/blob/master/components/date-picker/locale/example.json) |  |
-| mode | 初始模式 | `month` \| `year` | `month` |  |
-| validRange | 设置可以显示的日期 | \[[dayjs](https://day.js.org/), [dayjs](https://day.js.org/)] | - |  |
-| value | 展示日期 | [dayjs](https://day.js.org/) | - |  |
-| onChange | 日期变化回调 | function(date: Dayjs) | - |  |
-| onPanelChange | 日期面板变化回调 | function(date: Dayjs, mode: string) | - |  |
-| onSelect | 选择日期回调，包含来源信息 | function(date: Dayjs, info: { source: 'year' \| 'month' \| 'date' \| 'customize' }) | - | `info`: 5.6.0 |
+| 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| cellRender | 自定义单元格的内容 | function(current: dayjs, info: { prefixCls: string, originNode: React.ReactElement, today: dayjs, range?: 'start' \| 'end', type: PanelMode, locale?: Locale, subType?: 'hour' \| 'minute' \| 'second' \| 'meridiem' }) => React.ReactNode | - | 5.4.0 | × |
+| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
+| ~~dateFullCellRender~~ | 自定义渲染日期单元格，返回内容覆盖单元格，>= 5.4.0 请用 `fullCellRender` | function(date: Dayjs): ReactNode | - | < 5.4.0 | × |
+| fullCellRender | 自定义单元格的内容 | function(current: dayjs, info: { prefixCls: string, originNode: React.ReactElement, today: dayjs, range?: 'start' \| 'end', type: PanelMode, locale?: Locale, subType?: 'hour' \| 'minute' \| 'second' \| 'meridiem' }) => React.ReactNode | - | 5.4.0 | × |
+| defaultValue | 默认展示的日期 | [dayjs](https://day.js.org/) | - |  | × |
+| disabledDate | 不可选择的日期，参数为当前 `value`，注意使用时[不要直接修改](https://github.com/ant-design/ant-design/issues/30987) | (currentDate: Dayjs) => boolean | - |  | × |
+| fullscreen | 是否全屏显示 | boolean | true |  | × |
+| showWeek | 是否显示周数列 | boolean | false | 5.23.0 | × |
+| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
+| headerRender | 自定义头部内容 | function(object:{value: Dayjs, type: 'year' \| 'month', onChange: f(), onTypeChange: f()}) | - |  | × |
+| locale | 国际化配置 | object | [(默认配置)](https://github.com/ant-design/ant-design/blob/master/components/date-picker/locale/example.json) |  | × |
+| mode | 初始模式 | `month` \| `year` | `month` |  | × |
+| validRange | 设置可以显示的日期 | \[[dayjs](https://day.js.org/), [dayjs](https://day.js.org/)] | - |  | × |
+| value | 展示日期 | [dayjs](https://day.js.org/) | - |  | × |
+| onChange | 日期变化回调 | function(date: Dayjs) | - |  | × |
+| onPanelChange | 日期面板变化回调 | function(date: Dayjs, mode: string) | - |  | × |
+| onSelect | 选择日期回调，包含来源信息 | function(date: Dayjs, info: { source: 'year' \| 'month' \| 'date' \| 'customize' }) | - | `info`: 5.6.0 | × |
 
 ## Semantic DOM
 

--- a/components/card/index.en-US.md
+++ b/components/card/index.en-US.md
@@ -36,28 +36,28 @@ Common props ref：[Common props](/docs/react/common-props)
 <Card title="Card title">Card content</Card>
 ```
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| actions | The action list, shows at the bottom of the Card | Array&lt;ReactNode> | - |  |
-| activeTabKey | Current TabPane's key | string | - |  |
-| ~~bordered~~ | Toggles rendering of the border around the card, please use `variant` instead | boolean | true |  |
-| ~~bodyStyle~~ | Style of card body, please use `styles.body` instead | CSSProperties | - | - |
-| variant | Variants of Card | `outlined` \| `borderless` \| | `outlined` | 5.24.0 |
-| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| cover | Card cover | ReactNode | - |  |
-| defaultActiveTabKey | Initial active TabPane's key, if `activeTabKey` is not set | string | `The key of first tab` |  |
-| extra | Content to render in the top-right corner of the card | ReactNode | - |  |
-| hoverable | Lift up when hovering card | boolean | false |  |
-| ~~headStyle~~ | Style of card head, please use `styles.header` instead | CSSProperties | - | - |
-| loading | Shows a loading indicator while the contents of the card are being fetched | boolean | false |  |
-| size | Size of card | `medium` \| `small` | `medium` |  |
-| tabBarExtraContent | Extra content in tab bar | ReactNode | - |  |
-| tabList | List of TabPane's head | [TabItemType](/components/tabs#tabitemtype)[] | - |  |
-| tabProps | [Tabs](/components/tabs/#tabs) | - | - |  |
-| title | Card title | ReactNode | - |  |
-| type | Card style type, can be set to `inner` or not set | string | - |  |
-| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
-| onTabChange | Callback when tab is switched | (key) => void | - |  |
+| Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| actions | The action list, shows at the bottom of the Card | Array&lt;ReactNode> | - |  | × |
+| activeTabKey | Current TabPane's key | string | - |  | × |
+| ~~bordered~~ | Toggles rendering of the border around the card, please use `variant` instead | boolean | true |  | × |
+| ~~bodyStyle~~ | Style of card body, please use `styles.body` instead | CSSProperties | - | - | × |
+| variant | Variants of Card | `outlined` \| `borderless` \| | `outlined` | 5.24.0 | × |
+| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 5.14.0 |
+| cover | Card cover | ReactNode | - |  | × |
+| defaultActiveTabKey | Initial active TabPane's key, if `activeTabKey` is not set | string | `The key of first tab` |  | × |
+| extra | Content to render in the top-right corner of the card | ReactNode | - |  | × |
+| hoverable | Lift up when hovering card | boolean | false |  | × |
+| ~~headStyle~~ | Style of card head, please use `styles.header` instead | CSSProperties | - | - | × |
+| loading | Shows a loading indicator while the contents of the card are being fetched | boolean | false |  | × |
+| size | Size of card | `medium` \| `small` | `medium` |  | × |
+| tabBarExtraContent | Extra content in tab bar | ReactNode | - |  | × |
+| tabList | List of TabPane's head | [TabItemType](/components/tabs#tabitemtype)[] | - |  | × |
+| tabProps | [Tabs](/components/tabs/#tabs) | - | - |  | × |
+| title | Card title | ReactNode | - |  | × |
+| type | Card style type, can be set to `inner` or not set | string | - |  | × |
+| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 5.14.0 |
+| onTabChange | Callback when tab is switched | (key) => void | - |  | × |
 
 ### Card.Grid
 
@@ -69,13 +69,15 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### Card.Meta
 
-| Property    | Description                   | Type          | Default | Version |
-| ----------- | ----------------------------- | ------------- | ------- | ------- |
-| avatar      | Avatar or icon                | ReactNode     | -       |         |
-| className   | The className of container    | string        | -       |         |
-| description | Description content           | ReactNode     | -       |         |
-| style       | The style object of container | CSSProperties | -       |         |
-| title       | Title content                 | ReactNode     | -       |         |
+| Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| avatar | Avatar or icon | ReactNode | - |  | × |
+| className | The className of container | string | - |  | 6.0.0 |
+| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | 6.0.0 | 6.0.0 |
+| description | Description content | ReactNode | - |  | × |
+| style | The style object of container | CSSProperties | - |  | 6.0.0 |
+| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.0.0 | 6.0.0 |
+| title | Title content | ReactNode | - |  | × |
 
 ## Semantic DOM
 

--- a/components/card/index.zh-CN.md
+++ b/components/card/index.zh-CN.md
@@ -37,28 +37,28 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*5WDvQp_H7LUAAA
 <Card title="卡片标题">卡片内容</Card>
 ```
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| actions | 卡片操作组，位置在卡片底部 | Array&lt;ReactNode> | - |  |
-| activeTabKey | 当前激活页签的 key | string | - |  |
-| ~~bordered~~ | 是否有边框, 请使用 `variant` 替换 | boolean | true |  |
-| ~~bodyStyle~~ | 卡片内容区域样式，请使用 `styles.body` 替代 | CSSProperties | - | - |
-| variant | 形态变体 | `outlined` \| `borderless` \| | `outlined` | 5.24.0 |
-| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| cover | 卡片封面 | ReactNode | - |  |
-| defaultActiveTabKey | 初始化选中页签的 key，如果没有设置 activeTabKey | string | `第一个页签的 key` |  |
-| extra | 卡片右上角的操作区域 | ReactNode | - |  |
-| hoverable | 鼠标移过时可浮起 | boolean | false |  |
-| ~~headStyle~~ | 卡片头部样式，请使用 `styles.header` 替代 | CSSProperties | - | - |
-| loading | 当卡片内容还在加载中时，可以用 loading 展示一个占位 | boolean | false |  |
-| size | card 的尺寸 | `medium` \| `small` | `medium` |  |
-| tabBarExtraContent | tab bar 上额外的元素 | ReactNode | - |  |
-| tabList | 页签标题列表 | [TabItemType](/components/tabs-cn#tabitemtype)[] | - |  |
-| tabProps | [Tabs](/components/tabs-cn#tabs) | - | - |  |
-| title | 卡片标题 | ReactNode | - |  |
-| type | 卡片类型，可设置为 `inner` 或 不设置 | string | - |  |
-| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
-| onTabChange | 页签切换的回调 | (key) => void | - |  |
+| 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| actions | 卡片操作组，位置在卡片底部 | Array&lt;ReactNode> | - |  | × |
+| activeTabKey | 当前激活页签的 key | string | - |  | × |
+| ~~bordered~~ | 是否有边框, 请使用 `variant` 替换 | boolean | true |  | × |
+| ~~bodyStyle~~ | 卡片内容区域样式，请使用 `styles.body` 替代 | CSSProperties | - | - | × |
+| variant | 形态变体 | `outlined` \| `borderless` \| | `outlined` | 5.24.0 | × |
+| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 5.14.0 |
+| cover | 卡片封面 | ReactNode | - |  | × |
+| defaultActiveTabKey | 初始化选中页签的 key，如果没有设置 activeTabKey | string | `第一个页签的 key` |  | × |
+| extra | 卡片右上角的操作区域 | ReactNode | - |  | × |
+| hoverable | 鼠标移过时可浮起 | boolean | false |  | × |
+| ~~headStyle~~ | 卡片头部样式，请使用 `styles.header` 替代 | CSSProperties | - | - | × |
+| loading | 当卡片内容还在加载中时，可以用 loading 展示一个占位 | boolean | false |  | × |
+| size | card 的尺寸 | `medium` \| `small` | `medium` |  | × |
+| tabBarExtraContent | tab bar 上额外的元素 | ReactNode | - |  | × |
+| tabList | 页签标题列表 | [TabItemType](/components/tabs-cn#tabitemtype)[] | - |  | × |
+| tabProps | [Tabs](/components/tabs-cn#tabs) | - | - |  | × |
+| title | 卡片标题 | ReactNode | - |  | × |
+| type | 卡片类型，可设置为 `inner` 或 不设置 | string | - |  | × |
+| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 5.14.0 |
+| onTabChange | 页签切换的回调 | (key) => void | - |  | × |
 
 ### Card.Grid
 
@@ -70,13 +70,15 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*5WDvQp_H7LUAAA
 
 ### Card.Meta
 
-| 参数        | 说明               | 类型          | 默认值 | 版本 |
-| ----------- | ------------------ | ------------- | ------ | ---- |
-| avatar      | 头像/图标          | ReactNode     | -      |      |
-| className   | 容器类名           | string        | -      |      |
-| description | 描述内容           | ReactNode     | -      |      |
-| style       | 定义容器类名的样式 | CSSProperties | -      |      |
-| title       | 标题内容           | ReactNode     | -      |      |
+| 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| avatar | 头像/图标 | ReactNode | - |  | × |
+| className | 容器类名 | string | - |  | 6.0.0 |
+| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | 6.0.0 | 6.0.0 |
+| description | 描述内容 | ReactNode | - |  | × |
+| style | 定义容器类名的样式 | CSSProperties | - |  | 6.0.0 |
+| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.0.0 | 6.0.0 |
+| title | 标题内容 | ReactNode | - |  | × |
 
 ## Semantic DOM
 

--- a/components/carousel/index.en-US.md
+++ b/components/carousel/index.en-US.md
@@ -30,24 +30,24 @@ demo:
 
 Common props ref：[Common props](/docs/react/common-props)
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| arrows | Whether to show switch arrows | boolean | false | 5.17.0 |
-| autoplay | Whether to scroll automatically, you can specify `autoplay={{ dotDuration: true }}` to display the progress bar | boolean \| { dotDuration?: boolean } | false | dotDuration: 5.24.0 |
-| autoplaySpeed | Delay between each auto scroll (in milliseconds) | number | 3000 |  |
-| adaptiveHeight | Adjust the slide's height automatically | boolean | false |  |
-| dotPlacement | The position of the dots, which can be one of `top` `bottom` `start` `end` | string | `bottom` |  |
-| ~~dotPosition~~ | The position of the dots, which can be one of `top` `bottom` `left` `right` `start` `end`, Please use `dotPlacement` instead | string | `bottom` |  |
-| dots | Whether to show the dots at the bottom of the gallery, `object` for `dotsClass` | boolean \| { className?: string } | true |  |
-| draggable | Enable scrollable via dragging on desktop | boolean | false |  |
-| fade | Whether to use fade transition | boolean | false |  |
-| infinite | Infinitely wrap around contents | boolean | true |  |
-| speed | Animation speed in milliseconds | number | 500 |  |
-| easing | Transition interpolation function name | string | `linear` |  |
-| effect | Transition effect | `scrollx` \| `fade` | `scrollx` |  |
-| afterChange | Callback function called after the current index changes | (current: number) => void | - |  |
-| beforeChange | Callback function called before the current index changes | (current: number, next: number) => void | - |  |
-| waitForAnimate | Whether to wait for the animation when switching | boolean | false |  |
+| Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| arrows | Whether to show switch arrows | boolean | false | 5.17.0 | × |
+| autoplay | Whether to scroll automatically, you can specify `autoplay={{ dotDuration: true }}` to display the progress bar | boolean \| { dotDuration?: boolean } | false | dotDuration: 5.24.0 | × |
+| autoplaySpeed | Delay between each auto scroll (in milliseconds) | number | 3000 |  | × |
+| adaptiveHeight | Adjust the slide's height automatically | boolean | false |  | × |
+| dotPlacement | The position of the dots, which can be one of `top` `bottom` `start` `end` | string | `bottom` |  | × |
+| ~~dotPosition~~ | The position of the dots, which can be one of `top` `bottom` `left` `right` `start` `end`, Please use `dotPlacement` instead | string | `bottom` |  | × |
+| dots | Whether to show the dots at the bottom of the gallery, `object` for `dotsClass` | boolean \| { className?: string } | true |  | × |
+| draggable | Enable scrollable via dragging on desktop | boolean | false |  | × |
+| fade | Whether to use fade transition | boolean | false |  | × |
+| infinite | Infinitely wrap around contents | boolean | true |  | × |
+| speed | Animation speed in milliseconds | number | 500 |  | × |
+| easing | Transition interpolation function name | string | `linear` |  | × |
+| effect | Transition effect | `scrollx` \| `fade` | `scrollx` |  | × |
+| afterChange | Callback function called after the current index changes | (current: number) => void | - |  | × |
+| beforeChange | Callback function called before the current index changes | (current: number, next: number) => void | - |  | × |
+| waitForAnimate | Whether to wait for the animation when switching | boolean | false |  | × |
 
 Find more APIs in react-slick [documentation](https://react-slick.neostack.com/docs/api).
 

--- a/components/carousel/index.zh-CN.md
+++ b/components/carousel/index.zh-CN.md
@@ -31,24 +31,24 @@ demo:
 
 通用属性参考：[通用属性](/docs/react/common-props)
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| arrows | 是否显示箭头 | boolean | false | 5.17.0 |
-| autoplay | 是否自动切换，如果为 object 可以指定 `dotDuration` 来展示指示点进度条 | boolean \| { dotDuration?: boolean } | false | dotDuration: 5.24.0 |
-| autoplaySpeed | 自动切换的间隔（毫秒） | number | 3000 |  |
-| adaptiveHeight | 高度自适应 | boolean | false |  |
-| dotPlacement | 面板指示点位置，可选 `top` `bottom` `start` `end` | string | `bottom` |  |
-| ~~dotPosition~~ | 面板指示点位置，可选 `top` `bottom` `left` `right` `start` `end`，请使用 `dotPlacement` 替换 | string | `bottom` |  |
-| dots | 是否显示面板指示点，如果为 `object` 则可以指定 `dotsClass` | boolean \| { className?: string } | true |  |
-| draggable | 是否启用拖拽切换 | boolean | false |  |
-| fade | 使用渐变切换动效 | boolean | false |  |
-| infinite | 是否无限循环切换（实现方式是复制两份 children 元素，如果子元素有副作用则可能会引发 bug） | boolean | true |  |
-| speed | 切换动效的时间（毫秒） | number | 500 |  |
-| easing | 动画效果 | string | `linear` |  |
-| effect | 动画效果函数 | `scrollx` \| `fade` | `scrollx` |  |
-| afterChange | 切换面板的回调 | (current: number) => void | - |  |
-| beforeChange | 切换面板的回调 | (current: number, next: number) => void | - |  |
-| waitForAnimate | 是否等待切换动画 | boolean | false |  |
+| 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| arrows | 是否显示箭头 | boolean | false | 5.17.0 | × |
+| autoplay | 是否自动切换，如果为 object 可以指定 `dotDuration` 来展示指示点进度条 | boolean \| { dotDuration?: boolean } | false | dotDuration: 5.24.0 | × |
+| autoplaySpeed | 自动切换的间隔（毫秒） | number | 3000 |  | × |
+| adaptiveHeight | 高度自适应 | boolean | false |  | × |
+| dotPlacement | 面板指示点位置，可选 `top` `bottom` `start` `end` | string | `bottom` |  | × |
+| ~~dotPosition~~ | 面板指示点位置，可选 `top` `bottom` `left` `right` `start` `end`，请使用 `dotPlacement` 替换 | string | `bottom` |  | × |
+| dots | 是否显示面板指示点，如果为 `object` 则可以指定 `dotsClass` | boolean \| { className?: string } | true |  | × |
+| draggable | 是否启用拖拽切换 | boolean | false |  | × |
+| fade | 使用渐变切换动效 | boolean | false |  | × |
+| infinite | 是否无限循环切换（实现方式是复制两份 children 元素，如果子元素有副作用则可能会引发 bug） | boolean | true |  | × |
+| speed | 切换动效的时间（毫秒） | number | 500 |  | × |
+| easing | 动画效果 | string | `linear` |  | × |
+| effect | 动画效果函数 | `scrollx` \| `fade` | `scrollx` |  | × |
+| afterChange | 切换面板的回调 | (current: number) => void | - |  | × |
+| beforeChange | 切换面板的回调 | (current: number, next: number) => void | - |  | × |
+| waitForAnimate | 是否等待切换动画 | boolean | false |  | × |
 
 更多 API 可参考：<https://react-slick.neostack.com/docs/api>
 

--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -50,59 +50,61 @@ Common props ref：[Common props](/docs/react/common-props)
 <Cascader options={options} onChange={onChange} />
 ```
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| allowClear | Show clear button | boolean \| { clearIcon?: ReactNode } | true | 5.8.0: Support object type |
-| ~~autoClearSearchValue~~ | Whether the current search will be cleared on selecting an item. Only applies when `multiple` is `true` | boolean | true | 5.9.0 |
-| ~~bordered~~ | Whether has border style, please use `variant` instead | boolean | true | - |
-| changeOnSelect | Change value on each selection if set to true, see above demo for details | boolean | false |  |
-| className | The additional css class | string | - |  |
-| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| defaultOpen | Initial visible of cascader popup | boolean | - |  |
-| defaultValue | Initial selected value | string\[] \| number\[] | \[] |  |
-| disabled | Whether disabled select | boolean | false |  |
-| displayRender | The render function of displaying selected options | (label, selectedOptions) => ReactNode | label => label.join(`/`) | `multiple`: 4.18.0 |
-| tagRender | Custom render function for tags in `multiple` mode | (label: string, onClose: function, value: string) => ReactNode | - |  |
-| ~~popupClassName~~ | The additional className of popup overlay, use `classNames.popup.root` instead | string | - | 4.23.0 |
-| ~~dropdownClassName~~ | The additional className of popup overlay, please use `classNames.popup.root` instead | string | - | - |
-| ~~dropdownRender~~ | Customize dropdown content, use `popupRender` instead | (menus: ReactNode) => ReactNode | - | 4.4.0 |
-| popupRender | Customize dropdown content | (menus: ReactNode) => ReactNode | - |  |
-| ~~dropdownStyle~~ | The style of dropdown menu, use `styles.popup.root` instead | CSSProperties | - |  |
-| expandIcon | Customize the current item expand icon | ReactNode | - | 4.4.0 |
-| expandTrigger | expand current item when click or hover, one of `click` `hover` | string | `click` |  |
-| fieldNames | Custom field name for label and value and children | object | { label: `label`, value: `value`, children: `children` } |  |
-| getPopupContainer | Parent Node which the selector should be rendered to. Default to `body`. When position issues happen, try to modify it into scrollable content and position it relative. [example](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | function(triggerNode) | () => document.body |  |
-| loadData | To load option lazily, and it cannot work with `showSearch` | (selectedOptions) => void | - |  |
-| loadingIcon | Customize the loading icon | ReactNode | - |  |
-| maxTagCount | Max tag count to show. `responsive` will cost render performance | number \| `responsive` | - | 4.17.0 |
-| maxTagPlaceholder | Placeholder for not showing tags | ReactNode \| function(omittedValues) | - | 4.17.0 |
-| maxTagTextLength | Max tag text length to show | number | - | 4.17.0 |
-| notFoundContent | Specify content to show when no result matches | ReactNode | `Not Found` |  |
-| open | Set visible of cascader popup | boolean | - | 4.17.0 |
-| options | The data options of cascade | [Option](#option)\[] | - |  |
-| placeholder | The input placeholder | string | - |  |
-| placement | Use preset popup align config from builtinPlacements | `bottomLeft` `bottomRight` `topLeft` `topRight` | `bottomLeft` | 4.17.0 |
-| prefix | The custom prefix | ReactNode | - | 5.22.0 |
-| ~~showArrow~~ | Whether to show the arrow icon, please use `suffixIcon={null}` instead | boolean | true | - |
-| showSearch | Whether show search input in single mode | boolean \| [Object](#showsearch) | false |  |
-| size | The input size | `large` \| `medium` \| `small` | `medium` |  |
-| status | Set validation status | 'error' \| 'warning' | - | 4.19.0 |
-| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
-| suffixIcon | The custom suffix icon | ReactNode | - |  |
-| value | The selected value | string\[] \| number\[] | - |  |
-| variant | Variants of selector | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 |
-| onChange | Callback when finishing cascader select | (value, selectedOptions) => void | - |  |
-| ~~onDropdownVisibleChange~~ | Callback when popup shown or hidden, use `onOpenChange` instead | (value) => void | - | 4.17.0 |
-| onOpenChange | Callback when popup shown or hidden | (value) => void | - |  |
-| ~~onPopupVisibleChange~~ | Callback when popup shown or hidden, please use `onOpenChange` instead | (value) => void | - | - |
-| multiple | Support multiple or not | boolean | - | 4.17.0 |
-| removeIcon | The custom remove icon | ReactNode | - |  |
-| showCheckedStrategy | The way to show selected items in the box (only effective when `multiple` is `true`). `Cascader.SHOW_CHILD`: just show child treeNode. `Cascader.SHOW_PARENT`: just show parent treeNode (when all child treeNode under the parent treeNode are checked) | `Cascader.SHOW_PARENT` \| `Cascader.SHOW_CHILD` | `Cascader.SHOW_PARENT` | 4.20.0 |
-| ~~searchValue~~ | Set search value, Need work with `showSearch` | string | - | 4.17.0 |
-| ~~onSearch~~ | The callback function triggered when input changed | (search: string) => void | - | 4.17.0 |
-| ~~dropdownMenuColumnStyle~~ | The style of the drop-down menu column, use `styles.popup.listItem` instead | CSSProperties | - |  |
-| ~~popupMenuColumnStyle~~ | The style of the drop-down menu column, use `styles.popup.listItem` instead | CSSProperties | - |  |
-| optionRender | Customize the rendering dropdown options | (option: Option) => React.ReactNode | - | 5.16.0 |
+| Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| allowClear | Show clear button | boolean \| { clearIcon?: ReactNode } | true | 5.8.0: Support object type | × |
+| ~~autoClearSearchValue~~ | Whether the current search will be cleared on selecting an item. Only applies when `multiple` is `true` | boolean | true | 5.9.0 | × |
+| ~~bordered~~ | Whether has border style, please use `variant` instead | boolean | true | - | × |
+| changeOnSelect | Change value on each selection if set to true, see above demo for details | boolean | false |  | × |
+| className | The additional css class | string | - |  | 5.7.0 |
+| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
+| clearIcon | (Only supports global configuration) Customize the clear icon | ReactNode | - | × | 6.4.0 |
+| defaultOpen | Initial visible of cascader popup | boolean | - |  | × |
+| defaultValue | Initial selected value | string\[] \| number\[] | \[] |  | × |
+| disabled | Whether disabled select | boolean | false |  | × |
+| displayRender | The render function of displaying selected options | (label, selectedOptions) => ReactNode | label => label.join(`/`) | `multiple`: 4.18.0 | × |
+| tagRender | Custom render function for tags in `multiple` mode | (label: string, onClose: function, value: string) => ReactNode | - |  | × |
+| ~~popupClassName~~ | The additional className of popup overlay, use `classNames.popup.root` instead | string | - | 4.23.0 | × |
+| ~~dropdownClassName~~ | The additional className of popup overlay, please use `classNames.popup.root` instead | string | - | - | × |
+| ~~dropdownRender~~ | Customize dropdown content, use `popupRender` instead | (menus: ReactNode) => ReactNode | - | 4.4.0 | × |
+| popupRender | Customize dropdown content | (menus: ReactNode) => ReactNode | - |  | × |
+| ~~dropdownStyle~~ | The style of dropdown menu, use `styles.popup.root` instead | CSSProperties | - |  | × |
+| expandIcon | Customize the current item expand icon | ReactNode | - | 4.4.0 | 6.4.0 |
+| expandTrigger | expand current item when click or hover, one of `click` `hover` | string | `click` |  | × |
+| fieldNames | Custom field name for label and value and children | object | { label: `label`, value: `value`, children: `children` } |  | × |
+| getPopupContainer | Parent Node which the selector should be rendered to. Default to `body`. When position issues happen, try to modify it into scrollable content and position it relative. [example](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | function(triggerNode) | () => document.body |  | × |
+| loadData | To load option lazily, and it cannot work with `showSearch` | (selectedOptions) => void | - |  | × |
+| loadingIcon | Customize the loading icon | ReactNode | - |  | 6.4.0 |
+| maxTagCount | Max tag count to show. `responsive` will cost render performance | number \| `responsive` | - | 4.17.0 | × |
+| maxTagPlaceholder | Placeholder for not showing tags | ReactNode \| function(omittedValues) | - | 4.17.0 | × |
+| maxTagTextLength | Max tag text length to show | number | - | 4.17.0 | × |
+| notFoundContent | Specify content to show when no result matches | ReactNode | `Not Found` |  | × |
+| open | Set visible of cascader popup | boolean | - | 4.17.0 | × |
+| options | The data options of cascade | [Option](#option)\[] | - |  | × |
+| placeholder | The input placeholder | string | - |  | × |
+| placement | Use preset popup align config from builtinPlacements | `bottomLeft` `bottomRight` `topLeft` `topRight` | `bottomLeft` | 4.17.0 | × |
+| prefix | The custom prefix | ReactNode | - | 5.22.0 | × |
+| ~~showArrow~~ | Whether to show the arrow icon, please use `suffixIcon={null}` instead | boolean | true | - | × |
+| searchIcon | (Only supports global configuration) Customize the search icon | ReactNode | - | × | 6.4.0 |
+| showSearch | Whether show search input in single mode | boolean \| [Object](#showsearch) | false |  | × |
+| size | The input size | `large` \| `medium` \| `small` | `medium` |  | × |
+| status | Set validation status | 'error' \| 'warning' | - | 4.19.0 | × |
+| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
+| suffixIcon | The custom suffix icon | ReactNode | - |  | 6.4.0 |
+| value | The selected value | string\[] \| number\[] | - |  | × |
+| variant | Variants of selector | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 | × |
+| onChange | Callback when finishing cascader select | (value, selectedOptions) => void | - |  | × |
+| ~~onDropdownVisibleChange~~ | Callback when popup shown or hidden, use `onOpenChange` instead | (value) => void | - | 4.17.0 | × |
+| onOpenChange | Callback when popup shown or hidden | (value) => void | - |  | × |
+| ~~onPopupVisibleChange~~ | Callback when popup shown or hidden, please use `onOpenChange` instead | (value) => void | - | - | × |
+| multiple | Support multiple or not | boolean | - | 4.17.0 | × |
+| removeIcon | The custom remove icon | ReactNode | - |  | 6.4.0 |
+| showCheckedStrategy | The way to show selected items in the box (only effective when `multiple` is `true`). `Cascader.SHOW_CHILD`: just show child treeNode. `Cascader.SHOW_PARENT`: just show parent treeNode (when all child treeNode under the parent treeNode are checked) | `Cascader.SHOW_PARENT` \| `Cascader.SHOW_CHILD` | `Cascader.SHOW_PARENT` | 4.20.0 | × |
+| ~~searchValue~~ | Set search value, Need work with `showSearch` | string | - | 4.17.0 | × |
+| ~~onSearch~~ | The callback function triggered when input changed | (search: string) => void | - | 4.17.0 | × |
+| ~~dropdownMenuColumnStyle~~ | The style of the drop-down menu column, use `styles.popup.listItem` instead | CSSProperties | - |  | × |
+| ~~popupMenuColumnStyle~~ | The style of the drop-down menu column, use `styles.popup.listItem` instead | CSSProperties | - |  | × |
+| optionRender | Customize the rendering dropdown options | (option: Option) => React.ReactNode | - | 5.16.0 | × |
 
 ### showSearch
 

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -51,59 +51,61 @@ demo:
 <Cascader options={options} onChange={onChange} />
 ```
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| allowClear | 支持清除 | boolean \| { clearIcon?: ReactNode } | true | 5.8.0: 支持对象形式 |
-| ~~autoClearSearchValue~~ | 是否在选中项后清空搜索框，只在 `multiple` 为 `true` 时有效 | boolean | true | 5.9.0 |
-| ~~bordered~~ | 是否带边框，请使用 `variant` 替代 | boolean | true | - |
-| changeOnSelect | 单选时生效（multiple 下始终都可以选择），点选每级菜单选项值都会发生变化。 | boolean | false |  |
-| className | 自定义类名 | string | - |  |
-| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| defaultOpen | 是否默认展示浮层 | boolean | - |  |
-| defaultValue | 默认的选中项 | string\[] \| number\[] | \[] |  |
-| disabled | 禁用 | boolean | false |  |
-| displayRender | 选择后展示的渲染函数 | (label, selectedOptions) => ReactNode | label => label.join(`/`) | `multiple`: 4.18.0 |
-| tagRender | 自定义 tag 内容 render，仅在多选时生效 | ({ label: string, onClose: function, value: string }) => ReactNode | - |  |
-| ~~popupClassName~~ | 自定义浮层类名，使用 `classNames.popup.root` 替换 | string | - | 4.23.0 |
-| ~~dropdownClassName~~ | 自定义浮层类名，请使用 `classNames.popup.root` 替代 | string | - | - |
-| ~~dropdownRender~~ | 自定义下拉框内容，请使用 `popupRender` 替换 | (menus: ReactNode) => ReactNode | - | 4.4.0 |
-| popupRender | 自定义下拉框内容 | (menus: ReactNode) => ReactNode | - |  |
-| ~~dropdownStyle~~ | 下拉菜单的 style 属性，使用 `styles.popup.root` 替换 | CSSProperties | - |  |
-| expandIcon | 自定义次级菜单展开图标 | ReactNode | - | 4.4.0 |
-| expandTrigger | 次级菜单的展开方式，可选 'click' 和 'hover' | string | `click` |  |
-| fieldNames | 自定义 options 中 label value children 的字段 | object | { label: `label`, value: `value`, children: `children` } |  |
-| getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | function(triggerNode) | () => document.body |  |
-| loadData | 用于动态加载选项，无法与 `showSearch` 一起使用 | (selectedOptions) => void | - |  |
-| loadingIcon | 自定义的加载图标 | ReactNode | - |  |
-| maxTagCount | 最多显示多少个 tag，响应式模式会对性能产生损耗 | number \| `responsive` | - | 4.17.0 |
-| maxTagPlaceholder | 隐藏 tag 时显示的内容 | ReactNode \| function(omittedValues) | - | 4.17.0 |
-| maxTagTextLength | 最大显示的 tag 文本长度 | number | - | 4.17.0 |
-| notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | `Not Found` |  |
-| open | 控制浮层显隐 | boolean | - | 4.17.0 |
-| options | 可选项数据源 | [Option](#option)\[] | - |  |
-| placeholder | 输入框占位文本 | string | - |  |
-| placement | 浮层预设位置 | `bottomLeft` `bottomRight` `topLeft` `topRight` | `bottomLeft` | 4.17.0 |
-| prefix | 自定义前缀 | ReactNode | - | 5.22.0 |
-| ~~showArrow~~ | 是否显示箭头图标，请使用 `suffixIcon={null}` 替代 | boolean | true | - |
-| showSearch | 在选择框中显示搜索框 | boolean \| [Object](#showsearch) | false |  |
-| size | 输入框大小 | `large` \| `medium` \| `small` | `medium` |  |
-| status | 设置校验状态 | 'error' \| 'warning' | - | 4.19.0 |
-| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
-| suffixIcon | 自定义的选择框后缀图标 | ReactNode | - |  |
-| value | 指定选中项 | string\[] \| number\[] | - |  |
-| variant | 形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 |
-| onChange | 选择完成后的回调 | (value, selectedOptions) => void | - |  |
-| ~~onDropdownVisibleChange~~ | 显示/隐藏浮层的回调，请使用 `onOpenChange` 替换 | (value) => void | - | 4.17.0 |
-| onOpenChange | 显示/隐藏浮层的回调 | (value) => void | - |  |
-| ~~onPopupVisibleChange~~ | 显示或隐藏浮层的回调，请使用 `onOpenChange` 替代 | (value) => void | - | - |
-| multiple | 支持多选节点 | boolean | - | 4.17.0 |
-| removeIcon | 自定义的多选框清除图标 | ReactNode | - |  |
-| showCheckedStrategy | 定义选中项回填的方式（仅在 `multiple` 为 `true` 时生效）。`Cascader.SHOW_CHILD`: 只显示选中的子节点。`Cascader.SHOW_PARENT`: 只显示父节点（当父节点下所有子节点都选中时）。 | `Cascader.SHOW_PARENT` \| `Cascader.SHOW_CHILD` | `Cascader.SHOW_PARENT` | 4.20.0 |
-| ~~searchValue~~ | 设置搜索的值，需要与 `showSearch` 配合使用 | string | - | 4.17.0 |
-| ~~onSearch~~ | 监听搜索，返回输入的值 | (search: string) => void | - | 4.17.0 |
-| ~~dropdownMenuColumnStyle~~ | 下拉菜单列的样式，请使用 `styles.popup.listItem` 替换 | CSSProperties | - |  |
-| ~~popupMenuColumnStyle~~ | 下拉菜单列的样式，请使用 `styles.popup.listItem` 替换 | CSSProperties | - |  |
-| optionRender | 自定义渲染下拉选项 | (option: Option) => React.ReactNode | - | 5.16.0 |
+| 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| allowClear | 支持清除 | boolean \| { clearIcon?: ReactNode } | true | 5.8.0: 支持对象形式 | × |
+| ~~autoClearSearchValue~~ | 是否在选中项后清空搜索框，只在 `multiple` 为 `true` 时有效 | boolean | true | 5.9.0 | × |
+| ~~bordered~~ | 是否带边框，请使用 `variant` 替代 | boolean | true | - | × |
+| changeOnSelect | 单选时生效（multiple 下始终都可以选择），点选每级菜单选项值都会发生变化。 | boolean | false |  | × |
+| className | 自定义类名 | string | - |  | 5.7.0 |
+| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
+| clearIcon | （仅支持全局配置）自定义清除图标 | ReactNode | - | × | 6.4.0 |
+| defaultOpen | 是否默认展示浮层 | boolean | - |  | × |
+| defaultValue | 默认的选中项 | string\[] \| number\[] | \[] |  | × |
+| disabled | 禁用 | boolean | false |  | × |
+| displayRender | 选择后展示的渲染函数 | (label, selectedOptions) => ReactNode | label => label.join(`/`) | `multiple`: 4.18.0 | × |
+| tagRender | 自定义 tag 内容 render，仅在多选时生效 | ({ label: string, onClose: function, value: string }) => ReactNode | - |  | × |
+| ~~popupClassName~~ | 自定义浮层类名，使用 `classNames.popup.root` 替换 | string | - | 4.23.0 | × |
+| ~~dropdownClassName~~ | 自定义浮层类名，请使用 `classNames.popup.root` 替代 | string | - | - | × |
+| ~~dropdownRender~~ | 自定义下拉框内容，请使用 `popupRender` 替换 | (menus: ReactNode) => ReactNode | - | 4.4.0 | × |
+| popupRender | 自定义下拉框内容 | (menus: ReactNode) => ReactNode | - |  | × |
+| ~~dropdownStyle~~ | 下拉菜单的 style 属性，使用 `styles.popup.root` 替换 | CSSProperties | - |  | × |
+| expandIcon | 自定义次级菜单展开图标 | ReactNode | - | 4.4.0 | 6.4.0 |
+| expandTrigger | 次级菜单的展开方式，可选 'click' 和 'hover' | string | `click` |  | × |
+| fieldNames | 自定义 options 中 label value children 的字段 | object | { label: `label`, value: `value`, children: `children` } |  | × |
+| getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。[示例](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | function(triggerNode) | () => document.body |  | × |
+| loadData | 用于动态加载选项，无法与 `showSearch` 一起使用 | (selectedOptions) => void | - |  | × |
+| loadingIcon | 自定义的加载图标 | ReactNode | - |  | 6.4.0 |
+| maxTagCount | 最多显示多少个 tag，响应式模式会对性能产生损耗 | number \| `responsive` | - | 4.17.0 | × |
+| maxTagPlaceholder | 隐藏 tag 时显示的内容 | ReactNode \| function(omittedValues) | - | 4.17.0 | × |
+| maxTagTextLength | 最大显示的 tag 文本长度 | number | - | 4.17.0 | × |
+| notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | `Not Found` |  | × |
+| open | 控制浮层显隐 | boolean | - | 4.17.0 | × |
+| options | 可选项数据源 | [Option](#option)\[] | - |  | × |
+| placeholder | 输入框占位文本 | string | - |  | × |
+| placement | 浮层预设位置 | `bottomLeft` `bottomRight` `topLeft` `topRight` | `bottomLeft` | 4.17.0 | × |
+| prefix | 自定义前缀 | ReactNode | - | 5.22.0 | × |
+| ~~showArrow~~ | 是否显示箭头图标，请使用 `suffixIcon={null}` 替代 | boolean | true | - | × |
+| searchIcon | （仅支持全局配置）自定义搜索图标 | ReactNode | - | × | 6.4.0 |
+| showSearch | 在选择框中显示搜索框 | boolean \| [Object](#showsearch) | false |  | × |
+| size | 输入框大小 | `large` \| `medium` \| `small` | `medium` |  | × |
+| status | 设置校验状态 | 'error' \| 'warning' | - | 4.19.0 | × |
+| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
+| suffixIcon | 自定义的选择框后缀图标 | ReactNode | - |  | 6.4.0 |
+| value | 指定选中项 | string\[] \| number\[] | - |  | × |
+| variant | 形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 | × |
+| onChange | 选择完成后的回调 | (value, selectedOptions) => void | - |  | × |
+| ~~onDropdownVisibleChange~~ | 显示/隐藏浮层的回调，请使用 `onOpenChange` 替换 | (value) => void | - | 4.17.0 | × |
+| onOpenChange | 显示/隐藏浮层的回调 | (value) => void | - |  | × |
+| ~~onPopupVisibleChange~~ | 显示或隐藏浮层的回调，请使用 `onOpenChange` 替代 | (value) => void | - | - | × |
+| multiple | 支持多选节点 | boolean | - | 4.17.0 | × |
+| removeIcon | 自定义的多选框清除图标 | ReactNode | - |  | 6.4.0 |
+| showCheckedStrategy | 定义选中项回填的方式（仅在 `multiple` 为 `true` 时生效）。`Cascader.SHOW_CHILD`: 只显示选中的子节点。`Cascader.SHOW_PARENT`: 只显示父节点（当父节点下所有子节点都选中时）。 | `Cascader.SHOW_PARENT` \| `Cascader.SHOW_CHILD` | `Cascader.SHOW_PARENT` | 4.20.0 | × |
+| ~~searchValue~~ | 设置搜索的值，需要与 `showSearch` 配合使用 | string | - | 4.17.0 | × |
+| ~~onSearch~~ | 监听搜索，返回输入的值 | (search: string) => void | - | 4.17.0 | × |
+| ~~dropdownMenuColumnStyle~~ | 下拉菜单列的样式，请使用 `styles.popup.listItem` 替换 | CSSProperties | - |  | × |
+| ~~popupMenuColumnStyle~~ | 下拉菜单列的样式，请使用 `styles.popup.listItem` 替换 | CSSProperties | - |  | × |
+| optionRender | 自定义渲染下拉选项 | (option: Option) => React.ReactNode | - | 5.16.0 | × |
 
 ### showSearch
 

--- a/components/checkbox/index.en-US.md
+++ b/components/checkbox/index.en-US.md
@@ -35,17 +35,17 @@ Common props ref：[Common props](/docs/react/common-props)
 
 #### Checkbox
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| checked | Specifies whether the checkbox is selected | boolean | false |  |
-| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| defaultChecked | Specifies the initial state: whether or not the checkbox is selected | boolean | false |  |
-| disabled | If disable checkbox | boolean | false |  |
-| indeterminate | The indeterminate checked state of checkbox | boolean | false |  |
-| onChange | The callback function that is triggered when the state changes | (e: CheckboxChangeEvent) => void | - |  |
-| onBlur | Called when leaving the component | function() | - |  |
-| onFocus | Called when entering the component | function() | - |  |
-| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
+| Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| checked | Specifies whether the checkbox is selected | boolean | false |  | × |
+| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
+| defaultChecked | Specifies the initial state: whether or not the checkbox is selected | boolean | false |  | × |
+| disabled | If disable checkbox | boolean | false |  | × |
+| indeterminate | The indeterminate checked state of checkbox | boolean | false |  | × |
+| onChange | The callback function that is triggered when the state changes | (e: CheckboxChangeEvent) => void | - |  | × |
+| onBlur | Called when leaving the component | function() | - |  | × |
+| onFocus | Called when entering the component | function() | - |  | × |
+| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
 
 #### Checkbox.Group
 

--- a/components/checkbox/index.zh-CN.md
+++ b/components/checkbox/index.zh-CN.md
@@ -36,17 +36,17 @@ demo:
 
 #### Checkbox
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| checked | 指定当前是否选中 | boolean | false |  |
-| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| defaultChecked | 初始是否选中 | boolean | false |  |
-| disabled | 失效状态 | boolean | false |  |
-| indeterminate | 设置 indeterminate 状态，只负责样式控制 | boolean | false |  |
-| onChange | 变化时的回调函数 | (e: CheckboxChangeEvent) => void | - |  |
-| onBlur | 失去焦点时的回调 | function() | - |  |
-| onFocus | 获得焦点时的回调 | function() | - |  |
-| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
+| 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| checked | 指定当前是否选中 | boolean | false |  | × |
+| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
+| defaultChecked | 初始是否选中 | boolean | false |  | × |
+| disabled | 失效状态 | boolean | false |  | × |
+| indeterminate | 设置 indeterminate 状态，只负责样式控制 | boolean | false |  | × |
+| onChange | 变化时的回调函数 | (e: CheckboxChangeEvent) => void | - |  | × |
+| onBlur | 失去焦点时的回调 | function() | - |  | × |
+| onFocus | 获得焦点时的回调 | function() | - |  | × |
+| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
 
 #### Checkbox.Group
 

--- a/components/collapse/index.en-US.md
+++ b/components/collapse/index.en-US.md
@@ -34,24 +34,24 @@ Common props ref：[Common props](/docs/react/common-props)
 
 ### Collapse
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| accordion | If true, Collapse renders as Accordion | boolean | false |  |
-| activeKey | Key of the active panel | string\[] \| string <br/> number\[] \| number | No default value. In [accordion mode](#collapse-demo-accordion), it's the key of the first panel |  |
-| bordered | Toggles rendering of the border around the collapse block | boolean | true |  |
-| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| collapsible | Specify how to trigger Collapse. Either by clicking icon or by clicking any area in header or disable collapse functionality itself | `header` \| `icon` \| `disabled` | - | 4.9.0 |
-| defaultActiveKey | Key of the initial active panel | string\[] \| string <br/> number\[] \| number | - |  |
-| ~~destroyInactivePanel~~ | Destroy Inactive Panel | boolean | false |  |
-| destroyOnHidden | Destroy Inactive Panel | boolean | false | 5.25.0 |
-| expandIcon | Allow to customize collapse icon | (panelProps) => ReactNode | - |  |
-| expandIconPlacement | Set expand icon placement | `start` \| `end` | `start` | - |
-| ~~expandIconPosition~~ | Set expand icon position, Please use `expandIconPlacement` instead | `start` \| `end` | - | 4.21.0 |
-| ghost | Make the collapse borderless and its background transparent | boolean | false | 4.4.0 |
-| size | Set the size of collapse | `large` \| `medium` \| `small` | `medium` | 5.2.0 |
-| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
-| onChange | Callback function executed when active panel is changed | function | - |  |
-| items | collapse items content | [ItemType](#itemtype) | - | 5.6.0 |
+| Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| accordion | If true, Collapse renders as Accordion | boolean | false |  | × |
+| activeKey | Key of the active panel | string\[] \| string <br/> number\[] \| number | No default value. In [accordion mode](#collapse-demo-accordion), it's the key of the first panel |  | × |
+| bordered | Toggles rendering of the border around the collapse block | boolean | true |  | × |
+| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
+| collapsible | Specify how to trigger Collapse. Either by clicking icon or by clicking any area in header or disable collapse functionality itself | `header` \| `icon` \| `disabled` | - | 4.9.0 | × |
+| defaultActiveKey | Key of the initial active panel | string\[] \| string <br/> number\[] \| number | - |  | × |
+| ~~destroyInactivePanel~~ | Destroy Inactive Panel | boolean | false |  | × |
+| destroyOnHidden | Destroy Inactive Panel | boolean | false | 5.25.0 | × |
+| expandIcon | Allow to customize collapse icon | (panelProps) => ReactNode | - |  | 5.15.0 |
+| expandIconPlacement | Set expand icon placement | `start` \| `end` | `start` | - | × |
+| ~~expandIconPosition~~ | Set expand icon position, Please use `expandIconPlacement` instead | `start` \| `end` | - | 4.21.0 | × |
+| ghost | Make the collapse borderless and its background transparent | boolean | false | 4.4.0 | × |
+| size | Set the size of collapse | `large` \| `medium` \| `small` | `medium` | 5.2.0 | × |
+| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
+| onChange | Callback function executed when active panel is changed | function | - |  | × |
+| items | collapse items content | [ItemType](#itemtype) | - | 5.6.0 | × |
 
 ### ItemType
 

--- a/components/collapse/index.zh-CN.md
+++ b/components/collapse/index.zh-CN.md
@@ -35,24 +35,24 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*sir-TK0HkWcAAA
 
 ### Collapse
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| accordion | 手风琴模式 | boolean | false |  |
-| activeKey | 当前激活 tab 面板的 key | string\[] \| string <br/> number\[] \| number | [手风琴模式](#collapse-demo-accordion)下默认第一个元素 |  |
-| bordered | 带边框风格的折叠面板 | boolean | true |  |
-| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |
-| collapsible | 所有子面板是否可折叠或指定可折叠触发区域 | `header` \| `icon` \| `disabled` | - | 4.9.0 |
-| defaultActiveKey | 初始化选中面板的 key | string\[] \| string<br/> number\[] \| number | - |  |
-| ~~destroyInactivePanel~~ | 销毁折叠隐藏的面板 | boolean | false |  |
-| destroyOnHidden | 销毁折叠隐藏的面板 | boolean | false | 5.25.0 |
-| expandIcon | 自定义切换图标 | (panelProps) => ReactNode | - |  |
-| expandIconPlacement | 设置图标位置 | `start` \| `end` | `start` | - |
-| ~~expandIconPosition~~ | 设置图标位置，请使用 `expandIconPlacement` 替换 | `start` \| `end` | - | 4.21.0 |
-| ghost | 使折叠面板透明且无边框 | boolean | false | 4.4.0 |
-| size | 设置折叠面板大小 | `large` \| `medium` \| `small` | `medium` | 5.2.0 |
-| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
-| onChange | 切换面板的回调 | function | - |  |
-| items | 折叠项目内容 | [ItemType](#itemtype) | - | 5.6.0 |
+| 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
+| --- | --- | --- | --- | --- | --- |
+| accordion | 手风琴模式 | boolean | false |  | × |
+| activeKey | 当前激活 tab 面板的 key | string\[] \| string <br/> number\[] \| number | [手风琴模式](#collapse-demo-accordion)下默认第一个元素 |  | × |
+| bordered | 带边框风格的折叠面板 | boolean | true |  | × |
+| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
+| collapsible | 所有子面板是否可折叠或指定可折叠触发区域 | `header` \| `icon` \| `disabled` | - | 4.9.0 | × |
+| defaultActiveKey | 初始化选中面板的 key | string\[] \| string<br/> number\[] \| number | - |  | × |
+| ~~destroyInactivePanel~~ | 销毁折叠隐藏的面板 | boolean | false |  | × |
+| destroyOnHidden | 销毁折叠隐藏的面板 | boolean | false | 5.25.0 | × |
+| expandIcon | 自定义切换图标 | (panelProps) => ReactNode | - |  | 5.15.0 |
+| expandIconPlacement | 设置图标位置 | `start` \| `end` | `start` | - | × |
+| ~~expandIconPosition~~ | 设置图标位置，请使用 `expandIconPlacement` 替换 | `start` \| `end` | - | 4.21.0 | × |
+| ghost | 使折叠面板透明且无边框 | boolean | false | 4.4.0 | × |
+| size | 设置折叠面板大小 | `large` \| `medium` \| `small` | `medium` | 5.2.0 | × |
+| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
+| onChange | 切换面板的回调 | function | - |  | × |
+| items | 折叠项目内容 | [ItemType](#itemtype) | - | 5.6.0 | × |
 
 ### ItemType
 

--- a/components/color-picker/index.en-US.md
+++ b/components/color-picker/index.en-US.md
@@ -41,35 +41,35 @@ Common props ref：[Common props](/docs/react/common-props)
 > This component is available since `antd@5.5.0`.
 
 <!-- prettier-ignore -->
-| Property | Description | Type | Default | Version |
-| :-- | :-- | :-- | :-- | :-- |
-| allowClear | 	Allow clearing color selected | boolean | false | |
-| arrow | Configuration for popup arrow | `boolean \| { pointAtCenter: boolean }` | true | |
-| children | Trigger of ColorPicker | React.ReactNode | - | |
-| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | |
-| defaultValue | Default value of color | [ColorType](#colortype) | - | |
-| defaultFormat | Default format of color | `rgb` \| `hex` \| `hsb` | `hex` | 5.9.0 |
-| disabled | Disable ColorPicker | boolean | - | |
-| disabledAlpha | Disable Alpha | boolean | - | 5.8.0 |
-| disabledFormat | Disable format of color | boolean | - | 5.22.0 |
-| ~~destroyTooltipOnHide~~ | Whether destroy dom when close | `boolean` | false | 5.7.0 |
-| destroyOnHidden | Whether destroy dom when close | `boolean` | false | 5.25.0 |
-| format | Format of color | `rgb` \| `hex` \| `hsb` | - | |
-| mode | Configure single or gradient color | `'single' \| 'gradient' \| ('single' \| 'gradient')[]` | `single` | 5.20.0 |
-| open | Whether to show popup | boolean | - | |
-| presets | Preset colors | [PresetColorType](#presetcolortype) | - | |
-| placement | Placement of popup | The design of the [placement](/components/tooltip/#api) parameter is the same as the `Tooltips` component. | `bottomLeft` | |
-| panelRender | Custom Render Panel | `(panel: React.ReactNode, extra: { components: { Picker: FC; Presets: FC } }) => React.ReactNode` | - | 5.7.0 |
-| showText | Show color text | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 |
-| size | Setting the trigger size | `large` \| `medium` \| `small` | `medium` | 5.7.0 |
-| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | |
-| trigger | ColorPicker trigger mode | `hover` \| `click` | `click` | |
-| value | Value of color | [ColorType](#colortype) | - | |
-| onChange | Callback when `value` is changed | `(value: Color, css: string) => void` | - | |
-| onChangeComplete | Called when color pick ends. Will not change the display color when `value` controlled by `onChangeComplete` | `(value: Color) => void` | - | 5.7.0 |
-| onFormatChange | Callback when `format` is changed | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - | |
-| onOpenChange | Callback when `open` is changed | `(open: boolean) => void` | - | |
-| onClear | Called when clear | `() => void` | - | 5.6.0 |
+| Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
+| :-- | :-- | :-- | :-- | :-- | :-- |
+| allowClear | Allow clearing color selected | boolean | false | | × |
+| arrow | Configuration for popup arrow | `boolean \| { pointAtCenter: boolean }` | true | | × |
+| children | Trigger of ColorPicker | React.ReactNode | - | | × |
+| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | | 6.0.0 |
+| defaultValue | Default value of color | [ColorType](#colortype) | - | | × |
+| defaultFormat | Default format of color | `rgb` \| `hex` \| `hsb` | `hex` | 5.9.0 | × |
+| disabled | Disable ColorPicker | boolean | - | | × |
+| disabledAlpha | Disable Alpha | boolean | - | 5.8.0 | × |
+| disabledFormat | Disable format of color | boolean | - | 5.22.0 | × |
+| ~~destroyTooltipOnHide~~ | Whether destroy dom when close | `boolean` | false | 5.7.0 | × |
+| destroyOnHidden | Whether destroy dom when close | `boolean` | false | 5.25.0 | × |
+| format | Format of color | `rgb` \| `hex` \| `hsb` | - | | × |
+| mode | Configure single or gradient color | `'single' \| 'gradient' \| ('single' \| 'gradient')[]` | `single` | 5.20.0 | × |
+| open | Whether to show popup | boolean | - | | × |
+| presets | Preset colors | [PresetColorType](#presetcolortype) | - | | × |
+| placement | Placement of popup | The design of the [placement](/components/tooltip/#api) parameter is the same as the `Tooltips` component. | `bottomLeft` | | × |
+| panelRender | Custom Render Panel | `(panel: React.ReactNode, extra: { components: { Picker: FC; Presets: FC } }) => React.ReactNode` | - | 5.7.0 | × |
+| showText | Show color text | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 | × |
+| size | Setting the trigger size | `large` \| `medium` \| `small` | `medium` | 5.7.0 | × |
+| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | | 6.0.0 |
+| trigger | ColorPicker trigger mode | `hover` \| `click` | `click` | | × |
+| value | Value of color | [ColorType](#colortype) | - | | × |
+| onChange | Callback when `value` is changed | `(value: Color, css: string) => void` | - | | × |
+| onChangeComplete | Called when color pick ends. Will not change the display color when `value` controlled by `onChangeComplete` | `(value: Color) => void` | - | 5.7.0 | × |
+| onFormatChange | Callback when `format` is changed | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - | | × |
+| onOpenChange | Callback when `open` is changed | `(open: boolean) => void` | - | | × |
+| onClear | Called when clear | `() => void` | - | 5.6.0 | × |
 
 #### ColorType
 

--- a/components/color-picker/index.zh-CN.md
+++ b/components/color-picker/index.zh-CN.md
@@ -42,35 +42,35 @@ group:
 > 自 `antd@5.5.0` 版本开始提供该组件。
 
 <!-- prettier-ignore -->
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| :-- | :-- | :-- | :-- | :-- |
-| allowClear | 允许清除选择的颜色 | boolean | false | |
-| arrow | 配置弹出的箭头 | `boolean \| { pointAtCenter: boolean }` | true | |
-| children | 颜色选择器的触发器 | React.ReactNode | - | |
-| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | |
-| defaultValue | 颜色默认的值 | [ColorType](#colortype) | - | |
-| defaultFormat | 颜色格式默认的值 | `rgb` \| `hex` \| `hsb` | `hex` | 5.9.0 |
-| disabled | 禁用颜色选择器 | boolean | - | |
-| disabledAlpha | 禁用透明度 | boolean | - | 5.8.0 |
-| disabledFormat | 禁用选择颜色格式 | boolean | - | 5.22.0 |
-| ~~destroyTooltipOnHide~~ | 关闭后是否销毁弹窗 | `boolean` | false | 5.7.0 |
-| destroyOnHidden | 关闭后是否销毁弹窗 | `boolean` | false | 5.25.0 |
-| format | 颜色格式 | `rgb` \| `hex` \| `hsb` | - | |
-| mode | 选择器模式，用于配置单色与渐变 | `'single' \| 'gradient' \| ('single' \| 'gradient')[]` | `single` | 5.20.0 |
-| open | 是否显示弹出窗口 | boolean | - | |
-| presets | 预设的颜色 | [PresetColorType](#presetcolortype) | - | |
-| placement | 弹出窗口的位置 | 同 `Tooltips` 组件的 [placement](/components/tooltip-cn/#api) 参数设计 | `bottomLeft` | |
-| panelRender | 自定义渲染面板 | `(panel: React.ReactNode, extra: { components: { Picker: FC; Presets: FC } }) => React.ReactNode` | - | 5.7.0 |
-| showText | 显示颜色文本 | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 |
-| size | 设置触发器大小 | `large` \| `medium` \| `small` | `medium` | 5.7.0 |
-| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | |
-| trigger | 颜色选择器的触发模式 | `hover` \| `click` | `click` | |
-| value | 颜色的值 | [ColorType](#colortype) | - | |
-| onChange | 颜色变化的回调 | `(value: Color, css: string) => void` | - | |
-| onChangeComplete | 颜色选择完成的回调，通过 `onChangeComplete` 对 `value` 受控时拖拽不会改变展示颜色 | `(value: Color) => void` | - | 5.7.0 |
-| onFormatChange | 颜色格式变化的回调 | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - | |
-| onOpenChange | 当 `open` 被改变时的回调 | `(open: boolean) => void` | - | |
-| onClear | 清除的回调 | `() => void` | - | 5.6.0 |
+| 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
+| :-- | :-- | :-- | :-- | :-- | :-- |
+| allowClear | 允许清除选择的颜色 | boolean | false | | × |
+| arrow | 配置弹出的箭头 | `boolean \| { pointAtCenter: boolean }` | true | | × |
+| children | 颜色选择器的触发器 | React.ReactNode | - | | × |
+| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | | 6.0.0 |
+| defaultValue | 颜色默认的值 | [ColorType](#colortype) | - | | × |
+| defaultFormat | 颜色格式默认的值 | `rgb` \| `hex` \| `hsb` | `hex` | 5.9.0 | × |
+| disabled | 禁用颜色选择器 | boolean | - | | × |
+| disabledAlpha | 禁用透明度 | boolean | - | 5.8.0 | × |
+| disabledFormat | 禁用选择颜色格式 | boolean | - | 5.22.0 | × |
+| ~~destroyTooltipOnHide~~ | 关闭后是否销毁弹窗 | `boolean` | false | 5.7.0 | × |
+| destroyOnHidden | 关闭后是否销毁弹窗 | `boolean` | false | 5.25.0 | × |
+| format | 颜色格式 | `rgb` \| `hex` \| `hsb` | - | | × |
+| mode | 选择器模式，用于配置单色与渐变 | `'single' \| 'gradient' \| ('single' \| 'gradient')[]` | `single` | 5.20.0 | × |
+| open | 是否显示弹出窗口 | boolean | - | | × |
+| presets | 预设的颜色 | [PresetColorType](#presetcolortype) | - | | × |
+| placement | 弹出窗口的位置 | 同 `Tooltips` 组件的 [placement](/components/tooltip-cn/#api) 参数设计 | `bottomLeft` | | × |
+| panelRender | 自定义渲染面板 | `(panel: React.ReactNode, extra: { components: { Picker: FC; Presets: FC } }) => React.ReactNode` | - | 5.7.0 | × |
+| showText | 显示颜色文本 | boolean \| `(color: Color) => React.ReactNode` | - | 5.7.0 | × |
+| size | 设置触发器大小 | `large` \| `medium` \| `small` | `medium` | 5.7.0 | × |
+| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | | 6.0.0 |
+| trigger | 颜色选择器的触发模式 | `hover` \| `click` | `click` | | × |
+| value | 颜色的值 | [ColorType](#colortype) | - | | × |
+| onChange | 颜色变化的回调 | `(value: Color, css: string) => void` | - | | × |
+| onChangeComplete | 颜色选择完成的回调，通过 `onChangeComplete` 对 `value` 受控时拖拽不会改变展示颜色 | `(value: Color) => void` | - | 5.7.0 | × |
+| onFormatChange | 颜色格式变化的回调 | `(format: 'hex' \| 'rgb' \| 'hsb') => void` | - | | × |
+| onOpenChange | 当 `open` 被改变时的回调 | `(open: boolean) => void` | - | | × |
+| onClear | 清除的回调 | `() => void` | - | 5.6.0 | × |
 
 #### ColorType
 


### PR DESCRIPTION
…ker): document global config support

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 📝 Site / documentation improvement

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

当前部分组件已经在 ConfigProvider 的 Component Config 中支持全局配置，但对应组件文档的 API 表格缺少“全局配置 / Global Config”列，导致用户无法直接从组件文档确认哪些属性支持全局配置。

本次更新为 Calendar、Card、Carousel、Cascader、Checkbox、Collapse、ColorPicker 的中英文 API 表补充全局配置列，并根据 ConfigProvider 中的组件配置标注支持版本或 ×。同时补充了部分仅支持全局配置的配置项说明，使组件文档与 ConfigProvider 文档保持一致。

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       document global config support    |
| 🇨🇳 Chinese |     全局配置支持文档      |
