### PR TITLE
demo(ConfigProvider): modernize direction demo spacing

### DIFF
--- a/components/config-provider/demo/direction.md
+++ b/components/config-provider/demo/direction.md
@@ -7,17 +7,6 @@
 Components which support rtl direction are listed here, you can toggle the direction in the demo.
 
 ```css
-.button-demo .ant-btn,
-.button-demo .ant-btn-group {
-  margin-inline-end: 8px;
-  margin-bottom: 12px;
-}
-.button-demo .ant-btn-group > .ant-btn,
-.button-demo .ant-btn-group > span > .ant-btn {
-  margin-inline-end: 0;
-  margin-inline-start: 0;
-}
-
 .head-example {
   display: inline-block;
   width: 42px;
@@ -25,14 +14,5 @@ Components which support rtl direction are listed here, you can toggle the direc
   vertical-align: middle;
   background: #eee;
   border-radius: 4px;
-}
-
-.ant-badge:not(.ant-badge-not-a-wrapper) {
-  margin-inline-end: 20px;
-}
-
-.ant-badge-rtl:not(.ant-badge-not-a-wrapper) {
-  margin-inline-end: 0;
-  margin-inline-start: 20px;
 }
 ```

--- a/components/config-provider/demo/direction.tsx
+++ b/components/config-provider/demo/direction.tsx
@@ -34,11 +34,52 @@ import {
 
 type DirectionType = ConfigProviderProps['direction'];
 
-const InputGroup = Input.Group;
-const ButtonGroup = Button.Group;
-
-const { TreeNode } = Tree;
 const { Search } = Input;
+
+const treeData = [
+  {
+    title: 'parent 1',
+    key: '0-0',
+    children: [
+      {
+        title: 'parent 1-0',
+        key: '0-0-0',
+        disabled: true,
+        children: [
+          { title: 'leaf', key: '0-0-0-0', disableCheckbox: true },
+          { title: 'leaf', key: '0-0-0-1' },
+        ],
+      },
+      {
+        title: 'parent 1-1',
+        key: '0-0-1',
+        children: [{ title: <span style={{ color: '#1677ff' }}>sss</span>, key: '0-0-1-0' }],
+      },
+    ],
+  },
+];
+
+const treeSelectData = [
+  {
+    title: 'parent 1',
+    value: '0-1',
+    children: [
+      {
+        title: 'parent 1-0',
+        value: '0-1-1',
+        children: [
+          { title: 'my leaf', value: 'random' },
+          { title: 'your leaf', value: 'random1' },
+        ],
+      },
+      {
+        title: 'parent 1-1',
+        value: 'random2',
+        children: [{ title: <b style={{ color: '#08c' }}>sss</b>, value: 'random3' }],
+      },
+    ],
+  },
+];
 
 const cascaderOptions = [
   {
@@ -213,7 +254,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
       <Row>
         <Col span={12}>
           <Divider titlePlacement="start">Button example</Divider>
-          <div className="button-demo">
+          <Flex wrap gap="small">
             <Button type="primary" icon={<DownloadOutlined />} />
             <Button type="primary" shape="circle" icon={<DownloadOutlined />} />
             <Button type="primary" shape="round" icon={<DownloadOutlined />} />
@@ -223,24 +264,21 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
             <Button type="primary" icon={<DownloadOutlined />}>
               Download
             </Button>
-            <br />
-            <Button.Group>
-              <Button type="primary">
-                <LeftOutlined />
+            <Space.Compact>
+              <Button type="primary" icon={<LeftOutlined />}>
                 Backward
               </Button>
-              <Button type="primary">
+              <Button type="primary" icon={<RightOutlined />} iconPlacement="end">
                 Forward
-                <RightOutlined />
               </Button>
-            </Button.Group>
+            </Space.Compact>
             <Button type="primary" loading>
               Loading
             </Button>
             <Button type="primary" size="small" loading>
               Loading
             </Button>
-          </div>
+          </Flex>
         </Col>
         <Col span={12}>
           <Divider titlePlacement="start">Tree example</Divider>
@@ -250,17 +288,8 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
             defaultExpandedKeys={['0-0-0', '0-0-1']}
             defaultSelectedKeys={['0-0-0', '0-0-1']}
             defaultCheckedKeys={['0-0-0', '0-0-1']}
-          >
-            <TreeNode title="parent 1" key="0-0">
-              <TreeNode title="parent 1-0" key="0-0-0" disabled>
-                <TreeNode title="leaf" key="0-0-0-0" disableCheckbox />
-                <TreeNode title="leaf" key="0-0-0-1" />
-              </TreeNode>
-              <TreeNode title="parent 1-1" key="0-0-1">
-                <TreeNode title={<span style={{ color: '#1677ff' }}>sss</span>} key="0-0-1-0" />
-              </TreeNode>
-            </TreeNode>
-          </Tree>
+            treeData={treeData}
+          />
         </Col>
       </Row>
       <Row>
@@ -268,21 +297,19 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           <Divider titlePlacement="start">Input (Input Group) example</Divider>
           <Flex vertical gap="large">
             <Flex vertical gap="middle">
-              <InputGroup size="large">
-                <Row gutter={8}>
-                  <Col span={5}>
-                    <Input defaultValue="0571" />
-                  </Col>
-                  <Col span={8}>
-                    <Input defaultValue="26888888" />
-                  </Col>
-                </Row>
-              </InputGroup>
-              <InputGroup compact>
+              <Row gutter={8}>
+                <Col span={5}>
+                  <Input size="large" defaultValue="0571" />
+                </Col>
+                <Col span={8}>
+                  <Input size="large" defaultValue="26888888" />
+                </Col>
+              </Row>
+              <Space.Compact>
                 <Input style={{ width: '20%' }} defaultValue="0571" />
                 <Input style={{ width: '30%' }} defaultValue="26888888" />
-              </InputGroup>
-              <InputGroup compact>
+              </Space.Compact>
+              <Space.Compact>
                 <Select
                   defaultValue="Option1"
                   options={[
@@ -292,7 +319,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
                 />
                 <Input style={{ width: '50%' }} defaultValue="input content" />
                 <InputNumber />
-              </InputGroup>
+              </Space.Compact>
               <Search placeholder="input search text" enterButton="Search" size="large" />
               <Space.Compact>
                 {selectBefore}
@@ -352,17 +379,8 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
                   placeholder="Please select"
                   allowClear
                   treeDefaultExpandAll
-                >
-                  <TreeNode title="parent 1" key="0-1">
-                    <TreeNode title="parent 1-0" key="0-1-1">
-                      <TreeNode title="my leaf" key="random" />
-                      <TreeNode title="your leaf" key="random1" />
-                    </TreeNode>
-                    <TreeNode title="parent 1-1" key="random2">
-                      <TreeNode title={<b style={{ color: '#08c' }}>sss</b>} key="random3" />
-                    </TreeNode>
-                  </TreeNode>
-                </TreeSelect>
+                  treeData={treeSelectData}
+                />
               </Col>
             </Row>
             <Row>
@@ -442,23 +460,21 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
               </Col>
               <Col span={12}>
                 <Divider titlePlacement="start">Badge example</Divider>
-                <Badge count={badgeCount}>
-                  <a href="#" className="head-example" />
-                </Badge>
-                <ButtonGroup>
-                  <Button onClick={declineBadge}>
-                    <MinusOutlined />
-                  </Button>
-                  <Button onClick={increaseBadge}>
-                    <PlusOutlined />
-                  </Button>
-                </ButtonGroup>
-                <div style={{ marginTop: 12 }}>
+                <Flex align="center" gap="middle">
+                  <Badge count={badgeCount}>
+                    <a href="#" className="head-example" />
+                  </Badge>
+                  <Space.Compact>
+                    <Button icon={<MinusOutlined />} onClick={declineBadge} />
+                    <Button icon={<PlusOutlined />} onClick={increaseBadge} />
+                  </Space.Compact>
+                </Flex>
+                <Flex align="center" gap="middle" style={{ marginTop: 12 }}>
                   <Badge dot={showBadge}>
                     <a href="#" className="head-example" />
                   </Badge>
                   <Switch onChange={onChangeBadge} checked={showBadge} />
-                </div>
+                </Flex>
               </Col>
             </Row>
           </Flex>

--- a/components/config-provider/demo/direction.tsx
+++ b/components/config-provider/demo/direction.tsx
@@ -16,6 +16,7 @@ import {
   Col,
   ConfigProvider,
   Divider,
+  Flex,
   Input,
   InputNumber,
   Modal,
@@ -165,7 +166,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
   // ==== End Badge ====
 
   return (
-    <div className="direction-components">
+    <Flex className="direction-components" vertical gap="large">
       <Row>
         <Col span={24}>
           <Divider titlePlacement="start">Cascader example</Divider>
@@ -187,7 +188,6 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           />
         </Col>
       </Row>
-      <br />
       <Row>
         <Col span={12}>
           <Divider titlePlacement="start">Switch example</Divider>
@@ -210,7 +210,6 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           </Radio.Group>
         </Col>
       </Row>
-      <br />
       <Row>
         <Col span={12}>
           <Divider titlePlacement="start">Button example</Divider>
@@ -264,220 +263,213 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           </Tree>
         </Col>
       </Row>
-      <br />
       <Row>
         <Col span={24}>
           <Divider titlePlacement="start">Input (Input Group) example</Divider>
-          <InputGroup size="large">
-            <Row gutter={8}>
-              <Col span={5}>
-                <Input defaultValue="0571" />
+          <Flex vertical gap="large">
+            <Flex vertical gap="middle">
+              <InputGroup size="large">
+                <Row gutter={8}>
+                  <Col span={5}>
+                    <Input defaultValue="0571" />
+                  </Col>
+                  <Col span={8}>
+                    <Input defaultValue="26888888" />
+                  </Col>
+                </Row>
+              </InputGroup>
+              <InputGroup compact>
+                <Input style={{ width: '20%' }} defaultValue="0571" />
+                <Input style={{ width: '30%' }} defaultValue="26888888" />
+              </InputGroup>
+              <InputGroup compact>
+                <Select
+                  defaultValue="Option1"
+                  options={[
+                    { label: 'Option1', value: 'Option1' },
+                    { label: 'Option2', value: 'Option2' },
+                  ]}
+                />
+                <Input style={{ width: '50%' }} defaultValue="input content" />
+                <InputNumber />
+              </InputGroup>
+              <Search placeholder="input search text" enterButton="Search" size="large" />
+              <Space.Compact>
+                {selectBefore}
+                <Input defaultValue="mysite" />
+                {selectAfter}
+              </Space.Compact>
+            </Flex>
+            <Row>
+              <Col span={12}>
+                <Divider titlePlacement="start">Select example</Divider>
+                <Space wrap>
+                  <Select
+                    mode="multiple"
+                    defaultValue="مورچه"
+                    style={{ width: 120 }}
+                    options={[
+                      { label: 'jack', value: 'jack' },
+                      { label: 'مورچه', value: 'مورچه' },
+                      { label: 'disabled', value: 'disabled', disabled: true },
+                      { label: 'yiminghe', value: 'Yiminghe' },
+                    ]}
+                  />
+                  <Select
+                    disabled
+                    defaultValue="مورچه"
+                    style={{ width: 120 }}
+                    options={[{ label: 'مورچه', value: 'مورچه' }]}
+                  />
+                  <Select
+                    loading
+                    defaultValue="مورچه"
+                    style={{ width: 120 }}
+                    options={[{ label: 'مورچه', value: 'مورچه' }]}
+                  />
+                  <Select
+                    showSearch
+                    style={{ width: 200 }}
+                    placeholder="Select a person"
+                    options={[
+                      { label: 'jack', value: 'jack' },
+                      { label: 'سعید', value: 'سعید' },
+                      { label: 'Tom', value: 'tom' },
+                    ]}
+                  />
+                </Space>
               </Col>
-              <Col span={8}>
-                <Input defaultValue="26888888" />
+              <Col span={12}>
+                <Divider titlePlacement="start">TreeSelect example</Divider>
+                <TreeSelect
+                  showSearch
+                  style={{ width: '100%' }}
+                  styles={{
+                    popup: {
+                      root: { maxHeight: 400, overflow: 'auto' },
+                    },
+                  }}
+                  placeholder="Please select"
+                  allowClear
+                  treeDefaultExpandAll
+                >
+                  <TreeNode title="parent 1" key="0-1">
+                    <TreeNode title="parent 1-0" key="0-1-1">
+                      <TreeNode title="my leaf" key="random" />
+                      <TreeNode title="your leaf" key="random1" />
+                    </TreeNode>
+                    <TreeNode title="parent 1-1" key="random2">
+                      <TreeNode title={<b style={{ color: '#08c' }}>sss</b>} key="random3" />
+                    </TreeNode>
+                  </TreeNode>
+                </TreeSelect>
               </Col>
             </Row>
-          </InputGroup>
-          <br />
-          <InputGroup compact>
-            <Input style={{ width: '20%' }} defaultValue="0571" />
-            <Input style={{ width: '30%' }} defaultValue="26888888" />
-          </InputGroup>
-          <br />
-          <InputGroup compact>
-            <Select
-              defaultValue="Option1"
-              options={[
-                { label: 'Option1', value: 'Option1' },
-                { label: 'Option2', value: 'Option2' },
-              ]}
-            />
-            <Input style={{ width: '50%' }} defaultValue="input content" />
-            <InputNumber />
-          </InputGroup>
-          <br />
-          <Search placeholder="input search text" enterButton="Search" size="large" />
-          <br />
-          <br />
-          <div style={{ marginBottom: 16 }}>
-            <Space.Compact>
-              {selectBefore}
-              <Input defaultValue="mysite" />
-              {selectAfter}
-            </Space.Compact>
-          </div>
-          <br />
-          <Row>
-            <Col span={12}>
-              <Divider titlePlacement="start">Select example</Divider>
-              <Space wrap>
-                <Select
-                  mode="multiple"
-                  defaultValue="مورچه"
-                  style={{ width: 120 }}
-                  options={[
-                    { label: 'jack', value: 'jack' },
-                    { label: 'مورچه', value: 'مورچه' },
-                    { label: 'disabled', value: 'disabled', disabled: true },
-                    { label: 'yiminghe', value: 'Yiminghe' },
-                  ]}
-                />
-                <Select
-                  disabled
-                  defaultValue="مورچه"
-                  style={{ width: 120 }}
-                  options={[{ label: 'مورچه', value: 'مورچه' }]}
-                />
-                <Select
-                  loading
-                  defaultValue="مورچه"
-                  style={{ width: 120 }}
-                  options={[{ label: 'مورچه', value: 'مورچه' }]}
-                />
-                <Select
-                  showSearch
-                  style={{ width: 200 }}
-                  placeholder="Select a person"
-                  options={[
-                    { label: 'jack', value: 'jack' },
-                    { label: 'سعید', value: 'سعید' },
-                    { label: 'Tom', value: 'tom' },
-                  ]}
-                />
-              </Space>
-            </Col>
-            <Col span={12}>
-              <Divider titlePlacement="start">TreeSelect example</Divider>
-              <TreeSelect
-                showSearch
-                style={{ width: '100%' }}
-                styles={{
-                  popup: {
-                    root: { maxHeight: 400, overflow: 'auto' },
-                  },
-                }}
-                placeholder="Please select"
-                allowClear
-                treeDefaultExpandAll
-              >
-                <TreeNode title="parent 1" key="0-1">
-                  <TreeNode title="parent 1-0" key="0-1-1">
-                    <TreeNode title="my leaf" key="random" />
-                    <TreeNode title="your leaf" key="random1" />
-                  </TreeNode>
-                  <TreeNode title="parent 1-1" key="random2">
-                    <TreeNode title={<b style={{ color: '#08c' }}>sss</b>} key="random3" />
-                  </TreeNode>
-                </TreeNode>
-              </TreeSelect>
-            </Col>
-          </Row>
-          <br />
-          <Row>
-            <Col span={24}>
-              <Divider titlePlacement="start">Modal example</Divider>
-              <Button type="primary" onClick={showModal}>
-                Open Modal
-              </Button>
-              <Modal title="پنچره ساده" open={modalOpen} onOk={handleOk} onCancel={handleCancel}>
-                <p>نگاشته‌های خود را اینجا قراردهید</p>
-                <p>نگاشته‌های خود را اینجا قراردهید</p>
-                <p>نگاشته‌های خود را اینجا قراردهید</p>
-              </Modal>
-            </Col>
-          </Row>
-          <br />
-          <Row>
-            <Col span={24}>
-              <Divider titlePlacement="start">Steps example</Divider>
-              <Steps
-                progressDot
-                current={currentStep}
-                items={[
-                  {
-                    title: 'Finished',
-                    description: 'This is a description.',
-                  },
-                  {
-                    title: 'In Progress',
-                    description: 'This is a description.',
-                  },
-                  {
-                    title: 'Waiting',
-                    description: 'This is a description.',
-                  },
-                ]}
-              />
-              <br />
-              <Steps
-                current={currentStep}
-                onChange={onStepsChange}
-                items={[
-                  {
-                    title: 'Step 1',
-                    description: 'This is a description.',
-                  },
-                  {
-                    title: 'Step 2',
-                    description: 'This is a description.',
-                  },
-                  {
-                    title: 'Step 3',
-                    description: 'This is a description.',
-                  },
-                ]}
-              />
-            </Col>
-          </Row>
-          <br />
-          <Row>
-            <Col span={12}>
-              <Divider titlePlacement="start">Rate example</Divider>
-              <Rate defaultValue={2.5} />
-              <br />
-              <strong>* Note:</strong> Half star not implemented in RTL direction, it will be
-              supported after{' '}
-              <a
-                href="https://github.com/react-component/rate"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                rc-rate
-              </a>{' '}
-              implement rtl support.
-            </Col>
-            <Col span={12}>
-              <Divider titlePlacement="start">Badge example</Divider>
-              <Badge count={badgeCount}>
-                <a href="#" className="head-example" />
-              </Badge>
-              <ButtonGroup>
-                <Button onClick={declineBadge}>
-                  <MinusOutlined />
+            <Row>
+              <Col span={24}>
+                <Divider titlePlacement="start">Modal example</Divider>
+                <Button type="primary" onClick={showModal}>
+                  Open Modal
                 </Button>
-                <Button onClick={increaseBadge}>
-                  <PlusOutlined />
-                </Button>
-              </ButtonGroup>
-              <div style={{ marginTop: 12 }}>
-                <Badge dot={showBadge}>
+                <Modal title="پنچره ساده" open={modalOpen} onOk={handleOk} onCancel={handleCancel}>
+                  <p>نگاشته‌های خود را اینجا قراردهید</p>
+                  <p>نگاشته‌های خود را اینجا قراردهید</p>
+                  <p>نگاشته‌های خود را اینجا قراردهید</p>
+                </Modal>
+              </Col>
+            </Row>
+            <Row>
+              <Col span={24}>
+                <Divider titlePlacement="start">Steps example</Divider>
+                <Flex vertical gap="middle">
+                  <Steps
+                    progressDot
+                    current={currentStep}
+                    items={[
+                      {
+                        title: 'Finished',
+                        description: 'This is a description.',
+                      },
+                      {
+                        title: 'In Progress',
+                        description: 'This is a description.',
+                      },
+                      {
+                        title: 'Waiting',
+                        description: 'This is a description.',
+                      },
+                    ]}
+                  />
+                  <Steps
+                    current={currentStep}
+                    onChange={onStepsChange}
+                    items={[
+                      {
+                        title: 'Step 1',
+                        description: 'This is a description.',
+                      },
+                      {
+                        title: 'Step 2',
+                        description: 'This is a description.',
+                      },
+                      {
+                        title: 'Step 3',
+                        description: 'This is a description.',
+                      },
+                    ]}
+                  />
+                </Flex>
+              </Col>
+            </Row>
+            <Row>
+              <Col span={12}>
+                <Divider titlePlacement="start">Rate example</Divider>
+                <Flex vertical gap="small">
+                  <Rate defaultValue={2.5} />
+                  <div>
+                    <strong>* Note:</strong> Half star not implemented in RTL direction, it will be
+                    supported after{' '}
+                    <a
+                      href="https://github.com/react-component/rate"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      rc-rate
+                    </a>{' '}
+                    implement rtl support.
+                  </div>
+                </Flex>
+              </Col>
+              <Col span={12}>
+                <Divider titlePlacement="start">Badge example</Divider>
+                <Badge count={badgeCount}>
                   <a href="#" className="head-example" />
                 </Badge>
-                <Switch onChange={onChangeBadge} checked={showBadge} />
-              </div>
-            </Col>
-          </Row>
+                <ButtonGroup>
+                  <Button onClick={declineBadge}>
+                    <MinusOutlined />
+                  </Button>
+                  <Button onClick={increaseBadge}>
+                    <PlusOutlined />
+                  </Button>
+                </ButtonGroup>
+                <div style={{ marginTop: 12 }}>
+                  <Badge dot={showBadge}>
+                    <a href="#" className="head-example" />
+                  </Badge>
+                  <Switch onChange={onChangeBadge} checked={showBadge} />
+                </div>
+              </Col>
+            </Row>
+          </Flex>
         </Col>
       </Row>
-      <br />
-      <br />
       <Row>
         <Col span={24}>
           <Divider titlePlacement="start">Pagination example</Divider>
           <Pagination showSizeChanger defaultCurrent={3} total={500} />
         </Col>
       </Row>
-      <br />
       <Row>
         <Col span={24}>
           <Divider titlePlacement="start">Grid System example</Divider>
@@ -518,7 +510,7 @@ const Page: React.FC<{ placement: Placement }> = ({ placement }) => {
           </div>
         </Col>
       </Row>
-    </div>
+    </Flex>
   );
 };
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

None

### 💡 需求背景和解决方案

ConfigProvider 的 RTL direction demo 中仍使用 `<br />`、`Button.Group`、`Input.Group` 和 `TreeNode` 等旧写法来控制布局或声明数据，维护成本较高，间距也不够稳定。

这个 PR 使用 `Flex` 和 `Space.Compact` 统一整理 demo 间距，并将 Tree / TreeSelect 示例改为 `treeData` 数据配置形式，同时移除不再需要的 demo 样式。不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述              |
| ------- | --------------------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志          |
