### PR TITLE
fix(Alert): restore actions spacing with hashed styles

### DIFF
--- a/components/alert/style/index.ts
+++ b/components/alert/style/index.ts
@@ -210,7 +210,7 @@ export const genActionStyle: GenerateStyle<AlertToken, CSSObject> = (token) => {
 
   return {
     [componentCls]: {
-      '&-actions': {
+      [`${componentCls}-actions`]: {
         marginInlineStart: marginXS,
       },
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

Alert 的 `actions` 节点是 root 下的子节点，hash class 只挂在 Alert root 上。原样式使用 `&-actions` 生成了 `.css-xxx.ant-alert-actions`，要求 hash class 和 `.ant-alert-actions` 出现在同一个元素上，导致 runtime hashed 样式下 `marginInlineStart` 无法命中。

本次将 selector 调整为 root descendant 形式，使其生成 `.css-xxx.ant-alert .ant-alert-actions`，与实际 DOM 结构一致，从而恢复 section 和 actions 之间的间距。这个改动不调整 DOM 结构，也不影响 Semantic DOM API。

验证：
- Alert 相关 Jest 测试通过，快照无需更新
- `eslint` 通过
- `git diff --check` 通过

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Alert actions spacing not taking effect when hashed styles are enabled. |
| 🇨🇳 中文 | 🐞 修复 Alert 在开启 hashed 样式时 actions 间距不生效的问题。 |
