### PR TITLE
fix: avoid popup root drop-shadow filter

### DIFF
--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 import { warning } from '@rc-component/util';
 
 import Popover from '..';
@@ -255,5 +256,22 @@ describe('Popover', () => {
 
     const arrow = container.querySelector('.ant-popover-arrow');
     expect(arrow).not.toHaveStyle({ background: 'red' });
+  });
+
+  it('does not put drop-shadow filter on popup root', () => {
+    const cache = createCache();
+
+    render(
+      <StyleProvider cache={cache}>
+        <Popover content="hello" open>
+          <span>Show</span>
+        </Popover>
+      </StyleProvider>,
+    );
+
+    const styleText = extractStyle(cache, { plain: true });
+
+    expect(styleText).not.toMatch(/\.ant-popover\{[^}]*filter:drop-shadow/);
+    expect(styleText).toMatch(/\.ant-popover-container\{[^}]*box-shadow:/);
   });
 });

--- a/components/popover/style/index.ts
+++ b/components/popover/style/index.ts
@@ -76,7 +76,7 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
     titleMinWidth,
     fontWeightStrong,
     innerPadding,
-    dropShadowPopover,
+    boxShadowSecondary,
     colorTextHeading,
     borderRadiusLG,
     zIndexPopup,
@@ -108,7 +108,6 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
         textAlign: 'start',
         cursor: 'auto',
         userSelect: 'text',
-        filter: dropShadowPopover,
 
         // When use `autoArrow`, origin will follow the arrow position
         [varName('valid-offset-x')]: varRef('arrow-offset-x', 'var(--arrow-x)'),
@@ -137,6 +136,7 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
           backgroundColor: popoverBg,
           backgroundClip: 'padding-box',
           borderRadius: borderRadiusLG,
+          boxShadow: boxShadowSecondary,
           padding: innerPadding,
         },
 

--- a/components/theme/interface/alias.ts
+++ b/components/theme/interface/alias.ts
@@ -627,8 +627,6 @@ export interface AliasToken extends MapToken {
   /** @internal */
   boxShadowPopoverArrow: string;
   /** @internal */
-  dropShadowPopover: string;
-  /** @internal */
   boxShadowCard: string;
   /** @internal */
   boxShadowDrawerRight: string;

--- a/components/theme/util/alias.ts
+++ b/components/theme/util/alias.ts
@@ -179,7 +179,6 @@ export default function formatToken(derivativeToken: RawMergedToken): AliasToken
     screenXXXLMin: screenXXXL,
 
     boxShadowPopoverArrow: `2px 2px 5px ${getShadowColor(0.05)}`,
-    dropShadowPopover: `drop-shadow(0 6px 16px ${getShadowColor(0.08)}) drop-shadow(0 3px 6px ${getShadowColor(0.12)}) drop-shadow(0 9px 28px ${getShadowColor(0.05)})`,
     boxShadowCard: `
       0 1px 2px -2px ${getShadowColor(0.16)},
       0 3px 6px 0 ${getShadowColor(0.12)},

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 import { spyElementPrototype, warning } from '@rc-component/util';
 
 import type { TooltipPlacement } from '..';
@@ -656,5 +657,23 @@ describe('Tooltip', () => {
 
     const arrow = container.querySelector('.ant-tooltip-arrow');
     expect(arrow).toHaveStyle({ background: 'red' });
+  });
+
+  it('does not put drop-shadow filter on popup root', () => {
+    const cache = createCache();
+
+    render(
+      <StyleProvider cache={cache}>
+        <Tooltip title="hello" open>
+          <span>Hover me</span>
+        </Tooltip>
+      </StyleProvider>,
+    );
+
+    const styleText = extractStyle(cache, { plain: true });
+
+    expect(styleText).not.toMatch(/\.ant-tooltip\{[^}]*filter:drop-shadow/);
+    expect(styleText).toMatch(/\.ant-tooltip-container\{[^}]*box-shadow:/);
+    expect(styleText).toMatch(/\.ant-tooltip-unique-container\{[^}]*box-shadow:/);
   });
 });

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -48,7 +48,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
     tooltipBorderRadius,
     zIndexPopup,
     controlHeight,
-    dropShadowPopover,
+    boxShadowSecondary,
     paddingSM,
     paddingXS,
     arrowOffsetHorizontal,
@@ -77,6 +77,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
     wordWrap: 'break-word',
     backgroundColor: tooltipBg,
     borderRadius: tooltipBorderRadius,
+    boxShadow: boxShadowSecondary,
     boxSizing: 'border-box',
   };
 
@@ -99,7 +100,6 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
         width: 'max-content',
         maxWidth: tooltipMaxWidth,
         visibility: 'visible',
-        filter: dropShadowPopover,
 
         ...sharedTransformOrigin,
 
@@ -116,6 +116,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
           [`${componentCls}-container`]: {
             border: 'none',
             background: 'transparent',
+            boxShadow: 'none',
           },
         },
 
@@ -185,7 +186,6 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
         ...sharedTransformOrigin,
         position: 'absolute',
         zIndex: calc(zIndexPopup).sub(1).equal(),
-        filter: dropShadowPopover,
 
         '&-hidden': {
           display: 'none',


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close #58384

### 💡 Background and Solution

#57988 moved Tooltip and Popover elevation to `filter: drop-shadow(...)` on the popup root so the arrow and popup body share one shadow. That root filter also creates a backdrop root, which prevents descendant `backdrop-filter` styles on popup content from blurring the page behind the popup.

This PR removes the root-level drop-shadow filter from Tooltip and Popover, restores popup elevation on the body containers with `boxShadowSecondary`, and keeps arrow shadow disabled to avoid bringing back the darker-arrow overlap fixed by #57988. Tooltip unique containers keep the body shadow while the transparent placeholder container resets its shadow.

Regression tests assert that generated Tooltip and Popover CSS no longer applies `drop-shadow` on the popup root and that the popup body containers still receive a box shadow.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Tooltip and Popover root drop-shadow filter blocking `backdrop-filter` on popup content. |
| 🇨🇳 Chinese | 🐞 修复 Tooltip 和 Popover 根节点 drop-shadow filter 导致弹层内容 `backdrop-filter` 失效的问题。 |