### PR TITLE
fix: keep Tour previous button hover color readable

### DIFF
--- a/components/tour/style/index.ts
+++ b/components/tour/style/index.ts
@@ -226,6 +226,7 @@ const genBaseStyle: GenerateStyle<TourToken> = (token) => {
               backgroundColor: colorPrimary,
 
               '&:hover': {
+                color: colorTextLightSolid,
                 backgroundColor: primaryPrevBtnBg,
                 borderColor: 'transparent',
               },


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #58308

### 💡 需求背景和解决方案

Tour 在 primary 类型下，上一步按钮 hover 时只覆盖了背景色和边框色，文字色可能被 Button 默认 hover 色覆盖，导致在官网示例中出现对比度较差的问题。

本次在 Tour primary 的上一步按钮 hover 状态中显式保持文字为浅色，保证按钮文字可读性。不涉及 API 变更。

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | 🐞 Fix Tour previous button text color on hover in primary type. |
| 🇨🇳 中文 | 🐞 修复 Tour 主色模式下上一步按钮 hover 时文字颜色可读性问题。 |
