### PR TITLE
fix: stack vertical Radio button group

### DIFF
--- a/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2,91 +2,205 @@
 
 exports[`renders components/radio/demo/badge.tsx extend context correctly 1`] = `
 <div
-  class="ant-radio-group ant-radio-group-solid css-var-test-id ant-radio-css-var"
-  role="radiogroup"
+  class="ant-flex css-var-test-id ant-flex-align-start ant-flex-gap-middle ant-flex-vertical"
 >
-  <span
-    class="ant-badge css-var-test-id"
+  <div
+    class="ant-radio-group ant-radio-group-solid css-var-test-id ant-radio-css-var"
+    role="radiogroup"
   >
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+    <span
+      class="ant-badge css-var-test-id"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="1"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Click Me
-      </span>
-    </label>
-    <sup
-      class="ant-scroll-number ant-badge-count"
-      data-show="true"
-      title="1"
-    >
-      <bdi>
         <span
-          class="ant-scroll-number-only"
-          style="transition: none;"
+          class="ant-radio-button"
         >
-          <span
-            class="ant-scroll-number-only-unit current"
-          >
-            1
-          </span>
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="1"
+          />
         </span>
-      </bdi>
-    </sup>
-  </span>
-  <span
-    class="ant-badge css-var-test-id"
+        <span
+          class="ant-radio-button-label"
+        >
+          Click Me
+        </span>
+      </label>
+      <sup
+        class="ant-scroll-number ant-badge-count"
+        data-show="true"
+        title="1"
+      >
+        <bdi>
+          <span
+            class="ant-scroll-number-only"
+            style="transition: none;"
+          >
+            <span
+              class="ant-scroll-number-only-unit current"
+            >
+              1
+            </span>
+          </span>
+        </bdi>
+      </sup>
+    </span>
+    <span
+      class="ant-badge css-var-test-id"
+    >
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="2"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Not Me
+        </span>
+      </label>
+      <sup
+        class="ant-scroll-number ant-badge-count"
+        data-show="true"
+        title="2"
+      >
+        <bdi>
+          <span
+            class="ant-scroll-number-only"
+            style="transition: none;"
+          >
+            <span
+              class="ant-scroll-number-only-unit current"
+            >
+              2
+            </span>
+          </span>
+        </bdi>
+      </sup>
+    </span>
+  </div>
+  <div
+    class="ant-radio-group ant-radio-group-solid css-var-test-id ant-radio-css-var ant-radio-group-vertical"
+    role="radiogroup"
   >
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+    <span
+      class="ant-badge css-var-test-id"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="2"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Not Me
-      </span>
-    </label>
-    <sup
-      class="ant-scroll-number ant-badge-count"
-      data-show="true"
-      title="2"
-    >
-      <bdi>
         <span
-          class="ant-scroll-number-only"
-          style="transition: none;"
+          class="ant-radio-button"
         >
-          <span
-            class="ant-scroll-number-only-unit current"
-          >
-            2
-          </span>
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="vertical-1"
+          />
         </span>
-      </bdi>
-    </sup>
-  </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Click Me
+        </span>
+      </label>
+      <sup
+        class="ant-scroll-number ant-badge-count"
+        data-show="true"
+        title="1"
+      >
+        <bdi>
+          <span
+            class="ant-scroll-number-only"
+            style="transition: none;"
+          >
+            <span
+              class="ant-scroll-number-only-unit current"
+            >
+              1
+            </span>
+          </span>
+        </bdi>
+      </sup>
+    </span>
+    <span
+      class="ant-badge css-var-test-id"
+    >
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="vertical-0"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Hidden Badge
+        </span>
+      </label>
+    </span>
+    <span
+      class="ant-badge css-var-test-id"
+    >
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="vertical-2"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Not Me
+        </span>
+      </label>
+      <sup
+        class="ant-scroll-number ant-badge-count"
+        data-show="true"
+        title="2"
+      >
+        <bdi>
+          <span
+            class="ant-scroll-number-only"
+            style="transition: none;"
+          >
+            <span
+              class="ant-scroll-number-only-unit current"
+            >
+              2
+            </span>
+          </span>
+        </bdi>
+      </sup>
+    </span>
+  </div>
 </div>
 `;
 

--- a/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1466,90 +1466,165 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
 
 exports[`renders components/radio/demo/radiogroup-more.tsx extend context correctly 1`] = `
 <div
-  class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var ant-radio-group-vertical"
-  role="radiogroup"
+  class="ant-flex css-var-test-id ant-flex-align-start ant-flex-gap-large"
 >
-  <label
-    class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
-    style="height: 32px; line-height: 32px;"
+  <div
+    style="flex: 1 1 0%;"
   >
-    <span
-      class="ant-radio ant-wave-target ant-radio-checked"
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var ant-radio-group-vertical"
+      role="radiogroup"
     >
-      <input
-        checked=""
-        class="ant-radio-input"
-        name="test-id"
-        type="radio"
-        value="1"
-      />
-    </span>
-    <span
-      class="ant-radio-label"
-    >
-      Option A
-    </span>
-  </label>
-  <label
-    class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
-    style="height: 32px; line-height: 32px;"
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
+        style="height: 32px; line-height: 32px;"
+      >
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="1"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Option A
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+        style="height: 32px; line-height: 32px;"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="2"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Option B
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+        style="height: 32px; line-height: 32px;"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="3"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Option C
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+        style="height: 32px; line-height: 32px;"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="4"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          More...
+        </span>
+      </label>
+    </div>
+  </div>
+  <div
+    style="flex: 1 1 0%;"
   >
-    <span
-      class="ant-radio ant-wave-target"
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var ant-radio-group-vertical"
+      role="radiogroup"
     >
-      <input
-        class="ant-radio-input"
-        name="test-id"
-        type="radio"
-        value="2"
-      />
-    </span>
-    <span
-      class="ant-radio-label"
-    >
-      Option B
-    </span>
-  </label>
-  <label
-    class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
-    style="height: 32px; line-height: 32px;"
-  >
-    <span
-      class="ant-radio ant-wave-target"
-    >
-      <input
-        class="ant-radio-input"
-        name="test-id"
-        type="radio"
-        value="3"
-      />
-    </span>
-    <span
-      class="ant-radio-label"
-    >
-      Option C
-    </span>
-  </label>
-  <label
-    class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
-    style="height: 32px; line-height: 32px;"
-  >
-    <span
-      class="ant-radio ant-wave-target"
-    >
-      <input
-        class="ant-radio-input"
-        name="test-id"
-        type="radio"
-        value="4"
-      />
-    </span>
-    <span
-      class="ant-radio-label"
-    >
-      More...
-    </span>
-  </label>
+      <label
+        class="ant-radio-button-wrapper label-1 css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="Apple"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Apple
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper label-2 css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="Pear"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Pear
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper label-3 css-var-test-id ant-radio-css-var"
+        title="Orange"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="Orange"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Orange
+        </span>
+      </label>
+    </div>
+  </div>
 </div>
 `;
 

--- a/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1446,90 +1446,165 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
 
 exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
 <div
-  class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var ant-radio-group-vertical"
-  role="radiogroup"
+  class="ant-flex css-var-test-id ant-flex-align-start ant-flex-gap-large"
 >
-  <label
-    class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
-    style="height:32px;line-height:32px"
+  <div
+    style="flex:1"
   >
-    <span
-      class="ant-radio ant-wave-target ant-radio-checked"
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var ant-radio-group-vertical"
+      role="radiogroup"
     >
-      <input
-        checked=""
-        class="ant-radio-input"
-        name="test-id"
-        type="radio"
-        value="1"
-      />
-    </span>
-    <span
-      class="ant-radio-label"
-    >
-      Option A
-    </span>
-  </label>
-  <label
-    class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
-    style="height:32px;line-height:32px"
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
+        style="height:32px;line-height:32px"
+      >
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="1"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Option A
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+        style="height:32px;line-height:32px"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="2"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Option B
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+        style="height:32px;line-height:32px"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="3"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Option C
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+        style="height:32px;line-height:32px"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="4"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          More...
+        </span>
+      </label>
+    </div>
+  </div>
+  <div
+    style="flex:1"
   >
-    <span
-      class="ant-radio ant-wave-target"
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var ant-radio-group-vertical"
+      role="radiogroup"
     >
-      <input
-        class="ant-radio-input"
-        name="test-id"
-        type="radio"
-        value="2"
-      />
-    </span>
-    <span
-      class="ant-radio-label"
-    >
-      Option B
-    </span>
-  </label>
-  <label
-    class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
-    style="height:32px;line-height:32px"
-  >
-    <span
-      class="ant-radio ant-wave-target"
-    >
-      <input
-        class="ant-radio-input"
-        name="test-id"
-        type="radio"
-        value="3"
-      />
-    </span>
-    <span
-      class="ant-radio-label"
-    >
-      Option C
-    </span>
-  </label>
-  <label
-    class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
-    style="height:32px;line-height:32px"
-  >
-    <span
-      class="ant-radio ant-wave-target"
-    >
-      <input
-        class="ant-radio-input"
-        name="test-id"
-        type="radio"
-        value="4"
-      />
-    </span>
-    <span
-      class="ant-radio-label"
-    >
-      More...
-    </span>
-  </label>
+      <label
+        class="ant-radio-button-wrapper label-1 css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="Apple"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Apple
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper label-2 css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="Pear"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Pear
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper label-3 css-var-test-id ant-radio-css-var"
+        title="Orange"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="Orange"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Orange
+        </span>
+      </label>
+    </div>
+  </div>
 </div>
 `;
 

--- a/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2,91 +2,205 @@
 
 exports[`renders components/radio/demo/badge.tsx correctly 1`] = `
 <div
-  class="ant-radio-group ant-radio-group-solid css-var-test-id ant-radio-css-var"
-  role="radiogroup"
+  class="ant-flex css-var-test-id ant-flex-align-start ant-flex-gap-middle ant-flex-vertical"
 >
-  <span
-    class="ant-badge css-var-test-id"
+  <div
+    class="ant-radio-group ant-radio-group-solid css-var-test-id ant-radio-css-var"
+    role="radiogroup"
   >
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+    <span
+      class="ant-badge css-var-test-id"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="1"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Click Me
-      </span>
-    </label>
-    <sup
-      class="ant-scroll-number ant-badge-count"
-      data-show="true"
-      title="1"
-    >
-      <bdi>
         <span
-          class="ant-scroll-number-only"
-          style="transition:none"
+          class="ant-radio-button"
         >
-          <span
-            class="ant-scroll-number-only-unit current"
-          >
-            1
-          </span>
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="1"
+          />
         </span>
-      </bdi>
-    </sup>
-  </span>
-  <span
-    class="ant-badge css-var-test-id"
+        <span
+          class="ant-radio-button-label"
+        >
+          Click Me
+        </span>
+      </label>
+      <sup
+        class="ant-scroll-number ant-badge-count"
+        data-show="true"
+        title="1"
+      >
+        <bdi>
+          <span
+            class="ant-scroll-number-only"
+            style="transition:none"
+          >
+            <span
+              class="ant-scroll-number-only-unit current"
+            >
+              1
+            </span>
+          </span>
+        </bdi>
+      </sup>
+    </span>
+    <span
+      class="ant-badge css-var-test-id"
+    >
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="2"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Not Me
+        </span>
+      </label>
+      <sup
+        class="ant-scroll-number ant-badge-count"
+        data-show="true"
+        title="2"
+      >
+        <bdi>
+          <span
+            class="ant-scroll-number-only"
+            style="transition:none"
+          >
+            <span
+              class="ant-scroll-number-only-unit current"
+            >
+              2
+            </span>
+          </span>
+        </bdi>
+      </sup>
+    </span>
+  </div>
+  <div
+    class="ant-radio-group ant-radio-group-solid css-var-test-id ant-radio-css-var ant-radio-group-vertical"
+    role="radiogroup"
   >
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+    <span
+      class="ant-badge css-var-test-id"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="2"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Not Me
-      </span>
-    </label>
-    <sup
-      class="ant-scroll-number ant-badge-count"
-      data-show="true"
-      title="2"
-    >
-      <bdi>
         <span
-          class="ant-scroll-number-only"
-          style="transition:none"
+          class="ant-radio-button"
         >
-          <span
-            class="ant-scroll-number-only-unit current"
-          >
-            2
-          </span>
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="vertical-1"
+          />
         </span>
-      </bdi>
-    </sup>
-  </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Click Me
+        </span>
+      </label>
+      <sup
+        class="ant-scroll-number ant-badge-count"
+        data-show="true"
+        title="1"
+      >
+        <bdi>
+          <span
+            class="ant-scroll-number-only"
+            style="transition:none"
+          >
+            <span
+              class="ant-scroll-number-only-unit current"
+            >
+              1
+            </span>
+          </span>
+        </bdi>
+      </sup>
+    </span>
+    <span
+      class="ant-badge css-var-test-id"
+    >
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="vertical-0"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Hidden Badge
+        </span>
+      </label>
+    </span>
+    <span
+      class="ant-badge css-var-test-id"
+    >
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="vertical-2"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Not Me
+        </span>
+      </label>
+      <sup
+        class="ant-scroll-number ant-badge-count"
+        data-show="true"
+        title="2"
+      >
+        <bdi>
+          <span
+            class="ant-scroll-number-only"
+            style="transition:none"
+          >
+            <span
+              class="ant-scroll-number-only-unit current"
+            >
+              2
+            </span>
+          </span>
+        </bdi>
+      </sup>
+    </span>
+  </div>
 </div>
 `;
 

--- a/components/radio/demo/badge.tsx
+++ b/components/radio/demo/badge.tsx
@@ -1,15 +1,28 @@
 import React from 'react';
-import { Badge, Radio } from 'antd';
+import { Badge, Flex, Radio } from 'antd';
 
 const App: React.FC = () => (
-  <Radio.Group buttonStyle="solid">
-    <Badge count={1}>
-      <Radio.Button value={1}>Click Me</Radio.Button>
-    </Badge>
-    <Badge count={2}>
-      <Radio.Button value={2}>Not Me</Radio.Button>
-    </Badge>
-  </Radio.Group>
+  <Flex vertical gap="middle" align="start">
+    <Radio.Group buttonStyle="solid">
+      <Badge count={1}>
+        <Radio.Button value={1}>Click Me</Radio.Button>
+      </Badge>
+      <Badge count={2}>
+        <Radio.Button value={2}>Not Me</Radio.Button>
+      </Badge>
+    </Radio.Group>
+    <Radio.Group vertical buttonStyle="solid">
+      <Badge count={1}>
+        <Radio.Button value="vertical-1">Click Me</Radio.Button>
+      </Badge>
+      <Badge count={0}>
+        <Radio.Button value="vertical-0">Hidden Badge</Radio.Button>
+      </Badge>
+      <Badge count={2}>
+        <Radio.Button value="vertical-2">Not Me</Radio.Button>
+      </Badge>
+    </Radio.Group>
+  </Flex>
 );
 
 export default App;

--- a/components/radio/demo/radiogroup-more.tsx
+++ b/components/radio/demo/radiogroup-more.tsx
@@ -1,14 +1,13 @@
 import React, { useState } from 'react';
-import type { RadioChangeEvent } from 'antd';
+import type { RadioChangeEvent, RadioGroupProps } from 'antd';
 import { Flex, Input, Radio } from 'antd';
-import type { CheckboxGroupProps } from 'antd/es/checkbox';
 
 const labelStyle: React.CSSProperties = {
   height: 32,
   lineHeight: '32px',
 };
 
-const buttonOptions: CheckboxGroupProps<string>['options'] = [
+const buttonOptions: RadioGroupProps['options'] = [
   { label: 'Apple', value: 'Apple', className: 'label-1' },
   { label: 'Pear', value: 'Pear', className: 'label-2' },
   { label: 'Orange', value: 'Orange', title: 'Orange', className: 'label-3' },

--- a/components/radio/demo/radiogroup-more.tsx
+++ b/components/radio/demo/radiogroup-more.tsx
@@ -1,11 +1,18 @@
 import React, { useState } from 'react';
 import type { RadioChangeEvent } from 'antd';
-import { Input, Radio } from 'antd';
+import { Flex, Input, Radio } from 'antd';
+import type { CheckboxGroupProps } from 'antd/es/checkbox';
 
 const labelStyle: React.CSSProperties = {
   height: 32,
   lineHeight: '32px',
 };
+
+const buttonOptions: CheckboxGroupProps<string>['options'] = [
+  { label: 'Apple', value: 'Apple', className: 'label-1' },
+  { label: 'Pear', value: 'Pear', className: 'label-2' },
+  { label: 'Orange', value: 'Orange', title: 'Orange', className: 'label-3' },
+];
 
 const App: React.FC = () => {
   const [value, setValue] = useState(1);
@@ -15,32 +22,39 @@ const App: React.FC = () => {
   };
 
   return (
-    <Radio.Group
-      vertical
-      onChange={onChange}
-      value={value}
-      options={[
-        { value: 1, style: labelStyle, label: 'Option A' },
-        { value: 2, style: labelStyle, label: 'Option B' },
-        { value: 3, style: labelStyle, label: 'Option C' },
-        {
-          value: 4,
-          style: labelStyle,
-          label: (
-            <>
-              More...
-              {value === 4 && (
-                <Input
-                  variant="filled"
-                  placeholder="please input"
-                  style={{ width: 120, marginInlineStart: 12 }}
-                />
-              )}
-            </>
-          ),
-        },
-      ]}
-    />
+    <Flex align="start" gap="large">
+      <div style={{ flex: 1 }}>
+        <Radio.Group
+          vertical
+          onChange={onChange}
+          value={value}
+          options={[
+            { value: 1, style: labelStyle, label: 'Option A' },
+            { value: 2, style: labelStyle, label: 'Option B' },
+            { value: 3, style: labelStyle, label: 'Option C' },
+            {
+              value: 4,
+              style: labelStyle,
+              label: (
+                <>
+                  More...
+                  {value === 4 && (
+                    <Input
+                      variant="filled"
+                      placeholder="please input"
+                      style={{ width: 120, marginInlineStart: 12 }}
+                    />
+                  )}
+                </>
+              ),
+            },
+          ]}
+        />
+      </div>
+      <div style={{ flex: 1 }}>
+        <Radio.Group options={buttonOptions} optionType="button" vertical />
+      </div>
+    </Flex>
   );
 };
 

--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -114,6 +114,14 @@ const getGroupRadioStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
   const badgeCls = `${antCls}-badge`;
 
   const genVerticalBadgeButtonStyle = (radius: number): CSSObject => ({
+    [`> ${badgeCls}`]: {
+      width: 'auto',
+    },
+
+    [`> ${badgeCls} > ${buttonWrapperCls}`]: {
+      width: '100%',
+    },
+
     [`> ${badgeCls}:not(:last-child)`]: {
       marginBlockEnd: calc(lineWidth).mul(-1).equal(),
     },
@@ -173,7 +181,7 @@ const getGroupRadioStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
         flexDirection: 'column',
         rowGap: token.marginXS,
 
-        [`&:has(${buttonWrapperCls})`]: {
+        [`&:has(> ${buttonWrapperCls}, > ${badgeCls} > ${buttonWrapperCls})`]: {
           rowGap: 0,
         },
 
@@ -477,7 +485,7 @@ const getRadioButtonStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
         },
       },
 
-      [`${componentCls}-group-vertical &`]: {
+      [`${componentCls}-group-vertical > &`]: {
         marginInlineEnd: 0,
         borderRadius: 0,
 
@@ -504,7 +512,7 @@ const getRadioButtonStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
         },
       },
 
-      [`${componentCls}-group-vertical${componentCls}-group-large &`]: {
+      [`${componentCls}-group-vertical${componentCls}-group-large > &`]: {
         '&:first-child': {
           borderStartStartRadius: borderRadiusLG,
           borderStartEndRadius: borderRadiusLG,
@@ -520,7 +528,7 @@ const getRadioButtonStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
         },
       },
 
-      [`${componentCls}-group-vertical${componentCls}-group-small &`]: {
+      [`${componentCls}-group-vertical${componentCls}-group-small > &`]: {
         '&:first-child': {
           borderStartStartRadius: borderRadiusSM,
           borderStartEndRadius: borderRadiusSM,

--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -107,8 +107,43 @@ interface RadioToken extends FullToken<'Radio'> {
 // ============================== Styles ==============================
 // styles from RadioGroup only
 const getGroupRadioStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
-  const { componentCls, antCls } = token;
+  const { componentCls, antCls, lineWidth, borderRadius, borderRadiusLG, borderRadiusSM, calc } =
+    token;
   const groupPrefixCls = `${componentCls}-group`;
+  const buttonWrapperCls = `${componentCls}-button-wrapper`;
+  const badgeCls = `${antCls}-badge`;
+
+  const genVerticalBadgeButtonStyle = (radius: number): CSSObject => ({
+    [`> ${badgeCls}:not(:last-child)`]: {
+      marginBlockEnd: calc(lineWidth).mul(-1).equal(),
+    },
+
+    [`> ${badgeCls} > ${buttonWrapperCls}:not(:last-child)`]: {
+      marginBlockEnd: 0,
+    },
+
+    [`> ${badgeCls}:first-child > ${buttonWrapperCls}`]: {
+      borderStartStartRadius: radius,
+      borderStartEndRadius: radius,
+      borderEndStartRadius: 0,
+      borderEndEndRadius: 0,
+    },
+
+    [`> ${badgeCls}:last-child > ${buttonWrapperCls}`]: {
+      borderStartStartRadius: 0,
+      borderStartEndRadius: 0,
+      borderEndStartRadius: radius,
+      borderEndEndRadius: radius,
+    },
+
+    [`> ${badgeCls}:not(:first-child):not(:last-child) > ${buttonWrapperCls}`]: {
+      borderRadius: 0,
+    },
+
+    [`> ${badgeCls}:first-child:last-child > ${buttonWrapperCls}`]: {
+      borderRadius: radius,
+    },
+  });
 
   return {
     [groupPrefixCls]: {
@@ -138,12 +173,22 @@ const getGroupRadioStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
         flexDirection: 'column',
         rowGap: token.marginXS,
 
-        [`&:has(${componentCls}-button-wrapper)`]: {
+        [`&:has(${buttonWrapperCls})`]: {
           rowGap: 0,
         },
 
         [`${componentCls}-wrapper`]: {
           marginInlineEnd: 0,
+        },
+
+        ...genVerticalBadgeButtonStyle(borderRadius),
+
+        [`&${groupPrefixCls}-large`]: {
+          ...genVerticalBadgeButtonStyle(borderRadiusLG),
+        },
+
+        [`&${groupPrefixCls}-small`]: {
+          ...genVerticalBadgeButtonStyle(borderRadiusSM),
         },
       },
     },

--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -138,6 +138,10 @@ const getGroupRadioStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
         flexDirection: 'column',
         rowGap: token.marginXS,
 
+        [`&:has(${componentCls}-button-wrapper)`]: {
+          rowGap: 0,
+        },
+
         [`${componentCls}-wrapper`]: {
           marginInlineEnd: 0,
         },
@@ -425,6 +429,65 @@ const getRadioButtonStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
         '&:last-child': {
           borderStartEndRadius: borderRadiusSM,
           borderEndEndRadius: borderRadiusSM,
+        },
+      },
+
+      [`${componentCls}-group-vertical &`]: {
+        marginInlineEnd: 0,
+        borderRadius: 0,
+
+        '&:not(:last-child)': {
+          marginBlockEnd: calc(lineWidth).mul(-1).equal(),
+        },
+
+        '&:first-child': {
+          borderStartStartRadius: borderRadius,
+          borderStartEndRadius: borderRadius,
+          borderEndStartRadius: 0,
+          borderEndEndRadius: 0,
+        },
+
+        '&:last-child': {
+          borderStartStartRadius: 0,
+          borderStartEndRadius: 0,
+          borderEndStartRadius: borderRadius,
+          borderEndEndRadius: borderRadius,
+        },
+
+        '&:first-child:last-child': {
+          borderRadius,
+        },
+      },
+
+      [`${componentCls}-group-vertical${componentCls}-group-large &`]: {
+        '&:first-child': {
+          borderStartStartRadius: borderRadiusLG,
+          borderStartEndRadius: borderRadiusLG,
+        },
+
+        '&:last-child': {
+          borderEndStartRadius: borderRadiusLG,
+          borderEndEndRadius: borderRadiusLG,
+        },
+
+        '&:first-child:last-child': {
+          borderRadius: borderRadiusLG,
+        },
+      },
+
+      [`${componentCls}-group-vertical${componentCls}-group-small &`]: {
+        '&:first-child': {
+          borderStartStartRadius: borderRadiusSM,
+          borderStartEndRadius: borderRadiusSM,
+        },
+
+        '&:last-child': {
+          borderEndStartRadius: borderRadiusSM,
+          borderEndEndRadius: borderRadiusSM,
+        },
+
+        '&:first-child:last-child': {
+          borderRadius: borderRadiusSM,
         },
       },
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #58315

### 💡 需求背景和解决方案

修复 Radio.Group 在同时使用 `vertical` 和 `optionType="button"` 时仍沿用横向按钮组圆角逻辑的问题。

本次改动将竖向 button group 按纵向 segmented control 处理：移除 button 场景下的竖向间距，合并相邻边框，并分别为首项和末项设置上/下圆角。同时在垂直 Radio.Group demo 中补充 button 形态示例。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Radio.Group button style in vertical layout to stack with correct border radius. |
| 🇨🇳 中文 | 🐞 修复 Radio.Group button 形态在垂直布局下圆角和相邻边框展示异常的问题。 |