### PR TITLE
Revert "demo: implement image-image linear scaling"

### DIFF
--- a/components/image/demo/toolbarRender.tsx
+++ b/components/image/demo/toolbarRender.tsx
@@ -10,7 +10,7 @@ import {
   ZoomInOutlined,
   ZoomOutOutlined,
 } from '@ant-design/icons';
-import { Image, Slider, Space } from 'antd';
+import { Image, Space } from 'antd';
 
 const imageList = [
   'https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg',
@@ -61,43 +61,23 @@ const App: React.FC = () => {
               onReset,
             },
           },
-        ) => {
-          const handleScaleChange = (nextScale: number) => {
-            // `@rc-component/image` v1.7.x no longer exposes an `onChangeScale` action.
-            // We approximate scale changes by triggering one step of zoom in/out.
-            if (nextScale > scale) {
-              onZoomIn();
-            } else if (nextScale < scale) {
-              onZoomOut();
-            }
-          };
-
-          return (
-            <Space size={12} className="toolbar-wrapper">
-              <LeftOutlined disabled={current === 0} onClick={() => onActive?.(-1)} />
-              <RightOutlined
-                disabled={current === imageList.length - 1}
-                onClick={() => onActive?.(1)}
-              />
-              <DownloadOutlined onClick={onDownload} />
-              <SwapOutlined rotate={90} onClick={onFlipY} />
-              <SwapOutlined onClick={onFlipX} />
-              <RotateLeftOutlined onClick={onRotateLeft} />
-              <RotateRightOutlined onClick={onRotateRight} />
-              <ZoomOutOutlined disabled={scale === 1} onClick={onZoomOut} />
-              <Slider
-                min={1}
-                max={50}
-                step={0.1}
-                value={scale}
-                styles={{ root: { width: 100, marginInline: 12 } }}
-                onChange={handleScaleChange}
-              />
-              <ZoomInOutlined disabled={scale === 50} onClick={onZoomIn} />
-              <UndoOutlined onClick={onReset} />
-            </Space>
-          );
-        },
+        ) => (
+          <Space size={12} className="toolbar-wrapper">
+            <LeftOutlined disabled={current === 0} onClick={() => onActive?.(-1)} />
+            <RightOutlined
+              disabled={current === imageList.length - 1}
+              onClick={() => onActive?.(1)}
+            />
+            <DownloadOutlined onClick={onDownload} />
+            <SwapOutlined rotate={90} onClick={onFlipY} />
+            <SwapOutlined onClick={onFlipX} />
+            <RotateLeftOutlined onClick={onRotateLeft} />
+            <RotateRightOutlined onClick={onRotateRight} />
+            <ZoomOutOutlined disabled={scale === 1} onClick={onZoomOut} />
+            <ZoomInOutlined disabled={scale === 50} onClick={onZoomIn} />
+            <UndoOutlined onClick={onReset} />
+          </Space>
+        ),
         onChange: (index) => {
           setCurrent(index);
         },


### PR DESCRIPTION
## Related

Follow-up for #58291.
Reverts the demo update from #57158.

## Background

The Slider-based Image toolbar demo currently maps slider changes to one-step zoom in/out actions instead of controlling an absolute scale value directly. This implementation is relatively hardcoded and can lead to the jitter behavior reported in #58291.

Since the demo can be misleading in its current form, this PR restores the previous toolbar demo first. We can revisit the Slider interaction when the Image preview API can support it more directly.

## Changes

- Remove the hardcoded Slider from the Image toolbar demo.
- Restore the previous zoom in/out toolbar controls.

## Verification

- `git diff --check`
- `ut execute biome lint components/image/demo/toolbarRender.tsx`
- `ut execute eslint components/image/demo/toolbarRender.tsx`
