### PR TITLE
site: hide focus outline on Components Overview search input

### DIFF
--- a/.dumi/theme/builtins/ComponentOverview/index.tsx
+++ b/.dumi/theme/builtins/ComponentOverview/index.tsx
@@ -49,8 +49,7 @@ const styles = createStaticStyles(({ cssVar, css }) => ({
       color: ${cssVar.colorTextDisabled};
     }
     &:focus-visible,
-    &:has(input:focus-visible),
-    &:has(textarea:focus-visible) {
+    &:has(input:focus-visible) {
       outline: none !important;
     }
   `,

--- a/.dumi/theme/builtins/ComponentOverview/index.tsx
+++ b/.dumi/theme/builtins/ComponentOverview/index.tsx
@@ -48,6 +48,11 @@ const styles = createStaticStyles(({ cssVar, css }) => ({
     .anticon-search {
       color: ${cssVar.colorTextDisabled};
     }
+    &:focus-visible,
+    &:has(input:focus-visible),
+    &:has(textarea:focus-visible) {
+      outline: none !important;
+    }
   `,
   componentsOverviewContent: css`
     &:empty:after {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #58476

### 💡 需求背景和解决方案

#58250 为 `variant="borderless"` 的 Input 增加了 `:focus-visible` outline，导致组件总览页顶部搜索框聚焦时出现蓝色外框，与页面原本的无边框设计不一致。

本次在 `ComponentOverview` 的 `componentsOverviewSearch` 样式中覆盖 focus outline，仅作用于站点搜索框，不改动组件库行为。不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述              |
| ------- | --------------------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志          |