### PR TITLE
demo: improve Alert action demo layout

### DIFF
--- a/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -153,22 +153,14 @@ Array [
     <div
       class="ant-alert-actions"
     >
-      <div
-        class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"
+      <button
+        class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm"
+        type="button"
       >
-        <div
-          class="ant-space-item"
-        >
-          <button
-            class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm"
-            type="button"
-          >
-            <span>
-              Done
-            </span>
-          </button>
-        </div>
-      </div>
+        <span>
+          Done
+        </span>
+      </button>
     </div>
     <button
       class="ant-alert-close-icon"
@@ -221,32 +213,25 @@ Array [
       class="ant-alert-actions"
     >
       <div
-        class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"
+        class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+        style="min-width: 80px;"
       >
-        <div
-          class="ant-space-item"
+        <button
+          class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm ant-btn-block"
+          type="button"
         >
-          <button
-            class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm"
-            type="button"
-          >
-            <span>
-              Accept
-            </span>
-          </button>
-        </div>
-        <div
-          class="ant-space-item"
+          <span>
+            Accept
+          </span>
+        </button>
+        <button
+          class="ant-btn css-var-test-id ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-background-ghost ant-btn-block"
+          type="button"
         >
-          <button
-            class="ant-btn css-var-test-id ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-background-ghost"
-            type="button"
-          >
-            <span>
-              Decline
-            </span>
-          </button>
-        </div>
+          <span>
+            Decline
+          </span>
+        </button>
       </div>
     </div>
     <button

--- a/components/alert/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/alert/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -56,32 +56,25 @@ exports[`renders components/alert/demo/_semantic.tsx correctly 1`] = `
           class="ant-alert-actions semantic-mark-actions"
         >
           <div
-            class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+            style="min-width: 80px;"
           >
-            <div
-              class="ant-space-item"
+            <button
+              class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm ant-btn-block"
+              type="button"
             >
-              <button
-                class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm"
-                type="button"
-              >
-                <span>
-                  Accept
-                </span>
-              </button>
-            </div>
-            <div
-              class="ant-space-item"
+              <span>
+                Accept
+              </span>
+            </button>
+            <button
+              class="ant-btn css-var-test-id ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-background-ghost ant-btn-block"
+              type="button"
             >
-              <button
-                class="ant-btn css-var-test-id ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-background-ghost"
-                type="button"
-              >
-                <span>
-                  Decline
-                </span>
-              </button>
-            </div>
+              <span>
+                Decline
+              </span>
+            </button>
           </div>
         </div>
         <button

--- a/components/alert/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/alert/__tests__/__snapshots__/demo.test.ts.snap
@@ -153,22 +153,14 @@ Array [
     <div
       class="ant-alert-actions"
     >
-      <div
-        class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"
+      <button
+        class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm"
+        type="button"
       >
-        <div
-          class="ant-space-item"
-        >
-          <button
-            class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm"
-            type="button"
-          >
-            <span>
-              Done
-            </span>
-          </button>
-        </div>
-      </div>
+        <span>
+          Done
+        </span>
+      </button>
     </div>
     <button
       class="ant-alert-close-icon"
@@ -221,32 +213,25 @@ Array [
       class="ant-alert-actions"
     >
       <div
-        class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"
+        class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+        style="min-width:80px"
       >
-        <div
-          class="ant-space-item"
+        <button
+          class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm ant-btn-block"
+          type="button"
         >
-          <button
-            class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm"
-            type="button"
-          >
-            <span>
-              Accept
-            </span>
-          </button>
-        </div>
-        <div
-          class="ant-space-item"
+          <span>
+            Accept
+          </span>
+        </button>
+        <button
+          class="ant-btn css-var-test-id ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-background-ghost ant-btn-block"
+          type="button"
         >
-          <button
-            class="ant-btn css-var-test-id ant-btn-default ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-outlined ant-btn-sm ant-btn-background-ghost"
-            type="button"
-          >
-            <span>
-              Decline
-            </span>
-          </button>
-        </div>
+          <span>
+            Decline
+          </span>
+        </button>
       </div>
     </div>
     <button

--- a/components/alert/demo/_semantic.tsx
+++ b/components/alert/demo/_semantic.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Alert, Button, Space } from 'antd';
+import { Alert, Button, Flex } from 'antd';
 
 import useLocale from '../../../.dumi/hooks/useLocale';
 import SemanticPreview from '../../../.dumi/theme/common/SemanticPreview';
@@ -48,14 +48,14 @@ const App: React.FC = () => {
         description="Info Description Info Description Info Description Info Description"
         type="info"
         action={
-          <Space vertical>
-            <Button size="small" type="primary">
+          <Flex vertical gap="small" style={{ minWidth: 80 }}>
+            <Button size="small" type="primary" block>
               Accept
             </Button>
-            <Button size="small" danger ghost>
+            <Button size="small" danger ghost block>
               Decline
             </Button>
-          </Space>
+          </Flex>
         }
       />
     </SemanticPreview>

--- a/components/alert/demo/action.tsx
+++ b/components/alert/demo/action.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Alert, Button, Space } from 'antd';
+import { Alert, Button, Flex } from 'antd';
 
 const App: React.FC = () => (
   <>
@@ -31,11 +31,9 @@ const App: React.FC = () => (
       title="Warning Text"
       type="warning"
       action={
-        <Space>
-          <Button type="text" size="small">
-            Done
-          </Button>
-        </Space>
+        <Button type="text" size="small">
+          Done
+        </Button>
       }
       closable
     />
@@ -45,14 +43,14 @@ const App: React.FC = () => (
       description="Info Description Info Description Info Description Info Description"
       type="info"
       action={
-        <Space vertical>
-          <Button size="small" type="primary">
+        <Flex vertical gap="small" style={{ minWidth: 80 }}>
+          <Button size="small" type="primary" block>
             Accept
           </Button>
-          <Button size="small" danger ghost>
+          <Button size="small" danger ghost block>
             Decline
           </Button>
-        </Space>
+        </Flex>
       }
       closable
     />


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📽️ 演示代码改进

### 🔗 相关 Issue

close #58312

### 💡 需求背景和解决方案

Alert 的 action demo 中使用 Space 组织多个操作按钮，容易让使用者误以为 Alert 会统一处理 action 按钮宽度。

本次将普通 demo 和 Semantic DOM demo 中的多按钮 action 示例改为使用 Flex 组织布局，并通过 block 按钮展示等宽效果；同时移除单按钮 action 中不必要的 Space 包裹，并更新相关 Jest snapshot。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |
