### PR TITLE
fix(Cascader): keep parent column fixed for right-aligned placement

### DIFF
--- a/components/cascader/__tests__/index.test.tsx
+++ b/components/cascader/__tests__/index.test.tsx
@@ -433,6 +433,23 @@ describe('Cascader', () => {
     expect((global as any)?.triggerProps.popupPlacement).toEqual('topRight');
   });
 
+  it('right-aligned placement reverses column order to keep parent column fixed', () => {
+    const customOptions = [
+      {
+        value: 'zhejiang',
+        label: 'Zhejiang',
+        children: [{ value: 'hangzhou', label: 'Hangzhou' }],
+      },
+    ];
+    const { container } = render(
+      <Cascader options={customOptions} placement="bottomRight" defaultValue={['zhejiang']} open />,
+    );
+
+    const dropdown = getDropdown(container);
+    expect(dropdown?.className).toContain('ant-select-dropdown-placement-bottomRight');
+    expect(container.querySelector('.ant-cascader-menus')).toBeTruthy();
+  });
+
   it('popup correctly with defaultValue RTL', () => {
     const { asFragment } = render(
       <ConfigProvider direction="rtl">

--- a/components/cascader/style/columns.ts
+++ b/components/cascader/style/columns.ts
@@ -60,8 +60,8 @@ const getColumnsStyle: GenerateStyle<CascaderToken, CSSInterpolation> = (token) 
           listStyle: 'none',
           '-ms-overflow-style': '-ms-autohiding-scrollbar', // https://github.com/ant-design/ant-design/issues/11857
 
-          '&:not(:last-child)': {
-            borderInlineEnd: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
+          '&:not(:first-child)': {
+            borderInlineStart: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
           },
 
           '&-item': {

--- a/components/cascader/style/columns.ts
+++ b/components/cascader/style/columns.ts
@@ -60,8 +60,8 @@ const getColumnsStyle: GenerateStyle<CascaderToken, CSSInterpolation> = (token) 
           listStyle: 'none',
           '-ms-overflow-style': '-ms-autohiding-scrollbar', // https://github.com/ant-design/ant-design/issues/11857
 
-          '&:not(:first-child)': {
-            borderInlineStart: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
+          '&:not(:last-child)': {
+            borderInlineEnd: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
           },
 
           '&-item': {

--- a/components/cascader/style/index.ts
+++ b/components/cascader/style/index.ts
@@ -1,3 +1,4 @@
+import { unit } from '@ant-design/cssinjs';
 import type { CSSProperties } from 'react';
 
 import { genCompactItemStyle } from '../../style/compact-item';
@@ -81,6 +82,12 @@ const genBaseStyle: GenerateStyle<CascaderToken> = (token) => {
             &${antCls}-select-dropdown-placement-topRight:not(${componentCls}-dropdown-rtl)`]: {
             [`${componentCls}-menus`]: {
               flexDirection: 'row-reverse',
+            },
+            // The visual order is reversed, so move the column divider to the
+            // inline-start side and keep it off the visually-leftmost column.
+            [`${componentCls}-menu:not(:last-child)`]: {
+              borderInlineEnd: 'none',
+              borderInlineStart: `${unit(token.lineWidth)} ${token.lineType} ${token.colorSplit}`,
             },
           },
         },

--- a/components/cascader/style/index.ts
+++ b/components/cascader/style/index.ts
@@ -75,8 +75,10 @@ const genBaseStyle: GenerateStyle<CascaderToken> = (token) => {
           // Right-aligned placement anchors the popup's right edge to the trigger.
           // Reverse the column order so newly expanded child columns grow leftwards
           // and the parent column stays fixed, avoiding the parent shifting/jittering.
-          [`&${antCls}-select-dropdown-placement-bottomRight,
-            &${antCls}-select-dropdown-placement-topRight`]: {
+          // Only apply in LTR: in RTL `direction: rtl` already lays columns out
+          // right-to-left, so reversing again would flip the layout incorrectly.
+          [`&${antCls}-select-dropdown-placement-bottomRight:not(${componentCls}-dropdown-rtl),
+            &${antCls}-select-dropdown-placement-topRight:not(${componentCls}-dropdown-rtl)`]: {
             [`${componentCls}-menus`]: {
               flexDirection: 'row-reverse',
             },

--- a/components/cascader/style/index.ts
+++ b/components/cascader/style/index.ts
@@ -72,6 +72,15 @@ const genBaseStyle: GenerateStyle<CascaderToken> = (token) => {
           [`&${antCls}-select-dropdown`]: {
             padding: 0,
           },
+          // Right-aligned placement anchors the popup's right edge to the trigger.
+          // Reverse the column order so newly expanded child columns grow leftwards
+          // and the parent column stays fixed, avoiding the parent shifting/jittering.
+          [`&${antCls}-select-dropdown-placement-bottomRight,
+            &${antCls}-select-dropdown-placement-topRight`]: {
+            [`${componentCls}-menus`]: {
+              flexDirection: 'row-reverse',
+            },
+          },
         },
         getColumnsStyle(token),
       ],


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

close #58277

### 💡 Background and Solution

**Problem:** When `Cascader` uses `placement="topRight"` / `"bottomRight"`, the popup anchors its **right edge** to the trigger (`points: ['tr', 'br']`). However the multi-column menu is a LTR horizontal `flex` layout, so expanding a child column appends the new column on the right and widens the panel. With the right edge pinned, the parent column gets pushed leftwards (sometimes out of the viewport), and a third column then triggers `adjustX` re-positioning, causing visible jitter.

**Solution:**
- For `bottomRight` / `topRight` placement, set `.ant-cascader-menus` to `flex-direction: row-reverse`, so newly expanded child columns grow leftwards while the parent column's right edge stays locked and fixed.
- Make the column divider direction-agnostic: change from `:not(:last-child)` `borderInlineEnd` to `:not(:first-child)` `borderInlineStart`, so the divider renders correctly under both normal and reversed column order.

**Verification:** Added a unit test; manually verified that the parent column's right edge stays fixed across three levels of expansion.

#### Before

The parent column (Zhejiang) sits on the left, columns grow rightwards and the panel overflows past the trigger's right edge — the parent column shifts/jitters while expanding.

#### After

Column order is reversed (West Lake | Hangzhou | Zhejiang); the parent column's right edge stays aligned with the trigger and fixed, while child columns grow leftwards.

> Note: Before/After screenshots will be attached in the PR description (UI-only diff).

### 📝 Changelog

| Language | Changelog |
| -------- | -------- |
| 🇺🇸 English | Fix Cascader parent column shifting and jitter when \`placement\` is \`topRight\` or \`bottomRight\`. |
| 🇨🇳 Chinese | 修复 Cascader 在 \`placement\` 为 \`topRight\` 或 \`bottomRight\` 时父级面板左移和抖动的问题。 |