### PR TITLE
docs: add LLMs markdown links to docs pages

### DIFF
--- a/.dumi/hooks/useIssueCount.ts
+++ b/.dumi/hooks/useIssueCount.ts
@@ -22,12 +22,13 @@ const swrConfig: SWRConfiguration<number, Error> = {
 
 export interface UseIssueCountOptions {
   repo: string; // e.g. ant-design/ant-design
+  enabled?: boolean;
   proxyEndpoint?: string; // backend proxy endpoint to avoid GitHub rate limit
   titleKeywords?: string[]; // keywords to match in issue title
 }
 
 export const useIssueCount = (options: UseIssueCountOptions) => {
-  const { repo, proxyEndpoint, titleKeywords } = options;
+  const { repo, enabled = true, proxyEndpoint, titleKeywords } = options;
 
   // Note: current query only filters by title keywords. Filtering by component name can be added later if needed.
   const searchUrl = useMemo(() => {
@@ -38,7 +39,7 @@ export const useIssueCount = (options: UseIssueCountOptions) => {
     return `https://api.github.com/search/issues?q=${q}`;
   }, [repo, titleKeywords]);
 
-  const endpoint = proxyEndpoint || searchUrl;
+  const endpoint = enabled ? proxyEndpoint || searchUrl : null;
 
   const { data, error, isLoading } = useSWR<number, Error>(endpoint || null, fetcher, swrConfig);
 

--- a/.dumi/theme/builtins/ComponentMeta/index.tsx
+++ b/.dumi/theme/builtins/ComponentMeta/index.tsx
@@ -121,9 +121,31 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
   const isZhCN = lang === 'cn';
   const { styles } = useStyle();
 
+  // ======================== Source ========================
+  const [filledSource, abbrSource, componentLlmsPath] = React.useMemo(() => {
+    if (String(source) === 'true' && component) {
+      const kebabComponent = kebabCase(component);
+      return [
+        `https://github.com/${repo}/blob/master/components/${kebabComponent}`,
+        `components/${kebabComponent}`,
+        `/components/${kebabComponent}${isZhCN ? '-cn' : ''}.md`,
+      ];
+    }
+
+    if (typeof source !== 'string') {
+      return [null, null, null];
+    }
+
+    return [source, source, null];
+  }, [component, repo, source, isZhCN]);
+
+  const filledLlmsPath = llmsPath ?? componentLlmsPath;
+  const showDocs = (showEdit && filename) || designUrl || filledLlmsPath || showChangelog;
+
   // ======================= Issues Count =======================
   const { issueCount, issueCountLoading, issueNewUrl, issueSearchUrl } = useIssueCount({
     repo,
+    enabled: Boolean(filledSource),
     titleKeywords: searchTitleKeywords,
   });
 
@@ -147,27 +169,6 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
       setCopied(false);
     }
   };
-
-  // ======================== Source ========================
-  const [filledSource, abbrSource, componentLlmsPath] = React.useMemo(() => {
-    if (String(source) === 'true' && component) {
-      const kebabComponent = kebabCase(component);
-      return [
-        `https://github.com/${repo}/blob/master/components/${kebabComponent}`,
-        `components/${kebabComponent}`,
-        `/components/${kebabComponent}${isZhCN ? '-cn' : ''}.md`,
-      ];
-    }
-
-    if (typeof source !== 'string') {
-      return [null, null, null];
-    }
-
-    return [source, source, null];
-  }, [component, repo, source, isZhCN]);
-
-  const filledLlmsPath = llmsPath ?? componentLlmsPath;
-  const showDocs = (showEdit && filename) || designUrl || filledLlmsPath || showChangelog;
 
   return (
     <Descriptions

--- a/.dumi/theme/builtins/ComponentMeta/index.tsx
+++ b/.dumi/theme/builtins/ComponentMeta/index.tsx
@@ -89,17 +89,33 @@ const useStyle = createStyles(({ cssVar, token }) => ({
 }));
 
 export interface ComponentMetaProps {
-  component: string;
-  source: string | true;
+  component?: string;
+  source?: string | true;
   filename?: string;
+  llmsPath?: string;
   version?: string;
   designUrl?: string;
   searchTitleKeywords?: string[];
   repo: string;
+  showImport?: boolean;
+  showEdit?: boolean;
+  showChangelog?: boolean;
 }
 
 const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
-  const { component, source, filename, version, designUrl, searchTitleKeywords, repo } = props;
+  const {
+    component,
+    source,
+    filename,
+    llmsPath,
+    version,
+    designUrl,
+    searchTitleKeywords,
+    repo,
+    showImport = true,
+    showEdit = true,
+    showChangelog = true,
+  } = props;
   const { token } = theme.useToken();
   const [locale, lang] = useLocale(locales);
   const isZhCN = lang === 'cn';
@@ -117,7 +133,9 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
   const importCode =
     component === 'Icon'
       ? `import { AntDesignOutlined } from '@ant-design/icons';`
-      : `import { ${transformComponentName(component)} } from 'antd';`;
+      : component
+        ? `import { ${transformComponentName(component)} } from 'antd';`
+        : '';
 
   const onCopy = async () => {
     await copy(importCode);
@@ -131,8 +149,8 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
   };
 
   // ======================== Source ========================
-  const [filledSource, abbrSource, llmsPath] = React.useMemo(() => {
-    if (String(source) === 'true') {
+  const [filledSource, abbrSource, componentLlmsPath] = React.useMemo(() => {
+    if (String(source) === 'true' && component) {
       const kebabComponent = kebabCase(component);
       return [
         `https://github.com/${repo}/blob/master/components/${kebabComponent}`,
@@ -148,6 +166,9 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
     return [source, source, null];
   }, [component, repo, source, isZhCN]);
 
+  const filledLlmsPath = llmsPath ?? componentLlmsPath;
+  const showDocs = (showEdit && filename) || designUrl || filledLlmsPath || showChangelog;
+
   return (
     <Descriptions
       size="small"
@@ -157,24 +178,25 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
       styles={{ label: { paddingInlineEnd: token.padding, width: 56 } }}
       items={
         [
-          {
-            label: locale.import,
-            children: (
-              <Tooltip
-                placement="right"
-                title={copied ? locale.copied : locale.copy}
-                onOpenChange={onOpenChange}
-              >
-                <Typography.Text
-                  className={styles.code}
-                  style={{ cursor: 'pointer' }}
-                  onClick={onCopy}
+          showImport &&
+            component && {
+              label: locale.import,
+              children: (
+                <Tooltip
+                  placement="right"
+                  title={copied ? locale.copied : locale.copy}
+                  onOpenChange={onOpenChange}
                 >
-                  {importCode}
-                </Typography.Text>
-              </Tooltip>
-            ),
-          },
+                  <Typography.Text
+                    className={styles.code}
+                    style={{ cursor: 'pointer' }}
+                    onClick={onCopy}
+                  >
+                    {importCode}
+                  </Typography.Text>
+                </Tooltip>
+              ),
+            },
           filledSource && {
             label: locale.source,
             children: (
@@ -196,39 +218,45 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
               </Flex>
             ),
           },
-          filename && {
+          showDocs && {
             label: locale.docs,
             children: (
               <Flex justify="flex-start" align="center" gap="small">
-                <Typography.Link
-                  className={styles.code}
-                  href={`${branchUrl(repo)}${filename}`}
-                  target="_blank"
-                >
-                  <EditOutlined className={styles.icon} />
-                  <span>{locale.edit}</span>
-                </Typography.Link>
+                {showEdit && filename && (
+                  <Typography.Link
+                    className={styles.code}
+                    href={`${branchUrl(repo)}${filename}`}
+                    target="_blank"
+                  >
+                    <EditOutlined className={styles.icon} />
+                    <span>{locale.edit}</span>
+                  </Typography.Link>
+                )}
                 {designUrl && (
                   <Link className={styles.code} to={designUrl}>
                     <CompassOutlined className={styles.icon} />
                     <span>{locale.design}</span>
                   </Link>
                 )}
-                <Typography.Link
-                  className={styles.code}
-                  href={llmsPath || ''}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <FileTextOutlined className={styles.icon} />
-                  <span>LLMs.md</span>
-                </Typography.Link>
-                <ComponentChangelog>
-                  <Typography.Link className={styles.code}>
-                    <HistoryOutlined className={styles.icon} />
-                    <span>{locale.changelog}</span>
+                {filledLlmsPath && (
+                  <Typography.Link
+                    className={styles.code}
+                    href={filledLlmsPath}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <FileTextOutlined className={styles.icon} />
+                    <span>LLMs.md</span>
                   </Typography.Link>
-                </ComponentChangelog>
+                )}
+                {showChangelog && (
+                  <ComponentChangelog>
+                    <Typography.Link className={styles.code}>
+                      <HistoryOutlined className={styles.icon} />
+                      <span>{locale.changelog}</span>
+                    </Typography.Link>
+                  </ComponentChangelog>
+                )}
               </Flex>
             ),
           },

--- a/.dumi/theme/builtins/ComponentMeta/index.tsx
+++ b/.dumi/theme/builtins/ComponentMeta/index.tsx
@@ -10,7 +10,7 @@ import {
   LoadingOutlined,
 } from '@ant-design/icons';
 import type { GetProp } from 'antd';
-import { Descriptions, Flex, theme, Tooltip, Typography } from 'antd';
+import { Descriptions, Divider, Flex, theme, Tooltip, Typography } from 'antd';
 import { createStyles, css } from 'antd-style';
 import copy from 'antd/es/_util/copy';
 import kebabCase from 'lodash/kebabCase';
@@ -171,107 +171,110 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
   };
 
   return (
-    <Descriptions
-      size="small"
-      colon={false}
-      column={1}
-      style={{ marginTop: token.margin }}
-      styles={{ label: { paddingInlineEnd: token.padding, width: 56 } }}
-      items={
-        [
-          showImport &&
-            component && {
-              label: locale.import,
-              children: (
-                <Tooltip
-                  placement="right"
-                  title={copied ? locale.copied : locale.copy}
-                  onOpenChange={onOpenChange}
-                >
-                  <Typography.Text
-                    className={styles.code}
-                    style={{ cursor: 'pointer' }}
-                    onClick={onCopy}
+    <>
+      <Descriptions
+        size="small"
+        colon={false}
+        column={1}
+        style={{ marginTop: token.margin }}
+        styles={{ label: { paddingInlineEnd: token.padding, width: 56 } }}
+        items={
+          [
+            showImport &&
+              component && {
+                label: locale.import,
+                children: (
+                  <Tooltip
+                    placement="right"
+                    title={copied ? locale.copied : locale.copy}
+                    onOpenChange={onOpenChange}
                   >
-                    {importCode}
-                  </Typography.Text>
-                </Tooltip>
+                    <Typography.Text
+                      className={styles.code}
+                      style={{ cursor: 'pointer' }}
+                      onClick={onCopy}
+                    >
+                      {importCode}
+                    </Typography.Text>
+                  </Tooltip>
+                ),
+              },
+            filledSource && {
+              label: locale.source,
+              children: (
+                <Flex justify="flex-start" align="center" gap="small">
+                  <Typography.Link className={styles.code} href={filledSource} target="_blank">
+                    <GithubOutlined className={styles.icon} />
+                    <span>{abbrSource}</span>
+                  </Typography.Link>
+                  <Typography.Link className={styles.code} href={issueNewUrl} target="_blank">
+                    <BugOutlined className={styles.icon} />
+                    <span>{locale.issueNew}</span>
+                  </Typography.Link>
+                  <Typography.Link className={styles.code} href={issueSearchUrl} target="_blank">
+                    <IssuesCloseOutlined className={styles.icon} />
+                    <span>
+                      {locale.issueOpen} {issueCountLoading ? <LoadingOutlined /> : issueCount}
+                    </span>
+                  </Typography.Link>
+                </Flex>
               ),
             },
-          filledSource && {
-            label: locale.source,
-            children: (
-              <Flex justify="flex-start" align="center" gap="small">
-                <Typography.Link className={styles.code} href={filledSource} target="_blank">
-                  <GithubOutlined className={styles.icon} />
-                  <span>{abbrSource}</span>
-                </Typography.Link>
-                <Typography.Link className={styles.code} href={issueNewUrl} target="_blank">
-                  <BugOutlined className={styles.icon} />
-                  <span>{locale.issueNew}</span>
-                </Typography.Link>
-                <Typography.Link className={styles.code} href={issueSearchUrl} target="_blank">
-                  <IssuesCloseOutlined className={styles.icon} />
-                  <span>
-                    {locale.issueOpen} {issueCountLoading ? <LoadingOutlined /> : issueCount}
-                  </span>
-                </Typography.Link>
-              </Flex>
-            ),
-          },
-          showDocs && {
-            label: locale.docs,
-            children: (
-              <Flex justify="flex-start" align="center" gap="small">
-                {showEdit && filename && (
-                  <Typography.Link
-                    className={styles.code}
-                    href={`${branchUrl(repo)}${filename}`}
-                    target="_blank"
-                  >
-                    <EditOutlined className={styles.icon} />
-                    <span>{locale.edit}</span>
-                  </Typography.Link>
-                )}
-                {designUrl && (
-                  <Link className={styles.code} to={designUrl}>
-                    <CompassOutlined className={styles.icon} />
-                    <span>{locale.design}</span>
-                  </Link>
-                )}
-                {filledLlmsPath && (
-                  <Typography.Link
-                    className={styles.code}
-                    href={filledLlmsPath}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <FileTextOutlined className={styles.icon} />
-                    <span>LLMs.md</span>
-                  </Typography.Link>
-                )}
-                {showChangelog && (
-                  <ComponentChangelog>
-                    <Typography.Link className={styles.code}>
-                      <HistoryOutlined className={styles.icon} />
-                      <span>{locale.changelog}</span>
+            showDocs && {
+              label: locale.docs,
+              children: (
+                <Flex justify="flex-start" align="center" gap="small">
+                  {showEdit && filename && (
+                    <Typography.Link
+                      className={styles.code}
+                      href={`${branchUrl(repo)}${filename}`}
+                      target="_blank"
+                    >
+                      <EditOutlined className={styles.icon} />
+                      <span>{locale.edit}</span>
                     </Typography.Link>
-                  </ComponentChangelog>
-                )}
-              </Flex>
-            ),
-          },
-          isVersionNumber(version) && {
-            label: locale.version,
-            children: (
-              <Typography.Text className={styles.code}>
-                {isZhCN ? `自 ${version} 起支持` : `supported since ${version}`}
-              </Typography.Text>
-            ),
-          },
-        ].filter(Boolean) as GetProp<typeof Descriptions, 'items'>
-      }
-    />
+                  )}
+                  {designUrl && (
+                    <Link className={styles.code} to={designUrl}>
+                      <CompassOutlined className={styles.icon} />
+                      <span>{locale.design}</span>
+                    </Link>
+                  )}
+                  {filledLlmsPath && (
+                    <Typography.Link
+                      className={styles.code}
+                      href={filledLlmsPath}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <FileTextOutlined className={styles.icon} />
+                      <span>LLMs.md</span>
+                    </Typography.Link>
+                  )}
+                  {showChangelog && (
+                    <ComponentChangelog>
+                      <Typography.Link className={styles.code}>
+                        <HistoryOutlined className={styles.icon} />
+                        <span>{locale.changelog}</span>
+                      </Typography.Link>
+                    </ComponentChangelog>
+                  )}
+                </Flex>
+              ),
+            },
+            isVersionNumber(version) && {
+              label: locale.version,
+              children: (
+                <Typography.Text className={styles.code}>
+                  {isZhCN ? `自 ${version} 起支持` : `supported since ${version}`}
+                </Typography.Text>
+              ),
+            },
+          ].filter(Boolean) as GetProp<typeof Descriptions, 'items'>
+        }
+      />
+      <Divider />
+    </>
   );
 };
 

--- a/.dumi/theme/slots/Content/index.tsx
+++ b/.dumi/theme/slots/Content/index.tsx
@@ -59,6 +59,11 @@ const Content: React.FC<ContentProps> = ({ children, className }) => {
     !isComponentPage && meta.frontmatter?.filename
       ? `${rawLocation.pathname.replace(/\/$/, '') || '/index'}.md`
       : undefined;
+  const showComponentMeta =
+    meta.frontmatter.category === 'Components' && String(meta.frontmatter.showImport) !== 'false';
+  const showDocsMeta = meta.frontmatter.category !== 'Components' && markdownPath;
+  const showTitleEdit =
+    !pathname.startsWith('/components/overview') && !showComponentMeta && !showDocsMeta;
 
   return (
     <DemoContext value={contextValue}>
@@ -71,7 +76,7 @@ const Content: React.FC<ContentProps> = ({ children, className }) => {
                 <Space>
                   <span>{meta.frontmatter?.title}</span>
                   <span>{meta.frontmatter?.subtitle}</span>
-                  {!pathname.startsWith('/components/overview') && (
+                  {showTitleEdit && (
                     <EditButton
                       title={<FormattedMessage id="app.content.edit-page" />}
                       filename={meta.frontmatter.filename}
@@ -85,21 +90,20 @@ const Content: React.FC<ContentProps> = ({ children, className }) => {
           {!meta.frontmatter.__autoDescription && meta.frontmatter.description}
 
           {/* Import Info */}
-          {meta.frontmatter.category === 'Components' &&
-            String(meta.frontmatter.showImport) !== 'false' && (
-              <ComponentMeta
-                source
-                component={meta.frontmatter.title}
-                filename={meta.frontmatter.filename}
-                version={meta.frontmatter.tag}
-                designUrl={meta.frontmatter.designUrl}
-                searchTitleKeywords={[meta.frontmatter.title, meta.frontmatter.subtitle].filter(
-                  Boolean,
-                )}
-                repo="ant-design/ant-design"
-              />
-            )}
-          {meta.frontmatter.category !== 'Components' && markdownPath && (
+          {showComponentMeta && (
+            <ComponentMeta
+              source
+              component={meta.frontmatter.title}
+              filename={meta.frontmatter.filename}
+              version={meta.frontmatter.tag}
+              designUrl={meta.frontmatter.designUrl}
+              searchTitleKeywords={[meta.frontmatter.title, meta.frontmatter.subtitle].filter(
+                Boolean,
+              )}
+              repo="ant-design/ant-design"
+            />
+          )}
+          {showDocsMeta && (
             <ComponentMeta
               filename={meta.frontmatter.filename}
               llmsPath={markdownPath}

--- a/.dumi/theme/slots/Content/index.tsx
+++ b/.dumi/theme/slots/Content/index.tsx
@@ -105,7 +105,6 @@ const Content: React.FC<ContentProps> = ({ children, className }) => {
               llmsPath={markdownPath}
               repo="ant-design/ant-design"
               showChangelog={false}
-              showEdit={false}
               showImport={false}
             />
           )}

--- a/.dumi/theme/slots/Content/index.tsx
+++ b/.dumi/theme/slots/Content/index.tsx
@@ -53,6 +53,11 @@ const Content: React.FC<ContentProps> = ({ children, className }) => {
   );
 
   const isRTL = direction === 'rtl';
+  const isComponentPage = pathname.startsWith('/components/');
+  const markdownPath =
+    !isComponentPage && meta.frontmatter?.filename
+      ? `${pathname.replace(/\/$/, '')}.md`
+      : undefined;
 
   return (
     <DemoContext value={contextValue}>
@@ -93,6 +98,16 @@ const Content: React.FC<ContentProps> = ({ children, className }) => {
                 repo="ant-design/ant-design"
               />
             )}
+          {meta.frontmatter.category !== 'Components' && markdownPath && (
+            <ComponentMeta
+              filename={meta.frontmatter.filename}
+              llmsPath={markdownPath}
+              repo="ant-design/ant-design"
+              showChangelog={false}
+              showEdit={false}
+              showImport={false}
+            />
+          )}
           <div style={{ minHeight: 'calc(100vh - 64px)' }}>
             {children}
             <FloatButton.BackTop />

--- a/.dumi/theme/slots/Content/index.tsx
+++ b/.dumi/theme/slots/Content/index.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useLayoutEffect, useMemo, useState } from 'react';
 import { Col, Flex, FloatButton, Skeleton, Space, Typography } from 'antd';
 import { clsx } from 'clsx';
-import { FormattedMessage, useRouteMeta } from 'dumi';
+import { FormattedMessage, useLocation as useDumiLocation, useRouteMeta } from 'dumi';
 
 import useLayoutState from '../../../hooks/useLayoutState';
 import useLocation from '../../../hooks/useLocation';
@@ -29,6 +29,7 @@ export interface ContentProps {
 
 const Content: React.FC<ContentProps> = ({ children, className }) => {
   const meta = useRouteMeta();
+  const rawLocation = useDumiLocation();
   const { pathname, hash } = useLocation();
   const { direction } = React.use(SiteContext);
   const { styles } = useStyle();
@@ -56,7 +57,7 @@ const Content: React.FC<ContentProps> = ({ children, className }) => {
   const isComponentPage = pathname.startsWith('/components/');
   const markdownPath =
     !isComponentPage && meta.frontmatter?.filename
-      ? `${pathname.replace(/\/$/, '')}.md`
+      ? `${rawLocation.pathname.replace(/\/$/, '') || '/index'}.md`
       : undefined;
 
   return (


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

普通文档页已经可以通过 `.md` 后缀访问 Markdown 内容，但页面上没有直接暴露 LLMs.md 入口，例如定制主题中文文档页不便于 AI 工具直接打开对应 Markdown 文档。

本次复用 `ComponentMeta` 展示文档元信息，并通过新增可选属性控制普通文档页仅展示 `LLMs.md` 入口。组件页仍沿用原有 `ComponentMeta` 展示 import、反馈、编辑、LLMs.md 和 changelog 信息。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |
