### PR TITLE
fix: prevent disabled FloatButton.Group hover menu opening

### DIFF
--- a/components/float-button/FloatButtonGroup.tsx
+++ b/components/float-button/FloatButtonGroup.tsx
@@ -10,6 +10,7 @@ import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
+import DisabledContext from '../config-provider/DisabledContext';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import Flex from '../flex';
 import Space from '../space';
@@ -82,6 +83,7 @@ const FloatButtonGroup: React.FC<Readonly<FloatButtonGroupProps>> = (props) => {
     onOpenChange,
     open: customOpen,
     onClick: onTriggerButtonClick,
+    disabled: customDisabled,
     ...floatButtonProps
   } = props;
 
@@ -105,6 +107,10 @@ const FloatButtonGroup: React.FC<Readonly<FloatButtonGroupProps>> = (props) => {
 
   const isMenuMode = trigger && ['click', 'hover'].includes(trigger);
 
+  // ========================== Disabled ==========================
+  const disabled = React.useContext(DisabledContext);
+  const mergedDisabled = customDisabled ?? disabled;
+
   // ============================ zIndex ============================
   const [zIndex] = useZIndex('FloatButton', style?.zIndex as number);
 
@@ -123,6 +129,9 @@ const FloatButtonGroup: React.FC<Readonly<FloatButtonGroupProps>> = (props) => {
   const clickTrigger = trigger === 'click';
 
   const triggerOpen = useEvent((nextOpen: boolean) => {
+    if (mergedDisabled) {
+      return;
+    }
     if (open !== nextOpen) {
       setOpen(nextOpen);
       onOpenChange?.(nextOpen);
@@ -184,6 +193,7 @@ const FloatButtonGroup: React.FC<Readonly<FloatButtonGroupProps>> = (props) => {
     shape,
     type,
     placement: mergedPlacement,
+    disabled: mergedDisabled,
   };
 
   // ============================ Styles ============================
@@ -305,6 +315,7 @@ const FloatButtonGroup: React.FC<Readonly<FloatButtonGroupProps>> = (props) => {
               aria-label={props['aria-label']}
               className={`${groupPrefixCls}-trigger`}
               onClick={onInternalTriggerButtonClick}
+              disabled={mergedDisabled}
               {...floatButtonProps}
             />
           </GroupContext.Provider>

--- a/components/float-button/__tests__/group.test.tsx
+++ b/components/float-button/__tests__/group.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import FloatButton from '..';
 import type { FloatButtonGroupProps } from '..';
 import { fireEvent, render } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
 
 describe('FloatButtonGroup', () => {
   it('should correct render', () => {
@@ -59,6 +60,32 @@ describe('FloatButtonGroup', () => {
     fireEvent.mouseEnter(container.querySelector('.ant-float-btn-group')!);
     fireEvent.mouseLeave(container.querySelector('.ant-float-btn-group')!);
     expect(onOpenChange).toHaveBeenCalled();
+  });
+  it('should not trigger open when hover menu is disabled', () => {
+    const onOpenChange = jest.fn();
+    const { container, rerender } = render(
+      <FloatButton.Group disabled trigger="hover" onOpenChange={onOpenChange}>
+        <FloatButton />
+        <FloatButton />
+      </FloatButton.Group>,
+    );
+    const group = container.querySelector('.ant-float-btn-group')!;
+
+    fireEvent.mouseEnter(group);
+    fireEvent.mouseLeave(group);
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    rerender(
+      <ConfigProvider componentDisabled>
+        <FloatButton.Group trigger="hover" onOpenChange={onOpenChange}>
+          <FloatButton />
+          <FloatButton />
+        </FloatButton.Group>
+      </ConfigProvider>,
+    );
+    fireEvent.mouseEnter(container.querySelector('.ant-float-btn-group')!);
+    fireEvent.mouseLeave(container.querySelector('.ant-float-btn-group')!);
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
   it('support click floatButtonGroup not close', () => {
     const onOpenChange = jest.fn();


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

FloatButton.Group 在 `disabled` 且 `trigger="hover"` 时，hover 外层 group 仍会触发菜单展开；而 click 触发会被禁用按钮拦截，两个触发方式行为不一致。

本次让 FloatButton.Group 合并自身 `disabled` 与 ConfigProvider `componentDisabled`，并在禁用态阻止菜单触发逻辑，同时将禁用态传给菜单触发按钮。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix FloatButton.Group still opening on hover when disabled. |
| 🇨🇳 中文 | 修复 FloatButton.Group 在禁用状态下 hover 仍会展开菜单的问题。 |