### PR TITLE
fix(Select): follow-up refine single-mode open-state labelRender dimming

### DIFF
--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -308,7 +308,7 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
             '&-has-search-value': {
               color: 'transparent',
 
-              [`> :not(${componentCls}-input)`]: {
+              [`> *:not(${componentCls}-input)`]: {
                 opacity: 0,
               },
             },
@@ -317,14 +317,24 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
             '&-value': {
               transition: `all ${token.motionDurationMid} ${token.motionEaseInOut}`,
               zIndex: 1,
+              opacity: 1,
             },
           },
 
+          // Dim the selected content while the dropdown is open. Shared by all select-like
+          // components (Select / Cascader / TreeSelect) since they render through the same
+          // `content` structure.
           [`&${componentCls}-open ${componentCls}-content`]: {
-            color: token.colorTextPlaceholder,
+            '&-has-value': {
+              opacity: 0.25,
+            },
 
             '&-has-search-value': {
+              opacity: 1,
               color: 'transparent',
+              [`> *:not(${componentCls}-input)`]: {
+                opacity: 0,
+              },
             },
           },
         },

--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -331,6 +331,7 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
 
             '&-has-search-value': {
               opacity: 1,
+              transition: `opacity ${token.motionDurationMid} ${token.motionEaseInOut}`,
               color: 'transparent',
               [`> *:not(${componentCls}-input)`]: {
                 opacity: 0,


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
ref #57951
follow-up to #57954

### 💡 Background and Solution
**Background:**
The search-state bug in #57951 (non-text labelRender content staying visible while typing) was already fixed by #57954.
This PR is a follow-up focused only on open-state visual consistency in Select single mode.

Problem in current behavior
When dropdown is open (before typing), plain text labels are dimmed by placeholder color.
But if labelRender wraps text in an element (for example, span + icon/text), the current rule also applies child opacity 0.25, so wrapped text becomes much dimmer than plain text.

https://codesandbox.io/p/sandbox/ji-ben-shi-yong-antd-6-4-3-forked-tx65jq?file=%2Fdemo.tsx%3A17%2C23

**Solution:**
Refine the open-state CSS so custom labelRender text does not get double-dimmed:
- keep text dimming behavior consistent with plain text labels
- avoid stacking parent placeholder color with child opacity on wrapped text
- preserve intended dimming for non-text rich content (such as image/icon visuals) where needed
- keep search input text and caret fully visible
- no extra DOM wrappers introduced

### 📝 Change Log

| Language | Changelog |
| -------- | --------- |
| 🇺🇸 English |  🐞 Refine Select single-mode open-state dimming for custom labelRender content to avoid over-dimming wrapped text while keeping rich-content visibility behavior consistent. |
| 🇨🇳 Chinese |     -      |
