### PR TITLE
site: restore demo descriptions in utoopack

### DIFF
--- a/.dumi/theme/plugins/tech-stack.ts
+++ b/.dumi/theme/plugins/tech-stack.ts
@@ -8,7 +8,7 @@ import { dependencies, devDependencies } from '../../../package.json';
 /**
  * extends dumi internal tech stack, for customize previewer props
  */
-class AntdReactTechStack extends ReactTechStack {
+export class AntdReactTechStack extends ReactTechStack {
   generatePreviewerProps(...[props, opts]: any) {
     props.pkgDependencyList = { ...devDependencies, ...dependencies };
     props.jsx ??= '';


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

在 utoopack 模式下，dumi 会在 markdown loader 中重新构造 tech stack。Ant Design 自定义的 `AntdReactTechStack` 未导出时，loader ctx 无法通过模块导出反查并重建该 tech stack，导致 `generatePreviewerProps` 未执行，组件 demo 的描述内容没有生成。

本次将 `AntdReactTechStack` 导出，使 dumi loader ctx 能正确重建自定义 tech stack，从而恢复 demo description 的生成。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |