### PR TITLE
docs: clarify Form field state path entries

### DIFF
--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -9484,6 +9484,43 @@ Array [
         </div>
       </div>
     </div>
+    <div
+      class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-inline"
+    >
+      <div
+        class="ant-row ant-form-item-row css-var-test-id"
+      >
+        <div
+          class="ant-col ant-form-item-label css-var-test-id"
+        >
+          <label
+            class=""
+            for="global_state_profile_email"
+            title="Email"
+          >
+            Email
+          </label>
+        </div>
+        <div
+          class="ant-col ant-form-item-control css-var-test-id"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <input
+                class="ant-input ant-input-outlined css-var-test-id ant-input-css-var"
+                id="global_state_profile_email"
+                type="text"
+                value="antd@example.com"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </form>,
   <div
     class="ant-typography css-var-test-id"
@@ -9496,6 +9533,13 @@ Array [
       "username"
     ],
     "value": "Ant Design"
+  },
+  {
+    "name": [
+      "profile",
+      "email"
+    ],
+    "value": "antd@example.com"
   }
 ]
     </pre>

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -5817,6 +5817,43 @@ Array [
         </div>
       </div>
     </div>
+    <div
+      class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-inline"
+    >
+      <div
+        class="ant-row ant-form-item-row css-var-test-id"
+      >
+        <div
+          class="ant-col ant-form-item-label css-var-test-id"
+        >
+          <label
+            class=""
+            for="global_state_profile_email"
+            title="Email"
+          >
+            Email
+          </label>
+        </div>
+        <div
+          class="ant-col ant-form-item-control css-var-test-id"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <input
+                class="ant-input ant-input-outlined css-var-test-id ant-input-css-var"
+                id="global_state_profile_email"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </form>,
   <div
     class="ant-typography css-var-test-id"
@@ -5831,6 +5868,13 @@ Array [
       "username"
     ],
     "value": "Ant Design"
+  },
+  {
+    "name": [
+      "profile",
+      "email"
+    ],
+    "value": "antd@example.com"
   }
 ]
     </pre>

--- a/components/form/demo/global-state.md
+++ b/components/form/demo/global-state.md
@@ -2,10 +2,14 @@
 
 通过 `onFieldsChange` 和 `fields`，可以把表单的数据存储到上层组件或者 [Redux](https://github.com/reactjs/redux)、[dva](https://github.com/dvajs/dva) 中，更多可参考 [rc-field-form 示例](https://rc-field-form.react-component.now.sh/?selectedKind=rc-field-form&selectedStory=StateForm-redux&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)。
 
+`onFieldsChange` 返回扁平的 `FieldData[]`。当字段名为数组路径时，`FieldData.name` 会保留该路径，而不是转换为嵌套对象，便于在外部状态中逐项处理字段。
+
 **注意：** 将表单数据存储于外部容器[并非好的实践](https://github.com/reduxjs/redux/issues/1287#issuecomment-175351978)，如无必要请避免使用。
 
 ## en-US
 
 We can store form data into upper component or [Redux](https://github.com/reactjs/redux) or [dva](https://github.com/dvajs/dva) by using `onFieldsChange` and `fields`, see more at this [rc-field-form demo](https://rc-field-form.react-component.now.sh/?selectedKind=rc-field-form&selectedStory=StateForm-redux&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel).
+
+`onFieldsChange` returns a flat `FieldData[]`. When a field uses an array name path, `FieldData.name` keeps that path instead of converting it into a nested object, which makes every field entry easy to process in external state.
 
 **Note:** Save Form data globally [is not a good practice](https://github.com/reduxjs/redux/issues/1287#issuecomment-175351978). You should avoid this if not necessary.

--- a/components/form/demo/global-state.md
+++ b/components/form/demo/global-state.md
@@ -10,6 +10,6 @@
 
 We can store form data into upper component or [Redux](https://github.com/reactjs/redux) or [dva](https://github.com/dvajs/dva) by using `onFieldsChange` and `fields`, see more at this [rc-field-form demo](https://rc-field-form.react-component.now.sh/?selectedKind=rc-field-form&selectedStory=StateForm-redux&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel).
 
-`onFieldsChange` returns a flat `FieldData[]`. When a field uses an array name path, `FieldData.name` keeps that path instead of converting it into a nested object, which makes every field entry easy to process in external state.
+`onFieldsChange` returns a flat `FieldData[]`. When a field uses an array name path, `FieldData.name` keeps that path instead of converting it into a nested object, making it easier to process each field entry in the external state.
 
-**Note:** Save Form data globally [is not a good practice](https://github.com/reduxjs/redux/issues/1287#issuecomment-175351978). You should avoid this if not necessary.
+**Note:** Saving form data globally [is not a good practice](https://github.com/reduxjs/redux/issues/1287#issuecomment-175351978). You should avoid this if not necessary.

--- a/components/form/demo/global-state.tsx
+++ b/components/form/demo/global-state.tsx
@@ -32,11 +32,17 @@ const CustomizedForm: React.FC<CustomizedFormProps> = ({ onChange, fields }) => 
     >
       <Input />
     </Form.Item>
+    <Form.Item name={['profile', 'email']} label="Email">
+      <Input />
+    </Form.Item>
   </Form>
 );
 
 const App: React.FC = () => {
-  const [fields, setFields] = useState<FieldData[]>([{ name: ['username'], value: 'Ant Design' }]);
+  const [fields, setFields] = useState<FieldData[]>([
+    { name: ['username'], value: 'Ant Design' },
+    { name: ['profile', 'email'], value: 'antd@example.com' },
+  ]);
 
   return (
     <>

--- a/components/form/demo/global-state.tsx
+++ b/components/form/demo/global-state.tsx
@@ -5,7 +5,7 @@ const { Paragraph } = Typography;
 
 interface FieldData {
   name: string | number | (string | number)[];
-  value?: any;
+  value?: unknown;
   touched?: boolean;
   validating?: boolean;
   errors?: string[];


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Related #13255

### 💡 Background and Solution

The global state Form demo already shows how to persist `fields` with `onFieldsChange`, but it only uses one top-level field. For nested names it may not be obvious whether `onFieldsChange` returns nested objects or field entries.

This updates the demo to include a nested name path and clarifies that `onFieldsChange` returns a flat `FieldData[]`; nested field names stay on `FieldData.name` as a path array.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Clarify that Form `onFieldsChange` returns flat field entries for nested name paths. |
| 🇨🇳 Chinese | 明确 Form `onFieldsChange` 对嵌套字段名返回扁平字段项。 |


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#13255: Form: 为 onFieldsChange() 提供一个无 nested 版本](https://oss.issuehunt.io/repos/34526884/issues/13255)
---
</details>
<!-- /Issuehunt content-->