### PR TITLE
fix(Table): remove extra vertical line on last fixed-right column in bordered table

### DIFF
--- a/components/table/style/bordered.ts
+++ b/components/table/style/bordered.ts
@@ -71,10 +71,15 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
                 },
 
                 // Fixed right should provides additional border
+                // Only add separator border when there are multiple fixed-right columns
+                // (i.e. fix-right-first is not also fix-right-last), otherwise the
+                // ::after border doubles up with the cell's own borderInlineEnd and
+                // creates a spurious extra vertical line. See #56287.
                 '> thead > tr, > tbody > tr, > tfoot > tr': {
-                  [`> ${componentCls}-cell-fix-right-first::after`]: {
-                    borderInlineEnd: tableBorder,
-                  },
+                  [`> ${componentCls}-cell-fix-right-first:not(${componentCls}-cell-fix-right-last)::after`]:
+                    {
+                      borderInlineEnd: tableBorder,
+                    },
                 },
 
                 // ========================== Expandable ==========================


### PR DESCRIPTION
## Summary

When a bordered  has a **fixed right column** and **vertical scroll** () enabled, an extra vertical line appears on the rightmost column.

**Before:**
The last fixed-right column shows a duplicate vertical line on its right edge.

**After:**
No extra line — the bordered table looks clean with fixed right columns and vertical scroll.

## Root Cause

In `bordered.ts`, `cell-fix-right-first` always receives an `::after` pseudo-element with `borderInlineEnd` to visually separate the scrollable area from the fixed columns:

```ts
`> ${componentCls}-cell-fix-right-first::after`: {
  borderInlineEnd: tableBorder,
}
```

When there is only **one** fixed-right column, that cell carries both the `cell-fix-right-first` and `cell-fix-right-last` classes. Its regular `borderInlineEnd` (applied to all bordered cells) already provides the right edge. The `::after` border then stacks on top, producing a second visible line.

## Fix

Scope the `::after` separator border so it only applies when `cell-fix-right-first` is **not** also `cell-fix-right-last` — i.e. only when there are genuinely multiple fixed-right columns that need a separator:

```ts
`> ${componentCls}-cell-fix-right-first:not(${componentCls}-cell-fix-right-last)::after`: {
  borderInlineEnd: tableBorder,
}
```

This preserves the separator for multi-column fixed-right layouts while eliminating the duplicate line in the single fixed-right column case.

## Reproduction

Reproduced on the official demo: https://ant-design.antgroup.com/components/table-cn#table-demo-fixed-columns-header

Environment: antd 6.1.1, React 19, Chrome, Windows

Closes #56287