### PR TITLE
fix: stop Menu icon from jittering when toggling inline-collapse

### DIFF
--- a/components/menu/__tests__/index.test.tsx
+++ b/components/menu/__tests__/index.test.tsx
@@ -1352,4 +1352,19 @@ describe('Menu', () => {
       }),
     );
   });
+
+  // https://github.com/ant-design/ant-design/issues/56196
+  it('should not transition padding on first-level inline items', () => {
+    const { unmount } = render(<Menu mode="inline" items={[{ key: '1', label: 'nav 1' }]} />);
+    const css = Array.from(document.head.querySelectorAll('style'))
+      .map((style) => style.innerHTML)
+      .join('');
+    const rule = css.match(
+      /\.ant-menu-inline\.ant-menu-root[^{]*\.ant-menu-item[^{]*\{[^}]*transition:[^}]*\}/,
+    );
+    // Animating `padding` makes the icon overshoot and snap back while expanding
+    expect(rule).toBeTruthy();
+    expect(/transition:[^}]*padding/.test(rule?.[0] ?? '')).toBe(false);
+    unmount();
+  });
 });

--- a/components/menu/style/vertical.ts
+++ b/components/menu/style/vertical.ts
@@ -58,12 +58,10 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
     colorTextLightSolid,
     dropdownWidth,
     controlHeightLG,
-    motionEaseOut,
     padding,
     paddingXL,
     itemMarginInline,
     fontSizeLG,
-    motionDurationFast,
     motionDurationSlow,
     paddingXS,
     boxShadowSecondary,
@@ -121,15 +119,15 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
       [`${componentCls}-inline`]: {
         width: '100%',
 
-        // Motion enhance for first level
         [`&${componentCls}-root`]: {
           [`${componentCls}-item, ${componentCls}-submenu-title`]: {
             display: 'flex',
             alignItems: 'center',
+            // No `padding` transition on expand: the collapsed `calc(50%)` padding must
+            // settle at once, otherwise the icon overshoots and snaps back. #56196
             transition: [
               `border-color ${motionDurationSlow}`,
               `background-color ${motionDurationSlow}`,
-              `padding ${motionDurationFast} ${motionEaseOut}`,
             ].join(','),
 
             [`> ${componentCls}-title-content`]: {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

ref #56196 (follow-up to #58271)

### 💡 Background and Solution

When an inline `Menu` collapses, the first-level items animate `padding`. The collapsed padding is a percentage (`calc(50% - ...)`) and the expanded padding is a fixed length, so the value being tweened is resolved against the item width, which is animating at the same moment. Tweening a percentage toward a pixel value while the reference width also changes isn't monotonic, so the icon slides past where it should land and snaps back. That's the jitter reported in #56196.

#58271 already removed most of it by switching the collapsed item to `justify-content: flex-start`, but a residual overshoot stayed because the `padding` transition is still there. Dropping `padding` from the transition lets the icon track the width animation directly.

I sampled the menu icon's center during expand/collapse on the `custom-trigger` demo (`requestAnimationFrame` + `getBoundingClientRect`):

| antd | expand overshoot | direction reversal |
| --- | --- | --- |
| 6.1.1 (before #58271) | ~5.7px | yes |
| 6.5.0 (current master) | ~0.78px | yes |
| this PR | 0px | no |

The static expanded and collapsed states are unchanged, so the visual snapshots are unaffected.

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Fixed `Menu` icon jitter when expanding or collapsing an inline menu. |
| 🇨🇳 Chinese | 修复内联 `Menu` 展开或收起时图标抖动的问题。 |
