### PR TITLE
fix: avoid untrusted checkout in workflow_run privileged workflow (replaces #58391 as unrelated)

### DIFF
--- a/.github/workflows/visual-regression-persist-finish.yml
+++ b/.github/workflows/visual-regression-persist-finish.yml
@@ -92,9 +92,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          # checkout the head sha/branch that triggered this workflow
-          ref: ${{ github.event.workflow_run.head_sha || github.event.workflow_run.head_branch}}
 
       # We need get persist key first
       - name: Download Visual Regression Ref


### PR DESCRIPTION
Fix CodeQL security alert #3370 (actions/untrusted-checkout/critical).

## Problem
The `visual-regression-persist-finish.yml` workflow runs as a privileged `workflow_run` subscriber and was checking out the SHA/branch from the triggering workflow run. When triggered by a PR from a fork, `github.event.workflow_run.head_sha` could reference untrusted fork code, running in a context with access to repository secrets.

## Fix
Remove the explicit `ref` parameter from `actions/checkout`. The checkout now defaults to the base repository's current branch (trusted), while image snapshot files continue to be supplied via artifact download. The `upload.js` script lives on the trusted base repo.

## Verification
- Removed `ref: ${{ github.event.workflow_run.head_sha || github.event.workflow_run.head_branch }}` from checkout step
- Trust check job still gates execution of sensitive operations (OSS upload with secrets)
- No breaking changes to artifact download or upload logic