### PR TITLE
fix: avoid Form warning hook compiler memoization

### DIFF
--- a/.github/workflows/visual-regression-diff-build.yml
+++ b/.github/workflows/visual-regression-diff-build.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # v1
+      - run: ut config set registry https://registry.npmjs.org/ --global
       - run: ut
 
       - name: generate image snapshots
@@ -52,6 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # v1
+      - run: ut config set registry https://registry.npmjs.org/ --global
       - run: ut
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/components/form/FormItem/index.tsx
+++ b/components/form/FormItem/index.tsx
@@ -107,6 +107,8 @@ function genEmptyMeta(): Meta {
 }
 
 function InternalFormItem<Values = any>(props: FormItemProps<Values>): React.ReactElement {
+  'use no memo';
+
   const {
     name,
     noStyle,

--- a/components/form/FormList.tsx
+++ b/components/form/FormList.tsx
@@ -35,6 +35,8 @@ const FormList: React.FC<FormListProps> = ({
   children,
   ...props
 }) => {
+  'use no memo';
+
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('Form.List');
 

--- a/components/form/__tests__/compiler.test.ts
+++ b/components/form/__tests__/compiler.test.ts
@@ -1,11 +1,12 @@
 import fs from 'node:fs';
+import path from 'node:path';
 
 import * as babel from '@babel/core';
 import getBabelCommonConfig from '@ant-design/tools/lib/getBabelCommonConfig';
 
 describe('Form compiler output', () => {
   it('should not memoize warning hook with React Compiler', () => {
-    const filename = 'components/form/hooks/useFormWarning.ts';
+    const filename = path.resolve(__dirname, '../hooks/useFormWarning.ts');
     const source = fs.readFileSync(filename, 'utf8');
     const babelConfig = getBabelCommonConfig(false, { enabledReactCompiler: true });
     const result = babel.transformSync(source, {
@@ -15,6 +16,8 @@ describe('Form compiler output', () => {
       configFile: false,
     });
 
+    expect(result).toBeTruthy();
+    expect(result?.code).toBeDefined();
     expect(result?.code).not.toContain('react.memo_cache_sentinel');
   });
 });

--- a/components/form/__tests__/compiler.test.ts
+++ b/components/form/__tests__/compiler.test.ts
@@ -5,8 +5,15 @@ import * as babel from '@babel/core';
 import getBabelCommonConfig from '@ant-design/tools/lib/getBabelCommonConfig';
 
 describe('Form compiler output', () => {
-  it('should not memoize warning hook with React Compiler', () => {
-    const filename = path.resolve(__dirname, '../hooks/useFormWarning.ts');
+  const files = [
+    '../FormItem/index.tsx',
+    '../FormList.tsx',
+    '../hooks/useFormItemStatus.ts',
+    '../hooks/useFormWarning.ts',
+  ];
+
+  it.each(files)('should not memoize warning hook in %s with React Compiler', (file) => {
+    const filename = path.resolve(__dirname, file);
     const source = fs.readFileSync(filename, 'utf8');
     const babelConfig = getBabelCommonConfig(false, { enabledReactCompiler: true });
     const result = babel.transformSync(source, {

--- a/components/form/__tests__/compiler.test.ts
+++ b/components/form/__tests__/compiler.test.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs';
+
+import * as babel from '@babel/core';
+import getBabelCommonConfig from '@ant-design/tools/lib/getBabelCommonConfig';
+
+describe('Form compiler output', () => {
+  it('should not memoize warning hook with React Compiler', () => {
+    const filename = 'components/form/hooks/useFormWarning.ts';
+    const source = fs.readFileSync(filename, 'utf8');
+    const babelConfig = getBabelCommonConfig(false, { enabledReactCompiler: true });
+    const result = babel.transformSync(source, {
+      ...babelConfig,
+      filename,
+      babelrc: false,
+      configFile: false,
+    });
+
+    expect(result?.code).not.toContain('react.memo_cache_sentinel');
+  });
+});

--- a/components/form/hooks/useFormItemStatus.ts
+++ b/components/form/hooks/useFormItemStatus.ts
@@ -11,6 +11,8 @@ type UseFormItemStatus = () => {
 };
 
 const useFormItemStatus: UseFormItemStatus = () => {
+  'use no memo';
+
   const { status, errors = [], warnings = [] } = React.useContext(FormItemInputContext);
 
   if (process.env.NODE_ENV !== 'production') {

--- a/components/form/hooks/useFormWarning.ts
+++ b/components/form/hooks/useFormWarning.ts
@@ -6,6 +6,8 @@ import type { FormProps } from '../Form';
 const names: Record<string, number> = {};
 
 export default function useFormWarning({ name }: FormProps) {
+  'use no memo';
+
   const warning = devUseWarning('Form');
 
   React.useEffect(() => {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Fix #56021.

### 💡 Background and Solution

Form's development warning hook calls `devUseWarning`, which reads React context. In the UMD development build with React Compiler enabled, that call can be memoized behind the compiler cache sentinel while `useEffect` still runs on every render. React 19 then reports a hook order mismatch when Form rerenders.

This opts `useFormWarning` out of React Compiler memoization so the warning hook call keeps the same order across renders. A compiler-level regression test verifies that the generated output no longer contains the compiler cache sentinel for this hook.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Form hook order warning in the UMD development build with React 19. |
| 🇨🇳 Chinese | 修复 Form 在 React 19 开发环境使用 UMD 构建时触发 hooks 顺序警告的问题。 |

### ✅ Checks

- `npm test -- --runTestsByPath components/form/__tests__/compiler.test.ts components/form/__tests__/index.test.tsx --runInBand`
- `npm run lint`
