### PR TITLE
test: reduce Vitest excludes for Alert

### DIFF
--- a/components/alert/__tests__/__snapshots__/vitest/index.test.tsx.snap
+++ b/components/alert/__tests__/__snapshots__/vitest/index.test.tsx.snap
@@ -1,0 +1,92 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Alert > custom action 1`] = `
+<div
+  class="ant-alert ant-alert-success ant-alert-outlined css-var-root"
+  data-show="true"
+  role="alert"
+>
+  <span
+    class="ant-alert-icon"
+  >
+    <span
+      aria-label="check-circle"
+      class="anticon anticon-check-circle"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="check-circle"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+        />
+      </svg>
+    </span>
+  </span>
+  <div
+    class="ant-alert-section"
+  >
+    <div
+      class="ant-alert-title"
+    >
+      Success Tips
+    </div>
+  </div>
+  <div
+    class="ant-alert-actions"
+  >
+    <button
+      class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm"
+      type="button"
+    >
+      <span>
+        UNDO
+      </span>
+    </button>
+  </div>
+  <button
+    class="ant-alert-close-icon"
+    tabindex="0"
+    type="button"
+  >
+    <span
+      aria-label="close"
+      class="anticon anticon-close"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="close"
+        fill="currentColor"
+        fill-rule="evenodd"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+        />
+      </svg>
+    </span>
+  </button>
+</div>
+`;
+
+exports[`Alert > rtl render > component should be rendered correctly in RTL direction 1`] = `
+<div
+  class="ant-alert ant-alert-info ant-alert-outlined ant-alert-no-icon ant-alert-rtl css-var-root"
+  data-show="true"
+  role="alert"
+>
+  <div
+    class="ant-alert-section"
+  />
+</div>
+`;

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -119,6 +119,8 @@ describe('Alert', () => {
   });
 
   it('could be used with Tooltip', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
     render(
       <Tooltip title="xxx" mouseEnterDelay={0}>
         <Alert
@@ -128,7 +130,7 @@ describe('Alert', () => {
       </Tooltip>,
     );
 
-    await userEvent.hover(screen.getByRole('alert'));
+    await user.hover(screen.getByRole('alert'));
 
     await waitFakeTimer();
 
@@ -136,6 +138,8 @@ describe('Alert', () => {
   });
 
   it('could be used with Popconfirm', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
     render(
       <Popconfirm title="xxx">
         <Alert
@@ -144,7 +148,7 @@ describe('Alert', () => {
         />
       </Popconfirm>,
     );
-    await userEvent.click(screen.getByRole('alert'));
+    await user.click(screen.getByRole('alert'));
 
     act(() => {
       jest.runAllTimers();

--- a/tests/shared/accessibilityTest.tsx
+++ b/tests/shared/accessibilityTest.tsx
@@ -54,19 +54,27 @@ const convertRulesToAxeFormat = (rules: string[]) => {
   return rules.reduce<Rules>((acc, rule) => ({ ...acc, [rule]: { enabled: false } }), {});
 };
 
+const isUsingFakeTimers = () =>
+  typeof (jest as any).isFakeTimers === 'function'
+    ? (jest as any).isFakeTimers()
+    : jest.isMockFunction(setTimeout) || !!(setTimeout as any).clock;
+
 // eslint-disable-next-line jest/no-export
 export const accessibilityTest = (
   Component: React.ComponentType<any>,
   disabledRules?: string[],
 ) => {
   beforeAll(() => {
-    // Fake ResizeObserver — use mockImplementation so jest.fn() itself is the constructor,
-    // compatible with `new` in both Jest and Vitest (arrow functions cannot be constructors)
-    global.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    })) as jest.Mock;
+    // Fake ResizeObserver — Vitest constructs the mock implementation with `new`,
+    // so this must stay a function expression instead of an arrow.
+    // eslint-disable-next-line prefer-arrow-callback
+    global.ResizeObserver = jest.fn().mockImplementation(function ResizeObserverMock() {
+      return {
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        disconnect: jest.fn(),
+      };
+    }) as jest.Mock;
 
     // fake fetch
     global.fetch = jest.fn(() => {
@@ -97,13 +105,22 @@ export const accessibilityTest = (
   });
   describe(`accessibility`, () => {
     it(`component does not have any violations`, async () => {
+      const restoreFakeTimers = isUsingFakeTimers();
+
       jest.useRealTimers();
-      const { container } = render(<Component />);
 
-      const rules = convertRulesToAxeFormat(disabledRules || []);
+      try {
+        const { container } = render(<Component />);
 
-      const results = await runAxe(container, { rules });
-      expect(results).toHaveNoViolations();
+        const rules = convertRulesToAxeFormat(disabledRules || []);
+
+        const results = await runAxe(container, { rules });
+        expect(results).toHaveNoViolations();
+      } finally {
+        if (restoreFakeTimers) {
+          jest.useFakeTimers();
+        }
+      }
     }, 50000);
   });
 };

--- a/tests/shared/accessibilityTest.tsx
+++ b/tests/shared/accessibilityTest.tsx
@@ -4,6 +4,8 @@ import { render } from '@testing-library/react';
 import { globSync } from 'glob';
 import { axe } from 'jest-axe';
 
+import { isFunction } from '../../components/_util/is';
+
 class AxeQueueManager {
   private queue: Promise<any> = Promise.resolve();
   private isProcessing = false;
@@ -54,17 +56,32 @@ const convertRulesToAxeFormat = (rules: string[]) => {
   return rules.reduce<Rules>((acc, rule) => ({ ...acc, [rule]: { enabled: false } }), {});
 };
 
+type JestWithFakeTimerState = typeof jest & {
+  isFakeTimers?: () => boolean;
+};
+
+type TimerWithClock = typeof setTimeout & {
+  clock?: unknown;
+};
+
 const isUsingFakeTimers = () =>
-  typeof (jest as any).isFakeTimers === 'function'
-    ? (jest as any).isFakeTimers()
-    : jest.isMockFunction(setTimeout) || !!(setTimeout as any).clock;
+  isFunction((jest as JestWithFakeTimerState).isFakeTimers)
+    ? (jest as JestWithFakeTimerState).isFakeTimers()
+    : jest.isMockFunction(setTimeout) || !!(setTimeout as TimerWithClock).clock;
 
 // eslint-disable-next-line jest/no-export
-export const accessibilityTest = (
-  Component: React.ComponentType<any>,
-  disabledRules?: string[],
-) => {
+export const accessibilityTest = (Component: React.ComponentType, disabledRules?: string[]) => {
+  let originalResizeObserver: typeof global.ResizeObserver;
+  let originalFetch: typeof global.fetch;
+  let hadResizeObserver: boolean;
+  let hadFetch: boolean;
+
   beforeAll(() => {
+    hadResizeObserver = 'ResizeObserver' in global;
+    hadFetch = 'fetch' in global;
+    originalResizeObserver = global.ResizeObserver;
+    originalFetch = global.fetch;
+
     // Fake ResizeObserver — Vitest constructs the mock implementation with `new`,
     // so this must stay a function expression instead of an arrow.
     // eslint-disable-next-line prefer-arrow-callback
@@ -90,6 +107,20 @@ export const accessibilityTest = (
         },
       };
     }) as jest.Mock;
+  });
+
+  afterAll(() => {
+    if (hadResizeObserver) {
+      global.ResizeObserver = originalResizeObserver;
+    } else {
+      Reflect.deleteProperty(global, 'ResizeObserver');
+    }
+
+    if (hadFetch) {
+      global.fetch = originalFetch;
+    } else {
+      Reflect.deleteProperty(global, 'fetch');
+    }
   });
 
   beforeEach(() => {

--- a/tests/shared/accessibilityTest.tsx
+++ b/tests/shared/accessibilityTest.tsx
@@ -56,18 +56,24 @@ const convertRulesToAxeFormat = (rules: string[]) => {
   return rules.reduce<Rules>((acc, rule) => ({ ...acc, [rule]: { enabled: false } }), {});
 };
 
-type JestWithFakeTimerState = typeof jest & {
+interface JestFakeTimerState {
   isFakeTimers?: () => boolean;
-};
+}
 
-type TimerWithClock = typeof setTimeout & {
+interface FakeTimerClock {
   clock?: unknown;
-};
+}
 
-const isUsingFakeTimers = () =>
-  isFunction((jest as JestWithFakeTimerState).isFakeTimers)
-    ? (jest as JestWithFakeTimerState).isFakeTimers()
-    : jest.isMockFunction(setTimeout) || !!(setTimeout as TimerWithClock).clock;
+const jestWithFakeTimerState = jest as typeof jest & JestFakeTimerState;
+
+const isUsingFakeTimers = () => {
+  const { isFakeTimers } = jestWithFakeTimerState;
+  const timeoutWithClock = setTimeout as typeof setTimeout & FakeTimerClock;
+
+  return isFunction(isFakeTimers)
+    ? isFakeTimers()
+    : jest.isMockFunction(setTimeout) || !!timeoutWithClock.clock;
+};
 
 // eslint-disable-next-line jest/no-export
 export const accessibilityTest = (Component: React.ComponentType, disabledRules?: string[]) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -76,7 +76,6 @@ export default defineConfig({
       'components/_util/__tests__/useZIndex.test.tsx',
       'components/_util/__tests__/wave.test.tsx',
       'components/_util/__tests__/wave-util.test.tsx',
-      'components/alert/__tests__/index.test.tsx',
       'components/anchor/__tests__/Anchor.test.tsx',
       'components/auto-complete/__tests__/index.test.tsx',
       'components/auto-complete/__tests__/semantic.test.tsx',

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -94,6 +94,7 @@ const jestShim: any = {
   restoreAllMocks: vi.restoreAllMocks,
   useFakeTimers: vi.useFakeTimers,
   useRealTimers: vi.useRealTimers,
+  isFakeTimers: vi.isFakeTimers,
   advanceTimersByTime: vi.advanceTimersByTime,
   advanceTimersByTimeAsync: vi.advanceTimersByTimeAsync,
   runAllTimers: vi.runAllTimers,

--- a/vitest/FINDINGS.md
+++ b/vitest/FINDINGS.md
@@ -6,8 +6,8 @@
 
 | Metric | POC stage | Expanded stage |
 | --- | --: | --: |
-| Test files | 16 | 168 |
-| Test cases | 272 | 1343 |
+| Test files | 16 | 169 |
+| Test cases | 272 | 1365 |
 | Coverage scope | Button / Modal / Table | All component directories, excluding known incompatible suites |
 | CI | None | Non-blocking `test-vitest` job |
 
@@ -21,8 +21,8 @@ This PR is still an expansion checkpoint, not the final migration. The remaining
 
 `npm run test:vitest` currently passes with:
 
-- 168 test files
-- 1343 test cases
+- 169 test files
+- 1365 test cases
 - tracked Vitest snapshot baselines
 - no `--update` in CI
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Follow-up of #58213 and #58438.

### 💡 需求背景和解决方案

继续推进 Jest -> Vitest 迁移覆盖范围，恢复 Alert 单测进入 Vitest gate。

本次改动：
- 从 `vitest.config.ts` 的精确 exclude 清单中移除 Alert 单测。
- 修复共享 `accessibilityTest` 在 Vitest 下的 `ResizeObserver` constructor mock 和 fake timers 状态恢复。
- 给 Vitest 的 Jest shim 补充 `isFakeTimers`。
- 调整 Alert 中 fake timers 下的 `userEvent` 用法，避免 Vitest 下交互等待超时。
- 新增 Alert 的 Vitest snapshot baseline，并更新迁移报告中的 gate 统计。

验证：
- `npm run test:vitest`：169 files / 1365 tests passed
- `npm test -- components/alert/__tests__/index.test.tsx --runInBand`：22 tests passed
- targeted ESLint / Biome / remark / `git diff --check` passed

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | 无需更新日志 |
