### PR TITLE
refactor: remove unused Form.Item split styles

### DIFF
--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -214,18 +214,6 @@ const genFormItemStyle: GenerateStyle<FormToken, CSSObject> = (token) => {
         display: 'none',
       },
 
-      '&-has-warning': {
-        [`${formItemCls}-split`]: {
-          color: token.colorError,
-        },
-      },
-
-      '&-has-error': {
-        [`${formItemCls}-split`]: {
-          color: token.colorWarning,
-        },
-      },
-
       // ==============================================================
       // =                            Label                           =
       // ==============================================================


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [x] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

`ant-form-split` 曾用于早期 Form demo 中手写的表单控件分隔符，例如日期范围中间的 `-`。后续 demo 用法已移除，v4 新 Form 迁移后样式名变为 `ant-form-item-split`，但当前 Form 和 `@rc-component/form` 均不再生成或引用该 class。

本 PR 删除 Form.Item 中已无渲染入口的 `form-item-split` 状态样式，清理历史遗留代码。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |