### PR TITLE
site: correct icon search count

### DIFF
--- a/.dumi/theme/builtins/IconSearch/fields.ts
+++ b/.dumi/theme/builtins/IconSearch/fields.ts
@@ -2,7 +2,11 @@ import * as AntdIcons from '@ant-design/icons';
 
 export const all = Object.keys(AntdIcons)
   .map((n) => n.replace(/(Outlined|Filled|TwoTone)$/, ''))
-  .filter((n, i, arr) => arr.indexOf(n) === i);
+  .filter(
+    (n, i, arr) =>
+      (`${n}Outlined` in AntdIcons || `${n}Filled` in AntdIcons || `${n}TwoTone` in AntdIcons) &&
+      arr.indexOf(n) === i,
+  );
 
 const direction = [
   'StepBackward',


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Icon 文档搜索框的图标总数会把 `@ant-design/icons` 中的非图标导出也统计进去，导致展示数量比实际图标数量多。

本次调整图标总数统计逻辑，仅统计存在 `Outlined`、`Filled` 或 `TwoTone` 主题组件的图标名称，使搜索框展示数量从 486 修正为 481。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |