### PR TITLE
docs: add onClear docs for Cascader and TreeSelect

### DIFF
--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -91,6 +91,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | value | The selected value | string\[] \| number\[] | - |  | × |
 | variant | Variants of selector | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 | 5.19.0 |
 | onChange | Callback when finishing cascader select | (value, selectedOptions) => void | - |  | × |
+| onClear | Called when clear | () => void | - | - | × |
 | ~~onDropdownVisibleChange~~ | Callback when popup shown or hidden, use `onOpenChange` instead | (value) => void | - | 4.17.0 | × |
 | onOpenChange | Callback when popup shown or hidden | (value) => void | - |  | × |
 | ~~onPopupVisibleChange~~ | Callback when popup shown or hidden, please use `onOpenChange` instead | (value) => void | - | - | × |

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -92,6 +92,7 @@ demo:
 | value | 指定选中项 | string\[] \| number\[] | - |  | × |
 | variant | 形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 | 5.19.0 |
 | onChange | 选择完成后的回调 | (value, selectedOptions) => void | - |  | × |
+| onClear | 清除内容时回调 | () => void | - | - | × |
 | ~~onDropdownVisibleChange~~ | 显示/隐藏浮层的回调，请使用 `onOpenChange` 替换 | (value) => void | - | 4.17.0 | × |
 | onOpenChange | 显示/隐藏浮层的回调 | (value) => void | - |  | × |
 | ~~onPopupVisibleChange~~ | 显示或隐藏浮层的回调，请使用 `onOpenChange` 替代 | (value) => void | - | - | × |

--- a/components/tree-select/index.en-US.md
+++ b/components/tree-select/index.en-US.md
@@ -97,6 +97,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | variant | Variants of selector | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 | 5.19.0 |
 | virtual | Disable virtual scroll when set to false | boolean | true | 4.1.0 | × |
 | onChange | A callback function, can be executed when selected treeNodes or input value change | function(value, label, extra) | - |  | × |
+| onClear | Called when clear | () => void | - | - | × |
 | ~~onDropdownVisibleChange~~ | Called when dropdown open, use `onOpenChange` instead | function(open) | - |  | × |
 | onOpenChange | Called when dropdown open | (open: boolean) => void | - |  | × |
 | onPopupScroll | Called when dropdown scrolls | (event: UIEvent) => void | - | 5.17.0 | × |

--- a/components/tree-select/index.zh-CN.md
+++ b/components/tree-select/index.zh-CN.md
@@ -98,6 +98,7 @@ demo:
 | variant | 形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 | 5.19.0 |
 | virtual | 设置 false 时关闭虚拟滚动 | boolean | true | 4.1.0 | × |
 | onChange | 选中树节点时调用此函数 | function(value, label, extra) | - |  | × |
+| onClear | 清除内容时回调 | () => void | - | - | × |
 | ~~onDropdownVisibleChange~~ | 展开下拉菜单的回调，使用 `onOpenChange` 替换 | (open: boolean) => void | - |  | × |
 | onOpenChange | 展开下拉菜单的回调 | (open: boolean) => void | - |  | × |
 | onPopupScroll | 下拉列表滚动时的回调 | (event: UIEvent) => void | - | 5.17.0 | × |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Related #58349

### 💡 需求背景和解决方案

Cascader 和 TreeSelect 已经支持清空时触发 `onClear` 回调，但 API 文档中没有列出该属性，导致能力不容易被发现。

本次补充 Cascader 和 TreeSelect 中英文文档的 `onClear` API 说明。

验证：

- `npx remark components/cascader/index.en-US.md components/cascader/index.zh-CN.md components/tree-select/index.en-US.md components/tree-select/index.zh-CN.md -f -q`
- `git diff --check --cached`

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A      |
| 🇨🇳 中文 | N/A      |
