### PR TITLE
docs: clarify Image movable behavior

### DIFF
--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -84,7 +84,7 @@ Other Property ref [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/
 | ~~maskClassName~~ | Thumbnail mask class name; please use 'classNames.cover' instead | string | - |  |
 | maxScale | Maximum zoom scale | number | 50 |  |
 | minScale | Minimum zoom scale | number | 1 |  |
-| movable | Whether it is movable | boolean | true |  |
+| movable | Whether the preview image can be dragged when it is larger than the viewport | boolean | true |  |
 | open | Whether to display preview | boolean | - |  |
 | rootClassName | Root DOM class name for preview; applies to both image and preview wrapper | string | - |  |
 | scaleStep | Each step's zoom multiplier is 1 + scaleStep | number | 0.5 |  |
@@ -121,7 +121,7 @@ Other Property ref [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/
 | ~~maskClassName~~ | Thumbnail mask class name; please use 'classNames.cover' instead | string | - |  |
 | minScale | Minimum zoom scale | number | 1 |  |
 | maxScale | Maximum zoom scale | number | 50 |  |
-| movable | Whether movable | boolean | true |  |
+| movable | Whether the preview image can be dragged when it is larger than the viewport | boolean | true |  |
 | open | Whether to display preview | boolean | - |  |
 | ~~rootClassName~~ | Root DOM class name for preview; applies to both image and preview wrapper. Use 'classNames.root' instead | string | - |  |
 | styles | Custom semantic structure styles | Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |

--- a/components/image/index.zh-CN.md
+++ b/components/image/index.zh-CN.md
@@ -85,7 +85,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | ~~maskClassName~~ | 缩略图遮罩类名，请使用 `classNames.cover` 替换 | string | - |  |
 | maxScale | 最大缩放倍数 | number | 50 |  |
 | minScale | 最小缩放倍数 | number | 1 |  |
-| movable | 是否可移动 | boolean | true |  |
+| movable | 预览图片大于视口时是否可拖拽移动 | boolean | true |  |
 | open | 是否显示预览 | boolean | - |  |
 | rootClassName | 预览图的根 DOM 类名，会同时作用在图片和预览层最外侧 | string | - |  |
 | scaleStep | `1 + scaleStep` 为缩放放大的每步倍数 | number | 0.5 |  |
@@ -122,7 +122,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | ~~maskClassName~~ | 缩略图遮罩类名，请使用 `classNames.cover` 替换 | string | - |  |
 | minScale | 最小缩放倍数 | number | 1 |  |
 | maxScale | 最大放大倍数 | number | 50 |  |
-| movable | 是否可移动 | boolean | true |  |
+| movable | 预览图片大于视口时是否可拖拽移动 | boolean | true |  |
 | open | 是否显示预览 | boolean | - |  |
 | ~~rootClassName~~ | 预览图的根 DOM 类名，会同时作用在图片和预览层最外侧，请使用 `classNames.root` 替换 | string | - |  |
 | styles | 自定义语义化结构样式 | Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Image 预览的 `movable` API 描述较宽泛，容易理解为原图或未超出视口时也能自由拖拽。

本次更新 Image 中英文文档，明确 `movable` 表示预览图片大于视口时是否可拖拽移动。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A      |
| 🇨🇳 中文 | N/A      |