### PR TITLE
fix: handle empty children in Space.Compact

### DIFF
--- a/components/space/Compact.tsx
+++ b/components/space/Compact.tsx
@@ -184,10 +184,6 @@ const Compact: React.FC<SpaceCompactProps> = (props) => {
 
     if (count === 0) {
       setRegisteredItemIds((prevIds) => {
-        if (prevIds.has(itemId)) {
-          return prevIds;
-        }
-
         const nextIds = new Set(prevIds);
         nextIds.add(itemId);
         return nextIds;
@@ -200,10 +196,6 @@ const Compact: React.FC<SpaceCompactProps> = (props) => {
       if (latestCount <= 1) {
         registeredItemCountRef.current.delete(itemId);
         setRegisteredItemIds((prevIds) => {
-          if (!prevIds.has(itemId)) {
-            return prevIds;
-          }
-
           const nextIds = new Set(prevIds);
           nextIds.delete(itemId);
           return nextIds;

--- a/components/space/Compact.tsx
+++ b/components/space/Compact.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { toArray } from '@rc-component/util';
+import { toArray, useLayoutEffect } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useOrientation } from '../_util/hooks';
@@ -16,6 +16,8 @@ export interface SpaceCompactItemContextType {
   compactDirection?: 'horizontal' | 'vertical';
   isFirstItem?: boolean;
   isLastItem?: boolean;
+  compactItemId?: React.Key;
+  registerCompactItem?: (itemId: React.Key) => () => void;
 }
 
 export const SpaceCompactItemContext = React.createContext<SpaceCompactItemContextType | null>(
@@ -24,6 +26,14 @@ export const SpaceCompactItemContext = React.createContext<SpaceCompactItemConte
 
 export const useCompactItemContext = (prefixCls: string, direction: DirectionType) => {
   const compactItemContext = React.useContext(SpaceCompactItemContext);
+
+  useLayoutEffect(() => {
+    if (compactItemContext?.compactItemId == null || !compactItemContext.registerCompactItem) {
+      return;
+    }
+
+    return compactItemContext.registerCompactItem(compactItemContext.compactItemId);
+  }, [compactItemContext?.compactItemId, compactItemContext?.registerCompactItem]);
 
   const compactItemClassnames = React.useMemo<string>(() => {
     if (!compactItemContext) {
@@ -66,10 +76,28 @@ export interface SpaceCompactProps extends React.HTMLAttributes<HTMLDivElement> 
 
 const CompactItem: React.FC<React.PropsWithChildren<SpaceCompactItemContextType>> = (props) => {
   const { children, ...others } = props;
+  const {
+    compactSize,
+    compactDirection,
+    isFirstItem,
+    isLastItem,
+    compactItemId,
+    registerCompactItem,
+  } = others;
+  const contextValue = React.useMemo<SpaceCompactItemContextType>(
+    () => ({
+      compactSize,
+      compactDirection,
+      isFirstItem,
+      isLastItem,
+      compactItemId,
+      registerCompactItem,
+    }),
+    [compactSize, compactDirection, isFirstItem, isLastItem, compactItemId, registerCompactItem],
+  );
+
   return (
-    <SpaceCompactItemContext.Provider
-      value={React.useMemo<SpaceCompactItemContextType>(() => others, [others])}
-    >
+    <SpaceCompactItemContext.Provider value={contextValue}>
       {children}
     </SpaceCompactItemContext.Provider>
   );
@@ -118,25 +146,107 @@ const Compact: React.FC<SpaceCompactProps> = (props) => {
 
   const childNodes = toArray(children);
 
+  useLayoutEffect(() => {
+    if (
+      childNodes.length === 0 ||
+      compactItemContext?.compactItemId == null ||
+      !compactItemContext.registerCompactItem
+    ) {
+      return;
+    }
+
+    return compactItemContext.registerCompactItem(compactItemContext.compactItemId);
+  }, [
+    childNodes.length,
+    compactItemContext?.compactItemId,
+    compactItemContext?.registerCompactItem,
+  ]);
+
+  const itemKeys = React.useMemo(
+    () => childNodes.map((child, i) => child?.key ?? `${prefixCls}-item-${i}`),
+    [childNodes, prefixCls],
+  );
+  const registeredItemCountRef = React.useRef<Map<React.Key, number>>(new Map());
+  const [registeredItemIds, setRegisteredItemIds] = React.useState<Set<React.Key>>(() => new Set());
+
+  const registerCompactItem = React.useCallback((itemId: React.Key) => {
+    const count = registeredItemCountRef.current.get(itemId) ?? 0;
+
+    registeredItemCountRef.current.set(itemId, count + 1);
+
+    if (count === 0) {
+      setRegisteredItemIds((prevIds) => {
+        if (prevIds.has(itemId)) {
+          return prevIds;
+        }
+
+        const nextIds = new Set(prevIds);
+        nextIds.add(itemId);
+        return nextIds;
+      });
+    }
+
+    return () => {
+      const latestCount = registeredItemCountRef.current.get(itemId) ?? 0;
+
+      if (latestCount <= 1) {
+        registeredItemCountRef.current.delete(itemId);
+        setRegisteredItemIds((prevIds) => {
+          if (!prevIds.has(itemId)) {
+            return prevIds;
+          }
+
+          const nextIds = new Set(prevIds);
+          nextIds.delete(itemId);
+          return nextIds;
+        });
+      } else {
+        registeredItemCountRef.current.set(itemId, latestCount - 1);
+      }
+    };
+  }, []);
+
+  const visibleItemKeys = React.useMemo(
+    () =>
+      registeredItemIds.size ? itemKeys.filter((key) => registeredItemIds.has(key)) : itemKeys,
+    [itemKeys, registeredItemIds],
+  );
+  const firstVisibleItemKey = visibleItemKeys[0];
+  const lastVisibleItemKey = visibleItemKeys[visibleItemKeys.length - 1];
+
   const nodes = React.useMemo(
     () =>
       childNodes.map((child, i) => {
-        const key = child?.key || `${prefixCls}-item-${i}`;
+        const key = itemKeys[i];
         return (
           <CompactItem
             key={key}
+            compactItemId={key}
+            registerCompactItem={registerCompactItem}
             compactSize={mergedSize}
             compactDirection={mergedOrientation}
-            isFirstItem={i === 0 && (!compactItemContext || compactItemContext?.isFirstItem)}
+            isFirstItem={
+              key === firstVisibleItemKey &&
+              (!compactItemContext || compactItemContext?.isFirstItem)
+            }
             isLastItem={
-              i === childNodes.length - 1 && (!compactItemContext || compactItemContext?.isLastItem)
+              key === lastVisibleItemKey && (!compactItemContext || compactItemContext?.isLastItem)
             }
           >
             {child}
           </CompactItem>
         );
       }),
-    [childNodes, compactItemContext, mergedOrientation, mergedSize, prefixCls],
+    [
+      childNodes,
+      compactItemContext,
+      firstVisibleItemKey,
+      itemKeys,
+      lastVisibleItemKey,
+      mergedOrientation,
+      mergedSize,
+      registerCompactItem,
+    ],
   );
 
   // =========================== Render ===========================

--- a/components/space/Compact.tsx
+++ b/components/space/Compact.tsx
@@ -103,6 +103,14 @@ const CompactItem: React.FC<React.PropsWithChildren<SpaceCompactItemContextType>
   );
 };
 
+const getCompactItemKey = (child: React.ReactNode, index: number, prefixCls: string) =>
+  React.isValidElement(child) && child.key != null ? child.key : `${prefixCls}-item-${index}`;
+
+const isVisibleNonCompactItem = (child: React.ReactNode) =>
+  (typeof child === 'string' && child !== '') ||
+  typeof child === 'number' ||
+  (React.isValidElement(child) && typeof child.type === 'string');
+
 const Compact: React.FC<SpaceCompactProps> = (props) => {
   const { getPrefixCls, direction: directionConfig } = React.useContext(ConfigContext);
 
@@ -144,7 +152,7 @@ const Compact: React.FC<SpaceCompactProps> = (props) => {
 
   const compactItemContext = React.useContext(SpaceCompactItemContext);
 
-  const childNodes = toArray(children);
+  const childNodes = toArray(children) as React.ReactNode[];
 
   useLayoutEffect(() => {
     if (
@@ -163,7 +171,7 @@ const Compact: React.FC<SpaceCompactProps> = (props) => {
   ]);
 
   const itemKeys = React.useMemo(
-    () => childNodes.map((child, i) => child?.key ?? `${prefixCls}-item-${i}`),
+    () => childNodes.map((child, i) => getCompactItemKey(child, i, prefixCls)),
     [childNodes, prefixCls],
   );
   const registeredItemCountRef = React.useRef<Map<React.Key, number>>(new Map());
@@ -208,8 +216,13 @@ const Compact: React.FC<SpaceCompactProps> = (props) => {
 
   const visibleItemKeys = React.useMemo(
     () =>
-      registeredItemIds.size ? itemKeys.filter((key) => registeredItemIds.has(key)) : itemKeys,
-    [itemKeys, registeredItemIds],
+      registeredItemIds.size
+        ? itemKeys.filter(
+            (key, index) =>
+              registeredItemIds.has(key) || isVisibleNonCompactItem(childNodes[index]),
+          )
+        : itemKeys,
+    [childNodes, itemKeys, registeredItemIds],
   );
   const firstVisibleItemKey = visibleItemKeys[0];
   const lastVisibleItemKey = visibleItemKeys[visibleItemKeys.length - 1];

--- a/components/space/__tests__/space-compact.test.tsx
+++ b/components/space/__tests__/space-compact.test.tsx
@@ -66,6 +66,23 @@ describe('Space.Compact', () => {
     expect(container.querySelector('.test-button')).toHaveClass('ant-btn-compact-last-item');
   });
 
+  it('should ignore children which render nothing when marking first and last items', () => {
+    const Empty = () => null;
+
+    [
+      [<Button key="visible">Submit</Button>, <Empty key="empty" />],
+      [<Empty key="empty" />, <Button key="visible">Submit</Button>],
+    ].forEach((children) => {
+      const { container, unmount } = render(<Space.Compact>{children}</Space.Compact>);
+      const button = container.querySelector('.ant-btn');
+
+      expect(button).toHaveClass('ant-btn-compact-first-item');
+      expect(button).toHaveClass('ant-btn-compact-last-item');
+
+      unmount();
+    });
+  });
+
   [
     {
       name: 'Button',

--- a/components/space/__tests__/space-compact.test.tsx
+++ b/components/space/__tests__/space-compact.test.tsx
@@ -83,6 +83,20 @@ describe('Space.Compact', () => {
     });
   });
 
+  it('should not ignore plain elements or text when marking first and last items', () => {
+    const { container } = render(
+      <Space.Compact>
+        <span className="addon">$</span>
+        <Button>Submit</Button>
+        Text
+      </Space.Compact>,
+    );
+    const button = container.querySelector('.ant-btn');
+
+    expect(button).not.toHaveClass('ant-btn-compact-first-item');
+    expect(button).not.toHaveClass('ant-btn-compact-last-item');
+  });
+
   [
     {
       name: 'Button',


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- Fix #58191

### 💡 Background and Solution

`Space.Compact` assigned first/last item context from the original React children list. When a child component existed in that list but rendered `null`, the visible compact item could miss the `*-compact-last-item` or `*-compact-first-item` class.

This PR lets rendered compact-aware children register themselves with the nearest `Space.Compact`. The parent keeps the source order as the fallback, then uses the registered visible item ids to mark the actual first and last compact items. A regression test covers hidden children before and after the visible button.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Space.Compact not applying both first and last item styles when sibling children render nothing. |
| 🇨🇳 Chinese | 🐞 修复 Space.Compact 在兄弟子节点渲染为空时未同时应用首尾项样式的问题。 |
