### PR TITLE
Revert "fix(table): prevent ellipsis from disappearing on cell click"

### DIFF
--- a/components/table/style/ellipsis.ts
+++ b/components/table/style/ellipsis.ts
@@ -10,7 +10,6 @@ const genEllipsisStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
     [`${componentCls}-wrapper`]: {
       [`${componentCls}-cell-ellipsis`]: {
         ...textEllipsis,
-        overflow: 'clip',
         wordBreak: 'keep-all',
 
         // Fixed first or last should special process
@@ -21,7 +20,6 @@ const genEllipsisStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
           overflow: 'visible',
           [`${componentCls}-cell-content`]: {
             ...textEllipsis,
-            overflow: 'clip',
             display: 'block',
           },
         },


### PR DESCRIPTION
- Reverts ant-design/ant-design#58234

这个是最新版 Chrome 浏览器的问题，不应该人为干涉

<img width="1872" height="370" alt="image" src="https://github.com/user-attachments/assets/3f20d3d6-385f-4ea8-b245-b70324db55b6" />