### PR TITLE
fix(steps): remove subpixel translateY on horizontal rail to eliminate blurry rendering

### DIFF
--- a/components/steps/style/horizontal.ts
+++ b/components/steps/style/horizontal.ts
@@ -23,7 +23,6 @@ const genHorizontalStyle: GenerateStyle<StepsToken, CSSObject> = (token) => {
           flex: 1,
           minWidth: 0,
           alignSelf: 'flex-start',
-          transform: 'translateY(-50%)',
         },
       },
     },


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] 💄 Component style improvement

### 🔗 Related Issues

Fixes #58112

### 💡 Background and Solution

The `.ant-steps-item-rail` element in horizontal steps uses `transform: translateY(-50%)` alongside `marginTop` to center the 1px rail line on the icon's vertical midpoint.

Root cause: When the parent has an odd pixel height, `translateY(-50%)` resolves to a half-pixel offset. The browser distributes the 1px border across two physical pixels via anti-aliasing, making the rail appear ~2px thick and its color desaturated.

Fix: Remove `transform: translateY(-50%)`. The existing `marginTop: varRef('horizontal-rail-margin')` (= `icon-size-max / 2 + item-wrapper-padding-top`) already positions the rail top at the icon center. Removing the 0.5px correction eliminates the subpixel offset while keeping alignment correct — the rail renders as a crisp 1px line with accurate color.

This bug is visible on the ant.design documentation site in the Steps component examples.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix(Steps): horizontal rail line now renders as a crisp 1px line with correct color |
| 🇨🇳 Chinese | 修复(Steps): 水平步骤条连接线现在渲染为清晰的 1px 线条，颜色正确 |

🤖 Generated with [Claude Code](https://claude.ai/code)