### PR TITLE
docs: reduce semantic preview demo heights

### DIFF
--- a/.dumi/theme/common/SemanticPreview.tsx
+++ b/.dumi/theme/common/SemanticPreview.tsx
@@ -30,14 +30,19 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   colWrapPaddingLess: css`
     padding: 0;
   `,
+  listCol: css`
+    display: flex;
+    min-height: 0;
+  `,
   listWrap: css`
     display: flex;
+    flex: 1;
     flex-direction: column;
     list-style: none;
     margin: 0;
     padding: 0;
+    height: 100%;
     overflow: auto;
-    max-height: 600px;
   `,
   listItem: css`
     cursor: pointer;
@@ -188,7 +193,7 @@ const SemanticPreview: React.FC<SemanticPreviewProps> = (props) => {
         >
           <ConfigProvider theme={{ token: { motion } }}>{cloneNode}</ConfigProvider>
         </Col>
-        <Col span={8}>
+        <Col span={8} className={clsx(styles.listCol)}>
           <ul className={clsx(styles.listWrap)}>
             {semantics.map<React.ReactNode>((semantic) => (
               <li

--- a/.dumi/theme/common/SemanticPreview.tsx
+++ b/.dumi/theme/common/SemanticPreview.tsx
@@ -31,17 +31,17 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     padding: 0;
   `,
   listCol: css`
-    display: flex;
+    position: relative;
     min-height: 0;
   `,
   listWrap: css`
+    position: absolute;
+    inset: 0;
     display: flex;
-    flex: 1;
     flex-direction: column;
     list-style: none;
     margin: 0;
     padding: 0;
-    height: 100%;
     overflow: auto;
   `,
   listItem: css`
@@ -193,7 +193,7 @@ const SemanticPreview: React.FC<SemanticPreviewProps> = (props) => {
         >
           <ConfigProvider theme={{ token: { motion } }}>{cloneNode}</ConfigProvider>
         </Col>
-        <Col span={8} className={clsx(styles.listCol)}>
+        <Col span={8} className={styles.listCol}>
           <ul className={clsx(styles.listWrap)}>
             {semantics.map<React.ReactNode>((semantic) => (
               <li

--- a/.dumi/theme/common/SemanticPreview.tsx
+++ b/.dumi/theme/common/SemanticPreview.tsx
@@ -30,19 +30,14 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   colWrapPaddingLess: css`
     padding: 0;
   `,
-  listCol: css`
-    position: relative;
-    min-height: 0;
-  `,
   listWrap: css`
-    position: absolute;
-    inset: 0;
     display: flex;
     flex-direction: column;
     list-style: none;
     margin: 0;
     padding: 0;
     overflow: auto;
+    max-height: 600px;
   `,
   listItem: css`
     cursor: pointer;
@@ -193,7 +188,7 @@ const SemanticPreview: React.FC<SemanticPreviewProps> = (props) => {
         >
           <ConfigProvider theme={{ token: { motion } }}>{cloneNode}</ConfigProvider>
         </Col>
-        <Col span={8} className={styles.listCol}>
+        <Col span={8}>
           <ul className={clsx(styles.listWrap)}>
             {semantics.map<React.ReactNode>((semantic) => (
               <li

--- a/components/image/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/image/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`renders components/image/demo/_semantic.tsx correctly 1`] = `
           </div>
         </div>
         <div
-          style="flex: 1 1 0%; position: relative; min-height: 500px; width: 100%;"
+          style="flex: 1 1 0%; position: relative; min-height: 360px; width: 100%;"
         >
           <div
             aria-modal="true"

--- a/components/image/demo/_semantic.tsx
+++ b/components/image/demo/_semantic.tsx
@@ -65,7 +65,7 @@ const Block: React.FC<Readonly<ImagePropsBlock>> = ({ classNames, ...restProps }
           {...restProps}
         />
       </Flex>
-      <div style={{ flex: 1, position: 'relative', minHeight: 500, width: '100%' }} ref={holderRef}>
+      <div style={{ flex: 1, position: 'relative', minHeight: 360, width: '100%' }} ref={holderRef}>
         <Image.PreviewGroup
           items={[
             'https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg',

--- a/components/tour/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/tour/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`renders components/tour/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-16 acss-my3sst css-var-test-id"
     >
       <div
-        style="width: 100%; height: 825px; display: flex; align-items: center; justify-content: center; position: relative; overflow: hidden;"
+        style="width: 100%; height: 600px; display: flex; align-items: center; justify-content: center; position: relative; overflow: hidden;"
       >
         <button
           class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
@@ -67,6 +67,7 @@ exports[`renders components/tour/demo/_semantic.tsx correctly 1`] = `
                 <img
                   alt="tour.png"
                   src="https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png"
+                  style="width: 360px; max-width: 100%;"
                 />
               </div>
               <div

--- a/components/tour/demo/_semantic.tsx
+++ b/components/tour/demo/_semantic.tsx
@@ -53,7 +53,7 @@ const BlockList: React.FC<React.PropsWithChildren<TourProps>> = (props) => {
     <div
       style={{
         width: '100%',
-        height: 825,
+        height: 600,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
@@ -78,6 +78,7 @@ const BlockList: React.FC<React.PropsWithChildren<TourProps>> = (props) => {
             cover: (
               <img
                 alt="tour.png"
+                style={{ width: 360, maxWidth: '100%' }}
                 src="https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png"
               />
             ),


### PR DESCRIPTION
## Summary

Fixes #58294 by reducing the Image and Tour semantic preview demo heights so they fit the existing `SemanticPreview` semantic list cap without leaving blank space below the list.

## Reproduction

1. Open the Image or Tour Semantic DOM demo.
2. The left preview area is taller than the right semantic list, which is capped by `max-height: 600px`.
3. The right side leaves blank space below the list.

## Root cause

The Image semantic demo reserved `minHeight: 500` for the preview popup holder under the 200px image, and the Tour semantic demo used a fixed `height: 825`. Both make the preview column taller than the shared semantic list cap. Updating the shared `SemanticPreview` list layout had a wider blast radius and could regress demos whose preview content is also absolutely positioned.

## Changes

- Restored the shared `SemanticPreview` layout behavior.
- Reduced the Image semantic preview popup holder `minHeight` from `500` to `360`.
- Reduced the Tour semantic preview container height from `825` to `600`.

## Tests

- `git diff --check`
- `npx --yes @biomejs/biome@2.4.16 check components/image/demo/_semantic.tsx components/tour/demo/_semantic.tsx .dumi/theme/common/SemanticPreview.tsx`

## Screenshots/Logs

Not captured in this environment.