### PR TITLE
fix: pass zeroRuntime to icon context

### DIFF
--- a/components/config-provider/__tests__/nonce.test.tsx
+++ b/components/config-provider/__tests__/nonce.test.tsx
@@ -7,6 +7,12 @@ import ConfigProvider from '..';
 import { render } from '../../../tests/utils';
 import Button from '../../button';
 
+declare module '@ant-design/icons/lib/components/Context' {
+  interface IconContextProps {
+    zeroRuntime?: boolean;
+  }
+}
+
 describe('ConfigProvider.Icon', () => {
   beforeEach(() => {
     expect(document.querySelectorAll('style')).toHaveLength(0);
@@ -63,6 +69,21 @@ describe('ConfigProvider.Icon', () => {
     expect(container.querySelector('.bamboo-smile')).toBeTruthy();
     expect(styleNode?.nonce).toBe('light');
     expect(container.querySelector('#csp')?.innerHTML).toBe('light');
+  });
+
+  it('passes zeroRuntime theme config to icon context', () => {
+    const Checker = () => {
+      const { zeroRuntime } = React.useContext(IconContext);
+      return <div id="zero-runtime">{String(zeroRuntime)}</div>;
+    };
+
+    const { container } = render(
+      <ConfigProvider theme={{ zeroRuntime: true }}>
+        <Checker />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('#zero-runtime')?.innerHTML).toBe('true');
   });
 
   it('cssinjs should support nonce', () => {

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -637,8 +637,13 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
   const { layer } = React.useContext(CssInJsStyleContext);
 
   const memoIconContextValue = React.useMemo(
-    () => ({ prefixCls: iconPrefixCls, csp, layer: layer ? 'antd' : undefined }),
-    [iconPrefixCls, csp, layer],
+    () => ({
+      prefixCls: iconPrefixCls,
+      csp,
+      layer: layer ? 'antd' : undefined,
+      zeroRuntime: mergedTheme?.zeroRuntime,
+    }),
+    [iconPrefixCls, csp, layer, mergedTheme?.zeroRuntime],
   );
 
   let childNode = (


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix
- [ ] New feature
- [ ] Site / documentation update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Related to ant-design/ant-design-icons#715.

### 💡 Background and solution

`ConfigProvider` already supports `theme.zeroRuntime`, and antd registers icon base styles through its static style pipeline. However, the value was not passed to `@ant-design/icons`' `IconContext`, so icon components could not skip their own runtime style injection when zero-runtime mode is enabled.

This PR forwards `mergedTheme.zeroRuntime` into the icon context so the icons package can honor the same zero-runtime setting.

### 📝 Changelog

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Pass `theme.zeroRuntime` from `ConfigProvider` to icon context. |
| 🇨🇳 Chinese | 将 `ConfigProvider` 的 `theme.zeroRuntime` 透传给图标上下文。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
