### PR TITLE
fix: preserve Input.Search enterButton className

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -165,6 +165,8 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
   const isAntdButton =
     enterButtonAsElement.type && (enterButtonAsElement.type as typeof Button).__ANT_BUTTON === true;
   if (isAntdButton || enterButtonAsElement.type === 'button') {
+    const enterButtonProps = enterButtonAsElement.props as { className?: string };
+
     button = cloneElement(enterButtonAsElement, {
       onMouseDown,
       onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -176,7 +178,7 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
         onSearch(e);
       },
       key: 'enterButton',
-      ...(isAntdButton ? { className: btnClassName, size } : {}),
+      ...(isAntdButton ? { className: clsx(btnClassName, enterButtonProps.className), size } : {}),
     });
   } else {
     button = (

--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -26,6 +26,15 @@ describe('Input.Search', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
+  it('should preserve custom Button className', () => {
+    const { container } = render(
+      <Search enterButton={<Button className="custom-search-button">ok</Button>} />,
+    );
+    const button = container.querySelector('button');
+    expect(button).toHaveClass('ant-input-search-button');
+    expect(button).toHaveClass('custom-search-button');
+  });
+
   it('should support enterButton null', () => {
     expect(() => {
       render(<Search enterButton={null} />);

--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -31,7 +31,7 @@ describe('Input.Search', () => {
       <Search enterButton={<Button className="custom-search-button">ok</Button>} />,
     );
     const button = container.querySelector('button');
-    expect(button).toHaveClass('ant-input-search-button');
+    expect(button).toHaveClass('ant-input-search-btn');
     expect(button).toHaveClass('custom-search-button');
   });
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Fixes #58505

### 💡 需求背景和解决方案

当 Input.Search 使用自定义 antd Button 作为 enterButton 时，内部会覆盖该 Button 原有的 className，导致用户传入的自定义类名丢失。

本 PR 在保留 Input.Search 内部按钮类名的同时，合并用户传入的 Button className，并补充测试覆盖该行为。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Input.Search not preserving custom \`className\` on \`enterButton\`. |
| 🇨🇳 中文 | 🐞 修复 Input.Search 自定义 \`enterButton\` 的 \`className\` 丢失问题。 |