### PR TITLE
revert: remove rate star border tokens

### DIFF
--- a/components/rate/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/rate/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1868,535 +1868,301 @@ exports[`renders components/rate/demo/clear.tsx extend context correctly 1`] = `
 exports[`renders components/rate/demo/clear.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/rate/demo/component-token.tsx extend context correctly 1`] = `
-<div
-  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+<ul
+  class="ant-rate css-var-test-id"
+  tabindex="0"
 >
-  <ul
-    class="ant-rate css-var-test-id"
-    tabindex="0"
+  <li
+    class="ant-rate-star ant-rate-star-full"
   >
-    <li
-      class="ant-rate-star ant-rate-star-full"
+    <div
+      aria-checked="true"
+      aria-posinset="1"
+      aria-setsize="5"
+      role="radio"
+      tabindex="0"
     >
       <div
-        aria-checked="true"
-        aria-posinset="1"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-first"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-full"
-    >
       <div
-        aria-checked="true"
-        aria-posinset="2"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-second"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-zero"
-    >
-      <div
-        aria-checked="true"
-        aria-posinset="3"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
-      >
-        <div
-          class="ant-rate-star-first"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-      </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-zero"
-    >
-      <div
-        aria-checked="false"
-        aria-posinset="4"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
-      >
-        <div
-          class="ant-rate-star-first"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-      </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-zero"
-    >
-      <div
-        aria-checked="false"
-        aria-posinset="5"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
-      >
-        <div
-          class="ant-rate-star-first"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-      </div>
-    </li>
-  </ul>
-  <ul
-    class="ant-rate css-var-test-id"
-    tabindex="0"
+    </div>
+  </li>
+  <li
+    class="ant-rate-star ant-rate-star-full"
   >
-    <li
-      class="ant-rate-star ant-rate-star-full"
+    <div
+      aria-checked="true"
+      aria-posinset="2"
+      aria-setsize="5"
+      role="radio"
+      tabindex="0"
     >
       <div
-        aria-checked="true"
-        aria-posinset="1"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-first"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          A
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          A
-        </div>
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-full"
-    >
       <div
-        aria-checked="true"
-        aria-posinset="2"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-second"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          A
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          A
-        </div>
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-half ant-rate-star-active"
-    >
-      <div
-        aria-checked="true"
-        aria-posinset="3"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
-      >
-        <div
-          class="ant-rate-star-first"
-        >
-          A
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          A
-        </div>
-      </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-zero"
-    >
-      <div
-        aria-checked="false"
-        aria-posinset="4"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
-      >
-        <div
-          class="ant-rate-star-first"
-        >
-          A
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          A
-        </div>
-      </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-zero"
-    >
-      <div
-        aria-checked="false"
-        aria-posinset="5"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
-      >
-        <div
-          class="ant-rate-star-first"
-        >
-          A
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          A
-        </div>
-      </div>
-    </li>
-  </ul>
-  <ul
-    class="ant-rate css-var-test-id"
-    tabindex="0"
+    </div>
+  </li>
+  <li
+    class="ant-rate-star ant-rate-star-zero"
   >
-    <li
-      class="ant-rate-star ant-rate-star-full"
+    <div
+      aria-checked="true"
+      aria-posinset="3"
+      aria-setsize="5"
+      role="radio"
+      tabindex="0"
     >
       <div
-        aria-checked="true"
-        aria-posinset="1"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-first"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          好
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          好
-        </div>
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-full"
+      <div
+        class="ant-rate-star-second"
+      >
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
+      </div>
+    </div>
+  </li>
+  <li
+    class="ant-rate-star ant-rate-star-zero"
+  >
+    <div
+      aria-checked="false"
+      aria-posinset="4"
+      aria-setsize="5"
+      role="radio"
+      tabindex="0"
     >
       <div
-        aria-checked="true"
-        aria-posinset="2"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-first"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          好
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          好
-        </div>
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-half ant-rate-star-active"
+      <div
+        class="ant-rate-star-second"
+      >
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
+      </div>
+    </div>
+  </li>
+  <li
+    class="ant-rate-star ant-rate-star-zero"
+  >
+    <div
+      aria-checked="false"
+      aria-posinset="5"
+      aria-setsize="5"
+      role="radio"
+      tabindex="0"
     >
       <div
-        aria-checked="true"
-        aria-posinset="3"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-first"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          好
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          好
-        </div>
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-zero"
-    >
       <div
-        aria-checked="false"
-        aria-posinset="4"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-second"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          好
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          好
-        </div>
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-zero"
-    >
-      <div
-        aria-checked="false"
-        aria-posinset="5"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
-      >
-        <div
-          class="ant-rate-star-first"
-        >
-          好
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          好
-        </div>
-      </div>
-    </li>
-  </ul>
-</div>
+    </div>
+  </li>
+</ul>
 `;
 
 exports[`renders components/rate/demo/component-token.tsx extend context correctly 2`] = `[]`;

--- a/components/rate/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/rate/__tests__/__snapshots__/demo.test.ts.snap
@@ -1860,535 +1860,301 @@ exports[`renders components/rate/demo/clear.tsx correctly 1`] = `
 `;
 
 exports[`renders components/rate/demo/component-token.tsx correctly 1`] = `
-<div
-  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+<ul
+  class="ant-rate css-var-test-id"
+  tabindex="0"
 >
-  <ul
-    class="ant-rate css-var-test-id"
-    tabindex="0"
+  <li
+    class="ant-rate-star ant-rate-star-full"
   >
-    <li
-      class="ant-rate-star ant-rate-star-full"
+    <div
+      aria-checked="true"
+      aria-posinset="1"
+      aria-setsize="5"
+      role="radio"
+      tabindex="0"
     >
       <div
-        aria-checked="true"
-        aria-posinset="1"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-first"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-full"
-    >
       <div
-        aria-checked="true"
-        aria-posinset="2"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-second"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
           >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-zero"
-    >
-      <div
-        aria-checked="true"
-        aria-posinset="3"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
-      >
-        <div
-          class="ant-rate-star-first"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-      </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-zero"
-    >
-      <div
-        aria-checked="false"
-        aria-posinset="4"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
-      >
-        <div
-          class="ant-rate-star-first"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-      </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-zero"
-    >
-      <div
-        aria-checked="false"
-        aria-posinset="5"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
-      >
-        <div
-          class="ant-rate-star-first"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          <span
-            aria-label="star"
-            class="anticon anticon-star"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="star"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
-              />
-            </svg>
-          </span>
-        </div>
-      </div>
-    </li>
-  </ul>
-  <ul
-    class="ant-rate css-var-test-id"
-    tabindex="0"
+    </div>
+  </li>
+  <li
+    class="ant-rate-star ant-rate-star-full"
   >
-    <li
-      class="ant-rate-star ant-rate-star-full"
+    <div
+      aria-checked="true"
+      aria-posinset="2"
+      aria-setsize="5"
+      role="radio"
+      tabindex="0"
     >
       <div
-        aria-checked="true"
-        aria-posinset="1"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-first"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          A
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          A
-        </div>
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-full"
-    >
       <div
-        aria-checked="true"
-        aria-posinset="2"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-second"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          A
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          A
-        </div>
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-half ant-rate-star-active"
-    >
-      <div
-        aria-checked="true"
-        aria-posinset="3"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
-      >
-        <div
-          class="ant-rate-star-first"
-        >
-          A
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          A
-        </div>
-      </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-zero"
-    >
-      <div
-        aria-checked="false"
-        aria-posinset="4"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
-      >
-        <div
-          class="ant-rate-star-first"
-        >
-          A
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          A
-        </div>
-      </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-zero"
-    >
-      <div
-        aria-checked="false"
-        aria-posinset="5"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
-      >
-        <div
-          class="ant-rate-star-first"
-        >
-          A
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          A
-        </div>
-      </div>
-    </li>
-  </ul>
-  <ul
-    class="ant-rate css-var-test-id"
-    tabindex="0"
+    </div>
+  </li>
+  <li
+    class="ant-rate-star ant-rate-star-zero"
   >
-    <li
-      class="ant-rate-star ant-rate-star-full"
+    <div
+      aria-checked="true"
+      aria-posinset="3"
+      aria-setsize="5"
+      role="radio"
+      tabindex="0"
     >
       <div
-        aria-checked="true"
-        aria-posinset="1"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-first"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          好
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          好
-        </div>
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-full"
+      <div
+        class="ant-rate-star-second"
+      >
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
+      </div>
+    </div>
+  </li>
+  <li
+    class="ant-rate-star ant-rate-star-zero"
+  >
+    <div
+      aria-checked="false"
+      aria-posinset="4"
+      aria-setsize="5"
+      role="radio"
+      tabindex="0"
     >
       <div
-        aria-checked="true"
-        aria-posinset="2"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-first"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          好
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          好
-        </div>
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-half ant-rate-star-active"
+      <div
+        class="ant-rate-star-second"
+      >
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
+      </div>
+    </div>
+  </li>
+  <li
+    class="ant-rate-star ant-rate-star-zero"
+  >
+    <div
+      aria-checked="false"
+      aria-posinset="5"
+      aria-setsize="5"
+      role="radio"
+      tabindex="0"
     >
       <div
-        aria-checked="true"
-        aria-posinset="3"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-first"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          好
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          好
-        </div>
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-zero"
-    >
       <div
-        aria-checked="false"
-        aria-posinset="4"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
+        class="ant-rate-star-second"
       >
-        <div
-          class="ant-rate-star-first"
+        <span
+          aria-label="star"
+          class="anticon anticon-star"
+          role="img"
         >
-          好
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          好
-        </div>
+          <svg
+            aria-hidden="true"
+            data-icon="star"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M908.1 353.1l-253.9-36.9L540.7 86.1c-3.1-6.3-8.2-11.4-14.5-14.5-15.8-7.8-35-1.3-42.9 14.5L369.8 316.2l-253.9 36.9c-7 1-13.4 4.3-18.3 9.3a32.05 32.05 0 00.6 45.3l183.7 179.1-43.4 252.9a31.95 31.95 0 0046.4 33.7L512 754l227.1 119.4c6.2 3.3 13.4 4.4 20.3 3.2 17.4-3 29.1-19.5 26.1-36.9l-43.4-252.9 183.7-179.1c5-4.9 8.3-11.3 9.3-18.3 2.7-17.5-9.5-33.7-27-36.3z"
+            />
+          </svg>
+        </span>
       </div>
-    </li>
-    <li
-      class="ant-rate-star ant-rate-star-zero"
-    >
-      <div
-        aria-checked="false"
-        aria-posinset="5"
-        aria-setsize="5"
-        role="radio"
-        tabindex="0"
-      >
-        <div
-          class="ant-rate-star-first"
-        >
-          好
-        </div>
-        <div
-          class="ant-rate-star-second"
-        >
-          好
-        </div>
-      </div>
-    </li>
-  </ul>
-</div>
+    </div>
+  </li>
+</ul>
 `;
 
 exports[`renders components/rate/demo/disabled.tsx correctly 1`] = `

--- a/components/rate/demo/component-token.md
+++ b/components/rate/demo/component-token.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-通过组件 Token 调整评分颜色、尺寸与星形边框。自定义 `character` 也会应用星形边框 Token。
+调试使用。
 
 ## en-US
 
-Customize Rate color, size, and star borders with component tokens. Custom `character` also applies the star border tokens.
+Component Token Debug.

--- a/components/rate/demo/component-token.tsx
+++ b/components/rate/demo/component-token.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ConfigProvider, Flex, Rate } from 'antd';
+import { ConfigProvider, Rate } from 'antd';
 
 /** Test usage. Do not use in your production. */
 export default () => (
@@ -11,18 +11,10 @@ export default () => (
           starSize: 40,
           starHoverScale: 'scale(2)',
           starBg: 'red',
-          starBorderColor: 'green',
-          starBorderColorSelected: 'purple',
-          starBorderWidthDefault: 2,
-          starBorderWidthSelected: 2,
         },
       },
     }}
   >
-    <Flex vertical gap="middle">
-      <Rate defaultValue={2.5} />
-      <Rate character="A" defaultValue={2.5} allowHalf />
-      <Rate character="好" defaultValue={2.5} allowHalf />
-    </Flex>
+    <Rate defaultValue={2.5} />
   </ConfigProvider>
 );

--- a/components/rate/style/index.ts
+++ b/components/rate/style/index.ts
@@ -36,26 +36,6 @@ export interface ComponentToken {
    * @descEN Star background color
    */
   starBg: string;
-  /**
-   * @desc 星星边框颜色
-   * @descEN Star border color
-   */
-  starBorderColor: string;
-  /**
-   * @desc 默认星星边框宽度
-   * @descEN Default star border width
-   */
-  starBorderWidthDefault: number;
-  /**
-   * @desc 选中星星边框颜色
-   * @descEN Selected star border color
-   */
-  starBorderColorSelected: string;
-  /**
-   * @desc 选中星星边框宽度
-   * @descEN Selected star border width
-   */
-  starBorderWidthSelected: number;
 }
 
 interface RateToken extends FullToken<'Rate'> {}
@@ -95,13 +75,6 @@ const genRateStarStyle: GenerateStyle<RateToken, CSSObject> = (token) => {
         color: token.starBg,
         transition: `all ${token.motionDurationMid}`,
         userSelect: 'none',
-        WebkitTextStroke: `${unit(token.starBorderWidthDefault)} ${token.starBorderColor}`,
-
-        '> span svg, > svg': {
-          stroke: token.starBorderColor,
-          strokeWidth: token.starBorderWidthDefault,
-          strokeLinejoin: 'round',
-        },
       },
 
       '&-first': {
@@ -120,13 +93,6 @@ const genRateStarStyle: GenerateStyle<RateToken, CSSObject> = (token) => {
 
       [`&-half ${componentCls}-star-first, &-full ${componentCls}-star-second`]: {
         color: 'inherit',
-        WebkitTextStroke: `${unit(token.starBorderWidthSelected)} ${token.starBorderColorSelected}`,
-
-        '> span svg, > svg': {
-          stroke: token.starBorderColorSelected,
-          strokeWidth: token.starBorderWidthSelected,
-          strokeLinejoin: 'round',
-        },
       },
     },
   };
@@ -188,10 +154,6 @@ export const prepareComponentToken: GetDefaultToken<'Rate'> = (token) => ({
   starSizeLG: token.controlHeightLG * 0.625,
   starHoverScale: 'scale(1.1)',
   starBg: token.colorFillContent,
-  starBorderColor: token.colorTextTertiary,
-  starBorderWidthDefault: token.lineWidth,
-  starBorderColorSelected: token.yellow8,
-  starBorderWidthSelected: token.lineWidth,
 });
 
 export default genStyleHooks(


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] ❓ 其他改动（revert 未发布的 Rate token 变更）

### 🔗 相关 Issue

Reverts #58501.
Related #55225.

### 💡 需求背景和解决方案

#58501 新增了 Rate `starBorder*` 组件 token，并将边框样式应用到 Rate 的 SVG 和文本字符上。

由于 Rate 已支持通过 `character` function 返回自定义节点，用户可以自行控制自定义 SVG、icon 或文本的样式。当前 token 实现会影响用户传入的自定义 `character` 内部样式，存在覆盖用户自定义 `fill` / `stroke` 的风险。

在 6.5.0 发布前先撤回该未发布变更，避免暴露尚未收敛的公开 token API。后续如需继续支持默认星星的无障碍对比度优化，应重新设计作用范围，避免影响自定义 `character`。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A, revert unreleased change. |
| 🇨🇳 中文 | N/A，撤回未发布变更。 |
