### PR TITLE
fix: avoid polynomial hash parsing regexp in Anchor

### DIFF
--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -46,7 +46,7 @@ function getOffsetTop(element: HTMLElement, container: AnchorContainer): number 
   return rect.top;
 }
 
-const sharpMatcherRegex = /#([\S ]+)$/;
+const sharpMatcherRegex = /#([^\t\r\n\f\v]+)$/;
 
 interface Section {
   link: string;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Fix https://github.com/ant-design/ant-design/security/code-scanning/3361

### 💡 需求背景和解决方案

GitHub CodeQL 报告 Anchor 中用于解析链接 hash 的正则可能在特定异常输入下产生 polynomial ReDoS 风险。

本 PR 保留原有解析流程，仅将正则中的 `[\S ]` 匹配收敛为排除 tab、换行等控制空白字符的字符类，避免 CodeQL 指出的 `#\t` 重复输入触发回溯风险，同时保留现有 first-hash 解析行为。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Anchor potential slow hash parsing for malformed links. |
| 🇨🇳 中文 | 修复 Anchor 在异常链接下可能出现的哈希解析性能问题。 |
