### PR TITLE
fix: keep Popover/Popconfirm rendering when title or content is the number 0

### DIFF
--- a/components/_util/getRenderPropValue.ts
+++ b/components/_util/getRenderPropValue.ts
@@ -1,13 +1,13 @@
 import type * as React from 'react';
 
-import { isFunction } from './is';
+import { isFunction, isReactRenderable } from './is';
 
 export type RenderFunction = () => React.ReactNode;
 
 export const getRenderPropValue = (
   propValue?: React.ReactNode | RenderFunction,
 ): React.ReactNode => {
-  if (!propValue) {
+  if (!isReactRenderable(propValue)) {
     return null;
   }
   return isFunction(propValue) ? propValue() : propValue;

--- a/components/popconfirm/PurePanel.tsx
+++ b/components/popconfirm/PurePanel.tsx
@@ -4,6 +4,7 @@ import { clsx } from 'clsx';
 
 import ActionButton from '../_util/ActionButton';
 import { getRenderPropValue } from '../_util/getRenderPropValue';
+import { isReactRenderable } from '../_util/is';
 import Button from '../button/Button';
 import { convertLegacyProps } from '../button/buttonHelpers';
 import { ConfigContext } from '../config-provider';
@@ -79,12 +80,12 @@ export const Overlay: React.FC<OverlayProps> = (props) => {
           </span>
         )}
         <div className={`${prefixCls}-message-text`}>
-          {titleNode && (
+          {isReactRenderable(titleNode) && (
             <div className={clsx(`${prefixCls}-title`, classNames?.title)} style={styles?.title}>
               {titleNode}
             </div>
           )}
-          {descriptionNode && (
+          {isReactRenderable(descriptionNode) && (
             <div
               className={clsx(`${prefixCls}-description`, classNames?.content)}
               style={styles?.content}

--- a/components/popconfirm/__tests__/index.test.tsx
+++ b/components/popconfirm/__tests__/index.test.tsx
@@ -140,6 +140,17 @@ describe('Popconfirm', () => {
     jest.useRealTimers();
   });
 
+  it('should render title when it is the number 0', () => {
+    const { container } = render(
+      <Popconfirm title={0} open>
+        <span>show me your code</span>
+      </Popconfirm>,
+    );
+    const titleNode = container.querySelector('.ant-popconfirm-title');
+    expect(titleNode).not.toBe(null);
+    expect(titleNode?.textContent).toContain('0');
+  });
+
   it('should trigger onConfirm and onCancel', async () => {
     const confirm = jest.fn();
     const cancel = jest.fn();

--- a/components/popover/PurePanel.tsx
+++ b/components/popover/PurePanel.tsx
@@ -5,6 +5,7 @@ import { clsx } from 'clsx';
 import type { PopoverProps, PopoverSemanticAllType } from '.';
 import { getRenderPropValue } from '../_util/getRenderPropValue';
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { isReactRenderable } from '../_util/is';
 import { ConfigContext } from '../config-provider';
 import useStyle from './style';
 
@@ -19,18 +20,18 @@ interface OverlayProps {
 export const Overlay: React.FC<OverlayProps> = (props) => {
   const { title, content, prefixCls, classNames, styles } = props;
 
-  if (!title && !content) {
+  if (!isReactRenderable(title) && !isReactRenderable(content)) {
     return null;
   }
 
   return (
     <>
-      {title && (
+      {isReactRenderable(title) && (
         <div className={clsx(`${prefixCls}-title`, classNames?.title)} style={styles?.title}>
           {title}
         </div>
       )}
-      {content && (
+      {isReactRenderable(content) && (
         <div className={clsx(`${prefixCls}-content`, classNames?.content)} style={styles?.content}>
           {content}
         </div>

--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -137,6 +137,18 @@ describe('Popover', () => {
     });
   });
 
+  it('should display overlay when the content is the number 0', () => {
+    const { container } = render(
+      <Popover content={0} trigger="click">
+        <span>show me your code</span>
+      </Popover>,
+    );
+    fireEvent.click(container.querySelector<HTMLSpanElement>('span')!);
+    const popup = document.querySelector('.ant-popover');
+    expect(popup).not.toBe(null);
+    expect(popup?.textContent).toContain('0');
+  });
+
   it('ConfigProvider support arrow props', () => {
     const TooltipTestComponent = () => {
       const [configArrow, setConfigArrow] = React.useState(true);

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -6,6 +6,7 @@ import type { RenderFunction } from '../_util/getRenderPropValue';
 import { getRenderPropValue } from '../_util/getRenderPropValue';
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
+import { isReactRenderable } from '../_util/is';
 import { getTransitionName } from '../_util/motion';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
@@ -145,7 +146,7 @@ const InternalPopover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) 
       open={open}
       onOpenChange={settingOpen}
       overlay={
-        titleNode || contentNode ? (
+        isReactRenderable(titleNode) || isReactRenderable(contentNode) ? (
           <Overlay
             prefixCls={prefixCls}
             title={titleNode}


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

> N/A — found during a code audit.

### 💡 Background and Solution

`getRenderPropValue` is the shared helper that resolves `title` / `content` props (and their render-function form) for Popover and Popconfirm. It used a `!propValue` guard:

```ts
if (!propValue) {
  return null;
}
```

Since the prop type is `React.ReactNode` (which includes `number`), the guard wrongly discarded the **falsy-but-valid** node `0`. As a result:

- `<Popover content={0} />` rendered nothing (no overlay at all).
- `<Popconfirm title={0} />` rendered an empty title.

`0` is a legitimate, renderable React node (counts, amounts, scores, etc.), so dropping it is a correctness bug.

**Solution:** reuse the existing `isReactRenderable` predicate from `components/_util/is.ts`, which excludes only `false` / `''` / `null` / `undefined` while keeping `0`. The same predicate is applied to the downstream truthy checks (`titleNode || contentNode`, `!title && !content`, `{title && ...}`) that decide whether the overlay nodes get rendered, so a lone `0` now flows all the way through.

Functions are unaffected: they are truthy under both the old and new guard and still get invoked.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Popover and Popconfirm not rendering when `title` or `content` is the number `0`. |
| 🇨🇳 Chinese | 修复 Popover 与 Popconfirm 在 `title` 或 `content` 为数字 `0` 时不渲染的问题。 |
