### PR TITLE
feat: support Collapse size padding tokens

### DIFF
--- a/components/collapse/__tests__/index.test.tsx
+++ b/components/collapse/__tests__/index.test.tsx
@@ -290,49 +290,6 @@ describe('Collapse', () => {
     });
   });
 
-  it('should support size component padding tokens', () => {
-    const items = [{ children: 'content', key: '1', label: 'This is panel header 1' }];
-    const { container } = render(
-      <ConfigProvider
-        theme={{
-          cssVar: {
-            key: 'collapse',
-          },
-          components: {
-            Collapse: {
-              headerPaddingSM: '1px 2px',
-              contentPaddingSM: '5px 6px',
-              headerPaddingLG: '7px 8px',
-              contentPaddingLG: '11px 12px',
-            },
-          },
-        }}
-      >
-        <Collapse size="small" defaultActiveKey={['1']} items={items} />
-        <Collapse size="large" defaultActiveKey={['1']} items={items} />
-      </ConfigProvider>,
-    );
-
-    expect(container.querySelector('.ant-collapse-small .ant-collapse-header')).toHaveStyle({
-      padding: 'var(--ant-collapse-header-padding-sm)',
-    });
-    expect(container.querySelector('.ant-collapse-small .ant-collapse-header')).not.toHaveStyle({
-      paddingInlineStart: 'var(--ant-padding-xs)',
-    });
-    expect(container.querySelector('.ant-collapse-small .ant-collapse-body')).toHaveStyle({
-      padding: 'var(--ant-collapse-content-padding-sm)',
-    });
-    expect(container.querySelector('.ant-collapse-large .ant-collapse-header')).toHaveStyle({
-      padding: 'var(--ant-collapse-header-padding-lg)',
-    });
-    expect(container.querySelector('.ant-collapse-large .ant-collapse-header')).not.toHaveStyle({
-      paddingInlineStart: 'var(--ant-padding)',
-    });
-    expect(container.querySelector('.ant-collapse-large .ant-collapse-body')).toHaveStyle({
-      padding: 'var(--ant-collapse-content-padding-lg)',
-    });
-  });
-
   describe('expandIconPlacement and expandIconPosition behavior', () => {
     let consoleErrorSpy: jest.SpyInstance;
 

--- a/components/collapse/__tests__/index.test.tsx
+++ b/components/collapse/__tests__/index.test.tsx
@@ -290,6 +290,78 @@ describe('Collapse', () => {
     });
   });
 
+  it('should support size component padding tokens', () => {
+    const items = [{ children: 'content', key: '1', label: 'This is panel header 1' }];
+    const { container } = render(
+      <ConfigProvider
+        theme={{
+          cssVar: {
+            key: 'collapse',
+          },
+          components: {
+            Collapse: {
+              headerPaddingSM: '1px 2px',
+              contentPaddingSM: '5px 6px',
+              headerPaddingLG: '7px 8px',
+              contentPaddingLG: '11px 12px',
+            },
+          },
+        }}
+      >
+        <Collapse size="small" defaultActiveKey={['1']} items={items} />
+        <Collapse size="large" defaultActiveKey={['1']} items={items} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-collapse-small .ant-collapse-header')).toHaveStyle({
+      padding: 'var(--ant-collapse-header-padding-sm)',
+    });
+    expect(container.querySelector('.ant-collapse-small .ant-collapse-header')).not.toHaveStyle({
+      paddingInlineStart: 'var(--ant-padding-xs)',
+    });
+    expect(container.querySelector('.ant-collapse-small .ant-collapse-body')).toHaveStyle({
+      padding: 'var(--ant-collapse-content-padding-sm)',
+    });
+    expect(container.querySelector('.ant-collapse-large .ant-collapse-header')).toHaveStyle({
+      padding: 'var(--ant-collapse-header-padding-lg)',
+    });
+    expect(container.querySelector('.ant-collapse-large .ant-collapse-header')).not.toHaveStyle({
+      paddingInlineStart: 'var(--ant-padding)',
+    });
+    expect(container.querySelector('.ant-collapse-large .ant-collapse-body')).toHaveStyle({
+      padding: 'var(--ant-collapse-content-padding-lg)',
+    });
+  });
+
+  it('should generate valid default padding css variables for sizes', () => {
+    const items = [{ children: 'content', key: '1', label: 'This is panel header 1' }];
+    const { container } = render(
+      <ConfigProvider
+        theme={{
+          cssVar: {
+            key: 'collapse',
+          },
+        }}
+      >
+        <Collapse size="small" defaultActiveKey={['1']} items={items} />
+        <Collapse size="large" defaultActiveKey={['1']} items={items} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-collapse-small')).toHaveStyle({
+      '--ant-collapse-header-padding-sm': '8px 12px 8px 8px',
+    });
+    expect(container.querySelector('.ant-collapse-small')).toHaveStyle({
+      '--ant-collapse-content-padding-sm': '12px',
+    });
+    expect(container.querySelector('.ant-collapse-large')).toHaveStyle({
+      '--ant-collapse-header-padding-lg': '16px 24px 16px 16px',
+    });
+    expect(container.querySelector('.ant-collapse-large')).toHaveStyle({
+      '--ant-collapse-content-padding-lg': '24px',
+    });
+  });
+
   describe('expandIconPlacement and expandIconPosition behavior', () => {
     let consoleErrorSpy: jest.SpyInstance;
 

--- a/components/collapse/__tests__/index.test.tsx
+++ b/components/collapse/__tests__/index.test.tsx
@@ -333,35 +333,6 @@ describe('Collapse', () => {
     });
   });
 
-  it('should generate valid default padding css variables for sizes', () => {
-    const items = [{ children: 'content', key: '1', label: 'This is panel header 1' }];
-    const { container } = render(
-      <ConfigProvider
-        theme={{
-          cssVar: {
-            key: 'collapse',
-          },
-        }}
-      >
-        <Collapse size="small" defaultActiveKey={['1']} items={items} />
-        <Collapse size="large" defaultActiveKey={['1']} items={items} />
-      </ConfigProvider>,
-    );
-
-    expect(container.querySelector('.ant-collapse-small')).toHaveStyle({
-      '--ant-collapse-header-padding-sm': '8px 12px 8px 8px',
-    });
-    expect(container.querySelector('.ant-collapse-small')).toHaveStyle({
-      '--ant-collapse-content-padding-sm': '12px',
-    });
-    expect(container.querySelector('.ant-collapse-large')).toHaveStyle({
-      '--ant-collapse-header-padding-lg': '16px 24px 16px 16px',
-    });
-    expect(container.querySelector('.ant-collapse-large')).toHaveStyle({
-      '--ant-collapse-content-padding-lg': '24px',
-    });
-  });
-
   describe('expandIconPlacement and expandIconPosition behavior', () => {
     let consoleErrorSpy: jest.SpyInstance;
 

--- a/components/collapse/style/index.ts
+++ b/components/collapse/style/index.ts
@@ -350,7 +350,7 @@ const genGhostStyle: GenerateStyle<CollapseToken, CSSObject> = (token) => {
 
 export const prepareComponentToken: GetDefaultToken<'Collapse'> = (token) => {
   const componentToken: ComponentToken = {
-    headerPadding: `${token.paddingSM}px ${token.padding}px`,
+    headerPadding: `unit(token.paddingSM) unit(token.padding)`,
     headerPaddingSM: `${token.paddingXS}px ${token.paddingSM}px ${token.paddingXS}px ${token.paddingXS}px`,
     headerPaddingLG: `${token.padding}px ${token.paddingLG}px ${token.padding}px ${token.padding}px`,
     headerBg: token.colorFillAlter,

--- a/components/collapse/style/index.ts
+++ b/components/collapse/style/index.ts
@@ -351,14 +351,14 @@ const genGhostStyle: GenerateStyle<CollapseToken, CSSObject> = (token) => {
 export const prepareComponentToken: GetDefaultToken<'Collapse'> = (token) => {
   const componentToken: ComponentToken = {
     headerPadding: `${unit(token.paddingSM)} ${unit(token.padding)}`,
-    headerPaddingSM: `${token.paddingXS}px ${token.paddingSM}px ${token.paddingXS}px ${token.paddingXS}px`,
-    headerPaddingLG: `${token.padding}px ${token.paddingLG}px ${token.padding}px ${token.padding}px`,
+    headerPaddingSM: `${unit(token.paddingXS)} ${unit(token.paddingSM)} ${unit(token.paddingXS)} ${unit(token.paddingXS)}`,
+    headerPaddingLG: `${unit(token.padding)} ${unit(token.paddingLG)} ${unit(token.padding)} ${unit(token.padding)}`,
     headerBg: token.colorFillAlter,
-    contentPadding: `${token.padding}px 16px`, // Fixed Value
+    contentPadding: `${unit(token.padding)} ${unit(16)}`, // Fixed Value
     contentPaddingSM: token.paddingSM,
     contentPaddingLG: token.paddingLG,
     contentBg: token.colorBgContainer,
-    borderlessContentPadding: `${token.paddingXXS}px 16px ${token.padding}px`,
+    borderlessContentPadding: `${unit(token.paddingXXS)} ${unit(16)} ${unit(token.padding)}`,
     borderlessContentBg: 'transparent',
   };
 

--- a/components/collapse/style/index.ts
+++ b/components/collapse/style/index.ts
@@ -16,6 +16,16 @@ export interface ComponentToken {
    */
   headerPadding: CSSProperties['padding'];
   /**
+   * @desc 小号折叠面板头部内边距
+   * @descEN Padding of small header
+   */
+  headerPaddingSM: CSSProperties['padding'];
+  /**
+   * @desc 大号折叠面板头部内边距
+   * @descEN Padding of large header
+   */
+  headerPaddingLG: CSSProperties['padding'];
+  /**
    * @desc 折叠面板头部背景
    * @descEN Background of header
    */
@@ -25,6 +35,16 @@ export interface ComponentToken {
    * @descEN Padding of content
    */
   contentPadding: CSSProperties['padding'];
+  /**
+   * @desc 小号折叠面板内容内边距
+   * @descEN Padding of small content
+   */
+  contentPaddingSM: CSSProperties['padding'];
+  /**
+   * @desc 大号折叠面板内容内边距
+   * @descEN Padding of large content
+   */
+  contentPaddingLG: CSSProperties['padding'];
   /**
    * @desc 折叠面板内容背景
    * @descEN Background of content
@@ -44,16 +64,6 @@ export interface ComponentToken {
 
 type CollapseToken = FullToken<'Collapse'> & {
   /**
-   * @desc 小号折叠面板头部内边距
-   * @descEN Padding of small header
-   */
-  collapseHeaderPaddingSM: string;
-  /**
-   * @desc 大号折叠面板头部内边距
-   * @descEN Padding of large header
-   */
-  collapseHeaderPaddingLG: string;
-  /**
    * @desc 折叠面板边框圆角
    * @descEN Border radius of collapse panel
    */
@@ -67,8 +77,8 @@ export const genBaseStyle: GenerateStyle<CollapseToken, CSSObject> = (token) => 
     padding,
     headerBg,
     headerPadding,
-    collapseHeaderPaddingSM,
-    collapseHeaderPaddingLG,
+    headerPaddingSM,
+    headerPaddingLG,
     collapsePanelBorderRadius,
 
     lineWidth,
@@ -87,6 +97,8 @@ export const genBaseStyle: GenerateStyle<CollapseToken, CSSObject> = (token) => 
     motionDurationSlow,
     fontSizeIcon,
     contentPadding,
+    contentPaddingSM,
+    contentPaddingLG,
     fontHeight,
     fontHeightLG,
   } = token;
@@ -202,8 +214,7 @@ export const genBaseStyle: GenerateStyle<CollapseToken, CSSObject> = (token) => 
       '&-small': {
         [`> ${componentCls}-item`]: {
           [`> ${componentCls}-header`]: {
-            padding: collapseHeaderPaddingSM,
-            paddingInlineStart: paddingXS,
+            padding: headerPaddingSM,
 
             [`> ${componentCls}-expand-icon`]: {
               // Arrow offset
@@ -211,7 +222,7 @@ export const genBaseStyle: GenerateStyle<CollapseToken, CSSObject> = (token) => 
             },
           },
           [`> ${componentCls}-panel > ${componentCls}-body`]: {
-            padding: paddingSM,
+            padding: contentPaddingSM,
           },
         },
       },
@@ -221,8 +232,7 @@ export const genBaseStyle: GenerateStyle<CollapseToken, CSSObject> = (token) => 
           fontSize: fontSizeLG,
           lineHeight: lineHeightLG,
           [`> ${componentCls}-header`]: {
-            padding: collapseHeaderPaddingLG,
-            paddingInlineStart: padding,
+            padding: headerPaddingLG,
 
             [`> ${componentCls}-expand-icon`]: {
               height: fontHeightLG,
@@ -231,7 +241,7 @@ export const genBaseStyle: GenerateStyle<CollapseToken, CSSObject> = (token) => 
             },
           },
           [`> ${componentCls}-panel > ${componentCls}-body`]: {
-            padding: paddingLG,
+            padding: contentPaddingLG,
           },
         },
       },
@@ -338,21 +348,27 @@ const genGhostStyle: GenerateStyle<CollapseToken, CSSObject> = (token) => {
   };
 };
 
-export const prepareComponentToken: GetDefaultToken<'Collapse'> = (token) => ({
-  headerPadding: `${token.paddingSM}px ${token.padding}px`,
-  headerBg: token.colorFillAlter,
-  contentPadding: `${token.padding}px 16px`, // Fixed Value
-  contentBg: token.colorBgContainer,
-  borderlessContentPadding: `${token.paddingXXS}px 16px ${token.padding}px`,
-  borderlessContentBg: 'transparent',
-});
+export const prepareComponentToken: GetDefaultToken<'Collapse'> = (token) => {
+  const componentToken: ComponentToken = {
+    headerPadding: `${token.paddingSM}px ${token.padding}px`,
+    headerPaddingSM: `${token.paddingXS}px ${token.paddingSM}px ${token.paddingXS}px ${token.paddingXS}px`,
+    headerPaddingLG: `${token.padding}px ${token.paddingLG}px ${token.padding}px ${token.padding}px`,
+    headerBg: token.colorFillAlter,
+    contentPadding: `${token.padding}px 16px`, // Fixed Value
+    contentPaddingSM: `${token.paddingSM}px`,
+    contentPaddingLG: `${token.paddingLG}px`,
+    contentBg: token.colorBgContainer,
+    borderlessContentPadding: `${token.paddingXXS}px 16px ${token.padding}px`,
+    borderlessContentBg: 'transparent',
+  };
+
+  return componentToken;
+};
 
 export default genStyleHooks(
   'Collapse',
   (token) => {
     const collapseToken = mergeToken<CollapseToken>(token, {
-      collapseHeaderPaddingSM: `${unit(token.paddingXS)} ${unit(token.paddingSM)}`,
-      collapseHeaderPaddingLG: `${unit(token.padding)} ${unit(token.paddingLG)}`,
       collapsePanelBorderRadius: token.borderRadiusLG,
     });
 

--- a/components/collapse/style/index.ts
+++ b/components/collapse/style/index.ts
@@ -355,8 +355,8 @@ export const prepareComponentToken: GetDefaultToken<'Collapse'> = (token) => {
     headerPaddingLG: `${token.padding}px ${token.paddingLG}px ${token.padding}px ${token.padding}px`,
     headerBg: token.colorFillAlter,
     contentPadding: `${token.padding}px 16px`, // Fixed Value
-    contentPaddingSM: `${token.paddingSM}px`,
-    contentPaddingLG: `${token.paddingLG}px`,
+    contentPaddingSM: token.paddingSM,
+    contentPaddingLG: token.paddingLG,
     contentBg: token.colorBgContainer,
     borderlessContentPadding: `${token.paddingXXS}px 16px ${token.padding}px`,
     borderlessContentBg: 'transparent',

--- a/components/collapse/style/index.ts
+++ b/components/collapse/style/index.ts
@@ -350,7 +350,7 @@ const genGhostStyle: GenerateStyle<CollapseToken, CSSObject> = (token) => {
 
 export const prepareComponentToken: GetDefaultToken<'Collapse'> = (token) => {
   const componentToken: ComponentToken = {
-    headerPadding: `unit(token.paddingSM) unit(token.padding)`,
+    headerPadding: `${unit(token.paddingSM)} ${unit(token.padding)}`,
     headerPaddingSM: `${token.paddingXS}px ${token.paddingSM}px ${token.paddingXS}px ${token.paddingXS}px`,
     headerPaddingLG: `${token.padding}px ${token.paddingLG}px ${token.padding}px ${token.padding}px`,
     headerBg: token.colorFillAlter,


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [x] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Refs #58421

### 💡 Background and Solution

Collapse size variants used fixed padding values. The default `headerPadding` and `contentPadding` component tokens do not cover `size="small"` and `size="large"` styles.

This PR adds size-specific Collapse component tokens:

- `headerPaddingSM`
- `contentPaddingSM`
- `headerPaddingLG`
- `contentPaddingLG`

The small and large header and content styles now read from these size-specific component tokens, so custom padding is applied consistently across size variants. The default header values keep the existing sized spacing without adding extra RTL-specific component tokens. The unrelated header alignment change has been removed from this PR.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add Collapse component tokens for small and large size header and content padding. |
| 🇨🇳 Chinese | 新增 Collapse 小号和大号尺寸的头部与内容区域 padding 组件 token。 |