### PR TITLE
fix: address feature branch merge review issues

### DIFF
--- a/components/steps/__tests__/maxCount.test.tsx
+++ b/components/steps/__tests__/maxCount.test.tsx
@@ -13,13 +13,13 @@ describe('Steps maxCount', () => {
   }));
 
   const cases: Array<Array<number | null>> = [
-    [0, 1, 2, null, 5, 6],
-    [0, 1, 2, null, 5, 6],
-    [0, 1, 2, 3, null, 6],
-    [0, null, 2, 3, 4, null, 6],
-    [0, null, 3, 4, 5, 6],
-    [0, 1, null, 4, 5, 6],
-    [0, 1, null, 4, 5, 6],
+    [0, 1, 2, null, 6],
+    [0, 1, 2, null, 6],
+    [0, 1, 2, null, 6],
+    [0, null, 3, null, 6],
+    [0, null, 4, 5, 6],
+    [0, null, 4, 5, 6],
+    [0, null, 4, 5, 6],
   ];
 
   beforeEach(() => {
@@ -78,7 +78,7 @@ describe('Steps maxCount', () => {
   it('renders collapsed steps when current is out of range', () => {
     const { container } = render(<Steps current={9} maxCount={5} items={items} />);
 
-    expect(getRenderedSteps(container)).toEqual([0, 1, null, 4, 5, 6]);
+    expect(getRenderedSteps(container)).toEqual([0, null, 4, 5, 6]);
     expect(container.querySelector('.ant-steps-item-active')).toBeFalsy();
   });
 
@@ -115,8 +115,21 @@ describe('Steps maxCount', () => {
     const onChange = jest.fn();
 
     render(<Steps current={3} maxCount={5} items={items} onChange={onChange} />);
-    fireEvent.click(screen.getByText('Step 5'));
+    fireEvent.click(screen.getByText('Step 7'));
 
-    expect(onChange).toHaveBeenCalledWith(4);
+    expect(onChange).toHaveBeenCalledWith(6);
+  });
+
+  it('keeps current and onChange independent from initial', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Steps initial={2} current={3} maxCount={5} items={items} onChange={onChange} />,
+    );
+
+    expect(getActiveStep(container)).toBe(3);
+
+    fireEvent.click(screen.getByText('Step 7'));
+
+    expect(onChange).toHaveBeenCalledWith(6);
   });
 });

--- a/components/steps/index.tsx
+++ b/components/steps/index.tsx
@@ -454,7 +454,7 @@ const Steps = (props: StepsProps) => {
   const onDisplayChange = (displayCurrent: number) => {
     const target = displaySteps[displayCurrent];
     if (onChange && target && target.originIndex >= 0) {
-      onChange(initial + target.originIndex);
+      onChange(target.originIndex);
     }
   };
 

--- a/components/steps/useDisplaySteps.ts
+++ b/components/steps/useDisplaySteps.ts
@@ -75,33 +75,38 @@ function getCollapsedIndexes(
   maxCount: number,
 ): Array<number | null> {
   const safeCurrent = Math.min(Math.max(currentIndex, 0), total - 1);
-  const targetCount = Math.min(maxCount, total);
-  const indexes = new Set([0, safeCurrent, total - 1]);
+  const firstIndex = 0;
+  const lastIndex = total - 1;
+  const visibleCount = Math.min(maxCount, total);
 
-  for (let distance = 1; indexes.size < targetCount && distance < total; distance += 1) {
-    const candidates = [
-      safeCurrent - distance,
-      safeCurrent + distance,
-      distance,
-      total - 1 - distance,
-    ];
-
-    for (const index of candidates) {
-      if (indexes.size >= targetCount) {
-        break;
-      }
-
-      if (index >= 0 && index < total) {
-        indexes.add(index);
-      }
-    }
+  if (visibleCount < 5) {
+    return Array.from(new Set([firstIndex, safeCurrent, lastIndex])).sort((a, b) => a - b);
   }
 
-  return Array.from(indexes)
-    .sort((a, b) => a - b)
-    .flatMap((index, order, sortedIndexes) =>
-      order > 0 && index - sortedIndexes[order - 1] > 1 ? [null, index] : [index],
-    );
+  const edgeCount = visibleCount - 2;
+
+  if (safeCurrent <= edgeCount - 1) {
+    return [...Array.from({ length: edgeCount }, (_, index) => index), null, lastIndex];
+  }
+
+  if (safeCurrent >= total - edgeCount) {
+    return [
+      firstIndex,
+      null,
+      ...Array.from({ length: edgeCount }, (_, index) => total - edgeCount + index),
+    ];
+  }
+
+  const middleCount = visibleCount - 4;
+  const middleStart = safeCurrent - Math.floor((middleCount - 1) / 2);
+
+  return [
+    firstIndex,
+    null,
+    ...Array.from({ length: middleCount }, (_, index) => middleStart + index),
+    null,
+    lastIndex,
+  ];
 }
 
 /**
@@ -118,7 +123,7 @@ export default function useDisplaySteps(
 ): UseDisplayStepsResult {
   const canApplyMaxCount = maxCount !== undefined && maxCount >= 3 && mergedItems.length > maxCount;
 
-  const mappedCurrent = current - initial;
+  const mappedCurrent = current;
 
   const displaySteps = React.useMemo<DisplayStep[]>(() => {
     if (!canApplyMaxCount) {

--- a/components/watermark/__tests__/index.test.tsx
+++ b/components/watermark/__tests__/index.test.tsx
@@ -80,6 +80,10 @@ describe('Watermark', () => {
               font: { fontFamily: 'serif', fontSize: 12, fontStyle: 'italic' },
             },
             {
+              text: 'Style None',
+              font: { fontStyle: 'none' },
+            },
+            {
               text: 'Fallback',
               font: { fontFamily: 'monospace', fontSize: undefined },
             },
@@ -92,13 +96,19 @@ describe('Watermark', () => {
         expect.arrayContaining([
           'normal normal bold 20px sans-serif',
           'italic normal normal 12px serif',
+          'normal normal normal 16px sans-serif',
           'normal normal normal 16px monospace',
         ]),
       );
       const textCalls = fillText.mock.calls.filter(([text]) =>
-        ['Ant Design', 'Happy Working', 'Fallback'].includes(text as string),
+        ['Ant Design', 'Happy Working', 'Style None', 'Fallback'].includes(text as string),
       );
-      expect(textCalls.map(([text]) => text)).toEqual(['Ant Design', 'Happy Working', 'Fallback']);
+      expect(textCalls.map(([text]) => text)).toEqual([
+        'Ant Design',
+        'Happy Working',
+        'Style None',
+        'Fallback',
+      ]);
       textCalls.forEach(([, x, y]) => {
         expect(Number.isFinite(x)).toBeTruthy();
         expect(Number.isFinite(y)).toBeTruthy();
@@ -106,6 +116,22 @@ describe('Watermark', () => {
     } finally {
       fillText.mockRestore();
       spyCanvas.mockRestore();
+    }
+  });
+
+  it('falls back when canvas font bounding metrics are unavailable', async () => {
+    const measureText = jest
+      .spyOn(CanvasRenderingContext2D.prototype, 'measureText')
+      .mockReturnValue({ width: 80 } as TextMetrics);
+
+    try {
+      const { container } = render(<Watermark className="watermark" content="Ant Design" />);
+      await waitFakeTimer();
+
+      const target = container.querySelector<HTMLDivElement>('.watermark div');
+      expect(target?.style.backgroundSize).not.toContain('NaN');
+    } finally {
+      measureText.mockRestore();
     }
   });
 

--- a/components/watermark/index.tsx
+++ b/components/watermark/index.tsx
@@ -183,8 +183,13 @@ const Watermark: React.FC<WatermarkProps> = (props) => {
         const sizes = contentLines.map(({ text, font: lineFont }) => {
           ctx.font = getCanvasFont(lineFont);
           const metrics = ctx.measureText(text);
+          const fontHeight =
+            metrics.fontBoundingBoxAscent !== undefined &&
+            metrics.fontBoundingBoxDescent !== undefined
+              ? metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent
+              : Number(lineFont.fontSize) || 16;
 
-          return [metrics.width, metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent];
+          return [metrics.width, fontHeight];
         });
         defaultWidth = Math.ceil(Math.max(...sizes.map((size) => size[0])));
         defaultHeight =

--- a/components/watermark/utils.ts
+++ b/components/watermark/utils.ts
@@ -34,8 +34,9 @@ export const getFontSize = (font: Required<WatermarkFont>, ratio = 1) => {
 
 export const getCanvasFont = (font: Required<WatermarkFont>, ratio = 1, lineHeight?: number) => {
   const mergedLineHeight = lineHeight === undefined ? '' : `/${lineHeight}px`;
+  const fontStyle = font.fontStyle === 'none' ? 'normal' : font.fontStyle;
 
-  return `${font.fontStyle} normal ${font.fontWeight} ${getFontSize(
+  return `${fontStyle} normal ${font.fontWeight} ${getFontSize(
     font,
     ratio,
   )}px${mergedLineHeight} ${font.fontFamily}`;


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- Follow up #58519

### 💡 需求背景和解决方案

#58519 是 `feature` 合并到 `master` 的分支合并 PR，自动 review 发现 `feature` 上有几处需要先修复的问题：

- Steps `maxCount` 折叠后实际渲染项数可能超过 `maxCount`，并且 `initial` 会错误影响 `current` 和 `onChange` 的原始索引。
- Watermark 在 canvas font 字符串中会直接使用 `fontStyle: 'none'`，且当 `measureText` 缺少字体边界指标时可能计算出 `NaN` 尺寸。

本 PR 在 `feature` 分支上先修复这些问题，并补充对应回归测试。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Steps `maxCount` collapsed item count and keep `current` / `onChange` independent from `initial`. Fix Watermark canvas font fallback for `fontStyle: 'none'` and missing font metrics. |
| 🇨🇳 中文 | 🐞 修复 Steps `maxCount` 折叠后的展示数量，并保持 `current` / `onChange` 不受 `initial` 影响。修复 Watermark 在 `fontStyle: 'none'` 和缺失字体指标时的 canvas 字体兜底。 |
