### PR TITLE
fix(Form): improve useWatch field typing

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import FieldForm, { List, useWatch } from '@rc-component/form';
+import FieldForm, { List, useWatch as useRcWatch } from '@rc-component/form';
 import type {
   FormRef,
   InternalNamePath,
@@ -26,9 +26,85 @@ import type { FormTooltipProps } from './FormItemLabel';
 import useForm from './hooks/useForm';
 import type { FormInstance } from './hooks/useForm';
 import useFormWarning from './hooks/useFormWarning';
-import type { FormLabelAlign, ScrollFocusOptions } from './interface';
+import type { FormLabelAlign, NamePath, ScrollFocusOptions, Store } from './interface';
 import useStyle from './style';
 import ValidateMessagesContext from './validateMessagesContext';
+
+type ReturnPromise<T> = T extends Promise<infer ValueType> ? ValueType : never;
+type GetFormValues<TForm extends FormInstance> = ReturnPromise<ReturnType<TForm['validateFields']>>;
+type WatchOptions<TForm extends FormInstance = FormInstance> = {
+  form?: TForm;
+  preserve?: boolean;
+};
+type PathValue<Values, Path> = Path extends readonly [infer FieldKey, ...infer RestPath]
+  ? FieldKey extends keyof NonNullable<Values>
+    ? RestPath extends []
+      ? NonNullable<Values>[FieldKey] | Extract<Values, null | undefined>
+      :
+          | PathValue<NonNullable<NonNullable<Values>[FieldKey]>, RestPath>
+          | Extract<NonNullable<Values>[FieldKey], null | undefined>
+          | Extract<Values, null | undefined>
+    : never
+  : Path extends keyof NonNullable<Values>
+    ? NonNullable<Values>[Path] | Extract<Values, null | undefined>
+    : never;
+
+function useWatch<TForm extends FormInstance>(
+  dependencies: [],
+  form?: TForm | WatchOptions<TForm>,
+): GetFormValues<TForm>;
+function useWatch<TForm extends FormInstance, SelectedValue = unknown>(
+  selector: (values: GetFormValues<TForm>) => SelectedValue,
+  form?: TForm | WatchOptions<TForm>,
+): SelectedValue;
+function useWatch<ValueType = Store, SelectedValue = unknown>(
+  selector: (values: ValueType) => SelectedValue,
+  form?: FormInstance | WatchOptions<FormInstance>,
+): SelectedValue;
+function useWatch<
+  TForm extends FormInstance,
+  TField1 extends keyof GetFormValues<TForm>,
+  TField2 extends keyof NonNullable<GetFormValues<TForm>[TField1]>,
+  TField3 extends keyof NonNullable<NonNullable<GetFormValues<TForm>[TField1]>[TField2]>,
+  TField4 extends keyof NonNullable<
+    NonNullable<NonNullable<GetFormValues<TForm>[TField1]>[TField2]>[TField3]
+  >,
+>(
+  dependencies: [TField1, TField2, TField3, TField4],
+  form?: TForm | WatchOptions<TForm>,
+): PathValue<GetFormValues<TForm>, [TField1, TField2, TField3, TField4]>;
+function useWatch<
+  TForm extends FormInstance,
+  TField1 extends keyof GetFormValues<TForm>,
+  TField2 extends keyof NonNullable<GetFormValues<TForm>[TField1]>,
+  TField3 extends keyof NonNullable<NonNullable<GetFormValues<TForm>[TField1]>[TField2]>,
+>(
+  dependencies: [TField1, TField2, TField3],
+  form?: TForm | WatchOptions<TForm>,
+): PathValue<GetFormValues<TForm>, [TField1, TField2, TField3]>;
+function useWatch<
+  TForm extends FormInstance,
+  TField1 extends keyof GetFormValues<TForm>,
+  TField2 extends keyof NonNullable<GetFormValues<TForm>[TField1]>,
+>(
+  dependencies: [TField1, TField2],
+  form?: TForm | WatchOptions<TForm>,
+): PathValue<GetFormValues<TForm>, [TField1, TField2]>;
+function useWatch<TForm extends FormInstance, TField extends keyof GetFormValues<TForm>>(
+  dependencies: TField | [TField],
+  form?: TForm | WatchOptions<TForm>,
+): PathValue<GetFormValues<TForm>, TField>;
+function useWatch<
+  TForm extends FormInstance,
+  const TNamePath extends NamePath<GetFormValues<TForm>>,
+>(
+  dependencies: TNamePath,
+  form?: TForm | WatchOptions<TForm>,
+): PathValue<GetFormValues<TForm>, TNamePath>;
+function useWatch<ValueType = Store>(dependencies: NamePath): ValueType;
+function useWatch(...args: Parameters<typeof useRcWatch>) {
+  return useRcWatch(...args);
+}
 
 export type RequiredMark =
   | boolean

--- a/components/form/__tests__/type.test.tsx
+++ b/components/form/__tests__/type.test.tsx
@@ -6,8 +6,14 @@ import Input from '../../input';
 
 interface FormValues {
   username?: string;
+  value3: string;
   path1?: { path2?: number };
 }
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
 
 describe('Form.typescript', () => {
   it('Form.Item', () => {
@@ -82,13 +88,26 @@ describe('Form.typescript', () => {
     expect(Demo).toBeTruthy();
   });
 
-  // TODO: @crazyair fix for value types
   it('useWatch', () => {
     const Demo: React.FC = () => {
       const [form] = Form.useForm<FormValues>();
       const value = Form.useWatch('username', form);
+      const value3 = Form.useWatch('value3', form);
+      const pathValue = Form.useWatch(['path1', 'path2'], form);
+      const typeCheck: [
+        Expect<Equal<IsAny<typeof value3>, false>>,
+        Expect<Equal<typeof value3, string>>,
+        Expect<Equal<typeof pathValue, number | undefined>>,
+      ] = [true, true, true];
 
-      return <Form form={form}>{value}</Form>;
+      // @ts-expect-error not a field of FormValues
+      Form.useWatch('unknown', form);
+      // @ts-expect-error not a nested field of FormValues
+      Form.useWatch(['path1', 'unknown'], form);
+
+      expect(typeCheck).toBeTruthy();
+
+      return <Form form={form}>{value ?? value3 ?? pathValue}</Form>;
     };
 
     expect(Demo).toBeTruthy();


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #58405

### 💡 Background and Solution

`Form.useWatch` did not infer watched field value types correctly when using a typed form instance. It could fall back to `any`, and invalid typed field paths were still accepted by TypeScript.

This change adds typed overloads for `Form.useWatch` in the Ant Design Form wrapper while keeping runtime behavior delegated to the underlying form hook. Typed form instances can now infer watched field value types from the form values generic, including nested paths, and invalid typed field paths are rejected.

Validated with:

- `eslint components/form/Form.tsx components/form/__tests__/type.test.tsx --max-warnings=0`
- `npm test -- --runTestsByPath components/form/__tests__/type.test.tsx --runInBand`
- `git diff --cached --check`

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve Form `useWatch` TypeScript definitions to infer watched field values and reject invalid typed field paths. |
| 🇨🇳 Chinese | 改进 Form `useWatch` TypeScript 类型定义，使其能推导监听字段值并拒绝类型化表单中的无效字段路径。 |