### PR TITLE
fix(Result): render extra when it is zero

### DIFF
--- a/components/result/__tests__/index.test.tsx
+++ b/components/result/__tests__/index.test.tsx
@@ -71,6 +71,13 @@ describe('Result', () => {
     expect(container.querySelectorAll('.ant-result-extra')).toHaveLength(0);
   });
 
+  it('should render extra when it is the number 0', () => {
+    const { container } = render(<Result status="404" extra={0} />);
+    const extraNode = container.querySelector('.ant-result-extra');
+    expect(extraNode).not.toBe(null);
+    expect(extraNode?.textContent).toBe('0');
+  });
+
   it('🙂  When title is undefined, the title dom is not rendered', () => {
     const { container } = render(<Result status="404" />);
     expect(container.querySelectorAll('.ant-result-title')).toHaveLength(0);

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -128,7 +128,7 @@ interface ExtraProps {
 }
 
 const Extra: React.FC<ExtraProps> = ({ className, extra, style }) => {
-  if (!extra) {
+  if (!isReactRenderable(extra)) {
     return null;
   }
   return (


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Result 的 `extra` 支持传入 `ReactNode`，但此前使用 truthy 判断会导致 `extra={0}` 被当作空值跳过渲染。

本次改为使用已有的 `isReactRenderable` 判断，和 Result 中 `title`、`subTitle`、`children` 的渲染逻辑保持一致，并补充 `extra={0}` 的测试覆盖。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Result not rendering `extra` when it is `0`. |
| 🇨🇳 中文 | 🐞 修复 Result 的 `extra` 为 `0` 时不渲染的问题。 |
