### PR TITLE
docs: add For Agents page with ready-to-use prompt

### DIFF
--- a/docs/react/for-agents.en-US.md
+++ b/docs/react/for-agents.en-US.md
@@ -14,16 +14,62 @@ This page provides a ready-to-use prompt that lets any AI coding agent work with
 Copy into your agent conversation or automation runner.
 
 ```text
-Read https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md and follow the instructions to use Ant Design.
+Read https://ant.design/for-agents.md and follow the instructions to use Ant Design.
 
 If you can install skills, run:
 npx skills add ant-design/ant-design-cli
 ```
 
-## Want more?
+## What the agent gets
 
-| Capability                     | Guide                         |
-| ------------------------------ | ----------------------------- |
-| Structured docs for LLMs       | [LLMs.txt](/docs/react/llms)  |
-| MCP Server for IDE integration | [MCP Server](/docs/react/mcp) |
-| Full CLI reference             | [CLI](/docs/react/cli)        |
+### CLI — offline knowledge and project tools
+
+[`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) ships all metadata locally — every prop, token, demo, and changelog entry for antd v3 / v4 / v5 / v6 — queryable in milliseconds, fully offline.
+
+```bash
+npm install -g @ant-design/cli
+```
+
+```bash
+antd info Button                    # Component props, types, defaults
+antd demo Select basic              # Runnable demo source code
+antd token DatePicker               # Design Token values (v5+)
+antd semantic Table                 # classNames / styles structure
+antd changelog 4.24.0 5.0.0 Select  # API diff across versions
+antd doctor                         # Diagnose project issues
+antd lint ./src                     # Check deprecated APIs & best practices
+antd migrate 4 5 --apply ./src      # Agent-ready migration prompt
+```
+
+Full reference: [CLI](/docs/react/cli)
+
+### MCP Server — IDE integration
+
+The CLI also runs as an MCP server with 8 tools and 2 prompts for IDE integration (Claude Code, Cursor, VS Code, etc.).
+
+```json
+{
+  "mcpServers": {
+    "antd": {
+      "command": "npx",
+      "args": ["-y", "@ant-design/cli", "mcp"]
+    }
+  }
+}
+```
+
+Full reference: [MCP Server](/docs/react/mcp)
+
+### LLMs.txt — structured docs for LLMs
+
+Feed complete component documentation directly into AI context:
+
+| File | Description |
+| --- | --- |
+| [llms.txt](https://ant.design/llms.txt) | Navigation file with links to all docs and components |
+| [llms-full.txt](https://ant.design/llms-full.txt) | Full component documentation (English) |
+| [llms-full-cn.txt](https://ant.design/llms-full-cn.txt) | Full component documentation (Chinese) |
+
+Single component docs are also available at `https://ant.design/components/<name>.md`.
+
+Full reference: [LLMs.txt](/docs/react/llms)

--- a/docs/react/for-agents.en-US.md
+++ b/docs/react/for-agents.en-US.md
@@ -14,20 +14,13 @@ This page provides a ready-to-use prompt that lets any AI coding agent work with
 Copy into your agent conversation or automation runner.
 
 ```text
-Read https://ant.design/llms-full.txt and follow the Ant Design conventions when writing UI code.
+Install the Ant Design CLI and follow the instructions to use it.
+
+npm install -g @ant-design/cli
 
 If you can install skills, run:
 npx skills add ant-design/ant-design-cli
 ```
-
-That's it — two lines give your agent full Ant Design knowledge and CLI access.
-
-## What happens
-
-| Line | What it does |
-| --- | --- |
-| `Read https://ant.design/llms-full.txt ...` | Feeds the agent complete component docs — props, tokens, demos, and best practices — so it writes idiomatic antd code out of the box. |
-| `npx skills add ant-design/ant-design-cli` | Installs the [@ant-design/cli](https://github.com/ant-design/ant-design-cli) skill, teaching the agent to query APIs, debug issues, lint code, and run migrations via `antd` commands. |
 
 ## Want more?
 

--- a/docs/react/for-agents.en-US.md
+++ b/docs/react/for-agents.en-US.md
@@ -14,9 +14,7 @@ This page provides a ready-to-use prompt that lets any AI coding agent work with
 Copy into your agent conversation or automation runner.
 
 ```text
-Install the Ant Design CLI and follow the instructions to use it.
-
-npm install -g @ant-design/cli
+Read https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md and follow the instructions to use Ant Design.
 
 If you can install skills, run:
 npx skills add ant-design/ant-design-cli

--- a/docs/react/for-agents.en-US.md
+++ b/docs/react/for-agents.en-US.md
@@ -1,0 +1,38 @@
+---
+group:
+  title: AI
+  order: 0.9
+order: 0
+title: For Agents
+tag: New
+---
+
+This page provides a ready-to-use prompt that lets any AI coding agent work with Ant Design effectively.
+
+## Copy this prompt
+
+Copy into your agent conversation or automation runner.
+
+```text
+Read https://ant.design/llms-full.txt and follow the Ant Design conventions when writing UI code.
+
+If you can install skills, run:
+npx skills add ant-design/ant-design-cli
+```
+
+That's it — two lines give your agent full Ant Design knowledge and CLI access.
+
+## What happens
+
+| Line | What it does |
+| --- | --- |
+| `Read https://ant.design/llms-full.txt ...` | Feeds the agent complete component docs — props, tokens, demos, and best practices — so it writes idiomatic antd code out of the box. |
+| `npx skills add ant-design/ant-design-cli` | Installs the [@ant-design/cli](https://github.com/ant-design/ant-design-cli) skill, teaching the agent to query APIs, debug issues, lint code, and run migrations via `antd` commands. |
+
+## Want more?
+
+| Capability                     | Guide                         |
+| ------------------------------ | ----------------------------- |
+| Structured docs for LLMs       | [LLMs.txt](/docs/react/llms)  |
+| MCP Server for IDE integration | [MCP Server](/docs/react/mcp) |
+| Full CLI reference             | [CLI](/docs/react/cli)        |

--- a/docs/react/for-agents.zh-CN.md
+++ b/docs/react/for-agents.zh-CN.md
@@ -14,16 +14,62 @@ tag: New
 复制到你的 Agent 对话或自动化流程中。
 
 ```text
-Read https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md and follow the instructions to use Ant Design.
+Read https://ant.design/for-agents.md and follow the instructions to use Ant Design.
 
 If you can install skills, run:
 npx skills add ant-design/ant-design-cli
 ```
 
-## 更多能力 {#learn-more}
+## Agent 获得什么 {#what-the-agent-gets}
 
-| 能力                | 指南                             |
-| ------------------- | -------------------------------- |
-| LLM 结构化文档      | [LLMs.txt](/docs/react/llms-cn)  |
-| IDE 集成 MCP Server | [MCP Server](/docs/react/mcp-cn) |
-| 完整 CLI 参考       | [CLI](/docs/react/cli-cn)        |
+### CLI — 离线知识和项目工具 {#cli}
+
+[`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) 将所有元数据随包安装 — antd v3 / v4 / v5 / v6 的每个 Prop、Token、Demo 和 Changelog 条目 — 毫秒级查询，完全离线。
+
+```bash
+npm install -g @ant-design/cli
+```
+
+```bash
+antd info Button                    # 组件 Props、类型、默认值
+antd demo Select basic              # 可运行的 Demo 源码
+antd token DatePicker               # Design Token 值（v5+）
+antd semantic Table                 # classNames / styles 结构
+antd changelog 4.24.0 5.0.0 Select  # 跨版本 API 差异对比
+antd doctor                         # 诊断项目配置问题
+antd lint ./src                     # 检查废弃 API 和最佳实践
+antd migrate 4 5 --apply ./src      # 生成 Agent 迁移提示
+```
+
+完整参考：[CLI](/docs/react/cli-cn)
+
+### MCP Server — IDE 集成 {#mcp}
+
+CLI 同时支持作为 MCP 服务器运行，提供 8 个工具和 2 个提示词，支持 IDE 集成（Claude Code、Cursor、VS Code 等）。
+
+```json
+{
+  "mcpServers": {
+    "antd": {
+      "command": "npx",
+      "args": ["-y", "@ant-design/cli", "mcp"]
+    }
+  }
+}
+```
+
+完整参考：[MCP Server](/docs/react/mcp-cn)
+
+### LLMs.txt — LLM 结构化文档 {#llms-txt}
+
+将完整的组件文档直接注入 AI 上下文：
+
+| 文件                                                    | 说明                               |
+| ------------------------------------------------------- | ---------------------------------- |
+| [llms.txt](https://ant.design/llms.txt)                 | 导航文件，包含所有文档和组件的链接 |
+| [llms-full.txt](https://ant.design/llms-full.txt)       | 完整的组件文档（英文）             |
+| [llms-full-cn.txt](https://ant.design/llms-full-cn.txt) | 完整的组件文档（中文）             |
+
+也可以获取单个组件文档：`https://ant.design/components/<name>.md`。
+
+完整参考：[LLMs.txt](/docs/react/llms-cn)

--- a/docs/react/for-agents.zh-CN.md
+++ b/docs/react/for-agents.zh-CN.md
@@ -1,0 +1,38 @@
+---
+group:
+  title: AI
+  order: 0.9
+order: 0
+title: For Agents
+tag: New
+---
+
+本页面提供一段开箱即用的提示词，让任何 AI 编程 Agent 高效使用 Ant Design。
+
+## 复制这段 prompt {#copy-prompt}
+
+复制到你的 Agent 对话或自动化流程中。
+
+```text
+Read https://ant.design/llms-full.txt and follow the Ant Design conventions when writing UI code.
+
+If you can install skills, run:
+npx skills add ant-design/ant-design-cli
+```
+
+就这么简单 — 两行代码让你的 Agent 拥有完整的 Ant Design 知识和 CLI 访问能力。
+
+## 它做了什么 {#what-happens}
+
+| 行 | 作用 |
+| --- | --- |
+| `Read https://ant.design/llms-full.txt ...` | 为 Agent 提供完整的组件文档 — Props、Token、Demo 和最佳实践 — 让它开箱即写出符合 antd 规范的代码。 |
+| `npx skills add ant-design/ant-design-cli` | 安装 [@ant-design/cli](https://github.com/ant-design/ant-design-cli) 技能，让 Agent 学会通过 `antd` 命令查询 API、调试问题、代码检查和版本迁移。 |
+
+## 更多能力 {#learn-more}
+
+| 能力                | 指南                             |
+| ------------------- | -------------------------------- |
+| LLM 结构化文档      | [LLMs.txt](/docs/react/llms-cn)  |
+| IDE 集成 MCP Server | [MCP Server](/docs/react/mcp-cn) |
+| 完整 CLI 参考       | [CLI](/docs/react/cli-cn)        |

--- a/docs/react/for-agents.zh-CN.md
+++ b/docs/react/for-agents.zh-CN.md
@@ -14,20 +14,13 @@ tag: New
 复制到你的 Agent 对话或自动化流程中。
 
 ```text
-Read https://ant.design/llms-full.txt and follow the Ant Design conventions when writing UI code.
+Install the Ant Design CLI and follow the instructions to use it.
+
+npm install -g @ant-design/cli
 
 If you can install skills, run:
 npx skills add ant-design/ant-design-cli
 ```
-
-就这么简单 — 两行代码让你的 Agent 拥有完整的 Ant Design 知识和 CLI 访问能力。
-
-## 它做了什么 {#what-happens}
-
-| 行 | 作用 |
-| --- | --- |
-| `Read https://ant.design/llms-full.txt ...` | 为 Agent 提供完整的组件文档 — Props、Token、Demo 和最佳实践 — 让它开箱即写出符合 antd 规范的代码。 |
-| `npx skills add ant-design/ant-design-cli` | 安装 [@ant-design/cli](https://github.com/ant-design/ant-design-cli) 技能，让 Agent 学会通过 `antd` 命令查询 API、调试问题、代码检查和版本迁移。 |
 
 ## 更多能力 {#learn-more}
 

--- a/docs/react/for-agents.zh-CN.md
+++ b/docs/react/for-agents.zh-CN.md
@@ -14,9 +14,7 @@ tag: New
 复制到你的 Agent 对话或自动化流程中。
 
 ```text
-Install the Ant Design CLI and follow the instructions to use it.
-
-npm install -g @ant-design/cli
+Read https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md and follow the instructions to use Ant Design.
 
 If you can install skills, run:
 npx skills add ant-design/ant-design-cli

--- a/public/for-agents.md
+++ b/public/for-agents.md
@@ -1,64 +1,10 @@
 # Ant Design — For Agents
 
-> This file is the single entry point for AI coding agents to learn how to work with Ant Design. Read it fully before writing any antd code.
+> This file is the single entry point for AI coding agents to learn how to work with Ant Design.
 
-## 1. Install the CLI
+Read https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md and follow the instructions to use Ant Design.
 
-[`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) ships all metadata locally — every prop, token, demo, and changelog entry for antd v3 / v4 / v5 / v6 — queryable in milliseconds, fully offline.
-
-```bash
-npm install -g @ant-design/cli
-```
-
-### Key commands
-
-```bash
-antd info <Component>               # Props, types, defaults
-antd demo <Component> [name]        # Runnable demo source code (TSX)
-antd token [Component]              # Design Token values (v5+)
-antd semantic <Component>           # classNames / styles structure
-antd doc <Component>                # Full markdown documentation
-antd changelog [v1] [v2] [component]  # Changelog or cross-version API diff
-antd doctor                         # Diagnose project issues
-antd lint [target]                  # Check deprecated APIs & best practices
-antd migrate <from> <to>            # Migration checklist with --apply agent prompt
-antd list                           # List all components
-```
-
-Always use `--format json` for structured output you can parse programmatically.
-
-## 2. MCP Server
-
-If your environment supports [MCP (Model Context Protocol)](https://modelcontextprotocol.io/), configure it to access Ant Design knowledge as tools:
-
-```json
-{
-  "mcpServers": {
-    "antd": {
-      "command": "npx",
-      "args": ["-y", "@ant-design/cli", "mcp"]
-    }
-  }
-}
-```
-
-This provides 8 tools (`antd_list`, `antd_info`, `antd_doc`, `antd_demo`, `antd_token`, `antd_design_md`, `antd_semantic`, `antd_changelog`) and 2 prompts (`antd-expert`, `antd-page-generator`).
-
-## 3. LLMs.txt — structured documentation
-
-If you need to load full component documentation into context:
-
-| File                                                    | Description                            |
-| ------------------------------------------------------- | -------------------------------------- |
-| [llms.txt](https://ant.design/llms.txt)                 | Navigation file with links to all docs |
-| [llms-full.txt](https://ant.design/llms-full.txt)       | Full component docs (English)          |
-| [llms-full-cn.txt](https://ant.design/llms-full-cn.txt) | Full component docs (Chinese)          |
-
-Single component: `https://ant.design/components/<name>.md`
-
-## 4. Skill installation
-
-If your agent supports [skills](https://github.com/nicepkg/agent-skills), install the Ant Design skill for automatic CLI integration:
+If you can install skills, run:
 
 ```bash
 npx skills add ant-design/ant-design-cli

--- a/public/for-agents.md
+++ b/public/for-agents.md
@@ -27,12 +27,6 @@ antd list                           # List all components
 
 Always use `--format json` for structured output you can parse programmatically.
 
-### Full CLI skill file
-
-For detailed workflows, scenarios, and rules, read the full skill file:
-
-<https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md>
-
 ## 2. MCP Server
 
 If your environment supports [MCP (Model Context Protocol)](https://modelcontextprotocol.io/), configure it to access Ant Design knowledge as tools:

--- a/public/for-agents.md
+++ b/public/for-agents.md
@@ -2,6 +2,8 @@
 
 > This file is the single entry point for AI coding agents to learn how to work with Ant Design.
 
+## CLI
+
 Read https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md and follow the instructions to use Ant Design.
 
 If you can install skills, run:
@@ -9,3 +11,30 @@ If you can install skills, run:
 ```bash
 npx skills add ant-design/ant-design-cli
 ```
+
+## MCP Server
+
+If your environment supports [MCP (Model Context Protocol)](https://modelcontextprotocol.io/), configure the Ant Design MCP server:
+
+```json
+{
+  "mcpServers": {
+    "antd": {
+      "command": "npx",
+      "args": ["-y", "@ant-design/cli", "mcp"]
+    }
+  }
+}
+```
+
+This provides 8 tools (`antd_list`, `antd_info`, `antd_doc`, `antd_demo`, `antd_token`, `antd_design_md`, `antd_semantic`, `antd_changelog`) and 2 prompts (`antd-expert`, `antd-page-generator`).
+
+## LLMs.txt
+
+If you need to load full component documentation into context:
+
+- [llms.txt](https://ant.design/llms.txt) — Navigation file with links to all docs
+- [llms-full.txt](https://ant.design/llms-full.txt) — Full component docs (English)
+- [llms-full-cn.txt](https://ant.design/llms-full-cn.txt) — Full component docs (Chinese)
+
+Single component doc: `https://ant.design/components/<name>.md`

--- a/public/for-agents.md
+++ b/public/for-agents.md
@@ -1,0 +1,71 @@
+# Ant Design — For Agents
+
+> This file is the single entry point for AI coding agents to learn how to work with Ant Design. Read it fully before writing any antd code.
+
+## 1. Install the CLI
+
+[`@ant-design/cli`](https://github.com/ant-design/ant-design-cli) ships all metadata locally — every prop, token, demo, and changelog entry for antd v3 / v4 / v5 / v6 — queryable in milliseconds, fully offline.
+
+```bash
+npm install -g @ant-design/cli
+```
+
+### Key commands
+
+```bash
+antd info <Component>               # Props, types, defaults
+antd demo <Component> [name]        # Runnable demo source code (TSX)
+antd token [Component]              # Design Token values (v5+)
+antd semantic <Component>           # classNames / styles structure
+antd doc <Component>                # Full markdown documentation
+antd changelog [v1] [v2] [component]  # Changelog or cross-version API diff
+antd doctor                         # Diagnose project issues
+antd lint [target]                  # Check deprecated APIs & best practices
+antd migrate <from> <to>            # Migration checklist with --apply agent prompt
+antd list                           # List all components
+```
+
+Always use `--format json` for structured output you can parse programmatically.
+
+### Full CLI skill file
+
+For detailed workflows, scenarios, and rules, read the full skill file:
+
+<https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md>
+
+## 2. MCP Server
+
+If your environment supports [MCP (Model Context Protocol)](https://modelcontextprotocol.io/), configure it to access Ant Design knowledge as tools:
+
+```json
+{
+  "mcpServers": {
+    "antd": {
+      "command": "npx",
+      "args": ["-y", "@ant-design/cli", "mcp"]
+    }
+  }
+}
+```
+
+This provides 8 tools (`antd_list`, `antd_info`, `antd_doc`, `antd_demo`, `antd_token`, `antd_design_md`, `antd_semantic`, `antd_changelog`) and 2 prompts (`antd-expert`, `antd-page-generator`).
+
+## 3. LLMs.txt — structured documentation
+
+If you need to load full component documentation into context:
+
+| File                                                    | Description                            |
+| ------------------------------------------------------- | -------------------------------------- |
+| [llms.txt](https://ant.design/llms.txt)                 | Navigation file with links to all docs |
+| [llms-full.txt](https://ant.design/llms-full.txt)       | Full component docs (English)          |
+| [llms-full-cn.txt](https://ant.design/llms-full-cn.txt) | Full component docs (Chinese)          |
+
+Single component: `https://ant.design/components/<name>.md`
+
+## 4. Skill installation
+
+If your agent supports [skills](https://github.com/nicepkg/agent-skills), install the Ant Design skill for automatic CLI integration:
+
+```bash
+npx skills add ant-design/ant-design-cli
+```


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 📝 Site / documentation improvement

### 🔗 Related Issues

Inspired by [YouMind's For Agents page](https://youmind.com/zh-CN/for-agents). Provides a simple, copy-paste prompt for AI coding agents to work with Ant Design.

### 💡 Background and Solution

Adds a new "For Agents" page under the AI doc group (order: 0, making it the first page). The page provides a minimal two-line prompt that users can copy into any AI agent conversation:

1. `Read https://ant.design/llms-full.txt` — feeds the agent complete component docs
2. `npx skills add ant-design/ant-design-cli` — installs the CLI skill for API queries, debugging, linting, and migrations

Also links to LLMs.txt, MCP Server, and CLI pages for users who want deeper integration.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | N/A       |
| 🇨🇳 Chinese | N/A       |