### PR TITLE
fix: support ConfigProvider style for Input.Search

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -86,6 +86,8 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
   const {
     direction,
     getPrefixCls,
+    className: contextClassName,
+    style: contextStyle,
     classNames: contextClassNames,
     styles: contextStyles,
     searchIcon: contextSearchIcon,
@@ -216,6 +218,7 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
       [`${prefixCls}-with-button`]: !!enterButton,
     },
     className,
+    contextClassName,
     hashId,
     mergedClassNames.root,
   );
@@ -257,7 +260,7 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
   return (
     <Compact
       className={mergedClassName}
-      style={{ ...style, ...mergedStyles.root }}
+      style={{ ...mergedStyles.root, ...contextStyle, ...style }}
       {...rootProps}
       hidden={hidden}
     >

--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -384,4 +384,24 @@ describe('Input.Search', () => {
       expect(container.querySelector('.ant-input-search-btn')).toHaveTextContent('bamboo');
     });
   });
+
+  it('should support ConfigProvider className and style', () => {
+    const { container } = render(
+      <ConfigProvider
+        inputSearch={{
+          className: 'bamboo',
+          style: { color: 'rgb(255, 0, 0)', backgroundColor: 'rgb(0, 255, 0)' },
+        }}
+      >
+        <Search style={{ color: 'rgb(0, 0, 255)' }} />
+      </ConfigProvider>,
+    );
+
+    const root = container.querySelector('.ant-input-search');
+    expect(root).toHaveClass('bamboo');
+    expect(root).toHaveStyle({
+      color: 'rgb(0, 0, 255)',
+      backgroundColor: 'rgb(0, 255, 0)',
+    });
+  });
 });


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

`ConfigProvider` 的 `inputSearch` 配置类型支持 `className` 和 `style`，但 Input.Search 实际只消费了 `classNames`、`styles` 和 `searchIcon`，导致全局 `inputSearch.className` 和 `inputSearch.style` 不生效。

本次补齐 Input.Search 根节点对 `inputSearch.className` 和 `inputSearch.style` 的应用，并保持组件自身 `style` 优先于全局配置。新增单测覆盖全局 className/style 生效以及本地 style 覆盖全局 style 的场景。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Input.Search not applying ConfigProvider `inputSearch.className` and `inputSearch.style`. |
| 🇨🇳 中文 | 修复 Input.Search 未应用 ConfigProvider 的 `inputSearch.className` 和 `inputSearch.style` 的问题。 |
