### PR TITLE
docs: remove self-referencing URL from for-agents prompt

### DIFF
--- a/docs/react/for-agents.en-US.md
+++ b/docs/react/for-agents.en-US.md
@@ -14,9 +14,7 @@ This page provides a ready-to-use prompt that lets any AI coding agent work with
 Copy into your agent conversation or automation runner.
 
 ```text
-Before writing any code, please read https://ant.design/docs/react/for-agents.md, pay attention to deprecation warnings, and follow the instructions to use Ant Design.
-
-Read https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md and follow the instructions to use Ant Design.
+Before writing any code, please read https://ant.design/docs/react/for-agents.md and https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md, pay attention to deprecation warnings, and follow the instructions to use Ant Design.
 
 If you can install skills, run:
 npx skills add ant-design/ant-design-cli

--- a/docs/react/for-agents.en-US.md
+++ b/docs/react/for-agents.en-US.md
@@ -14,7 +14,7 @@ This page provides a ready-to-use prompt that lets any AI coding agent work with
 Copy into your agent conversation or automation runner.
 
 ```text
-Before writing any code, please read https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md, pay attention to deprecation warnings, and follow the instructions to use Ant Design.
+Before writing any code, please read https://ant.design/docs/react/for-agents.md and https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md, pay attention to deprecation warnings, and follow the instructions to use Ant Design.
 
 If you can install skills, run:
 npx skills add ant-design/ant-design-cli

--- a/docs/react/for-agents.en-US.md
+++ b/docs/react/for-agents.en-US.md
@@ -14,7 +14,7 @@ This page provides a ready-to-use prompt that lets any AI coding agent work with
 Copy into your agent conversation or automation runner.
 
 ```text
-Before writing any code, please read https://ant.design/docs/react/for-agents.md and https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md, pay attention to deprecation warnings, and follow the instructions to use Ant Design.
+Before writing any code, please read https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md, pay attention to deprecation warnings, and follow the instructions to use Ant Design.
 
 If you can install skills, run:
 npx skills add ant-design/ant-design-cli

--- a/docs/react/for-agents.zh-CN.md
+++ b/docs/react/for-agents.zh-CN.md
@@ -14,7 +14,7 @@ tag: New
 复制到你的 Agent 对话或自动化流程中。
 
 ```text
-在编写任何代码之前，请先阅读 https://ant.design/docs/react/for-agents-cn.md 和 https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md，留意弃用提示，并按照说明使用 Ant Design。
+在编写任何代码之前，请先阅读 https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md，留意弃用提示，并按照说明使用 Ant Design。
 
 如果你可以安装 skills，请运行：
 npx skills add ant-design/ant-design-cli

--- a/docs/react/for-agents.zh-CN.md
+++ b/docs/react/for-agents.zh-CN.md
@@ -14,9 +14,7 @@ tag: New
 复制到你的 Agent 对话或自动化流程中。
 
 ```text
-在编写任何代码之前，请先阅读 https://ant.design/docs/react/for-agents-cn.md 中的相关指南，留意弃用提示，并按照说明使用 Ant Design。
-
-阅读 https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md 并按照指引使用 Ant Design。
+在编写任何代码之前，请先阅读 https://ant.design/docs/react/for-agents-cn.md 和 https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md，留意弃用提示，并按照说明使用 Ant Design。
 
 如果你可以安装 skills，请运行：
 npx skills add ant-design/ant-design-cli

--- a/docs/react/for-agents.zh-CN.md
+++ b/docs/react/for-agents.zh-CN.md
@@ -14,7 +14,7 @@ tag: New
 复制到你的 Agent 对话或自动化流程中。
 
 ```text
-在编写任何代码之前，请先阅读 https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md，留意弃用提示，并按照说明使用 Ant Design。
+在编写任何代码之前，请先阅读 https://ant.design/docs/react/for-agents-cn.md 和 https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md，留意弃用提示，并按照说明使用 Ant Design。
 
 如果你可以安装 skills，请运行：
 npx skills add ant-design/ant-design-cli


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 📝 Site / documentation improvement

### 🔗 Related Issues

Follow-up to #58422

### 💡 Background and Solution

The prompt block in the For Agents page referenced `https://ant.design/docs/react/for-agents.md` — the very page it lives on. When an agent reads the page and follows the prompt, it would fetch the same page again, causing an infinite loop.

Removed the self-referencing URL and kept only the SKILL.md link, which points to the CLI usage guide on GitHub — a different resource with actionable instructions.

Before:
```
Before writing any code, please read https://ant.design/docs/react/for-agents.md, ...
Read https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md and follow the instructions to use Ant Design.
```

After:
```
Before writing any code, please read https://raw.githubusercontent.com/ant-design/ant-design-cli/main/skills/antd/SKILL.md, pay attention to deprecation warnings, and follow the instructions to use Ant Design.
```

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | N/A       |
| 🇨🇳 Chinese | N/A       |