### PR TITLE
site: fix ai theme drawer missing style

### DIFF
--- a/.dumi/theme/common/ThemeSwitch/PromptDrawer.tsx
+++ b/.dumi/theme/common/ThemeSwitch/PromptDrawer.tsx
@@ -7,6 +7,7 @@ import type { SenderRef } from '@ant-design/x/es/sender';
 import {
   theme as antdTheme,
   Button,
+  ConfigProvider,
   Divider,
   Drawer,
   Flex,
@@ -29,6 +30,8 @@ import usePromptTheme from './usePromptTheme';
 const antdLogoSrc = 'https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg';
 
 const THEME_EMOJIS = ['🌅', '🌊', '🌿', '🍂', '🌸', '🌌', '🎨', '⚡', '🔮', '🪐'];
+
+const runtimeThemeConfig: ThemeConfig = { zeroRuntime: false };
 
 const getEmojiForTheme = (index: number) => THEME_EMOJIS[index % THEME_EMOJIS.length];
 
@@ -460,31 +463,33 @@ const PromptDrawer: React.FC<PromptDrawerProps> = ({ open, onClose, onThemeChang
 
         {/* 右侧对话区域 */}
         <Splitter.Panel defaultSize="50%" min="30%" max="70%">
-          <Flex vertical gap={0} style={{ height: '100%', padding: '0 8px' }}>
-            <div
-              ref={scrollContainerRef}
-              onScroll={handleScroll}
-              style={{ flex: 1, padding: 0, overflow: 'auto' }}
-            >
-              {!prompt ? (
-                <>
-                  {renderedWelcome}
-                  {renderedPrompts}
-                </>
-              ) : (
-                <Bubble.List items={items} />
-              )}
-            </div>
-            <Sender
-              ref={senderRef}
-              value={inputValue}
-              onChange={setInputValue}
-              onSubmit={handleSubmit}
-              loading={loading}
-              onCancel={cancelRequest}
-              placeholder={locale.placeholder}
-            />
-          </Flex>
+          <ConfigProvider theme={runtimeThemeConfig}>
+            <Flex vertical gap={0} style={{ height: '100%', padding: '0 8px' }}>
+              <div
+                ref={scrollContainerRef}
+                onScroll={handleScroll}
+                style={{ flex: 1, padding: 0, overflow: 'auto' }}
+              >
+                {!prompt ? (
+                  <>
+                    {renderedWelcome}
+                    {renderedPrompts}
+                  </>
+                ) : (
+                  <Bubble.List items={items} />
+                )}
+              </div>
+              <Sender
+                ref={senderRef}
+                value={inputValue}
+                onChange={setInputValue}
+                onSubmit={handleSubmit}
+                loading={loading}
+                onCancel={cancelRequest}
+                placeholder={locale.placeholder}
+              />
+            </Flex>
+          </ConfigProvider>
         </Splitter.Panel>
       </Splitter>
     </Drawer>

--- a/.dumi/theme/common/ThemeSwitch/PromptDrawer.tsx
+++ b/.dumi/theme/common/ThemeSwitch/PromptDrawer.tsx
@@ -87,7 +87,9 @@ const PromptDrawer: React.FC<PromptDrawerProps> = ({ open, onClose, onThemeChang
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [copied, setCopied] = useState(false);
 
-  const [submitPrompt, loading, prompt, resText, cancelRequest] = usePromptTheme(onThemeChange);
+  const [submitPrompt, loading, prompt, resText, cancelRequest, generateErrorMessage] =
+    usePromptTheme(onThemeChange);
+  const hasGenerateError = generateErrorMessage !== undefined;
 
   const {
     recommendations,
@@ -180,7 +182,7 @@ const PromptDrawer: React.FC<PromptDrawerProps> = ({ open, onClose, onThemeChang
         key: 2,
         role: 'ai',
         placement: 'start',
-        content: resText,
+        content: hasGenerateError ? generateErrorMessage : resText,
         avatar: (
           <img
             draggable={false}
@@ -189,7 +191,7 @@ const PromptDrawer: React.FC<PromptDrawerProps> = ({ open, onClose, onThemeChang
             style={{ width: 28, height: 28 }}
           />
         ),
-        loading: !resText,
+        loading: loading && !resText && !hasGenerateError,
         contentRender: (content: string) => (
           <Typography>
             <pre
@@ -210,18 +212,19 @@ const PromptDrawer: React.FC<PromptDrawerProps> = ({ open, onClose, onThemeChang
             </pre>
           </Typography>
         ),
-        footer: !loading ? (
-          <Flex justify="flex-end" style={{ marginTop: 4 }}>
-            <Tooltip title={copied ? locale.copied : locale.copyTheme}>
-              <Button
-                type="text"
-                size="small"
-                icon={copied ? <CheckOutlined /> : <CopyOutlined />}
-                onClick={handleCopyTheme}
-              />
-            </Tooltip>
-          </Flex>
-        ) : undefined,
+        footer:
+          !loading && resText && !hasGenerateError ? (
+            <Flex justify="flex-end" style={{ marginTop: 4 }}>
+              <Tooltip title={copied ? locale.copied : locale.copyTheme}>
+                <Button
+                  type="text"
+                  size="small"
+                  icon={copied ? <CheckOutlined /> : <CopyOutlined />}
+                  onClick={handleCopyTheme}
+                />
+              </Tooltip>
+            </Flex>
+          ) : undefined,
         styles: {
           content: {
             background: 'transparent',
@@ -232,7 +235,7 @@ const PromptDrawer: React.FC<PromptDrawerProps> = ({ open, onClose, onThemeChang
       },
     ];
 
-    if (!loading) {
+    if (!loading && resText && !hasGenerateError) {
       nextItems.push({
         key: 3,
         role: 'system',
@@ -309,6 +312,8 @@ const PromptDrawer: React.FC<PromptDrawerProps> = ({ open, onClose, onThemeChang
     prompt,
     resText,
     loading,
+    hasGenerateError,
+    generateErrorMessage,
     recommendLoading,
     locale.finishTips,
     isDark,

--- a/.dumi/theme/common/ThemeSwitch/usePromptTheme.ts
+++ b/.dumi/theme/common/ThemeSwitch/usePromptTheme.ts
@@ -36,13 +36,30 @@ const fetchTheme = async (
     for await (const chunk of XStream({
       readableStream: response.body,
     })) {
-      if (chunk.event === 'message') {
-        const data = JSON.parse(chunk.data) as {
-          lane: string;
-          payload: string;
-        };
+      const data = JSON.parse(chunk.data) as {
+        lane?: string;
+        payload?: string;
+        type?: string;
+      };
 
-        const payload = JSON.parse(data.payload) as {
+      if (chunk.event === 'error' || data.type === 'error') {
+        let errorMessage = 'Failed to generate theme';
+
+        try {
+          const payload = JSON.parse(data.payload || '{}') as {
+            errorMsg?: string;
+          };
+
+          errorMessage = payload.errorMsg || errorMessage;
+        } catch {
+          // Keep fallback error message if the stream payload is not parseable.
+        }
+
+        throw new Error(errorMessage);
+      }
+
+      if (chunk.event === 'message') {
+        const payload = JSON.parse(data.payload || '{}') as {
           text: string;
         };
 
@@ -71,6 +88,7 @@ export default function usePromptTheme(
   const [prompt, setPrompt] = useState('');
   const [loading, setLoading] = useState(false);
   const [resText, setResText] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string>();
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const submitPrompt = async (nextPrompt: string) => {
@@ -91,6 +109,7 @@ export default function usePromptTheme(
 
     setLoading(true);
     setResText('');
+    setErrorMessage(undefined);
 
     try {
       const data = await fetchTheme(
@@ -111,6 +130,7 @@ export default function usePromptTheme(
         console.warn('Request was aborted');
       } else {
         console.error('Failed to generate theme:', error);
+        setErrorMessage(error instanceof Error ? error.message : 'Failed to generate theme');
       }
     } finally {
       setLoading(false);
@@ -126,5 +146,12 @@ export default function usePromptTheme(
     }
   };
 
-  return [submitPrompt, loading, prompt, getJsonText(resText), cancelRequest] as const;
+  return [
+    submitPrompt,
+    loading,
+    prompt,
+    getJsonText(resText),
+    cancelRequest,
+    errorMessage,
+  ] as const;
 }

--- a/.dumi/theme/common/ThemeSwitch/usePromptTheme.ts
+++ b/.dumi/theme/common/ThemeSwitch/usePromptTheme.ts
@@ -3,6 +3,12 @@ import { XStream } from '@ant-design/x-sdk';
 
 import type { SiteContextProps } from '../../../theme/slots/SiteContext';
 
+type ThemeStreamData = {
+  lane?: string;
+  payload?: string;
+  type?: string;
+};
+
 const fetchTheme = async (
   prompt: string,
   update: (currentFullContent: string) => void,
@@ -36,11 +42,25 @@ const fetchTheme = async (
     for await (const chunk of XStream({
       readableStream: response.body,
     })) {
-      const data = JSON.parse(chunk.data) as {
-        lane?: string;
-        payload?: string;
-        type?: string;
-      };
+      if (!chunk.data || chunk.data === '[DONE]') {
+        continue;
+      }
+
+      if (chunk.event !== 'message' && chunk.event !== 'error') {
+        continue;
+      }
+
+      let data: ThemeStreamData;
+
+      try {
+        data = JSON.parse(chunk.data) as ThemeStreamData;
+      } catch (error) {
+        if (chunk.event === 'error') {
+          throw new Error(chunk.data);
+        }
+
+        throw error;
+      }
 
       if (chunk.event === 'error' || data.type === 'error') {
         let errorMessage = 'Failed to generate theme';
@@ -52,7 +72,9 @@ const fetchTheme = async (
 
           errorMessage = payload.errorMsg || errorMessage;
         } catch {
-          // Keep fallback error message if the stream payload is not parseable.
+          if (data.payload) {
+            errorMessage = data.payload;
+          }
         }
 
         throw new Error(errorMessage);
@@ -130,11 +152,19 @@ export default function usePromptTheme(
         console.warn('Request was aborted');
       } else {
         console.error('Failed to generate theme:', error);
-        setErrorMessage(error instanceof Error ? error.message : 'Failed to generate theme');
+        setErrorMessage(
+          error instanceof SyntaxError
+            ? 'Failed to parse the generated theme. Please try again.'
+            : error instanceof Error
+              ? error.message
+              : 'Failed to generate theme',
+        );
       }
     } finally {
-      setLoading(false);
-      abortControllerRef.current = null;
+      if (abortControllerRef.current === abortController) {
+        setLoading(false);
+        abortControllerRef.current = null;
+      }
     }
   };
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

官网 AI 生成主题抽屉在生产环境中会丢失 `@ant-design/x` 组件样式。原因是站点生产环境开启了 zero-runtime 样式提取。

修复前：

<img width="360" alt="AI theme drawer before style fix" src="https://github.com/user-attachments/assets/b2b394b6-67d9-42c8-970a-adb26acd11c0" />

修复后：

<img width="360" alt="AI theme drawer after style fix" src="https://github.com/user-attachments/assets/f41068b2-987f-42f4-bc31-1f6cae90add8" />

同时补充了 AI 主题生成失败时的错误展示逻辑，避免失败后界面继续处于成功状态。

修复前：

<img width="360" alt="AI theme generation error before fix" src="https://github.com/user-attachments/assets/fa5ee142-294a-4192-bc5b-01cbaa24e8ec" />

修复后：

<img width="360" alt="AI theme generation error after fix" src="https://github.com/user-attachments/assets/0681c038-41fa-4afc-8f18-be7d286e00cb" />

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |