### PR TITLE
fix(ci): contributors.json not generated in CI deployment

### DIFF
--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -31,6 +31,7 @@ jobs:
         run: ut predeploy
         env:
           NODE_OPTIONS: --max_old_space_size=4096
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build dist and bundle analyzer report
         run: ut dist

--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-site:
@@ -62,6 +62,8 @@ jobs:
   deploy-to-pages:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: build-site
+    permissions:
+      contents: write
     steps:
       - uses: utooland/setup-utoo@e63ce40ce5f7e9838c666a57479344e91c3a9795 # v1
 
@@ -107,6 +109,8 @@ jobs:
   # https://github.com/ant-design/ant-design/pull/49213/files#r1625446496
   upload-to-release:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: write
     # 仅在 tag 的时候工作，因为我们要将内容发布到以 tag 为版本号的 release 里
     if: startsWith(github.ref, 'refs/tags/')
     needs: build-site

--- a/scripts/generate-contributors.ts
+++ b/scripts/generate-contributors.ts
@@ -34,18 +34,20 @@ const locales = [
   { locale: 'enUS', suffix: 'en-US' },
 ];
 
-const token = process.env.GITHUB_ACCESS_TOKEN;
+const token = process.env.GITHUB_ACCESS_TOKEN || process.env.GITHUB_TOKEN;
 
 const relativePath = path.relative(cwd, outputFile).replace(/\\/g, '/');
 
 if (token) {
   spinner.succeed(
-    chalk.green(`✅ GITHUB_ACCESS_TOKEN 验证成功，已完成权限校验，正在生成文件：${relativePath}`),
+    chalk.green(
+      `✅ ${process.env.GITHUB_ACCESS_TOKEN ? 'GITHUB_ACCESS_TOKEN' : 'GITHUB_TOKEN'} 验证成功，已完成权限校验，正在生成文件：${relativePath}`,
+    ),
   );
   console.log(''); // Keep an empty line here to make looks good~
 } else {
   spinner.fail(
-    chalk.red('🚨 请先设置 GITHUB_ACCESS_TOKEN 环境变量到本地，请不要泄露给任何在线页面'),
+    chalk.red('🚨 请先设置 GITHUB_ACCESS_TOKEN 或 GITHUB_TOKEN 环境变量，请不要泄露给任何在线页面'),
   );
   console.log(''); // Keep an empty line here to make looks good~
   process.exit(0);


### PR DESCRIPTION
### 🤔 This is a

  - [] 🐞 Bug fix
  - [] ⏩ Workflow

  ### 🔗 Related Issues

  > contributors.json is missing from the gh-pages branch after CI deployment.

  ### 💡 Background and Solution

  **Problem:** scripts/generate-contributors.ts reads process.env.GITHUB_ACCESS_TOKEN to authenticate GitHub API calls.
  In the CI workflow (site-deploy.yml), this variable is not set, so the script silently exits without generating
  contributors.json.

  **Solution:**
  1. scripts/generate-contributors.ts — fallback to GITHUB_TOKEN when GITHUB_ACCESS_TOKEN is not set.
  2. .github/workflows/site-deploy.yml — inject secrets.GITHUB_TOKEN as GITHUB_TOKEN env var in the build site step.

  ### 📝 Change Log

  | Language   | Changelog |
  | ---------- | --------- |
  | 🇺🇸 English | 🛠 Fix contributors.json not being generated during CI site deployment by falling back to GITHUB_TOKEN.
  |
  | 🇨🇳 Chinese | 🛠 修复 CI 站点部署时因缺少 GITHUB_ACCESS_TOKEN 导致 contributors.json 未生成的问题，改为降级使用
  GITHUB_TOKEN。 |