### PR TITLE
type: accept partial generic form values

### DIFF
--- a/components/form/__tests__/type.test.tsx
+++ b/components/form/__tests__/type.test.tsx
@@ -62,6 +62,16 @@ describe('Form.typescript', () => {
       };
       expect(Demo).toBeTruthy();
     });
+
+    it('accepts partial values from generic helper', () => {
+      const useGenericSetter = <Values,>() => {
+        const [form] = Form.useForm<Values>();
+
+        return (values: Partial<Values>) => form.setFieldsValue(values);
+      };
+
+      expect(useGenericSetter).toBeTruthy();
+    });
   });
 
   it('FormItem renderProps support generic', () => {

--- a/components/form/hooks/useForm.ts
+++ b/components/form/hooks/useForm.ts
@@ -8,7 +8,14 @@ import { isFunction } from '../../_util/is';
 import type { InternalNamePath, NamePath, ScrollOptions } from '../interface';
 import { getFieldId, toArray } from '../util';
 
-export interface FormInstance<Values = any> extends RcFormInstance<Values> {
+type RecursivePartial<T> = T extends (infer U)[]
+  ? RecursivePartial<U>[]
+  : T extends object
+    ? { [P in keyof T]?: RecursivePartial<T[P]> }
+    : T;
+
+export interface FormInstance<Values = any> extends Omit<RcFormInstance<Values>, 'setFieldsValue'> {
+  setFieldsValue: (values: RecursivePartial<Values> | Partial<Values>) => void;
   scrollToField: (name: NamePath, options?: ScrollOptions) => void;
   focusField: (name: NamePath) => void;
   /** @internal: This is an internal usage. Do not use in your prod */
@@ -48,6 +55,7 @@ export default function useForm<Values = any>(form?: FormInstance<Values>): [For
     () =>
       form ?? {
         ...rcForm,
+        setFieldsValue: rcForm.setFieldsValue as FormInstance<Values>['setFieldsValue'],
         __INTERNAL__: {
           itemRef: (name: InternalNamePath) => (node: React.ReactElement) => {
             const namePathStr = toNamePathStr(name);


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #57723

### 💡 Background and Solution

`FormInstance#setFieldsValue` is currently typed with a recursive partial value from the underlying form package. That rejects generic helpers that pass `Partial<Values>`, which regressed from previous releases.

This PR keeps the recursive partial support and also allows generic `Partial<Values>` inputs on the Ant Design exported `FormInstance` type. It adds a type test covering the generic helper pattern from the issue.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 这条 PR 已被回滚，无需纳入 ChangeLog |
| 🇨🇳 Chinese | 这条 PR 已被回滚，无需纳入 ChangeLog |

### ✅ Checks

- `npm run tsc`
- `npm test -- components/form/__tests__/type.test.tsx --runInBand`
- `npx eslint components/form/hooks/useForm.ts components/form/__tests__/type.test.tsx`