### PR TITLE
fix(collapse): use center alignment on header for icon/label/extra alignment

### DIFF
--- a/components/collapse/style/index.ts
+++ b/components/collapse/style/index.ts
@@ -128,7 +128,7 @@ export const genBaseStyle: GenerateStyle<CollapseToken, CSSObject> = (token) => 
           position: 'relative', // Compatible with old version of antd, should remove in next version
           display: 'flex',
           flexWrap: 'nowrap',
-          alignItems: 'flex-start',
+          alignItems: 'center',
           padding: headerPadding,
           color: colorTextHeading,
           lineHeight,


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 💄 Component style improvement
- [x] 🐞 Bug fix

### 🔗 Related Issues

Fixes #58421

### 💡 Background and Solution

The Collapse header uses `alignItems: 'flex-start'` on its flex container. When the expand icon, title, and extra slot have different heights (e.g. a large Button in the extra slot), they misalign vertically because `flex-start` anchors them to the top edge instead of centering them.

**Fix:** Change `alignItems: 'flex-start'` → `alignItems: 'center'` on the header flex container.

This is the targeted half of #58421 — the alignment fix. The token additions for SM/LG padding sizes are a separate enhancement.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(Collapse): header items (expand icon, title, extra) now center-align correctly when they differ in height |
| 🇨🇳 Chinese | 修复(Collapse): 折叠面板头部各元素（展开图标、标题、extra）高度不同时现在可以正确垂直居中对齐 |

🤖 Generated with [Claude Code](https://claude.ai/code)