### PR TITLE
fix(Input.Search): align button height with Input token

### DIFF
--- a/components/input/style/search.ts
+++ b/components/input/style/search.ts
@@ -1,14 +1,17 @@
 import type { CSSObject } from '@ant-design/cssinjs';
+import { unit } from '@ant-design/cssinjs';
 
 import type { GenerateStyle } from '../../theme/internal';
 import { genStyleHooks, mergeToken } from '../../theme/internal';
+import { genCssVar } from '../../theme/util/genStyleUtils';
 import type { InputToken } from './token';
 import { initComponentToken, initInputToken } from './token';
 
 const genSearchStyle: GenerateStyle<InputToken, CSSObject> = (token) => {
-  const { componentCls, calc, max } = token;
+  const { componentCls, antCls, calc, max } = token;
 
   const btnCls = `${componentCls}-btn`;
+  const [varName, varRef] = genCssVar(antCls, 'input-search');
   const inputFontSizeSM = token.inputFontSizeSM ?? token.fontSize;
   const smallButtonHeight = max(
     token.controlHeightSM,
@@ -21,10 +24,17 @@ const genSearchStyle: GenerateStyle<InputToken, CSSObject> = (token) => {
 
   return {
     [componentCls]: {
+      [varName('btn-height')]: unit(token.controlHeight),
       width: '100%',
 
       // =========================== Button ===========================
       [btnCls]: {
+        height: varRef('btn-height'),
+
+        [`&${antCls}-btn-icon-only`]: {
+          width: varRef('btn-height'),
+        },
+
         '&-filled': {
           background: token.colorFillTertiary,
 
@@ -38,6 +48,14 @@ const genSearchStyle: GenerateStyle<InputToken, CSSObject> = (token) => {
             },
           },
         },
+      },
+
+      [`&${componentCls}-large`]: {
+        [varName('btn-height')]: unit(token.controlHeightLG),
+      },
+
+      [`&${componentCls}-small`]: {
+        [varName('btn-height')]: unit(token.controlHeightSM),
       },
 
       [`&${componentCls}-small ${btnCls}`]: {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #55494

### 💡 需求背景和解决方案

在 6.x 最新版本中，开启 `cssVar` 后，`Input.Search` 的搜索按钮会同时带有 Button 的 CSS 变量 class，导致按钮高度读取 Button 自身的 `--ant-control-height`，没有跟随 `components.Input.controlHeight`。

本 PR 在 `Input.Search` 样式中通过 `genCssVar` 增加 Search 级别的按钮高度变量，并让搜索按钮高度和 icon-only 宽度读取该变量，避免被 Button 自身的同名 CSS 变量覆盖。

已验证：

```bash
npx eslint components/input/style/search.ts components/input/__tests__/Search.test.tsx
npm run tsc
```

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Input.Search button height not following Input `controlHeight` token in cssVar mode. |
| 🇨🇳 中文 | 修复 Input.Search 在 cssVar 模式下搜索按钮高度不跟随 Input `controlHeight` token 的问题。 |
