### PR TITLE
demo: fix Table column drag sorting indicator

### DIFF
--- a/components/table/demo/drag-column-sorting.tsx
+++ b/components/table/demo/drag-column-sorting.tsx
@@ -44,13 +44,16 @@ interface DragIndexState {
 const DragIndexContext = createContext<DragIndexState>({ active: -1, over: -1 });
 
 const dragActiveStyle = (dragState: DragIndexState, id: string) => {
-  const { active, over } = dragState;
+  const { active, over, direction } = dragState;
   // drag active style
   let style: React.CSSProperties = {};
   if (active && active === id) {
     style = { backgroundColor: 'gray', opacity: 0.5 };
   } else if (over && id === over && active !== over) {
-    style = { borderInlineStart: '1px dashed gray' };
+    style =
+      direction === 'right'
+        ? { borderInlineEnd: '1px dashed gray' }
+        : { borderInlineStart: '1px dashed gray' };
   }
   return style;
 };


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #58299

### 💡 需求背景和解决方案

Table 列拖拽排序 demo 在从左向右拖拽列时，落点指示线显示在目标列左侧，但实际排序会移动到目标列右侧，导致视觉提示和最终结果不一致。

本次调整复用已有的拖拽方向状态：向右拖拽时在目标列右侧显示指示线，向左拖拽时保持在目标列左侧显示，使 demo 的拖拽提示与实际落点一致。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | No changelog required for demo improvement. |
| 🇨🇳 中文 | 演示代码改进，无需更新日志。 |