### PR TITLE
fix: support title in submenu items

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -17108,6 +17108,7 @@ Array [
       >
         <span
           class="config-menu-title-content"
+          title="bamboo"
         >
           bamboo
         </span>
@@ -17185,6 +17186,7 @@ Array [
       >
         <span
           class="config-menu-title-content"
+          title="bamboo"
         >
           bamboo
         </span>
@@ -17262,6 +17264,7 @@ Array [
       >
         <span
           class="config-menu-title-content"
+          title="bamboo"
         >
           bamboo
         </span>
@@ -17339,6 +17342,7 @@ Array [
       >
         <span
           class="config-menu-title-content"
+          title="bamboo"
         >
           bamboo
         </span>
@@ -17416,6 +17420,7 @@ Array [
       >
         <span
           class="config-menu-title-content"
+          title="bamboo"
         >
           bamboo
         </span>
@@ -17493,6 +17498,7 @@ Array [
       >
         <span
           class="ant-menu-title-content"
+          title="bamboo"
         >
           bamboo
         </span>
@@ -17570,6 +17576,7 @@ Array [
       >
         <span
           class="prefix-Menu-title-content"
+          title="bamboo"
         >
           bamboo
         </span>

--- a/components/menu/SubMenu.tsx
+++ b/components/menu/SubMenu.tsx
@@ -9,38 +9,72 @@ import type { SubMenuType } from './interface';
 import type { MenuContextProps } from './MenuContext';
 import MenuContext from './MenuContext';
 
-export interface SubMenuProps extends Omit<SubMenuType, 'ref' | 'key' | 'children' | 'label'> {
+export interface SubMenuProps
+  extends Omit<SubMenuType, 'ref' | 'key' | 'children' | 'label' | 'title'> {
   title?: React.ReactNode;
   children?: React.ReactNode;
 }
 
+type InternalSubMenuProps = SubMenuProps & {
+  itemTitle?: string | false;
+};
+
 const SubMenu: React.FC<SubMenuProps> = (props) => {
-  const { popupClassName, icon, title, theme: customTheme } = props;
+  const { popupClassName, icon, title, itemTitle, theme: customTheme } =
+    props as InternalSubMenuProps;
   const context = React.useContext(MenuContext);
   const { prefixCls, inlineCollapsed, theme: contextTheme, classNames, styles } = context;
 
   const parentPath = useFullPath();
+  let titleAttr: string | undefined;
+  if (typeof itemTitle === 'string') {
+    titleAttr = itemTitle;
+  } else if (itemTitle !== false && typeof title === 'string') {
+    titleAttr = title;
+  }
+  const isTopLevelInlineCollapsed = inlineCollapsed && !parentPath.length;
+  const collapsedTitle = isTopLevelInlineCollapsed ? titleAttr : undefined;
+  const collapsedLabel = typeof title === 'string' ? title : titleAttr;
 
   let titleNode: React.ReactNode;
 
   if (!icon) {
     titleNode =
-      inlineCollapsed && !parentPath.length && title && typeof title === 'string' ? (
-        <div className={`${prefixCls}-inline-collapsed-noicon`}>{title.charAt(0)}</div>
+      isTopLevelInlineCollapsed &&
+      collapsedLabel !== undefined &&
+      (!React.isValidElement(title) || titleAttr !== undefined) ? (
+        <div className={`${prefixCls}-inline-collapsed-noicon`} title={titleAttr}>
+          {collapsedLabel.charAt(0)}
+        </div>
       ) : (
-        <span className={`${prefixCls}-title-content`}>{title}</span>
+        <span className={`${prefixCls}-title-content`} title={titleAttr}>
+          {title}
+        </span>
       );
   } else {
     // inline-collapsed.md demo 依赖 span 来隐藏文字,有 icon 属性，则内部包裹一个 span
     // ref: https://github.com/ant-design/ant-design/pull/23456
     const titleIsSpan = React.isValidElement(title) && title.type === 'span';
+    const titleContent = titleIsSpan
+      ? cloneElement<{ title?: string }>(title, (oriProps) => ({
+          title: titleAttr ?? oriProps.title,
+        }))
+      : title;
+
     titleNode = (
       <>
         {cloneElement(icon, (oriProps) => ({
           className: clsx(oriProps.className, `${prefixCls}-item-icon`, classNames?.itemIcon),
           style: { ...oriProps.style, ...styles?.itemIcon },
+          title: collapsedTitle ?? oriProps.title,
         }))}
-        {titleIsSpan ? title : <span className={`${prefixCls}-title-content`}>{title}</span>}
+        {titleIsSpan ? (
+          titleContent
+        ) : (
+          <span className={`${prefixCls}-title-content`} title={titleAttr}>
+            {title}
+          </span>
+        )}
       </>
     );
   }
@@ -56,7 +90,7 @@ const SubMenu: React.FC<SubMenuProps> = (props) => {
   return (
     <MenuContext.Provider value={contextValue}>
       <RcSubMenu
-        {...omit(props, ['icon'])}
+        {...omit(props as InternalSubMenuProps, ['icon', 'itemTitle'])}
         title={titleNode}
         classNames={{ list: classNames?.subMenu?.list, listTitle: classNames?.subMenu?.itemTitle }}
         styles={{ list: styles?.subMenu?.list, listTitle: styles?.subMenu?.itemTitle }}

--- a/components/menu/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/menu/__tests__/__snapshots__/index.test.tsx.snap
@@ -106,6 +106,7 @@ exports[`Menu Menu.Item with icon children auto wrap span 1`] = `
         </span>
         <span
           class="ant-menu-title-content"
+          title="Navigation One"
         >
           Navigation One
         </span>

--- a/components/menu/__tests__/index.test.tsx
+++ b/components/menu/__tests__/index.test.tsx
@@ -518,6 +518,134 @@ describe('Menu', () => {
     expect(container.querySelectorAll('.ant-tooltip-container')[2].textContent).toBe('item');
   });
 
+  it('items SubMenu should use title for collapsed title content', () => {
+    const items: MenuProps['items'] = [
+      {
+        key: 'sub',
+        label: 'Submenu',
+        title: 'Submenu Title',
+        children: [{ key: 'child', label: 'Child' }],
+      },
+    ];
+
+    const { container } = render(<Menu mode="inline" inlineCollapsed items={items} />);
+
+    expect(container.querySelector('.ant-menu-inline-collapsed-noicon')).toHaveAttribute(
+      'title',
+      'Submenu Title',
+    );
+  });
+
+  it('items SubMenu should keep label as collapsed no-icon content', () => {
+    const items: MenuProps['items'] = [
+      {
+        key: 'sub',
+        label: 'Users',
+        title: 'People',
+        children: [{ key: 'child', label: 'Child' }],
+      },
+    ];
+
+    const { container } = render(<Menu mode="inline" inlineCollapsed items={items} />);
+    const collapsedNoIcon = container.querySelector('.ant-menu-inline-collapsed-noicon');
+
+    expect(collapsedNoIcon).toHaveAttribute('title', 'People');
+    expect(collapsedNoIcon).toHaveTextContent('U');
+  });
+
+  it('items SubMenu should keep label when title is undefined', () => {
+    const items: MenuProps['items'] = [
+      {
+        key: 'sub',
+        label: <span className="custom-submenu-label">Submenu</span>,
+        title: undefined,
+        children: [{ key: 'child', label: 'Child' }],
+      },
+    ];
+
+    const { container } = render(<Menu mode="inline" items={items} />);
+
+    expect(container.querySelector('.custom-submenu-label')).toHaveTextContent('Submenu');
+  });
+
+  it('items SubMenu should not add native title from string label', () => {
+    const items: MenuProps['items'] = [
+      {
+        key: 'sub',
+        label: 'Submenu',
+        children: [{ key: 'child', label: 'Child' }],
+      },
+    ];
+
+    const { container } = render(<Menu mode="inline" items={items} />);
+
+    expect(container.querySelector('.ant-menu-title-content')).not.toHaveAttribute('title');
+  });
+
+  it('items SubMenu should keep title when label is a span with icon', () => {
+    const items: MenuProps['items'] = [
+      {
+        key: 'sub',
+        icon: <MailOutlined />,
+        label: <span className="custom-submenu-label">Submenu</span>,
+        title: 'Submenu Title',
+        children: [{ key: 'child', label: 'Child' }],
+      },
+    ];
+
+    const { container } = render(<Menu mode="inline" inlineCollapsed items={items} />);
+
+    expect(container.querySelector('.ant-menu-item-icon')).toHaveAttribute('title', 'Submenu Title');
+    expect(container.querySelector('.custom-submenu-label')).toHaveAttribute(
+      'title',
+      'Submenu Title',
+    );
+  });
+
+  it('items SubMenu should keep title on collapsed no-icon label node', () => {
+    const items: MenuProps['items'] = [
+      {
+        key: 'sub',
+        label: <span className="custom-submenu-label">Submenu</span>,
+        title: 'Submenu Title',
+        children: [{ key: 'child', label: 'Child' }],
+      },
+    ];
+
+    const { container } = render(<Menu mode="inline" inlineCollapsed items={items} />);
+
+    expect(container.querySelector('.ant-menu-inline-collapsed-noicon')).toHaveAttribute(
+      'title',
+      'Submenu Title',
+    );
+    expect(container.querySelector('.ant-menu-inline-collapsed-noicon')?.textContent).toBe('S');
+  });
+
+  it('items nested SubMenu should keep title', () => {
+    const items: MenuProps['items'] = [
+      {
+        key: 'root',
+        label: 'Root',
+        children: [
+          null,
+          {
+            key: 'child-sub',
+            label: <span className="nested-submenu-label">Child submenu</span>,
+            title: 'Nested Submenu Title',
+            children: [{ key: 'leaf', label: 'Leaf' }],
+          },
+        ],
+      },
+    ];
+
+    const { container } = render(<Menu mode="inline" defaultOpenKeys={['root']} items={items} />);
+    const nestedTitleContent = container
+      .querySelector('.nested-submenu-label')
+      ?.closest('.ant-menu-title-content');
+
+    expect(nestedTitleContent).toHaveAttribute('title', 'Nested Submenu Title');
+  });
+
   it('inlineCollapsed Menu.Item Tooltip can be disabled by prop', () => {
     const { container } = render(
       <Menu
@@ -1025,12 +1153,11 @@ describe('Menu', () => {
         <Menu.Item>Bamboo</Menu.Item>
       </Menu>,
     );
-    expect(container.querySelectorAll('.ant-menu-inline-collapsed-noicon')[0]?.textContent).toEqual(
-      'L',
-    );
-    expect(container.querySelectorAll('.ant-menu-inline-collapsed-noicon')[1]?.textContent).toEqual(
-      'B',
-    );
+    const collapsedNoIconNodes = container.querySelectorAll('.ant-menu-inline-collapsed-noicon');
+
+    expect(collapsedNoIconNodes[0]).toHaveAttribute('title', 'Light');
+    expect(collapsedNoIconNodes[0]?.textContent).toEqual('L');
+    expect(collapsedNoIconNodes[1]?.textContent).toEqual('B');
   });
 
   it('divider should show', () => {

--- a/components/menu/__tests__/type.test.tsx
+++ b/components/menu/__tests__/type.test.tsx
@@ -13,6 +13,7 @@ describe('Menu.typescript', () => {
           {
             key: 'submenu',
             theme: 'light',
+            title: 'Submenu',
             children: [
               { key: 'submenu-item', title: 'SubmenuItem' },
               { key: 'submenu-submenu', theme: 'light', children: [] },
@@ -53,6 +54,7 @@ describe('Menu.typescript', () => {
           {
             key: 'submenu',
             theme: 'light',
+            title: 'Submenu',
             children: [
               { key: 'submenu-item', title: 'SubmenuItem', 'data-x': 0 },
               { key: 'submenu-submenu', theme: 'light', children: [], 'data-x': 0 },

--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -105,6 +105,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | popupClassName | Sub-menu class name, not working when `mode="inline"` | string | - |  |
 | popupOffset | Sub-menu offset, not working when `mode="inline"` | \[number, number] | - |  |
 | theme | Color theme of the SubMenu (inherits from Menu by default) | `light` \| `dark` | - |  |
+| title | Set display title for collapsed sub-menu | string | - | 6.4.4 |
 | onTitleClick | Callback executed when the sub-menu title is clicked | function({ key, domEvent }) | - |  |
 | popupRender | Custom popup renderer for current sub-menu | (node: ReactElement, props: { item: SubMenuProps; keys: string[] }) => ReactElement | - |  |
 

--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -106,6 +106,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*Vn4XSqJFAxcAAA
 | popupOffset | 子菜单偏移量，`mode="inline"` 时无效 | \[number, number] | - |  |
 | onTitleClick | 点击子菜单标题 | function({ key, domEvent }) | - |  |
 | theme | 设置子菜单的主题，默认从 Menu 上继承 | `light` \| `dark` | - |  |
+| title | 设置收缩时展示的子菜单悬浮标题 | string | - | 6.4.4 |
 | popupRender | 自定义当前子菜单的弹出框 | (node: ReactElement, props: { item: SubMenuProps; keys: string[] }) => ReactElement | - |  |
 
 #### MenuItemGroupType

--- a/components/menu/interface.ts
+++ b/components/menu/interface.ts
@@ -20,6 +20,7 @@ export interface SubMenuType<T extends MenuItemType = MenuItemType>
   extends Omit<RcSubMenuType, 'children'> {
   icon?: React.ReactNode;
   theme?: 'dark' | 'light';
+  title?: string;
   children: ItemType<T>[];
 }
 

--- a/components/menu/menu.tsx
+++ b/components/menu/menu.tsx
@@ -36,6 +36,53 @@ const MENU_COMPONENTS: GetProp<RcMenuProps, '_internalComponents'> = {
   divider: Divider,
 };
 
+type InternalSubMenuItemType = Exclude<ItemType, null> & {
+  children?: ItemType[];
+  itemTitle?: string | false;
+  title?: string;
+};
+
+function normalizeSubMenuItemTitle(items?: ItemType[]): ItemType[] | undefined {
+  let changed = false;
+
+  const mergedItems = items?.map((item) => {
+    if (!item || typeof item !== 'object') {
+      return item;
+    }
+
+    const menuItem = item as InternalSubMenuItemType;
+    const children = menuItem.children;
+    const mergedChildren = normalizeSubMenuItemTitle(children);
+    const isSubMenu = Array.isArray(children) && menuItem.type !== 'group';
+    const hasTitle = Object.prototype.hasOwnProperty.call(menuItem, 'title');
+
+    if (isSubMenu) {
+      const { title, ...restItem } = menuItem;
+      const normalizedItem = hasTitle ? restItem : menuItem;
+      changed = true;
+
+      return {
+        ...normalizedItem,
+        itemTitle: typeof title === 'string' ? title : false,
+        children: mergedChildren,
+      } as unknown as ItemType;
+    }
+
+    if (mergedChildren !== children) {
+      changed = true;
+
+      return {
+        ...menuItem,
+        children: mergedChildren,
+      } as ItemType;
+    }
+
+    return item;
+  });
+
+  return changed ? mergedItems : items;
+}
+
 export type MenuSemanticName = keyof MenuSemanticClassNames & keyof MenuSemanticStyles;
 
 export type MenuSemanticClassNames = {
@@ -151,6 +198,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
     overflowedIndicatorPopupClassName,
     classNames,
     styles,
+    items,
     ...restProps
   } = props;
 
@@ -169,6 +217,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
   const rootPrefixCls = getPrefixCls();
 
   const passedProps = omit(restProps, ['collapsedWidth']);
+  const mergedItems = React.useMemo(() => normalizeSubMenuItemTitle(items), [items]);
 
   // ======================== Warning ==========================
   if (process.env.NODE_ENV !== 'production') {
@@ -309,6 +358,7 @@ const InternalMenu = forwardRef<RcMenuRef, InternalMenuProps>((props, ref) => {
           selectable={mergedSelectable}
           onClick={onItemClick}
           {...passedProps}
+          items={mergedItems}
           inlineCollapsed={mergedInlineCollapsed}
           style={{ ...mergedStyles.root, ...contextStyle, ...style }}
           className={menuClassName}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close #48850

### 💡 Background and Solution

When `Menu` items with `children` are converted into sub-menus, `@rc-component/menu` uses `label` as the rendered sub-menu title. The original `items[].title` value is not preserved, so collapsed sub-menu title content cannot expose the configured display title.

This preserves `items[].title` for sub-menu items as an internal title value and applies it to the rendered collapsed title content, including the span-label-with-icon path.

Validated with:

- `npm test -- components/menu/__tests__/index.test.tsx components/menu/__tests__/type.test.tsx --runInBand`
- `eslint components/menu/menu.tsx components/menu/SubMenu.tsx components/menu/interface.ts components/menu/__tests__/index.test.tsx components/menu/__tests__/type.test.tsx`
- `npm run lint:md -- components/menu/index.en-US.md components/menu/index.zh-CN.md`
- `npm run tsc -- --pretty false` reports existing Table demo `FullToken.antCls` errors outside this change.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Menu SubMenu `title` in items API not showing in collapsed state. |
| 🇨🇳 Chinese | 修复 Menu items API 中 SubMenu 的 `title` 在收缩状态下不展示的问题。 |