### PR TITLE
test: fix Spin nested loading selector

### DIFF
--- a/components/spin/__tests__/index.test.tsx
+++ b/components/spin/__tests__/index.test.tsx
@@ -35,7 +35,7 @@ describe('Spin', () => {
         <div>content</div>
       </Spin>,
     );
-    expect(container.querySelector<HTMLElement>('ant-spin-nested-loading')).toBeNull();
+    expect(container.querySelector<HTMLElement>('.ant-spin-nested-loading')).toBeNull();
   });
 
   it("should render custom indicator when it's set", () => {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

None

### 💡 需求背景和解决方案

Spin 的 fullscreen 测试中，断言使用了 `ant-spin-nested-loading` 标签选择器，实际没有检查 `.ant-spin-nested-loading` 类名。

本次将选择器修正为 `.ant-spin-nested-loading`，让测试断言真正覆盖预期 DOM。

已验证：

`npx jest --config .jest.js --no-cache components/spin/__tests__/index.test.tsx --runInBand`

### 📝 更新日志

| 语言    | 更新描述              |
| ------- | --------------------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志          |