### PR TITLE
docs: update CLI doc to match latest ant-design-cli

### DIFF
--- a/docs/react/cli.en-US.md
+++ b/docs/react/cli.en-US.md
@@ -11,12 +11,12 @@ This guide explains how to use `@ant-design/cli` to query Ant Design component k
 
 ## What is Ant Design CLI?
 
-[`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) is an official command-line tool that brings Ant Design knowledge to your terminal. It ships all metadata locally — every prop, token, demo, and changelog entry for antd v4 / v5 / v6 — queryable in milliseconds, fully offline.
+[`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) is an official command-line tool that brings Ant Design knowledge to your terminal. It ships all metadata locally — every prop, token, demo, and changelog entry for antd v3 / v4 / v5 / v6 — queryable in milliseconds, fully offline.
 
 ## Highlights
 
 - **Fully offline** — All metadata ships with the package. No network calls, no latency, no API keys.
-- **Version-accurate** — 55+ per-minor snapshots across v4/v5/v6. Query the exact API surface of any version.
+- **Version-accurate** — 55+ per-minor snapshots across v3/v4/v5/v6. Query the exact API surface of any version.
 - **Agent-optimized** — `--format json` on every command. Structured errors with codes and suggestions.
 - **Bilingual** — Every component name, description, and doc has both English and Chinese. Switch with `--lang zh`.
 - **Smart matching** — Typo `Buttn`? The CLI suggests `Button` using Levenshtein distance.
@@ -51,6 +51,7 @@ antd migrate 4 5 --apply ./src      # Agent-ready migration prompt
 | `antd doc <Component>` | Full markdown documentation for a component |
 | `antd demo <Component> [name]` | Runnable demo source code (TSX) |
 | `antd token [Component]` | Global or component-level Design Tokens |
+| `antd design.md` | Design-language document for AI design tools |
 | `antd semantic <Component>` | Semantic `classNames` / `styles` structure with usage examples |
 | `antd changelog [v1] [v2] [component]` | Changelog entries, version ranges, or cross-version API diff |
 
@@ -62,8 +63,23 @@ antd migrate 4 5 --apply ./src      # Agent-ready migration prompt
 | `antd usage [dir]` | Import stats, sub-component breakdown (`Form.Item`), non-component exports |
 | `antd lint [target]` | Deprecated APIs, accessibility gaps, performance issues, best practices |
 | `antd migrate <from> <to>` | Migration checklist with auto-fixable/manual split and `--apply` agent prompt |
-| `antd env [dir]` | Collect environment information for bug reports |
-| `antd bug` | Submit a bug to the ant-design repository |
+| `antd env [dir]` | Collect antd-related environment information for bug reports |
+
+### Issue Reporting
+
+| Command        | Description                                   |
+| -------------- | --------------------------------------------- |
+| `antd bug`     | Submit a bug to the ant-design repository     |
+| `antd bug-cli` | Submit a bug to the ant-design-cli repository |
+
+### CLI Management
+
+| Command        | Description                                                        |
+| -------------- | ------------------------------------------------------------------ |
+| `antd mcp`     | Start an MCP server with 8 tools and 2 prompts for IDE integration |
+| `antd upgrade` | Upgrade the CLI to the latest version                              |
+
+The `antd mcp` command launches a [Model Context Protocol](https://modelcontextprotocol.io/) server, allowing AI assistants to access Ant Design knowledge directly. See the [MCP Server](/docs/react/mcp-en-US) guide for full details and configuration.
 
 ### Global Flags
 
@@ -73,14 +89,15 @@ antd migrate 4 5 --apply ./src      # Agent-ready migration prompt
 | `--version <v>`                 | Target antd version (e.g. `5.20.0`) | auto-detect |
 | `--lang en\|zh`                 | Output language                     | `en`        |
 | `--detail`                      | Include extended information        | `false`     |
+| `-V, --cli-version`             | Print the CLI version               | -           |
 
-### MCP Server
+### Environment Variables
 
-| Command    | Description                                                        |
-| ---------- | ------------------------------------------------------------------ |
-| `antd mcp` | Start an MCP server with 7 tools and 2 prompts for IDE integration |
-
-The `antd mcp` command launches a [Model Context Protocol](https://modelcontextprotocol.io/) server, allowing AI assistants to access Ant Design knowledge directly. See the [MCP Server](/docs/react/mcp-en-US) guide for full details and configuration.
+| Variable                | Description                       |
+| ----------------------- | --------------------------------- |
+| `ANTD_NO_AUTO_REPORT=1` | Disable bug-reporting suggestions |
+| `NO_UPDATE_CHECK=1`     | Skip the version update check     |
+| `CI=1`                  | Same as `NO_UPDATE_CHECK=1`       |
 
 ## Usage with AI Tools
 

--- a/docs/react/cli.zh-CN.md
+++ b/docs/react/cli.zh-CN.md
@@ -11,12 +11,12 @@ tag: New
 
 ## 什么是 Ant Design CLI？ {#what-is-ant-design-cli}
 
-[`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) 是官方命令行工具，将 Ant Design 知识带到你的终端。所有元数据随包安装 — antd v4 / v5 / v6 的每个 Prop、Token、Demo 和 Changelog 条目 — 毫秒级查询，完全离线。
+[`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) 是官方命令行工具，将 Ant Design 知识带到你的终端。所有元数据随包安装 — antd v3 / v4 / v5 / v6 的每个 Prop、Token、Demo 和 Changelog 条目 — 毫秒级查询，完全离线。
 
 ## 亮点 {#highlights}
 
 - **完全离线** — 所有元数据随包安装，无需网络请求，无延迟，无 API Key。
-- **版本精确** — 跨 v4/v5/v6 的 55+ 小版本快照，查询任意版本的精确 API。
+- **版本精确** — 跨 v3/v4/v5/v6 的 55+ 小版本快照，查询任意版本的精确 API。
 - **Agent 优化** — 所有命令支持 `--format json`，结构化错误码与修复建议。
 - **双语输出** — 每个组件名、描述和文档均有中英文，通过 `--lang zh` 切换。
 - **智能纠错** — 输入 `Buttn`？CLI 基于 Levenshtein 距离建议 `Button`。
@@ -51,6 +51,7 @@ antd migrate 4 5 --apply ./src      # 生成 Agent 迁移提示
 | `antd doc <Component>`                 | 组件完整 Markdown 文档                         |
 | `antd demo <Component> [name]`         | 可运行的 Demo 源码（TSX）                      |
 | `antd token [Component]`               | 全局或组件级 Design Token                      |
+| `antd design.md`                       | 设计语言文档，供 AI 设计工具使用               |
 | `antd semantic <Component>`            | 语义化 `classNames` / `styles` 结构及用法示例  |
 | `antd changelog [v1] [v2] [component]` | Changelog 条目、版本范围或跨版本 API 对比      |
 
@@ -62,8 +63,23 @@ antd migrate 4 5 --apply ./src      # 生成 Agent 迁移提示
 | `antd usage [dir]`         | 导入统计、子组件分布（`Form.Item`）、非组件导出                   |
 | `antd lint [target]`       | 废弃 API、无障碍缺陷、性能问题、最佳实践                          |
 | `antd migrate <from> <to>` | 迁移清单，区分自动修复/手动处理，`--apply` 生成 Agent 提示        |
-| `antd env [dir]`           | 收集环境信息，用于 Bug 报告                                       |
-| `antd bug`                 | 提交 Bug 到 ant-design 仓库                                       |
+| `antd env [dir]`           | 收集 antd 相关环境信息，用于 Bug 报告                             |
+
+### 问题反馈 {#issue-reporting}
+
+| 命令           | 说明                            |
+| -------------- | ------------------------------- |
+| `antd bug`     | 提交 Bug 到 ant-design 仓库     |
+| `antd bug-cli` | 提交 Bug 到 ant-design-cli 仓库 |
+
+### CLI 管理 {#cli-management}
+
+| 命令           | 说明                                                       |
+| -------------- | ---------------------------------------------------------- |
+| `antd mcp`     | 启动 MCP 服务器，提供 8 个工具和 2 个提示词，支持 IDE 集成 |
+| `antd upgrade` | 将 CLI 升级到最新版本                                      |
+
+`antd mcp` 命令启动 [Model Context Protocol](https://modelcontextprotocol.io/) 服务器，让 AI 助手可以直接访问 Ant Design 知识。详细配置参见 [MCP Server](/docs/react/mcp-zh-CN) 指南。
 
 ### 全局参数 {#global-flags}
 
@@ -73,14 +89,15 @@ antd migrate 4 5 --apply ./src      # 生成 Agent 迁移提示
 | `--version <v>`                 | 目标 antd 版本（如 `5.20.0`） | 自动检测 |
 | `--lang en\|zh`                 | 输出语言                      | `en`     |
 | `--detail`                      | 包含扩展信息                  | `false`  |
+| `-V, --cli-version`             | 打印 CLI 版本号               | -        |
 
-### MCP Server {#mcp-server}
+### 环境变量 {#environment-variables}
 
-| 命令       | 说明                                                       |
-| ---------- | ---------------------------------------------------------- |
-| `antd mcp` | 启动 MCP 服务器，提供 7 个工具和 2 个提示词，支持 IDE 集成 |
-
-`antd mcp` 命令启动 [Model Context Protocol](https://modelcontextprotocol.io/) 服务器，让 AI 助手可以直接访问 Ant Design 知识。详细配置参见 [MCP Server](/docs/react/mcp-zh-CN) 指南。
+| 变量                    | 说明                       |
+| ----------------------- | -------------------------- |
+| `ANTD_NO_AUTO_REPORT=1` | 关闭 Bug 上报建议          |
+| `NO_UPDATE_CHECK=1`     | 跳过版本更新检查           |
+| `CI=1`                  | 等同于 `NO_UPDATE_CHECK=1` |
 
 ## 在 AI 工具中的使用 {#usage-with-ai-tools}
 

--- a/docs/react/mcp.en-US.md
+++ b/docs/react/mcp.en-US.md
@@ -15,7 +15,7 @@ This guide explains how to use Ant Design with AI tools through Model Context Pr
 
 ## Official MCP Server
 
-Starting from [`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) v6.3.5, you can launch an official MCP server with the `antd mcp` command, providing 7 tools and 2 prompts for IDE integration.
+Starting from [`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) v6.3.5, you can launch an official MCP server with the `antd mcp` command, providing 8 tools and 2 prompts for IDE integration.
 
 ### Tools
 
@@ -26,6 +26,7 @@ Starting from [`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) 
 | `antd_doc`       | Fetch complete documentation               |
 | `antd_demo`      | Access runnable code examples              |
 | `antd_token`     | Query design token values                  |
+| `antd_design_md` | Fetch the design-language document         |
 | `antd_semantic`  | Inspect DOM structure and styling hooks    |
 | `antd_changelog` | Analyze API changes across versions        |
 

--- a/docs/react/mcp.zh-CN.md
+++ b/docs/react/mcp.zh-CN.md
@@ -15,7 +15,7 @@ tag: New
 
 ## 官方 MCP Server {#official-mcp-server}
 
-从 [`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) v6.3.5 起，你可以通过 `antd mcp` 命令启动官方 MCP 服务器，提供 7 个工具和 2 个提示词，支持 IDE 集成。
+从 [`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) v6.3.5 起，你可以通过 `antd mcp` 命令启动官方 MCP 服务器，提供 8 个工具和 2 个提示词，支持 IDE 集成。
 
 ### 工具 {#tools}
 
@@ -26,6 +26,7 @@ tag: New
 | `antd_doc`       | 获取完整文档            |
 | `antd_demo`      | 获取可运行的代码示例    |
 | `antd_token`     | 查询 Design Token 值    |
+| `antd_design_md` | 获取设计语言文档        |
 | `antd_semantic`  | 查看 DOM 结构和样式钩子 |
 | `antd_changelog` | 分析跨版本 API 变更     |
 


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> N/A

### 💡 Background and Solution

The CLI guide (`docs/react/cli.*`) had drifted from the upstream [ant-design-cli](https://github.com/ant-design/ant-design-cli) README. This PR syncs both the English and Chinese docs:

- Cover **antd v3** alongside v4/v5/v6 in the intro and highlights.
- Add the missing `antd design.md` command to the Knowledge Query table.
- Split out an **Issue Reporting** section with `antd bug` and the newly documented `antd bug-cli`.
- Add a **CLI Management** section documenting `antd mcp` and the new `antd upgrade` command.
- Add the `-V, --cli-version` global flag.
- Add a new **Environment Variables** section (`ANTD_NO_AUTO_REPORT`, `NO_UPDATE_CHECK`, `CI`).
- Bump the MCP server tools count from 7 to **8** (adds the `antd_design_md` tool).

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Update CLI documentation to match the latest `@ant-design/cli`. |
| 🇨🇳 Chinese | 更新 CLI 文档，与最新的 `@ant-design/cli` 保持一致。 |
