### PR TITLE
demo: Updated the DiceBear API version and replaced the “miniavs” avatar style with “lorelei”

### DIFF
--- a/components/avatar/__tests__/Avatar.test.tsx
+++ b/components/avatar/__tests__/Avatar.test.tsx
@@ -53,7 +53,7 @@ describe('Avatar Render', () => {
 
   it('should handle onError correctly', () => {
     const LOAD_FAILURE_SRC = 'http://error.url/';
-    const LOAD_SUCCESS_SRC = 'https://api.dicebear.com/7.x/pixel-art/svg';
+    const LOAD_SUCCESS_SRC = 'https://api.dicebear.com/10.x/pixel-art/svg';
     const Foo: React.FC = () => {
       const [avatarSrc, setAvatarSrc] = useState<typeof LOAD_FAILURE_SRC | typeof LOAD_SUCCESS_SRC>(
         LOAD_FAILURE_SRC,
@@ -75,7 +75,7 @@ describe('Avatar Render', () => {
 
   it('should show image on success after a failure state', () => {
     const LOAD_FAILURE_SRC = 'http://error.url';
-    const LOAD_SUCCESS_SRC = 'https://api.dicebear.com/7.x/pixel-art/svg';
+    const LOAD_SUCCESS_SRC = 'https://api.dicebear.com/10.x/pixel-art/svg';
 
     const div = global.document.createElement('div');
     global.document.body.appendChild(div);
@@ -167,7 +167,7 @@ describe('Avatar Render', () => {
   });
 
   it('should exist crossorigin attribute', () => {
-    const LOAD_SUCCESS_SRC = 'https://api.dicebear.com/7.x/pixel-art/svg';
+    const LOAD_SUCCESS_SRC = 'https://api.dicebear.com/10.x/pixel-art/svg';
     const crossOrigin = 'anonymous';
     const { container } = render(
       <Avatar src={LOAD_SUCCESS_SRC} crossOrigin={crossOrigin}>
@@ -179,7 +179,7 @@ describe('Avatar Render', () => {
   });
 
   it('should not exist crossorigin attribute', () => {
-    const LOAD_SUCCESS_SRC = 'https://api.dicebear.com/7.x/pixel-art/svg';
+    const LOAD_SUCCESS_SRC = 'https://api.dicebear.com/10.x/pixel-art/svg';
     const { container } = render(<Avatar src={LOAD_SUCCESS_SRC}>crossorigin</Avatar>);
     expect(container.querySelector('img')?.crossOrigin).toBeFalsy();
     expect(container.querySelector('img')?.crossOrigin).toBeFalsy();

--- a/components/avatar/__tests__/__snapshots__/Avatar.test.tsx.snap
+++ b/components/avatar/__tests__/__snapshots__/Avatar.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`Avatar Render should handle onError correctly 1`] = `
   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-root ant-avatar-css-var"
 >
   <img
-    src="https://api.dicebear.com/7.x/pixel-art/svg"
+    src="https://api.dicebear.com/10.x/pixel-art/svg"
   />
 </span>
 `;
@@ -163,7 +163,7 @@ exports[`Avatar Render should show image on success after a failure state 2`] = 
   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-root ant-avatar-css-var"
 >
   <img
-    src="https://api.dicebear.com/7.x/pixel-art/svg"
+    src="https://api.dicebear.com/10.x/pixel-art/svg"
   />
 </span>
 `;

--- a/components/avatar/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/avatar/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -426,7 +426,7 @@ Array [
           class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
         >
           <img
-            src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+            src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
           />
         </span>
         <span
@@ -716,7 +716,7 @@ Array [
       class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
     >
       <img
-        src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+        src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
       />
     </span>
     <a
@@ -815,7 +815,7 @@ Array [
       class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
     >
       <img
-        src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+        src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
       />
     </span>
     <span
@@ -945,7 +945,7 @@ Array [
       class="ant-avatar ant-avatar-lg ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
     >
       <img
-        src="https://api.dicebear.com/7.x/miniavs/svg?seed=3"
+        src="https://api.dicebear.com/10.x/lorelei/svg?seed=3"
       />
     </span>
     <span

--- a/components/avatar/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/avatar/__tests__/__snapshots__/demo.test.tsx.snap
@@ -422,7 +422,7 @@ Array [
           class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
         >
           <img
-            src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+            src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
           />
         </span>
         <span
@@ -613,7 +613,7 @@ Array [
       class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
     >
       <img
-        src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+        src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
       />
     </span>
     <a
@@ -691,7 +691,7 @@ Array [
       class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
     >
       <img
-        src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+        src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
       />
     </span>
     <span
@@ -728,7 +728,7 @@ Array [
       class="ant-avatar ant-avatar-lg ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
     >
       <img
-        src="https://api.dicebear.com/7.x/miniavs/svg?seed=3"
+        src="https://api.dicebear.com/10.x/lorelei/svg?seed=3"
       />
     </span>
     <span

--- a/components/avatar/demo/component-token.tsx
+++ b/components/avatar/demo/component-token.tsx
@@ -38,7 +38,7 @@ const App: React.FC = () => (
           style: { color: '#f56a00', backgroundColor: '#fde3cf' },
         }}
       >
-        <Avatar src="https://api.dicebear.com/7.x/miniavs/svg?seed=2" />
+        <Avatar src="https://api.dicebear.com/10.x/lorelei/svg?seed=2" />
         <Avatar style={{ backgroundColor: '#f56a00' }}>K</Avatar>
         <Tooltip title="Ant User" placement="top">
           <Avatar style={{ backgroundColor: '#87d068' }} icon={<UserOutlined />} />

--- a/components/avatar/demo/group.tsx
+++ b/components/avatar/demo/group.tsx
@@ -5,7 +5,7 @@ import { Avatar, Divider, Tooltip } from 'antd';
 const App: React.FC = () => (
   <>
     <Avatar.Group>
-      <Avatar src="https://api.dicebear.com/7.x/miniavs/svg?seed=1" />
+      <Avatar src="https://api.dicebear.com/10.x/lorelei/svg?seed=1" />
       <a href="https://ant.design">
         <Avatar style={{ backgroundColor: '#f56a00' }}>K</Avatar>
       </a>
@@ -21,7 +21,7 @@ const App: React.FC = () => (
         style: { color: '#f56a00', backgroundColor: '#fde3cf' },
       }}
     >
-      <Avatar src="https://api.dicebear.com/7.x/miniavs/svg?seed=2" />
+      <Avatar src="https://api.dicebear.com/10.x/lorelei/svg?seed=2" />
       <Avatar style={{ backgroundColor: '#f56a00' }}>K</Avatar>
       <Tooltip title="Ant User" placement="top">
         <Avatar style={{ backgroundColor: '#87d068' }} icon={<UserOutlined />} />
@@ -36,7 +36,7 @@ const App: React.FC = () => (
         style: { color: '#f56a00', backgroundColor: '#fde3cf' },
       }}
     >
-      <Avatar src="https://api.dicebear.com/7.x/miniavs/svg?seed=3" />
+      <Avatar src="https://api.dicebear.com/10.x/lorelei/svg?seed=3" />
       <Avatar style={{ backgroundColor: '#f56a00' }}>K</Avatar>
       <Tooltip title="Ant User" placement="top">
         <Avatar style={{ backgroundColor: '#87d068' }} icon={<UserOutlined />} />

--- a/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -970,7 +970,7 @@ exports[`renders components/card/demo/meta.tsx extend context correctly 1`] = `
           class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
         >
           <img
-            src="https://api.dicebear.com/7.x/miniavs/svg?seed=8"
+            src="https://api.dicebear.com/10.x/lorelei/svg?seed=8"
           />
         </span>
       </div>
@@ -1084,7 +1084,7 @@ exports[`renders components/card/demo/no-body-debug.tsx extend context correctly
   >
     <img
       alt="example"
-      src="https://api.dicebear.com/7.x/miniavs/svg?seed=8"
+      src="https://api.dicebear.com/10.x/lorelei/svg?seed=8"
     />
   </div>
   <ul
@@ -1184,7 +1184,7 @@ exports[`renders components/card/demo/style-class.tsx extend context correctly 1
             class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
           >
             <img
-              src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+              src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
             />
           </span>
         </div>
@@ -1332,7 +1332,7 @@ exports[`renders components/card/demo/style-class.tsx extend context correctly 1
             class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
           >
             <img
-              src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+              src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
             />
           </span>
         </div>

--- a/components/card/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/card/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`renders components/card/demo/_semantic.tsx correctly 1`] = `
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=8"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=8"
                   />
                 </span>
               </div>
@@ -887,7 +887,7 @@ exports[`renders components/card/demo/_semantic_meta.tsx correctly 1`] = `
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=8"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=8"
                   />
                 </span>
               </div>

--- a/components/card/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.ts.snap
@@ -931,7 +931,7 @@ exports[`renders components/card/demo/meta.tsx correctly 1`] = `
           class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
         >
           <img
-            src="https://api.dicebear.com/7.x/miniavs/svg?seed=8"
+            src="https://api.dicebear.com/10.x/lorelei/svg?seed=8"
           />
         </span>
       </div>
@@ -1043,7 +1043,7 @@ exports[`renders components/card/demo/no-body-debug.tsx correctly 1`] = `
   >
     <img
       alt="example"
-      src="https://api.dicebear.com/7.x/miniavs/svg?seed=8"
+      src="https://api.dicebear.com/10.x/lorelei/svg?seed=8"
     />
   </div>
   <ul
@@ -1139,7 +1139,7 @@ exports[`renders components/card/demo/style-class.tsx correctly 1`] = `
             class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
           >
             <img
-              src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+              src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
             />
           </span>
         </div>
@@ -1287,7 +1287,7 @@ exports[`renders components/card/demo/style-class.tsx correctly 1`] = `
             class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
           >
             <img
-              src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+              src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
             />
           </span>
         </div>

--- a/components/card/__tests__/index.test.tsx
+++ b/components/card/__tests__/index.test.tsx
@@ -263,7 +263,7 @@ describe('Card', () => {
     const { container } = render(
       <Card
         title="Card title"
-        cover="https://api.dicebear.com/7.x/miniavs/svg?seed=8"
+        cover="https://api.dicebear.com/10.x/lorelei/svg?seed=8"
         extra="More"
         classNames={customClassNames}
         styles={customStyles}
@@ -272,7 +272,7 @@ describe('Card', () => {
         <Meta
           classNames={customClassNames}
           styles={customStyles}
-          avatar={<img alt="testimg" src="https://api.dicebear.com/7.x/miniavs/svg?seed=8" />}
+          avatar={<img alt="testimg" src="https://api.dicebear.com/10.x/lorelei/svg?seed=8" />}
           title="Card Meta title"
           description="This is the description"
         />

--- a/components/card/demo/_semantic.tsx
+++ b/components/card/demo/_semantic.tsx
@@ -78,7 +78,7 @@ const App: React.FC = () => {
     >
       <BlockCard>
         <Meta
-          avatar={<Avatar src="https://api.dicebear.com/7.x/miniavs/svg?seed=8" />}
+          avatar={<Avatar src="https://api.dicebear.com/10.x/lorelei/svg?seed=8" />}
           title="Card Meta title"
           description="This is the description"
         />

--- a/components/card/demo/_semantic_meta.tsx
+++ b/components/card/demo/_semantic_meta.tsx
@@ -30,7 +30,7 @@ const BlockCard: React.FC<React.PropsWithChildren> = (props) => {
       <Card style={{ width: 300 }}>
         <Meta
           {...props}
-          avatar={<Avatar src="https://api.dicebear.com/7.x/miniavs/svg?seed=8" />}
+          avatar={<Avatar src="https://api.dicebear.com/10.x/lorelei/svg?seed=8" />}
           title="Card Meta title"
           description="This is the description"
         />

--- a/components/card/demo/loading.tsx
+++ b/components/card/demo/loading.tsx
@@ -15,7 +15,7 @@ const App: React.FC = () => {
       <Switch checked={!loading} onChange={(checked) => setLoading(!checked)} />
       <Card loading={loading} actions={actions} style={{ minWidth: 300 }}>
         <Card.Meta
-          avatar={<Avatar src="https://api.dicebear.com/7.x/miniavs/svg?seed=1" />}
+          avatar={<Avatar src="https://api.dicebear.com/10.x/lorelei/svg?seed=1" />}
           title="Card title"
           description={
             <>
@@ -27,7 +27,7 @@ const App: React.FC = () => {
       </Card>
       <Card loading={loading} actions={actions} style={{ minWidth: 300 }}>
         <Card.Meta
-          avatar={<Avatar src="https://api.dicebear.com/7.x/miniavs/svg?seed=2" />}
+          avatar={<Avatar src="https://api.dicebear.com/10.x/lorelei/svg?seed=2" />}
           title="Card title"
           description={
             <>

--- a/components/card/demo/meta.tsx
+++ b/components/card/demo/meta.tsx
@@ -21,7 +21,7 @@ const App: React.FC = () => (
     ]}
   >
     <Meta
-      avatar={<Avatar src="https://api.dicebear.com/7.x/miniavs/svg?seed=8" />}
+      avatar={<Avatar src="https://api.dicebear.com/10.x/lorelei/svg?seed=8" />}
       title="Card title"
       description="This is the description"
     />

--- a/components/card/demo/no-body-debug.tsx
+++ b/components/card/demo/no-body-debug.tsx
@@ -4,7 +4,7 @@ import { Card } from 'antd';
 const App: React.FC = () => (
   <Card
     style={{ width: 300 }}
-    cover={<img alt="example" src="https://api.dicebear.com/7.x/miniavs/svg?seed=8" />}
+    cover={<img alt="example" src="https://api.dicebear.com/10.x/lorelei/svg?seed=8" />}
     actions={[<span key="setting">setting</span>, <span key="edit">edit</span>]}
   />
 );

--- a/components/card/demo/style-class.tsx
+++ b/components/card/demo/style-class.tsx
@@ -78,7 +78,7 @@ const App: React.FC = () => {
   };
 
   const sharedCardMetaProps: CardMetaProps = {
-    avatar: <Avatar src="https://api.dicebear.com/7.x/miniavs/svg?seed=1" />,
+    avatar: <Avatar src="https://api.dicebear.com/10.x/lorelei/svg?seed=1" />,
     description: 'This is the description',
   };
 

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -16734,7 +16734,7 @@ exports[`ConfigProvider components List configProvider 1`] = `
                 class="config-avatar config-avatar-circle config-avatar-image css-var-root config-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=9"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=9"
                 />
               </span>
             </div>
@@ -16788,7 +16788,7 @@ exports[`ConfigProvider components List configProvider componentDisabled 1`] = `
                 class="config-avatar config-avatar-circle config-avatar-image css-var-root config-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=9"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=9"
                 />
               </span>
             </div>
@@ -16842,7 +16842,7 @@ exports[`ConfigProvider components List configProvider componentSize large 1`] =
                 class="config-avatar config-avatar-lg config-avatar-circle config-avatar-image css-var-root config-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=9"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=9"
                 />
               </span>
             </div>
@@ -16896,7 +16896,7 @@ exports[`ConfigProvider components List configProvider componentSize medium 1`] 
                 class="config-avatar config-avatar-circle config-avatar-image css-var-root config-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=9"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=9"
                 />
               </span>
             </div>
@@ -16950,7 +16950,7 @@ exports[`ConfigProvider components List configProvider componentSize small 1`] =
                 class="config-avatar config-avatar-sm config-avatar-circle config-avatar-image css-var-root config-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=9"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=9"
                 />
               </span>
             </div>
@@ -17004,7 +17004,7 @@ exports[`ConfigProvider components List normal 1`] = `
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-root ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=9"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=9"
                 />
               </span>
             </div>
@@ -17058,7 +17058,7 @@ exports[`ConfigProvider components List prefixCls 1`] = `
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-root ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=9"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=9"
                 />
               </span>
             </div>

--- a/components/config-provider/__tests__/components.test.tsx
+++ b/components/config-provider/__tests__/components.test.tsx
@@ -354,7 +354,7 @@ describe('ConfigProvider', () => {
           <List.Item {...props}>
             <List.Item.Meta
               {...props}
-              avatar={<Avatar src="https://api.dicebear.com/7.x/miniavs/svg?seed=9" />}
+              avatar={<Avatar src="https://api.dicebear.com/10.x/lorelei/svg?seed=9" />}
               title="Ant Design"
               description="Ant Design, a design language for background applications, is refined by Ant UED Team"
             />

--- a/components/list/__tests__/Item.test.tsx
+++ b/components/list/__tests__/Item.test.tsx
@@ -11,7 +11,7 @@ describe('List Item Layout', () => {
       key: 1,
       href: 'https://ant.design',
       title: 'ant design',
-      avatar: 'https://api.dicebear.com/7.x/miniavs/svg?seed=10',
+      avatar: 'https://api.dicebear.com/10.x/lorelei/svg?seed=10',
       description:
         'Ant Design, a design language for background applications, is refined by Ant UED Team.',
       content:

--- a/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -28,7 +28,7 @@ exports[`renders components/list/demo/basic.tsx extend context correctly 1`] = `
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=0"
                 />
               </span>
             </div>
@@ -65,7 +65,7 @@ exports[`renders components/list/demo/basic.tsx extend context correctly 1`] = `
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
                 />
               </span>
             </div>
@@ -102,7 +102,7 @@ exports[`renders components/list/demo/basic.tsx extend context correctly 1`] = `
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
                 />
               </span>
             </div>
@@ -139,7 +139,7 @@ exports[`renders components/list/demo/basic.tsx extend context correctly 1`] = `
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=3"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=3"
                 />
               </span>
             </div>
@@ -474,7 +474,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=0"
                   />
                 </span>
               </div>
@@ -511,7 +511,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
                   />
                 </span>
               </div>
@@ -548,7 +548,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
                   />
                 </span>
               </div>
@@ -585,7 +585,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=3"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=3"
                   />
                 </span>
               </div>
@@ -656,7 +656,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=0"
                   />
                 </span>
               </div>
@@ -693,7 +693,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
                   />
                 </span>
               </div>
@@ -730,7 +730,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
                   />
                 </span>
               </div>
@@ -767,7 +767,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=3"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=3"
                   />
                 </span>
               </div>
@@ -3211,7 +3211,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=0"
                   />
                 </span>
               </div>
@@ -3248,7 +3248,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
                   />
                 </span>
               </div>
@@ -3285,7 +3285,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
                   />
                 </span>
               </div>
@@ -3322,7 +3322,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=3"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=3"
                   />
                 </span>
               </div>
@@ -3973,7 +3973,7 @@ exports[`renders components/list/demo/spin-debug.tsx extend context correctly 1`
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=0"
                 />
               </span>
             </div>
@@ -4040,7 +4040,7 @@ exports[`renders components/list/demo/vertical.tsx extend context correctly 1`] 
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=0"
                   />
                 </span>
               </div>
@@ -4204,7 +4204,7 @@ exports[`renders components/list/demo/vertical.tsx extend context correctly 1`] 
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
                   />
                 </span>
               </div>
@@ -4368,7 +4368,7 @@ exports[`renders components/list/demo/vertical.tsx extend context correctly 1`] 
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
                   />
                 </span>
               </div>

--- a/components/list/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`renders components/list/demo/_semantic.tsx correctly 1`] = `
                           class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                         >
                           <img
-                            src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                            src="https://api.dicebear.com/10.x/lorelei/svg?seed=0"
                           />
                         </span>
                       </div>

--- a/components/list/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.ts.snap
@@ -28,7 +28,7 @@ exports[`renders components/list/demo/basic.tsx correctly 1`] = `
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=0"
                 />
               </span>
             </div>
@@ -65,7 +65,7 @@ exports[`renders components/list/demo/basic.tsx correctly 1`] = `
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
                 />
               </span>
             </div>
@@ -102,7 +102,7 @@ exports[`renders components/list/demo/basic.tsx correctly 1`] = `
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
                 />
               </span>
             </div>
@@ -139,7 +139,7 @@ exports[`renders components/list/demo/basic.tsx correctly 1`] = `
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=3"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=3"
                 />
               </span>
             </div>
@@ -473,7 +473,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=0"
                   />
                 </span>
               </div>
@@ -510,7 +510,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
                   />
                 </span>
               </div>
@@ -547,7 +547,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
                   />
                 </span>
               </div>
@@ -584,7 +584,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=3"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=3"
                   />
                 </span>
               </div>
@@ -655,7 +655,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=0"
                   />
                 </span>
               </div>
@@ -692,7 +692,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
                   />
                 </span>
               </div>
@@ -729,7 +729,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
                   />
                 </span>
               </div>
@@ -766,7 +766,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=3"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=3"
                   />
                 </span>
               </div>
@@ -3137,7 +3137,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=0"
                   />
                 </span>
               </div>
@@ -3174,7 +3174,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
                   />
                 </span>
               </div>
@@ -3211,7 +3211,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
                   />
                 </span>
               </div>
@@ -3248,7 +3248,7 @@ Array [
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=3"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=3"
                   />
                 </span>
               </div>
@@ -3874,7 +3874,7 @@ exports[`renders components/list/demo/spin-debug.tsx correctly 1`] = `
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=0"
                 />
               </span>
             </div>
@@ -3935,7 +3935,7 @@ exports[`renders components/list/demo/vertical.tsx correctly 1`] = `
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=0"
                   />
                 </span>
               </div>
@@ -4099,7 +4099,7 @@ exports[`renders components/list/demo/vertical.tsx correctly 1`] = `
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
                   />
                 </span>
               </div>
@@ -4263,7 +4263,7 @@ exports[`renders components/list/demo/vertical.tsx correctly 1`] = `
                   class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
                 >
                   <img
-                    src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+                    src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
                   />
                 </span>
               </div>

--- a/components/list/demo/_semantic.tsx
+++ b/components/list/demo/_semantic.tsx
@@ -26,7 +26,7 @@ const IconText = ({ icon, text }: { icon: React.FC; text: string }) => (
 const data = Array.from({ length: 1 }).map((_, i) => ({
   href: 'https://ant.design',
   title: `ant design part ${i}`,
-  avatar: `https://api.dicebear.com/7.x/miniavs/svg?seed=${i}`,
+  avatar: `https://api.dicebear.com/10.x/lorelei/svg?seed=${i}`,
   description:
     'Ant Design, a design language for background applications, is refined by Ant UED Team.',
   content:

--- a/components/list/demo/basic.tsx
+++ b/components/list/demo/basic.tsx
@@ -23,7 +23,7 @@ const App: React.FC = () => (
     renderItem={(item, index) => (
       <List.Item>
         <List.Item.Meta
-          avatar={<Avatar src={`https://api.dicebear.com/7.x/miniavs/svg?seed=${index}`} />}
+          avatar={<Avatar src={`https://api.dicebear.com/10.x/lorelei/svg?seed=${index}`} />}
           title={<a href="https://ant.design">{item.title}</a>}
           description="Ant Design, a design language for background applications, is refined by Ant UED Team"
         />

--- a/components/list/demo/component-token.tsx
+++ b/components/list/demo/component-token.tsx
@@ -80,7 +80,7 @@ const App: React.FC = () => (
       renderItem={(item, index) => (
         <List.Item>
           <List.Item.Meta
-            avatar={<Avatar src={`https://api.dicebear.com/7.x/miniavs/svg?seed=${index}`} />}
+            avatar={<Avatar src={`https://api.dicebear.com/10.x/lorelei/svg?seed=${index}`} />}
             title={<a href="https://ant.design">{item.title}</a>}
             description="Ant Design, a design language for background applications, is refined by Ant UED Team"
           />
@@ -94,7 +94,7 @@ const App: React.FC = () => (
       renderItem={(item, index) => (
         <List.Item>
           <List.Item.Meta
-            avatar={<Avatar src={`https://api.dicebear.com/7.x/miniavs/svg?seed=${index}`} />}
+            avatar={<Avatar src={`https://api.dicebear.com/10.x/lorelei/svg?seed=${index}`} />}
             title={<a href="https://ant.design">{item.title}</a>}
             description="Ant Design, a design language for background applications, is refined by Ant UED Team"
           />

--- a/components/list/demo/pagination.tsx
+++ b/components/list/demo/pagination.tsx
@@ -70,7 +70,7 @@ const App: React.FC = () => {
         renderItem={(item, index) => (
           <List.Item>
             <List.Item.Meta
-              avatar={<Avatar src={`https://api.dicebear.com/7.x/miniavs/svg?seed=${index}`} />}
+              avatar={<Avatar src={`https://api.dicebear.com/10.x/lorelei/svg?seed=${index}`} />}
               title={<a href="https://ant.design">{item.title}</a>}
               description="Ant Design, a design language for background applications, is refined by Ant UED Team"
             />

--- a/components/list/demo/spin-debug.tsx
+++ b/components/list/demo/spin-debug.tsx
@@ -23,7 +23,7 @@ const App: React.FC = () => (
       renderItem={(item, index) => (
         <List.Item>
           <List.Item.Meta
-            avatar={<Avatar src={`https://api.dicebear.com/7.x/miniavs/svg?seed=${index}`} />}
+            avatar={<Avatar src={`https://api.dicebear.com/10.x/lorelei/svg?seed=${index}`} />}
             title={<a href="https://ant.design">{item.title}</a>}
             description="Ant Design, a design language for background applications, is refined by Ant UED Team"
           />

--- a/components/list/demo/vertical.tsx
+++ b/components/list/demo/vertical.tsx
@@ -5,7 +5,7 @@ import { Avatar, List, Space } from 'antd';
 const data = Array.from({ length: 23 }).map((_, i) => ({
   href: 'https://ant.design',
   title: `ant design part ${i}`,
-  avatar: `https://api.dicebear.com/7.x/miniavs/svg?seed=${i}`,
+  avatar: `https://api.dicebear.com/10.x/lorelei/svg?seed=${i}`,
   description:
     'Ant Design, a design language for background applications, is refined by Ant UED Team.',
   content:

--- a/components/segmented/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/segmented/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -562,7 +562,7 @@ exports[`renders components/segmented/demo/custom.tsx extend context correctly 1
             >
               <img
                 alt="User 1"
-                src="https://api.dicebear.com/7.x/miniavs/svg?seed=8"
+                src="https://api.dicebear.com/10.x/lorelei/svg?seed=8"
               />
             </span>
             <div>

--- a/components/segmented/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/segmented/__tests__/__snapshots__/demo.test.ts.snap
@@ -551,7 +551,7 @@ exports[`renders components/segmented/demo/custom.tsx correctly 1`] = `
             >
               <img
                 alt="User 1"
-                src="https://api.dicebear.com/7.x/miniavs/svg?seed=8"
+                src="https://api.dicebear.com/10.x/lorelei/svg?seed=8"
               />
             </span>
             <div>

--- a/components/segmented/demo/custom.tsx
+++ b/components/segmented/demo/custom.tsx
@@ -9,7 +9,7 @@ const App: React.FC = () => (
         {
           label: (
             <div style={{ padding: 4 }}>
-              <Avatar src="https://api.dicebear.com/7.x/miniavs/svg?seed=8" alt="User 1" />
+              <Avatar src="https://api.dicebear.com/10.x/lorelei/svg?seed=8" alt="User 1" />
               <div>User 1</div>
             </div>
           ),

--- a/components/skeleton/demo/list.tsx
+++ b/components/skeleton/demo/list.tsx
@@ -11,7 +11,7 @@ interface IconTextProps {
 const listData = Array.from({ length: 3 }).map((_, i) => ({
   href: 'https://ant.design',
   title: `ant design part ${i + 1}`,
-  avatar: `https://api.dicebear.com/7.x/miniavs/svg?seed=${i}`,
+  avatar: `https://api.dicebear.com/10.x/lorelei/svg?seed=${i}`,
   description:
     'Ant Design, a design language for background applications, is refined by Ant UED Team.',
   content:

--- a/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1590,7 +1590,7 @@ exports[`renders components/steps/demo/inline.tsx extend context correctly 1`] =
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=0"
                 />
               </span>
             </div>
@@ -1788,7 +1788,7 @@ exports[`renders components/steps/demo/inline.tsx extend context correctly 1`] =
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
                 />
               </span>
             </div>
@@ -1986,7 +1986,7 @@ exports[`renders components/steps/demo/inline.tsx extend context correctly 1`] =
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
                 />
               </span>
             </div>
@@ -2184,7 +2184,7 @@ exports[`renders components/steps/demo/inline.tsx extend context correctly 1`] =
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=3"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=3"
                 />
               </span>
             </div>

--- a/components/steps/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo.test.ts.snap
@@ -1468,7 +1468,7 @@ exports[`renders components/steps/demo/inline.tsx correctly 1`] = `
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=0"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=0"
                 />
               </span>
             </div>
@@ -1603,7 +1603,7 @@ exports[`renders components/steps/demo/inline.tsx correctly 1`] = `
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=1"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=1"
                 />
               </span>
             </div>
@@ -1738,7 +1738,7 @@ exports[`renders components/steps/demo/inline.tsx correctly 1`] = `
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=2"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=2"
                 />
               </span>
             </div>
@@ -1873,7 +1873,7 @@ exports[`renders components/steps/demo/inline.tsx correctly 1`] = `
                 class="ant-avatar ant-avatar-circle ant-avatar-image css-var-test-id ant-avatar-css-var"
               >
                 <img
-                  src="https://api.dicebear.com/7.x/miniavs/svg?seed=3"
+                  src="https://api.dicebear.com/10.x/lorelei/svg?seed=3"
                 />
               </span>
             </div>

--- a/components/steps/demo/inline.tsx
+++ b/components/steps/demo/inline.tsx
@@ -44,7 +44,7 @@ const App: React.FC = () => (
     renderItem={(item, index) => (
       <List.Item>
         <List.Item.Meta
-          avatar={<Avatar src={`https://api.dicebear.com/7.x/miniavs/svg?seed=${index}`} />}
+          avatar={<Avatar src={`https://api.dicebear.com/10.x/lorelei/svg?seed=${index}`} />}
           title={<a href="https://ant.design">{item.title}</a>}
           description="Ant Design, a design language for background applications, is refined by Ant UED Team"
         />


### PR DESCRIPTION
Updated the DiceBear API version and replaced the “miniavs” avatar style with “lorelei”

Version 7.x will be discontinued in 2028, so an update to 10.x is required. Also, the “miniavs” avatar style (CC BY 4.0) has been replaced with “lorelei” (CC0 1.0).

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [X] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> https://github.com/orgs/dicebear/discussions/491