### PR TITLE
fix: keep Table sticky header top border in bordered mode

### DIFF
--- a/components/table/__tests__/Table.test.tsx
+++ b/components/table/__tests__/Table.test.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from 'react';
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 
 import type { TableProps, TableRef } from '..';
 import Table from '..';
@@ -18,6 +19,30 @@ describe('Table', () => {
 
   afterAll(() => {
     warnSpy.mockRestore();
+  });
+
+  it('keeps top border for bordered sticky header', () => {
+    const cache = createCache();
+
+    render(
+      <StyleProvider cache={cache}>
+        <Table
+          bordered
+          sticky
+          columns={[{ title: 'Name', dataIndex: 'name' }]}
+          dataSource={[{ key: '1', name: 'John' }]}
+          pagination={false}
+        />
+      </StyleProvider>,
+    );
+
+    const stickyHeaderSelector =
+      '.ant-table.ant-table-bordered >.ant-table-container >.ant-table-header.ant-table-sticky-holder';
+    const styleText = extractStyle(cache, { plain: true });
+
+    expect(styleText).toContain(
+      `${stickyHeaderSelector}{margin-top:calc(var(--ant-line-width) * -1);border-top:var(--ant-line-width) var(--ant-line-type) var(--ant-table-border-color);}`,
+    );
   });
 
   it('renders JSX correctly', () => {

--- a/components/table/__tests__/Table.test.tsx
+++ b/components/table/__tests__/Table.test.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useState } from 'react';
-import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 
 import type { TableProps, TableRef } from '..';
 import Table from '..';
@@ -19,30 +18,6 @@ describe('Table', () => {
 
   afterAll(() => {
     warnSpy.mockRestore();
-  });
-
-  it('keeps top border for bordered sticky header', () => {
-    const cache = createCache();
-
-    render(
-      <StyleProvider cache={cache}>
-        <Table
-          bordered
-          sticky
-          columns={[{ title: 'Name', dataIndex: 'name' }]}
-          dataSource={[{ key: '1', name: 'John' }]}
-          pagination={false}
-        />
-      </StyleProvider>,
-    );
-
-    const stickyHeaderSelector =
-      '.ant-table.ant-table-bordered >.ant-table-container >.ant-table-header.ant-table-sticky-holder';
-    const styleText = extractStyle(cache, { plain: true });
-
-    expect(styleText).toContain(
-      `${stickyHeaderSelector}{margin-top:calc(var(--ant-line-width) * -1);border-top:var(--ant-line-width) var(--ant-line-type) var(--ant-table-border-color);}`,
-    );
   });
 
   it('renders JSX correctly', () => {

--- a/components/table/style/bordered.ts
+++ b/components/table/style/bordered.ts
@@ -50,6 +50,11 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
           borderInlineStart: tableBorder,
           borderTop: tableBorder,
 
+          [`> ${componentCls}-header${componentCls}-sticky-holder`]: {
+            marginTop: unit(calc(lineWidth).mul(-1).equal()),
+            borderTop: tableBorder,
+          },
+
           [`> ${componentCls}-content, > ${componentCls}-header, > ${componentCls}-body, > ${componentCls}-summary`]:
             {
               '> table': {

--- a/components/table/style/bordered.ts
+++ b/components/table/style/bordered.ts
@@ -51,7 +51,7 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
           borderTop: tableBorder,
 
           [`> ${componentCls}-header${componentCls}-sticky-holder`]: {
-            marginTop: unit(calc(lineWidth).mul(-1).equal()),
+            marginTop: calc(lineWidth).mul(-1).equal(),
             borderTop: tableBorder,
           },
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

Fixes #56708

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

In bordered Table, the top border is applied to `.ant-table-container`. When the header becomes sticky, the container border scrolls away while the sticky header remains fixed, so the top border appears missing.

This PR adds a top border to the sticky header holder in the bordered Table case, and applies a negative top margin by one line width to avoid showing a double border before the header becomes sticky.

AS-IS

<img width="1106" height="285" alt="image" src="https://github.com/user-attachments/assets/8b59989e-eb09-4b89-b24d-138cc3a03215" />

TO-BE

<img width="690" height="246" alt="image" src="https://github.com/user-attachments/assets/a1aab357-7180-4f16-af55-c475c14b9106" />

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Table missing top border when bordered sticky header becomes fixed |
| 🇨🇳 Chinese | 🐞 修复 Table 在边框模式下吸顶表头固定后顶部边框丢失的问题。 |
