### PR TITLE
fix(docs): fix CLI and MCP route links

### DIFF
--- a/.dumi/theme/builtins/ComponentMeta/index.tsx
+++ b/.dumi/theme/builtins/ComponentMeta/index.tsx
@@ -137,7 +137,7 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
       return [
         `https://github.com/${repo}/blob/master/components/${kebabComponent}`,
         `components/${kebabComponent}`,
-        `/docs/react/llms${isZhCN ? '-cn' : ''}`,
+        `/components/${kebabComponent}${isZhCN ? '-cn' : ''}.md`,
       ];
     }
 

--- a/.dumi/theme/builtins/ComponentMeta/index.tsx
+++ b/.dumi/theme/builtins/ComponentMeta/index.tsx
@@ -137,7 +137,7 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
       return [
         `https://github.com/${repo}/blob/master/components/${kebabComponent}`,
         `components/${kebabComponent}`,
-        `/components/${kebabComponent}${isZhCN ? '-cn' : ''}.md`,
+        `/docs/react/llms${isZhCN ? '-cn' : ''}`,
       ];
     }
 

--- a/docs/react/cli.en-US.md
+++ b/docs/react/cli.en-US.md
@@ -79,7 +79,7 @@ antd migrate 4 5 --apply ./src      # Agent-ready migration prompt
 | `antd mcp` | Start an MCP server with 8 tools and 2 prompts for IDE integration (Claude Code, Cursor, VS Code, etc.) |
 | `antd upgrade` | Upgrade the CLI to the latest version |
 
-The `antd mcp` command launches a [Model Context Protocol](https://modelcontextprotocol.io/) server, allowing AI assistants to access Ant Design knowledge directly. See the [MCP Server](/docs/react/mcp-en-US) guide for full details and configuration.
+The `antd mcp` command launches a [Model Context Protocol](https://modelcontextprotocol.io/) server, allowing AI assistants to access Ant Design knowledge directly. See the [MCP Server](/docs/react/mcp) guide for full details and configuration.
 
 ### Global Flags
 
@@ -120,5 +120,5 @@ Works with any agent supporting the [skills](https://github.com/nicepkg/agent-sk
 
 - [@ant-design/cli on GitHub](https://github.com/ant-design/ant-design-cli)
 - [@ant-design/cli on npm](https://www.npmjs.com/package/@ant-design/cli)
-- [Ant Design LLMs.txt Guide](/docs/react/llms-en-US)
-- [Ant Design MCP Server](/docs/react/mcp-en-US)
+- [Ant Design LLMs.txt Guide](/docs/react/llms)
+- [Ant Design MCP Server](/docs/react/mcp)

--- a/docs/react/cli.zh-CN.md
+++ b/docs/react/cli.zh-CN.md
@@ -79,7 +79,7 @@ antd migrate 4 5 --apply ./src      # 生成 Agent 迁移提示
 | `antd mcp` | 启动 MCP 服务器，提供 8 个工具和 2 个提示词，支持 IDE 集成（Claude Code、Cursor、VS Code 等） |
 | `antd upgrade` | 将 CLI 升级到最新版本 |
 
-`antd mcp` 命令启动 [Model Context Protocol](https://modelcontextprotocol.io/) 服务器，让 AI 助手可以直接访问 Ant Design 知识。详细配置参见 [MCP Server](/docs/react/mcp-zh-CN) 指南。
+`antd mcp` 命令启动 [Model Context Protocol](https://modelcontextprotocol.io/) 服务器，让 AI 助手可以直接访问 Ant Design 知识。详细配置参见 [MCP Server](/docs/react/mcp-cn) 指南。
 
 ### 全局参数 {#global-flags}
 
@@ -120,5 +120,5 @@ npx skills add ant-design/ant-design-cli
 
 - [@ant-design/cli GitHub 仓库](https://github.com/ant-design/ant-design-cli)
 - [@ant-design/cli npm 地址](https://www.npmjs.com/package/@ant-design/cli)
-- [Ant Design LLMs.txt 指南](/docs/react/llms-zh-CN)
-- [Ant Design MCP Server](/docs/react/mcp-zh-CN)
+- [Ant Design LLMs.txt 指南](/docs/react/llms-cn)
+- [Ant Design MCP Server](/docs/react/mcp-cn)

--- a/docs/react/mcp.en-US.md
+++ b/docs/react/mcp.en-US.md
@@ -118,7 +118,7 @@ Configuration:
 
 ## Alternative: Using LLMs.txt
 
-If your AI tool doesn't support MCP, you can use our [LLMs.txt](/docs/react/llms-en-US) support instead. We provide:
+If your AI tool doesn't support MCP, you can use our [LLMs.txt](/docs/react/llms) support instead. We provide:
 
 - [llms.txt](https://ant.design/llms.txt) - Structured overview of all components
 - [llms-full.txt](https://ant.design/llms-full.txt) - Complete documentation with examples
@@ -126,7 +126,7 @@ If your AI tool doesn't support MCP, you can use our [LLMs.txt](/docs/react/llms
 ## Learn More
 
 - [Model Context Protocol Documentation](https://modelcontextprotocol.io/)
-- [Ant Design CLI](/docs/react/cli-en-US)
+- [Ant Design CLI](/docs/react/cli)
 - [@ant-design/cli on GitHub](https://github.com/ant-design/ant-design-cli)
-- [Ant Design LLMs.txt Guide](/docs/react/llms-en-US)
+- [Ant Design LLMs.txt Guide](/docs/react/llms)
 - [@jzone-mcp/antd-components-mcp on npm](https://www.npmjs.com/package/@jzone-mcp/antd-components-mcp)

--- a/docs/react/mcp.zh-CN.md
+++ b/docs/react/mcp.zh-CN.md
@@ -118,7 +118,7 @@ tag: New
 
 ## 备选方案：使用 LLMs.txt {#alternative-llms-txt}
 
-如果您的 AI 工具不支持 MCP，可以使用我们的 [LLMs.txt](/docs/react/llms-zh-CN) 支持。我们提供：
+如果您的 AI 工具不支持 MCP，可以使用我们的 [LLMs.txt](/docs/react/llms-cn) 支持。我们提供：
 
 - [llms.txt](https://ant.design/llms.txt) - 所有组件的结构化概览
 - [llms-full.txt](https://ant.design/llms-full.txt) - 包含示例的完整文档
@@ -126,7 +126,7 @@ tag: New
 ## 了解更多 {#learn-more}
 
 - [Model Context Protocol 文档](https://modelcontextprotocol.io/)
-- [Ant Design CLI](/docs/react/cli-zh-CN)
+- [Ant Design CLI](/docs/react/cli-cn)
 - [@ant-design/cli GitHub 仓库](https://github.com/ant-design/ant-design-cli)
-- [Ant Design LLMs.txt 指南](/docs/react/llms-zh-CN)
+- [Ant Design LLMs.txt 指南](/docs/react/llms-cn)
 - [@jzone-mcp/antd-components-mcp npm 地址](https://www.npmjs.com/package/@jzone-mcp/antd-components-mcp)


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

CLI 和 MCP 文档中部分站内链接仍使用旧的本地化路由后缀，例如 `-en-US`、`-zh-CN`，会和当前实际生成的 dumi 路由不一致。

本次改动将相关链接更新为当前实际存在的路由格式：英文文档使用无语言后缀路径，中文文档使用 `-cn` 后缀，避免 CLI、MCP、LLMs 指南之间的站内跳转失效。

### 📝 更新日志

| 语言    | 更新描述                |
| ------- | ----------------------- |
| 🇺🇸 英文 | No changelog required. |
| 🇨🇳 中文 | 无需更新日志。          |