### PR TITLE
fix: add rate star border tokens

### DIFF
--- a/components/rate/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/rate/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2183,32 +2183,12 @@ exports[`renders components/rate/demo/component-token.tsx extend context correct
         <div
           class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
         <div
           class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
       </div>
     </li>
@@ -2225,32 +2205,12 @@ exports[`renders components/rate/demo/component-token.tsx extend context correct
         <div
           class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
         <div
           class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
       </div>
     </li>
@@ -2267,32 +2227,12 @@ exports[`renders components/rate/demo/component-token.tsx extend context correct
         <div
           class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
         <div
           class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
       </div>
     </li>
@@ -2309,32 +2249,12 @@ exports[`renders components/rate/demo/component-token.tsx extend context correct
         <div
           class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
         <div
           class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
       </div>
     </li>
@@ -2351,32 +2271,127 @@ exports[`renders components/rate/demo/component-token.tsx extend context correct
         <div
           class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
         <div
           class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
+        </div>
+      </div>
+    </li>
+  </ul>
+  <ul
+    class="ant-rate css-var-test-id"
+    tabindex="0"
+  >
+    <li
+      class="ant-rate-star ant-rate-star-full"
+    >
+      <div
+        aria-checked="true"
+        aria-posinset="1"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          好
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          好
+        </div>
+      </div>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-full"
+    >
+      <div
+        aria-checked="true"
+        aria-posinset="2"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          好
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          好
+        </div>
+      </div>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-half ant-rate-star-active"
+    >
+      <div
+        aria-checked="true"
+        aria-posinset="3"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          好
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          好
+        </div>
+      </div>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-zero"
+    >
+      <div
+        aria-checked="false"
+        aria-posinset="4"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          好
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          好
+        </div>
+      </div>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-zero"
+    >
+      <div
+        aria-checked="false"
+        aria-posinset="5"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          好
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          好
         </div>
       </div>
     </li>

--- a/components/rate/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/rate/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1868,301 +1868,520 @@ exports[`renders components/rate/demo/clear.tsx extend context correctly 1`] = `
 exports[`renders components/rate/demo/clear.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/rate/demo/component-token.tsx extend context correctly 1`] = `
-<ul
-  class="ant-rate css-var-test-id"
-  tabindex="0"
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
 >
-  <li
-    class="ant-rate-star ant-rate-star-full"
+  <ul
+    class="ant-rate css-var-test-id"
+    tabindex="0"
   >
-    <div
-      aria-checked="true"
-      aria-posinset="1"
-      aria-setsize="5"
-      role="radio"
-      tabindex="0"
+    <li
+      class="ant-rate-star ant-rate-star-full"
     >
       <div
-        class="ant-rate-star-first"
+        aria-checked="true"
+        aria-posinset="1"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
       >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+        <div
+          class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
-      </div>
-      <div
-        class="ant-rate-star-second"
-      >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
       </div>
-    </div>
-  </li>
-  <li
-    class="ant-rate-star ant-rate-star-full"
-  >
-    <div
-      aria-checked="true"
-      aria-posinset="2"
-      aria-setsize="5"
-      role="radio"
-      tabindex="0"
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-full"
     >
       <div
-        class="ant-rate-star-first"
+        aria-checked="true"
+        aria-posinset="2"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
       >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+        <div
+          class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
-      </div>
-      <div
-        class="ant-rate-star-second"
-      >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
       </div>
-    </div>
-  </li>
-  <li
-    class="ant-rate-star ant-rate-star-zero"
-  >
-    <div
-      aria-checked="true"
-      aria-posinset="3"
-      aria-setsize="5"
-      role="radio"
-      tabindex="0"
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-zero"
     >
       <div
-        class="ant-rate-star-first"
+        aria-checked="true"
+        aria-posinset="3"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
       >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+        <div
+          class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
-      </div>
-      <div
-        class="ant-rate-star-second"
-      >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
       </div>
-    </div>
-  </li>
-  <li
-    class="ant-rate-star ant-rate-star-zero"
-  >
-    <div
-      aria-checked="false"
-      aria-posinset="4"
-      aria-setsize="5"
-      role="radio"
-      tabindex="0"
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-zero"
     >
       <div
-        class="ant-rate-star-first"
+        aria-checked="false"
+        aria-posinset="4"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
       >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+        <div
+          class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
-      </div>
-      <div
-        class="ant-rate-star-second"
-      >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
       </div>
-    </div>
-  </li>
-  <li
-    class="ant-rate-star ant-rate-star-zero"
-  >
-    <div
-      aria-checked="false"
-      aria-posinset="5"
-      aria-setsize="5"
-      role="radio"
-      tabindex="0"
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-zero"
     >
       <div
-        class="ant-rate-star-first"
+        aria-checked="false"
+        aria-posinset="5"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
       >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+        <div
+          class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
       </div>
+    </li>
+  </ul>
+  <ul
+    class="ant-rate css-var-test-id"
+    tabindex="0"
+  >
+    <li
+      class="ant-rate-star ant-rate-star-full"
+    >
       <div
-        class="ant-rate-star-second"
+        aria-checked="true"
+        aria-posinset="1"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
       >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+        <div
+          class="ant-rate-star-first"
         >
           <svg
             aria-hidden="true"
-            data-icon="star"
             fill="currentColor"
-            focusable="false"
             height="1em"
-            viewBox="64 64 896 896"
+            viewBox="0 0 16 16"
             width="1em"
           >
             <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
             />
           </svg>
-        </span>
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
       </div>
-    </div>
-  </li>
-</ul>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-full"
+    >
+      <div
+        aria-checked="true"
+        aria-posinset="2"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-half ant-rate-star-active"
+    >
+      <div
+        aria-checked="true"
+        aria-posinset="3"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-zero"
+    >
+      <div
+        aria-checked="false"
+        aria-posinset="4"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-zero"
+    >
+      <div
+        aria-checked="false"
+        aria-posinset="5"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </li>
+  </ul>
+</div>
 `;
 
 exports[`renders components/rate/demo/component-token.tsx extend context correctly 2`] = `[]`;

--- a/components/rate/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/rate/__tests__/__snapshots__/demo.test.ts.snap
@@ -2175,32 +2175,12 @@ exports[`renders components/rate/demo/component-token.tsx correctly 1`] = `
         <div
           class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
         <div
           class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
       </div>
     </li>
@@ -2217,32 +2197,12 @@ exports[`renders components/rate/demo/component-token.tsx correctly 1`] = `
         <div
           class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
         <div
           class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
       </div>
     </li>
@@ -2259,32 +2219,12 @@ exports[`renders components/rate/demo/component-token.tsx correctly 1`] = `
         <div
           class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
         <div
           class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
       </div>
     </li>
@@ -2301,32 +2241,12 @@ exports[`renders components/rate/demo/component-token.tsx correctly 1`] = `
         <div
           class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
         <div
           class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
       </div>
     </li>
@@ -2343,32 +2263,127 @@ exports[`renders components/rate/demo/component-token.tsx correctly 1`] = `
         <div
           class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
         </div>
         <div
           class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
-            />
-          </svg>
+          A
+        </div>
+      </div>
+    </li>
+  </ul>
+  <ul
+    class="ant-rate css-var-test-id"
+    tabindex="0"
+  >
+    <li
+      class="ant-rate-star ant-rate-star-full"
+    >
+      <div
+        aria-checked="true"
+        aria-posinset="1"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          好
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          好
+        </div>
+      </div>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-full"
+    >
+      <div
+        aria-checked="true"
+        aria-posinset="2"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          好
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          好
+        </div>
+      </div>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-half ant-rate-star-active"
+    >
+      <div
+        aria-checked="true"
+        aria-posinset="3"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          好
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          好
+        </div>
+      </div>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-zero"
+    >
+      <div
+        aria-checked="false"
+        aria-posinset="4"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          好
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          好
+        </div>
+      </div>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-zero"
+    >
+      <div
+        aria-checked="false"
+        aria-posinset="5"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          好
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          好
         </div>
       </div>
     </li>

--- a/components/rate/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/rate/__tests__/__snapshots__/demo.test.ts.snap
@@ -1860,301 +1860,520 @@ exports[`renders components/rate/demo/clear.tsx correctly 1`] = `
 `;
 
 exports[`renders components/rate/demo/component-token.tsx correctly 1`] = `
-<ul
-  class="ant-rate css-var-test-id"
-  tabindex="0"
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
 >
-  <li
-    class="ant-rate-star ant-rate-star-full"
+  <ul
+    class="ant-rate css-var-test-id"
+    tabindex="0"
   >
-    <div
-      aria-checked="true"
-      aria-posinset="1"
-      aria-setsize="5"
-      role="radio"
-      tabindex="0"
+    <li
+      class="ant-rate-star ant-rate-star-full"
     >
       <div
-        class="ant-rate-star-first"
+        aria-checked="true"
+        aria-posinset="1"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
       >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+        <div
+          class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
-      </div>
-      <div
-        class="ant-rate-star-second"
-      >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
       </div>
-    </div>
-  </li>
-  <li
-    class="ant-rate-star ant-rate-star-full"
-  >
-    <div
-      aria-checked="true"
-      aria-posinset="2"
-      aria-setsize="5"
-      role="radio"
-      tabindex="0"
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-full"
     >
       <div
-        class="ant-rate-star-first"
+        aria-checked="true"
+        aria-posinset="2"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
       >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+        <div
+          class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
-      </div>
-      <div
-        class="ant-rate-star-second"
-      >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
       </div>
-    </div>
-  </li>
-  <li
-    class="ant-rate-star ant-rate-star-zero"
-  >
-    <div
-      aria-checked="true"
-      aria-posinset="3"
-      aria-setsize="5"
-      role="radio"
-      tabindex="0"
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-zero"
     >
       <div
-        class="ant-rate-star-first"
+        aria-checked="true"
+        aria-posinset="3"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
       >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+        <div
+          class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
-      </div>
-      <div
-        class="ant-rate-star-second"
-      >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
       </div>
-    </div>
-  </li>
-  <li
-    class="ant-rate-star ant-rate-star-zero"
-  >
-    <div
-      aria-checked="false"
-      aria-posinset="4"
-      aria-setsize="5"
-      role="radio"
-      tabindex="0"
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-zero"
     >
       <div
-        class="ant-rate-star-first"
+        aria-checked="false"
+        aria-posinset="4"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
       >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+        <div
+          class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
-      </div>
-      <div
-        class="ant-rate-star-second"
-      >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-rate-star-second"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
       </div>
-    </div>
-  </li>
-  <li
-    class="ant-rate-star ant-rate-star-zero"
-  >
-    <div
-      aria-checked="false"
-      aria-posinset="5"
-      aria-setsize="5"
-      role="radio"
-      tabindex="0"
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-zero"
     >
       <div
-        class="ant-rate-star-first"
+        aria-checked="false"
+        aria-posinset="5"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
       >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+        <div
+          class="ant-rate-star-first"
         >
-          <svg
-            aria-hidden="true"
-            data-icon="star"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="64 64 896 896"
-            width="1em"
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
           >
-            <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-            />
-          </svg>
-        </span>
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          <span
+            aria-label="star"
+            class="anticon anticon-star"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="star"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              />
+            </svg>
+          </span>
+        </div>
       </div>
+    </li>
+  </ul>
+  <ul
+    class="ant-rate css-var-test-id"
+    tabindex="0"
+  >
+    <li
+      class="ant-rate-star ant-rate-star-full"
+    >
       <div
-        class="ant-rate-star-second"
+        aria-checked="true"
+        aria-posinset="1"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
       >
-        <span
-          aria-label="star"
-          class="anticon anticon-star"
-          role="img"
+        <div
+          class="ant-rate-star-first"
         >
           <svg
             aria-hidden="true"
-            data-icon="star"
             fill="currentColor"
-            focusable="false"
             height="1em"
-            viewBox="64 64 896 896"
+            viewBox="0 0 16 16"
             width="1em"
           >
             <path
-              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
             />
           </svg>
-        </span>
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
       </div>
-    </div>
-  </li>
-</ul>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-full"
+    >
+      <div
+        aria-checked="true"
+        aria-posinset="2"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-half ant-rate-star-active"
+    >
+      <div
+        aria-checked="true"
+        aria-posinset="3"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-zero"
+    >
+      <div
+        aria-checked="false"
+        aria-posinset="4"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </li>
+    <li
+      class="ant-rate-star ant-rate-star-zero"
+    >
+      <div
+        aria-checked="false"
+        aria-posinset="5"
+        aria-setsize="5"
+        role="radio"
+        tabindex="0"
+      >
+        <div
+          class="ant-rate-star-first"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+        <div
+          class="ant-rate-star-second"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z"
+            />
+          </svg>
+        </div>
+      </div>
+    </li>
+  </ul>
+</div>
 `;
 
 exports[`renders components/rate/demo/disabled.tsx correctly 1`] = `

--- a/components/rate/__tests__/index.test.tsx
+++ b/components/rate/__tests__/index.test.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 import { render } from '@testing-library/react';
 
 import Rate from '..';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import ConfigProvider from '../../config-provider';
 
 describe('Rate', () => {
   focusTest(Rate, { refFocus: true });
@@ -22,40 +20,5 @@ describe('Rate', () => {
       const { container } = render(<Rate count={3} value={1} size="large" />);
       expect(container.querySelector('.ant-rate-large')).toBeTruthy();
     });
-  });
-
-  it('supports border tokens for default and selected stars', () => {
-    const cache = createCache();
-
-    render(
-      <StyleProvider cache={cache}>
-        <ConfigProvider
-          theme={{
-            components: {
-              Rate: {
-                starBorderColorDefault: '#111111',
-                starBorderWidthDefault: 2,
-                starBorderColorSelected: '#222222',
-                starBorderWidthSelected: 3,
-              },
-            },
-          }}
-        >
-          <Rate value={1} />
-        </ConfigProvider>
-      </StyleProvider>,
-    );
-
-    const styleText = extractStyle(cache, { plain: true });
-
-    expect(styleText).toContain('--ant-rate-star-border-color-default:#111111');
-    expect(styleText).toContain('--ant-rate-star-border-width-default:2px');
-    expect(styleText).toContain('--ant-rate-star-border-color-selected:#222222');
-    expect(styleText).toContain('--ant-rate-star-border-width-selected:3px');
-    expect(styleText).toContain('stroke:var(--ant-rate-star-border-color-default)');
-    expect(styleText).toContain('stroke-width:var(--ant-rate-star-border-width-default)');
-    expect(styleText).toContain('stroke-linejoin:round');
-    expect(styleText).toContain('stroke:var(--ant-rate-star-border-color-selected)');
-    expect(styleText).toContain('stroke-width:var(--ant-rate-star-border-width-selected)');
   });
 });

--- a/components/rate/__tests__/index.test.tsx
+++ b/components/rate/__tests__/index.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 import { render } from '@testing-library/react';
 
 import Rate from '..';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
+import ConfigProvider from '../../config-provider';
 
 describe('Rate', () => {
   focusTest(Rate, { refFocus: true });
@@ -20,5 +22,40 @@ describe('Rate', () => {
       const { container } = render(<Rate count={3} value={1} size="large" />);
       expect(container.querySelector('.ant-rate-large')).toBeTruthy();
     });
+  });
+
+  it('supports border tokens for default and selected stars', () => {
+    const cache = createCache();
+
+    render(
+      <StyleProvider cache={cache}>
+        <ConfigProvider
+          theme={{
+            components: {
+              Rate: {
+                starBorderColorDefault: '#111111',
+                starBorderWidthDefault: 2,
+                starBorderColorSelected: '#222222',
+                starBorderWidthSelected: 3,
+              },
+            },
+          }}
+        >
+          <Rate value={1} />
+        </ConfigProvider>
+      </StyleProvider>,
+    );
+
+    const styleText = extractStyle(cache, { plain: true });
+
+    expect(styleText).toContain('--ant-rate-star-border-color-default:#111111');
+    expect(styleText).toContain('--ant-rate-star-border-width-default:2px');
+    expect(styleText).toContain('--ant-rate-star-border-color-selected:#222222');
+    expect(styleText).toContain('--ant-rate-star-border-width-selected:3px');
+    expect(styleText).toContain('stroke:var(--ant-rate-star-border-color-default)');
+    expect(styleText).toContain('stroke-width:var(--ant-rate-star-border-width-default)');
+    expect(styleText).toContain('stroke-linejoin:round');
+    expect(styleText).toContain('stroke:var(--ant-rate-star-border-color-selected)');
+    expect(styleText).toContain('stroke-width:var(--ant-rate-star-border-width-selected)');
   });
 });

--- a/components/rate/demo/component-token.md
+++ b/components/rate/demo/component-token.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-调试使用。
+通过组件 Token 调整评分颜色、尺寸与星形边框。自定义 `character` 也会应用星形边框 Token。
 
 ## en-US
 
-Component Token Debug.
+Customize Rate color, size, and star borders with component tokens. Custom `character` also applies the star border tokens.

--- a/components/rate/demo/component-token.tsx
+++ b/components/rate/demo/component-token.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import { ConfigProvider, Flex, Rate } from 'antd';
 
-const customCharacter = (
-  <svg aria-hidden="true" viewBox="0 0 16 16" width="1em" height="1em" fill="currentColor">
-    <path d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z" />
-  </svg>
-);
-
 /** Test usage. Do not use in your production. */
 export default () => (
   <ConfigProvider
@@ -27,7 +21,8 @@ export default () => (
   >
     <Flex vertical gap="middle">
       <Rate defaultValue={2.5} />
-      <Rate character={customCharacter} defaultValue={2.5} allowHalf />
+      <Rate character="A" defaultValue={2.5} allowHalf />
+      <Rate character="好" defaultValue={2.5} allowHalf />
     </Flex>
   </ConfigProvider>
 );

--- a/components/rate/demo/component-token.tsx
+++ b/components/rate/demo/component-token.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { ConfigProvider, Rate } from 'antd';
+import { ConfigProvider, Flex, Rate } from 'antd';
+
+const customCharacter = (
+  <svg aria-hidden="true" viewBox="0 0 16 16" width="1em" height="1em" fill="currentColor">
+    <path d="M8 1l2 5h5l-4 3 2 5-5-3-5 3 2-5-4-3h5z" />
+  </svg>
+);
 
 /** Test usage. Do not use in your production. */
 export default () => (
@@ -11,10 +17,17 @@ export default () => (
           starSize: 40,
           starHoverScale: 'scale(2)',
           starBg: 'red',
+          starBorderColor: 'green',
+          starBorderColorSelected: 'purple',
+          starBorderWidthDefault: 2,
+          starBorderWidthSelected: 2,
         },
       },
     }}
   >
-    <Rate defaultValue={2.5} />
+    <Flex vertical gap="middle">
+      <Rate defaultValue={2.5} />
+      <Rate character={customCharacter} defaultValue={2.5} allowHalf />
+    </Flex>
   </ConfigProvider>
 );

--- a/components/rate/style/index.ts
+++ b/components/rate/style/index.ts
@@ -36,6 +36,26 @@ export interface ComponentToken {
    * @descEN Star background color
    */
   starBg: string;
+  /**
+   * @desc 默认星星边框颜色
+   * @descEN Default star border color
+   */
+  starBorderColorDefault: string;
+  /**
+   * @desc 默认星星边框宽度
+   * @descEN Default star border width
+   */
+  starBorderWidthDefault: number;
+  /**
+   * @desc 选中星星边框颜色
+   * @descEN Selected star border color
+   */
+  starBorderColorSelected: string;
+  /**
+   * @desc 选中星星边框宽度
+   * @descEN Selected star border width
+   */
+  starBorderWidthSelected: number;
 }
 
 interface RateToken extends FullToken<'Rate'> {}
@@ -75,6 +95,12 @@ const genRateStarStyle: GenerateStyle<RateToken, CSSObject> = (token) => {
         color: token.starBg,
         transition: `all ${token.motionDurationMid}`,
         userSelect: 'none',
+
+        '> span svg, > svg': {
+          stroke: token.starBorderColorDefault,
+          strokeWidth: token.starBorderWidthDefault,
+          strokeLinejoin: 'round',
+        },
       },
 
       '&-first': {
@@ -93,6 +119,12 @@ const genRateStarStyle: GenerateStyle<RateToken, CSSObject> = (token) => {
 
       [`&-half ${componentCls}-star-first, &-full ${componentCls}-star-second`]: {
         color: 'inherit',
+
+        '> span svg, > svg': {
+          stroke: token.starBorderColorSelected,
+          strokeWidth: token.starBorderWidthSelected,
+          strokeLinejoin: 'round',
+        },
       },
     },
   };
@@ -154,6 +186,10 @@ export const prepareComponentToken: GetDefaultToken<'Rate'> = (token) => ({
   starSizeLG: token.controlHeightLG * 0.625,
   starHoverScale: 'scale(1.1)',
   starBg: token.colorFillContent,
+  starBorderColorDefault: token.colorTextTertiary,
+  starBorderWidthDefault: token.lineWidth,
+  starBorderColorSelected: token.yellow8,
+  starBorderWidthSelected: token.lineWidth,
 });
 
 export default genStyleHooks(

--- a/components/rate/style/index.ts
+++ b/components/rate/style/index.ts
@@ -37,10 +37,10 @@ export interface ComponentToken {
    */
   starBg: string;
   /**
-   * @desc 默认星星边框颜色
-   * @descEN Default star border color
+   * @desc 星星边框颜色
+   * @descEN Star border color
    */
-  starBorderColorDefault: string;
+  starBorderColor: string;
   /**
    * @desc 默认星星边框宽度
    * @descEN Default star border width
@@ -97,7 +97,7 @@ const genRateStarStyle: GenerateStyle<RateToken, CSSObject> = (token) => {
         userSelect: 'none',
 
         '> span svg, > svg': {
-          stroke: token.starBorderColorDefault,
+          stroke: token.starBorderColor,
           strokeWidth: token.starBorderWidthDefault,
           strokeLinejoin: 'round',
         },
@@ -186,7 +186,7 @@ export const prepareComponentToken: GetDefaultToken<'Rate'> = (token) => ({
   starSizeLG: token.controlHeightLG * 0.625,
   starHoverScale: 'scale(1.1)',
   starBg: token.colorFillContent,
-  starBorderColorDefault: token.colorTextTertiary,
+  starBorderColor: token.colorTextTertiary,
   starBorderWidthDefault: token.lineWidth,
   starBorderColorSelected: token.yellow8,
   starBorderWidthSelected: token.lineWidth,

--- a/components/rate/style/index.ts
+++ b/components/rate/style/index.ts
@@ -95,6 +95,7 @@ const genRateStarStyle: GenerateStyle<RateToken, CSSObject> = (token) => {
         color: token.starBg,
         transition: `all ${token.motionDurationMid}`,
         userSelect: 'none',
+        WebkitTextStroke: `${unit(token.starBorderWidthDefault)} ${token.starBorderColor}`,
 
         '> span svg, > svg': {
           stroke: token.starBorderColor,
@@ -119,6 +120,7 @@ const genRateStarStyle: GenerateStyle<RateToken, CSSObject> = (token) => {
 
       [`&-half ${componentCls}-star-first, &-full ${componentCls}-star-second`]: {
         color: 'inherit',
+        WebkitTextStroke: `${unit(token.starBorderWidthSelected)} ${token.starBorderColorSelected}`,
 
         '> span svg, > svg': {
           stroke: token.starBorderColorSelected,


### PR DESCRIPTION
## Summary

- add Rate component tokens for default and selected star border color/width
- apply the border tokens to default and selected star SVGs as a redundant visual cue for non-text contrast
- add a style extraction regression test for the new token output

Fixes #55225.

This supersedes #58477, which was closed by automation after the base branch was still `master`. This PR targets `feature` as requested.

## Verification

- npm test -- components/rate/__tests__/index.test.tsx --runInBand
- npm exec eslint components/rate/style/index.ts components/rate/__tests__/index.test.tsx
