### PR TITLE
feat: add BorderBeam lineWidth prop

### DIFF
--- a/components/border-beam/BorderBeam.tsx
+++ b/components/border-beam/BorderBeam.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { unit } from '@ant-design/cssinjs';
 import { clsx } from 'clsx';
 
 import { isNonNullable, isNumber, isString } from '../_util/is';
@@ -24,6 +25,7 @@ export interface BorderBeamProps {
   children?: React.ReactNode;
   color?: BorderBeamColor;
   duration?: number;
+  lineWidth?: number | string;
   outset?: number | string;
 }
 
@@ -35,6 +37,7 @@ const BorderBeam: React.FC<React.PropsWithChildren<BorderBeamProps>> = (props) =
     children,
     color,
     duration,
+    lineWidth,
     outset,
   } = props;
 
@@ -73,6 +76,7 @@ const BorderBeam: React.FC<React.PropsWithChildren<BorderBeamProps>> = (props) =
           ...style,
           ...(beamGradient && { [varName('beam-gradient')]: beamGradient }),
           ...(isNumber(duration) && duration > 0 && { [varName('duration')]: `${duration}s` }),
+          ...(isNonNullable(lineWidth) && { [varName('line-width')]: unit(lineWidth) }),
           [varName('inset-offset')]: insetOffset,
           [varName('border-radius')]: borderRadius,
         }}

--- a/components/border-beam/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/border-beam/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -440,6 +440,43 @@ exports[`renders components/border-beam/demo/duration.tsx extend context correct
 
 exports[`renders components/border-beam/demo/duration.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/border-beam/demo/line-width.tsx extend context correctly 1`] = `
+<div
+  style="width: 360px;"
+>
+  <div
+    class="ant-card ant-card-bordered css-var-test-id"
+    style="border-width: 2px;"
+  >
+    <div
+      class="ant-card-head"
+    >
+      <div
+        class="ant-card-head-wrapper"
+      >
+        <div
+          class="ant-card-head-title"
+        >
+          Custom line width
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-card-body"
+    >
+      Set lineWidth to match the border width of this container.
+    </div>
+    <div
+      aria-hidden="true"
+      class="ant-border-beam css-var-test-id"
+      style="--ant-border-beam-line-width: 2px; --ant-border-beam-inset-offset: -2px -2px -2px -2px; --ant-border-beam-border-radius: var(--ant-border-radius-lg);"
+    />
+  </div>
+</div>
+`;
+
+exports[`renders components/border-beam/demo/line-width.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/border-beam/demo/non-uniform-radius.tsx extend context correctly 1`] = `
 <div
   style="width: 360px;"

--- a/components/border-beam/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/border-beam/__tests__/__snapshots__/demo.test.ts.snap
@@ -421,6 +421,36 @@ exports[`renders components/border-beam/demo/duration.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/border-beam/demo/line-width.tsx correctly 1`] = `
+<div
+  style="width:360px"
+>
+  <div
+    class="ant-card ant-card-bordered css-var-test-id"
+    style="border-width:2px"
+  >
+    <div
+      class="ant-card-head"
+    >
+      <div
+        class="ant-card-head-wrapper"
+      >
+        <div
+          class="ant-card-head-title"
+        >
+          Custom line width
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-card-body"
+    >
+      Set lineWidth to match the border width of this container.
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/border-beam/demo/non-uniform-radius.tsx correctly 1`] = `
 <div
   style="width:360px"

--- a/components/border-beam/__tests__/index.test.tsx
+++ b/components/border-beam/__tests__/index.test.tsx
@@ -165,6 +165,50 @@ describe('BorderBeam', () => {
     expect(getBeamElement(container).style.getPropertyValue(varName('duration'))).toBe('');
   });
 
+  it('should support customizing line width with prop', async () => {
+    const { container, rerender } = render(
+      <ConfigProvider
+        theme={{
+          components: {
+            BorderBeam: {
+              lineWidth: 3,
+            },
+          },
+        }}
+      >
+        <BorderBeam lineWidth={5}>
+          <div>
+            <span>content</span>
+          </div>
+        </BorderBeam>
+      </ConfigProvider>,
+    );
+
+    await waitFor(() => {
+      expect(getBeamElement(container).style.getPropertyValue(varName('line-width'))).toBe('5px');
+    });
+
+    rerender(
+      <BorderBeam lineWidth="0.25rem">
+        <div>
+          <span>content</span>
+        </div>
+      </BorderBeam>,
+    );
+
+    expect(getBeamElement(container).style.getPropertyValue(varName('line-width'))).toBe('0.25rem');
+
+    rerender(
+      <BorderBeam>
+        <div>
+          <span>content</span>
+        </div>
+      </BorderBeam>,
+    );
+
+    expect(getBeamElement(container).style.getPropertyValue(varName('line-width'))).toBe('');
+  });
+
   it('should infer child border radius from computed style', async () => {
     const { container } = render(
       <BorderBeam>

--- a/components/border-beam/demo/line-width.md
+++ b/components/border-beam/demo/line-width.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-通过 `lineWidth` 调整单个 BorderBeam 的流光线宽。默认值为 `1px`，数字类型按像素处理。
+通过 `lineWidth` 调整单个 BorderBeam 的流光线宽，数字类型按像素处理。
 
 ## en-US
 
-Use `lineWidth` to adjust the beam width of an individual BorderBeam. The default is `1px`, and numbers are treated as pixels.
+Use `lineWidth` to adjust the beam width of an individual BorderBeam. Numbers are treated as pixels.

--- a/components/border-beam/demo/line-width.md
+++ b/components/border-beam/demo/line-width.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+通过 `lineWidth` 调整单个 BorderBeam 的流光线宽。默认值为 `1px`，数字类型按像素处理。
+
+## en-US
+
+Use `lineWidth` to adjust the beam width of an individual BorderBeam. The default is `1px`, and numbers are treated as pixels.

--- a/components/border-beam/demo/line-width.tsx
+++ b/components/border-beam/demo/line-width.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { BorderBeam, Card } from 'antd';
+
+const App: React.FC = () => (
+  <div style={{ width: 360 }}>
+    <BorderBeam lineWidth={2}>
+      <Card title="Custom line width" style={{ borderWidth: 2 }}>
+        Set lineWidth to match the border width of this container.
+      </Card>
+    </BorderBeam>
+  </div>
+);
+
+export default App;

--- a/components/border-beam/index.en-US.md
+++ b/components/border-beam/index.en-US.md
@@ -22,8 +22,9 @@ tag: 6.4.0
 <code src="./demo/basic.tsx">Basic</code>
 <code src="./demo/customized-color.tsx">Gradients</code>
 <code src="./demo/duration.tsx">Duration</code>
+<code src="./demo/line-width.tsx" version="6.5.0">Line width</code>
 <code src="./demo/non-uniform-radius.tsx" debug>Non-uniform radius</code>
-<code src="./demo/component-token.tsx" debug>Line width</code>
+<code src="./demo/component-token.tsx" debug>Component token</code>
 
 ## API
 
@@ -36,6 +37,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | children | Decorated content | `ReactNode` | - | 6.4.0 | × |
 | color | Beam color configuration. Supports a single color string or gradient stops. `percent` uses the `0 ~ 100` input range and BorderBeam reserves tail space for the transparent fade | `string \| { color: string; percent: number }[]` | - | 6.4.0 | × |
 | duration | Time in seconds for the beam to complete one loop | number | 6 | 6.5.0 | × |
+| lineWidth | Width of the beam line. Numbers are treated as pixels | `number \| string` | `1px` | 6.5.0 | × |
 | outset | Outset distance of the beam layer from the container edge. Set to `0` for clipped containers | `number \| string` | - | 6.4.0 | × |
 
 ## Design Token

--- a/components/border-beam/index.zh-CN.md
+++ b/components/border-beam/index.zh-CN.md
@@ -23,8 +23,9 @@ tag: 6.4.0
 <code src="./demo/basic.tsx">基础用法</code>
 <code src="./demo/customized-color.tsx">渐变色</code>
 <code src="./demo/duration.tsx">动画时长</code>
+<code src="./demo/line-width.tsx" version="6.5.0">线宽</code>
 <code src="./demo/non-uniform-radius.tsx" debug>不规则圆角</code>
-<code src="./demo/component-token.tsx" debug>线宽</code>
+<code src="./demo/component-token.tsx" debug>组件 Token</code>
 
 ## API
 
@@ -37,6 +38,7 @@ tag: 6.4.0
 | children | 装饰内容 | `ReactNode` | - | 6.4.0 | × |
 | color | 流光颜色配置，支持单色字符串或渐变停靠点数组。`percent` 使用 `0 ~ 100` 的输入区间，组件会在内部为尾部透明过渡预留空间 | `string \| { color: string; percent: number }[]` | - | 6.4.0 | × |
 | duration | 流光完成一圈动画的时间，单位秒 | number | 6 | 6.5.0 | × |
+| lineWidth | 流光线宽，数字类型按像素处理 | `number \| string` | `1px` | 6.5.0 | × |
 | outset | 流光层相对容器边缘的外扩距离，遇到裁剪容器时可设为 `0` | `number \| string` | - | 6.4.0 | × |
 
 ## 主题变量（Design Token）{#design-token}

--- a/components/border-beam/style/index.ts
+++ b/components/border-beam/style/index.ts
@@ -1,5 +1,5 @@
 import type { CSSObject } from '@ant-design/cssinjs';
-import { Keyframes } from '@ant-design/cssinjs';
+import { Keyframes, unit } from '@ant-design/cssinjs';
 
 import { genNoMotionStyle } from '../../style/motion';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
@@ -39,7 +39,7 @@ const genBorderBeamStyle: GenerateStyle<BorderBeamToken, CSSObject> = (token) =>
       pointerEvents: 'none',
 
       // Border Beam
-      padding: token.lineWidth,
+      padding: varRef('line-width', unit(token.lineWidth)),
 
       // Border Beam Effect
       '@supports ((mask-composite: exclude) or (-webkit-mask-composite: xor))': {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [x] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

为 BorderBeam 新增 `lineWidth` 属性，用于按实例调整流光线宽。该属性支持 `number | string`，数字类型按像素处理，并通过 CSS 变量覆盖默认的全局 `lineWidth` token 行为。

同时补充 API 文档、线宽演示 demo 和相关测试。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🆕 Add BorderBeam `lineWidth` prop to customize beam line width. |
| 🇨🇳 中文 | 🆕 新增 BorderBeam `lineWidth` 属性以自定义流光线宽。 |