### PR TITLE
fix: show file icon for failed Upload files

### DIFF
--- a/components/upload/__tests__/uploadlist.test.tsx
+++ b/components/upload/__tests__/uploadlist.test.tsx
@@ -995,6 +995,22 @@ describe('Upload List', () => {
     unmount();
   });
 
+  it('when picture-card file upload fails, non-image file should render file icon', () => {
+    const items = [{ status: 'error', uid: 'upload-list-item', name: 'report.pdf' }];
+    const { container: wrapper, unmount } = render(
+      <UploadList
+        listType="picture-card"
+        items={items as UploadListProps['items']}
+        locale={{ uploadError: 'upload error' }}
+      />,
+    );
+
+    expect(wrapper.querySelector('.ant-upload-list-item-thumbnail .anticon-file')).toBeTruthy();
+    expect(wrapper.querySelector('.ant-upload-list-item-thumbnail .anticon-picture')).toBeFalsy();
+
+    unmount();
+  });
+
   it('onPreview should be called, when url exists', () => {
     const onPreview = jest.fn();
     const items = [{ thumbUrl: 'thumbUrl', url: 'url', uid: 'upload-list-item' }];

--- a/components/upload/utils.ts
+++ b/components/upload/utils.ts
@@ -73,7 +73,7 @@ export const isImageUrl = (file: UploadFile): boolean => {
     return isImageFileType(file.type);
   }
   const url = file.thumbUrl || file.url || '';
-  const extension = extname(url);
+  const extension = extname(url || file.name);
   if (/^data:image\//.test(url) || imageExtensions.includes(extension?.toLowerCase() || '')) {
     return true;
   }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Fixes #58471

### 💡 Background and Solution

When `Upload` renders a picture-card list item for a failed non-image file without `url`, `thumbUrl`, or `type`, the default `isImageUrl` fallback treats it as an image. This makes files such as `report.pdf` render the picture icon instead of the file icon after upload failure.

This change lets `isImageUrl` fall back to the file name extension only when there is no usable `url` or `thumbUrl`, so non-image failed files keep the default file icon while existing no-extension URL behavior stays unchanged.

It does not add built-in icons for many specific document types, keeping the package size unchanged.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Upload showing the picture icon for failed non-image files in picture-card lists when only the file name is available. |
| 🇨🇳 Chinese | 修复 Upload picture-card 列表中文件仅有文件名且上传失败时，非图片文件错误显示图片图标的问题。 |