### PR TITLE
fix: correct semantic root style priority in components

### DIFF
--- a/components/calendar/__tests__/semantic.test.tsx
+++ b/components/calendar/__tests__/semantic.test.tsx
@@ -3,6 +3,11 @@ import React from 'react';
 import dayjsGenerateConfig from '@rc-component/picker/generate/dayjs';
 import Calendar from '..';
 import { render } from '../../../tests/utils';
+import {
+  expectSemanticRootStylePriority,
+  semanticRootStylePriority,
+} from '../../../tests/shared/semanticStylePriority';
+import ConfigProvider from '../../config-provider';
 
 describe('Calendar.Semantic', () => {
   it('should support itemContent classNames and styles', () => {
@@ -99,5 +104,24 @@ describe('Calendar.Semantic', () => {
     const headerStyle = header?.getAttribute('style');
     expect(headerStyle).toContain('font-size: 14px');
     expect(headerStyle).toContain('color: red');
+  });
+
+  it('should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        calendar={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <Calendar
+          value={dayjsGenerateConfig.getNow()}
+          styles={semanticRootStylePriority.styles}
+          style={semanticRootStylePriority.style}
+        />
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-picker-calendar'));
   });
 });

--- a/components/calendar/generateCalendar.tsx
+++ b/components/calendar/generateCalendar.tsx
@@ -6,7 +6,7 @@ import type { CellRenderInfo } from '@rc-component/picker/interface';
 import { merge, useControlledState } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { isFunction } from '../_util/is';
 import type { AnyObject } from '../_util/type';
@@ -144,13 +144,16 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
       showWeek,
     };
 
-    const [mergedClassNames, mergedStyles] = useMergeSemantic(
-      [contextClassNames, classNames],
-      [contextStyles, styles],
-      {
-        props: mergedProps,
-      },
-    );
+    const contextStyleRoot = useSemanticRootStyle(contextStyle);
+    const styleRoot = useSemanticRootStyle(style);
+
+    const [mergedClassNames, mergedStyles] = useMergeSemantic<
+      CalendarSemanticAllType<DateType>['classNames'],
+      CalendarSemanticAllType<DateType>['styles'],
+      CalendarProps<DateType>
+    >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles, styleRoot], {
+      props: mergedProps,
+    });
 
     const [rootCls, headerCls, panelClassNames, rootStyle, headerStyle, panelStyles] =
       React.useMemo(() => {
@@ -367,7 +370,7 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
           hashId,
           cssVarCls,
         )}
-        style={{ ...rootStyle, ...contextStyle, ...style }}
+        style={rootStyle}
       >
         {headerRender ? (
           headerRender({

--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -3,7 +3,7 @@ import { useControlledState } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import ContextIsolator from '../_util/ContextIsolator';
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import genPurePanel from '../_util/PurePanel';
 import { getStatusClassNames } from '../_util/statusUtils';
 import type { GetProp } from '../_util/type';
@@ -22,7 +22,13 @@ import type { ColorPickerPanelProps } from './ColorPickerPanel';
 import ColorPickerPanel from './ColorPickerPanel';
 import ColorTrigger from './components/ColorTrigger';
 import useModeColor from './hooks/useModeColor';
-import type { ColorFormatType, ColorPickerProps, ModeType, TriggerPlacement } from './interface';
+import type {
+  ColorFormatType,
+  ColorPickerProps,
+  ColorPickerSemanticAllType,
+  ModeType,
+  TriggerPlacement,
+} from './interface';
 import useStyle from './style';
 import { genAlphaColor, generateColor, getColorAlpha } from './util';
 
@@ -101,9 +107,16 @@ const ColorPicker: CompoundedComponent = (props) => {
     size: mergedSize,
   };
 
-  const [mergedClassNames, mergedStyles] = useMergeSemantic(
+  const contextStyleRoot = useSemanticRootStyle(contextStyle);
+  const styleRoot = useSemanticRootStyle(style);
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    ColorPickerSemanticAllType['classNames'],
+    ColorPickerSemanticAllType['styles'],
+    ColorPickerProps
+  >(
     [contextClassNames, classNames],
-    [contextStyles, styles],
+    [contextStyles, contextStyleRoot, styles, styleRoot],
     {
       props: mergedProps,
     },
@@ -262,8 +275,6 @@ const ColorPicker: CompoundedComponent = (props) => {
     destroyOnHidden: destroyOnHidden ?? !!destroyTooltipOnHide,
   };
 
-  const mergedStyle: React.CSSProperties = { ...contextStyle, ...style };
-
   // ============================ zIndex ============================
 
   return (
@@ -307,7 +318,6 @@ const ColorPicker: CompoundedComponent = (props) => {
           activeIndex={popupOpen ? activeIndex : -1}
           open={popupOpen}
           className={mergedCls}
-          style={mergedStyle}
           classNames={mergedClassNames}
           styles={mergedStyles}
           prefixCls={prefixCls}

--- a/components/color-picker/__tests__/semantic.test.tsx
+++ b/components/color-picker/__tests__/semantic.test.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import { resetWarned } from '../../_util/warning';
+import ConfigProvider from '../../config-provider';
+import {
+  expectSemanticRootStylePriority,
+  semanticRootStylePriority,
+} from '../../../tests/shared/semanticStylePriority';
 import ColorPicker from '../ColorPicker';
 
 describe('ColorPicker.Semantic', () => {
@@ -72,5 +77,24 @@ describe('ColorPicker.Semantic', () => {
     );
 
     expect(root).toHaveStyle({ fontSize: '16px' });
+  });
+
+  it('should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        colorPicker={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <ColorPicker
+          defaultValue="red"
+          styles={semanticRootStylePriority.styles}
+          style={semanticRootStylePriority.style}
+        />
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-color-picker-trigger'));
   });
 });

--- a/components/date-picker/__tests__/semantic.test.tsx
+++ b/components/date-picker/__tests__/semantic.test.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 
 import DatePicker from '..';
 import { render } from '../../../tests/utils';
+import {
+  expectSemanticRootStylePriority,
+  semanticRootStylePriority,
+} from '../../../tests/shared/semanticStylePriority';
+import ConfigProvider from '../../config-provider';
 
 describe('DatePicker.Semantic', () => {
   describe('inline', () => {
@@ -173,5 +178,57 @@ describe('DatePicker.Semantic', () => {
     rerender(<DatePicker size="large" styles={stylesFn} />);
     const largeRootElement = container.querySelector('.ant-picker');
     expect(largeRootElement).toHaveStyle('font-size: 18px');
+  });
+
+  it('DatePicker should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        datePicker={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <DatePicker
+          styles={semanticRootStylePriority.styles}
+          style={semanticRootStylePriority.style}
+        />
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-picker'));
+  });
+
+  it('RangePicker should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        datePicker={{
+          styles: semanticRootStylePriority.contextStyles,
+        }}
+        rangePicker={{
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <DatePicker.RangePicker
+          styles={semanticRootStylePriority.styles}
+          style={semanticRootStylePriority.style}
+        />
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-picker'));
+  });
+
+  it('RangePicker should not use DatePicker root style config', () => {
+    const { container } = render(
+      <ConfigProvider
+        datePicker={{
+          style: { outlineWidth: '7px' },
+        }}
+      >
+        <DatePicker.RangePicker />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-picker')).not.toHaveStyle({ outlineWidth: '7px' });
   });
 });

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -86,16 +86,19 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
       });
     }
 
+    const { getPrefixCls, direction, getPopupContainer, rangePicker } = useContext(ConfigContext);
+
     const [mergedClassNames, mergedStyles] = useMergedPickerSemantic(
       pickerType,
       classNames,
       styles,
       popupClassName || dropdownClassName,
       popupStyle,
+      undefined,
+      rangePicker?.style ?? null,
     );
 
     const innerRef = React.useRef<PickerRef>(null);
-    const { getPrefixCls, direction, getPopupContainer, rangePicker } = useContext(ConfigContext);
     const prefixCls = getPrefixCls('picker', customizePrefixCls);
     const { compactSize, compactItemClassnames } = useCompactItemContext(prefixCls, direction);
     const rootPrefixCls = getPrefixCls();
@@ -190,7 +193,7 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
             className,
             rangePicker?.className,
           )}
-          style={{ ...rangePicker?.style, ...style }}
+          style={style}
           // Semantic Style
           classNames={mergedClassNames}
           styles={{

--- a/components/date-picker/generatePicker/generateSinglePicker.tsx
+++ b/components/date-picker/generatePicker/generateSinglePicker.tsx
@@ -147,6 +147,7 @@ const generatePicker = <DateType extends AnyObject = AnyObject>(
         popupClassName || dropdownClassName,
         popupStyle,
         mergedProps,
+        contextPickerConfig?.style,
       );
 
       const innerRef = React.useRef<PickerRef>(null);
@@ -251,7 +252,7 @@ const generatePicker = <DateType extends AnyObject = AnyObject>(
               contextPickerConfig?.className,
               className,
             )}
-            style={{ ...contextPickerConfig?.style, ...style }}
+            style={style}
             // Semantic Style
             classNames={mergedClassNames}
             styles={{

--- a/components/date-picker/hooks/useMergedPickerSemantic.ts
+++ b/components/date-picker/hooks/useMergedPickerSemantic.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { clsx } from 'clsx';
 
-import { useMergeSemantic } from '../../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../../_util/hooks/useMergeSemantic';
 import type { AnyObject } from '../../_util/type';
 import { useComponentConfig } from '../../config-provider/context';
 
@@ -12,12 +12,20 @@ const useMergedPickerSemantic = <P extends AnyObject = AnyObject>(
   popupClassName?: string,
   popupStyle?: React.CSSProperties,
   mergedProps?: P,
+  contextStyle?: React.CSSProperties | null,
 ) => {
-  const { classNames: contextClassNames, styles: contextStyles } = useComponentConfig(pickerType);
+  const {
+    classNames: contextClassNames,
+    style: componentContextStyle,
+    styles: contextStyles,
+  } = useComponentConfig(pickerType);
+  const mergedContextStyle =
+    contextStyle === null ? undefined : (contextStyle ?? componentContextStyle);
+  const contextStyleRoot = useSemanticRootStyle(mergedContextStyle);
 
   const [mergedClassNames, mergedStyles] = useMergeSemantic(
     [contextClassNames as P['classNames'], classNames],
-    [contextStyles as P['styles'], styles],
+    [contextStyles as P['styles'], contextStyleRoot as P['styles'], styles],
     { props: mergedProps as P },
     {
       popup: {

--- a/components/divider/__tests__/semantic.test.tsx
+++ b/components/divider/__tests__/semantic.test.tsx
@@ -3,6 +3,11 @@ import * as React from 'react';
 import Divider from '..';
 import type { DividerProps } from '..';
 import { render } from '../../../tests/utils';
+import {
+  expectSemanticRootStylePriority,
+  semanticRootStylePriority,
+} from '../../../tests/shared/semanticStylePriority';
+import ConfigProvider from '../../config-provider';
 
 describe('Divider.Semantic', () => {
   it('not show children when vertical', () => {
@@ -63,5 +68,22 @@ describe('Divider.Semantic', () => {
     root = container.querySelector('.ant-divider')!;
     expect(root).toHaveClass('divider-center');
     expect(root).toHaveStyle({ opacity: 1 });
+  });
+
+  it('should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        divider={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <Divider styles={semanticRootStylePriority.styles} style={semanticRootStylePriority.style}>
+          Text
+        </Divider>
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-divider'));
   });
 });

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -34,7 +34,7 @@ export type DividerSemanticType = {
   };
 };
 
-export type CardSemanticAllType = GenerateSemantic<DividerSemanticType, DividerProps>;
+export type DividerSemanticAllType = GenerateSemantic<DividerSemanticType, DividerProps>;
 
 export interface DividerProps {
   prefixCls?: string;
@@ -57,8 +57,8 @@ export interface DividerProps {
   style?: React.CSSProperties;
   size?: SizeType;
   plain?: boolean;
-  classNames?: CardSemanticAllType['classNamesAndFn'];
-  styles?: CardSemanticAllType['stylesAndFn'];
+  classNames?: DividerSemanticAllType['classNamesAndFn'];
+  styles?: DividerSemanticAllType['stylesAndFn'];
 }
 
 const Divider: React.FC<DividerProps> = (props) => {
@@ -131,8 +131,8 @@ const Divider: React.FC<DividerProps> = (props) => {
   const contextStyleRoot = useSemanticRootStyle(contextStyle);
 
   const [mergedClassNames, mergedStyles] = useMergeSemantic<
-    CardSemanticAllType['classNames'],
-    CardSemanticAllType['styles'],
+    DividerSemanticAllType['classNames'],
+    DividerSemanticAllType['styles'],
     DividerProps
   >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles], {
     props: mergedProps,

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -3,7 +3,7 @@ import { clsx } from 'clsx';
 
 import { useOrientation } from '../_util/hooks';
 import type { Orientation } from '../_util/hooks';
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { isNumber } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
@@ -128,11 +128,15 @@ const Divider: React.FC<DividerProps> = (props) => {
     size: sizeFullName,
   };
 
-  const [mergedClassNames, mergedStyles] = useMergeSemantic(
-    [contextClassNames, classNames],
-    [contextStyles, styles],
-    { props: mergedProps },
-  );
+  const contextStyleRoot = useSemanticRootStyle(contextStyle);
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    CardSemanticAllType['classNames'],
+    CardSemanticAllType['styles'],
+    DividerProps
+  >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles], {
+    props: mergedProps,
+  });
 
   const classString = clsx(
     prefixCls,
@@ -196,7 +200,6 @@ const Divider: React.FC<DividerProps> = (props) => {
     <div
       className={classString}
       style={{
-        ...contextStyle,
         ...mergedStyles.root,
         ...(children ? {} : mergedStyles.rail),
         ...style,

--- a/components/dropdown/__tests__/semantic.test.tsx
+++ b/components/dropdown/__tests__/semantic.test.tsx
@@ -3,6 +3,11 @@ import type { MenuProps } from '../../menu';
 import Dropdown from '..';
 import { SaveOutlined } from '@ant-design/icons';
 import { render } from '../../../tests/utils';
+import {
+  expectSemanticRootStylePriority,
+  semanticRootStylePriority,
+} from '../../../tests/shared/semanticStylePriority';
+import ConfigProvider from '../../config-provider';
 
 describe('Dropdown.Semantic', () => {
   it('support classNames and styles', () => {
@@ -75,5 +80,27 @@ describe('Dropdown.Semantic', () => {
     expect(itemContent).toHaveStyle(testStyles.itemContent);
     expect(itemTitle).toHaveClass(testClassNames.itemTitle);
     expect(itemTitle).toHaveStyle(testStyles.itemTitle);
+  });
+
+  it('should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        dropdown={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <Dropdown
+          open
+          menu={{ items: [{ key: '1', label: '1st menu item' }] }}
+          styles={semanticRootStylePriority.styles}
+          overlayStyle={semanticRootStylePriority.style}
+        >
+          <button type="button">button</button>
+        </Dropdown>
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-dropdown'));
   });
 });

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -8,7 +8,7 @@ import { getNodeRef, omit, useComposeRef, useControlledState, useEvent } from '@
 import { clsx } from 'clsx';
 
 import { useZIndex } from '../_util/hooks';
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { isPlainObject, isPrimitive } from '../_util/is';
 import type { AdjustOverflow } from '../_util/placements';
@@ -155,17 +155,18 @@ const Dropdown: CompoundedComponent = React.forwardRef<HTMLElement, DropdownProp
     mouseLeaveDelay,
     autoAdjustOverflow,
   };
-  const [mergedClassNames, mergedStyles] = useMergeSemantic(
-    [contextClassNames, classNames],
-    [contextStyles, styles],
-    {
-      props: mergedProps,
-    },
-  );
+  const contextStyleRoot = useSemanticRootStyle(contextStyle);
+  const overlayStyleRoot = useSemanticRootStyle(overlayStyle);
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    DropdownSemanticAllType['classNames'],
+    DropdownSemanticAllType['styles'],
+    DropdownProps
+  >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles, overlayStyleRoot], {
+    props: mergedProps,
+  });
 
   const mergedRootStyles: React.CSSProperties = {
-    ...contextStyle,
-    ...overlayStyle,
     ...mergedStyles.root,
   };
 

--- a/components/input/Password.tsx
+++ b/components/input/Password.tsx
@@ -5,13 +5,13 @@ import EyeOutlined from '@ant-design/icons/EyeOutlined';
 import { composeRef } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import { isPlainObject } from '../_util/is';
 import { useComponentConfig } from '../config-provider/context';
 import DisabledContext from '../config-provider/DisabledContext';
 import { useLocale } from '../locale';
 import useRemovePasswordTimeout from './hooks/useRemovePasswordTimeout';
-import type { InputProps, InputRef } from './Input';
+import type { InputProps, InputRef, InputSemanticAllType } from './Input';
 import Input from './Input';
 
 const defaultIconRender = (visible: boolean): React.ReactNode =>
@@ -76,11 +76,16 @@ const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
     disabled: mergedDisabled,
   };
 
-  const [mergedClassNames, mergedStyles] = useMergeSemantic(
-    [contextClassNames, classNames],
-    [contextStyles, styles],
-    { props: mergedProps },
-  );
+  const contextStyleRoot = useSemanticRootStyle(contextStyle);
+  const styleRoot = useSemanticRootStyle(style);
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    InputSemanticAllType['classNames'],
+    InputSemanticAllType['styles'],
+    PasswordProps
+  >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles, styleRoot], {
+    props: mergedProps,
+  });
 
   const visibilityControlled =
     isPlainObject(visibilityToggle) && visibilityToggle.visible !== undefined;
@@ -174,7 +179,6 @@ const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
     ),
     disabled: mergedDisabled,
     className: inputClassName,
-    style: { ...contextStyle, ...style },
     classNames: mergedClassNames,
     styles: mergedStyles,
   };

--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -4,7 +4,7 @@ import { composeRef, omit, pickAttrs } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import fallbackProp from '../_util/fallbackProp';
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { cloneElement } from '../_util/reactNode';
 import Button from '../button/Button';
@@ -98,9 +98,16 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
     enterButton,
   };
 
-  const [mergedClassNames, mergedStyles] = useMergeSemantic(
+  const contextStyleRoot = useSemanticRootStyle(contextStyle);
+  const styleRoot = useSemanticRootStyle(style);
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    InputSearchSemanticAllType['classNames'],
+    InputSearchSemanticAllType['styles'],
+    SearchProps
+  >(
     [contextClassNames, classNames],
-    [contextStyles, styles],
+    [contextStyles, contextStyleRoot, styles, styleRoot],
     { props: mergedProps },
     {
       button: {
@@ -260,12 +267,7 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
   );
 
   return (
-    <Compact
-      className={mergedClassName}
-      style={{ ...mergedStyles.root, ...contextStyle, ...style }}
-      {...rootProps}
-      hidden={hidden}
-    >
+    <Compact className={mergedClassName} style={mergedStyles.root} {...rootProps} hidden={hidden}>
       <Input ref={composeRef<InputRef>(inputRef, ref)} {...inputProps} />
       {button}
     </Compact>

--- a/components/input/__tests__/semantic.test.tsx
+++ b/components/input/__tests__/semantic.test.tsx
@@ -140,6 +140,24 @@ describe('Input.Semantic', () => {
     expect(count).toHaveStyle(testStyles.count);
   });
 
+  it('search should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        inputSearch={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <Input.Search
+          styles={semanticRootStylePriority.styles}
+          style={semanticRootStylePriority.style}
+        />
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-input-search'));
+  });
+
   it('password should support classNames and styles', () => {
     const { container } = render(
       <Input.Password
@@ -170,6 +188,24 @@ describe('Input.Semantic', () => {
     expect(clear).toHaveStyle(testStyles.clear);
     expect(count).toHaveClass(testClassNames.count);
     expect(count).toHaveStyle(testStyles.count);
+  });
+
+  it('password should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        inputPassword={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <Input.Password
+          styles={semanticRootStylePriority.styles}
+          style={semanticRootStylePriority.style}
+        />
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-input-affix-wrapper'));
   });
 
   it('otp should support classNames and styles', () => {

--- a/components/masonry/Masonry.tsx
+++ b/components/masonry/Masonry.tsx
@@ -5,7 +5,7 @@ import ResizeObserver from '@rc-component/resize-observer';
 import { composeRef, isEqual, useLayoutEffect } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { isNumber } from '../_util/is';
 import { responsiveArray } from '../_util/responsiveObserver';
@@ -156,13 +156,16 @@ const Masonry = React.forwardRef<MasonryRef, MasonryProps>((props, ref) => {
     columns: columnCount,
   };
 
-  const [mergedClassNames, mergedStyles] = useMergeSemantic(
-    [contextClassNames, classNames],
-    [contextStyles, styles],
-    {
-      props: mergedProps,
-    },
-  );
+  const contextStyleRoot = useSemanticRootStyle(contextStyle);
+  const styleRoot = useSemanticRootStyle(style);
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    MasonrySemanticAllType['classNames'],
+    MasonrySemanticAllType['styles'],
+    MasonryProps
+  >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles, styleRoot], {
+    props: mergedProps,
+  });
 
   // ================== Items Position ==================
   const [itemHeights, setItemHeights] = React.useState<ItemHeightData[]>([]);
@@ -243,7 +246,7 @@ const Masonry = React.forwardRef<MasonryRef, MasonryProps>((props, ref) => {
           cssVarCls,
           { [`${prefixCls}-rtl`]: direction === 'rtl' },
         )}
-        style={{ height: totalHeight, ...mergedStyles.root, ...contextStyle, ...style }}
+        style={{ height: totalHeight, ...mergedStyles.root }}
         // Listen for image events
         onLoad={collectItemSize}
         onError={collectItemSize}

--- a/components/masonry/__tests__/semantic.test.tsx
+++ b/components/masonry/__tests__/semantic.test.tsx
@@ -1,5 +1,14 @@
+import React from 'react';
+
 import type { MasonryProps } from '..';
+import Masonry from '..';
 import { isNumber } from '../../_util/is';
+import { render } from '../../../tests/utils';
+import {
+  expectSemanticRootStylePriority,
+  semanticRootStylePriority,
+} from '../../../tests/shared/semanticStylePriority';
+import ConfigProvider from '../../config-provider';
 
 describe('Masonry.Semantic', () => {
   it('should support classNames and styles props types', () => {
@@ -102,5 +111,30 @@ describe('Masonry.Semantic', () => {
     expect(responsiveClassNames.root).toBe('cols-responsive');
     expect(responsiveClassNames.item).toBe('gutter-0');
     expect(responsiveStyles.root.backgroundColor).toBe('#f6ffed');
+  });
+
+  it('should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        masonry={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <Masonry
+          items={[
+            {
+              key: 'item',
+              data: 'item',
+              children: <div style={{ height: 20 }}>item</div>,
+            },
+          ]}
+          styles={semanticRootStylePriority.styles}
+          style={semanticRootStylePriority.style}
+        />
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-masonry'));
   });
 });

--- a/components/popconfirm/__tests__/semantic.test.tsx
+++ b/components/popconfirm/__tests__/semantic.test.tsx
@@ -3,6 +3,11 @@ import { spyElementPrototype } from '@rc-component/util';
 
 import Popconfirm from '..';
 import { render } from '../../../tests/utils';
+import {
+  expectSemanticRootStylePriority,
+  semanticRootStylePriority,
+} from '../../../tests/shared/semanticStylePriority';
+import ConfigProvider from '../../config-provider';
 
 describe('Popconfirm.semantic', () => {
   beforeAll(() => {
@@ -80,5 +85,28 @@ describe('Popconfirm.semantic', () => {
     expect(popconfirmElement).toHaveStyle({ backgroundColor: 'rgb(0, 0, 255)' });
     expect(contentElement).toHaveStyle({ padding: '16px' });
     expect(iconElement).toHaveStyle({ color: 'rgb(0, 128, 0)' });
+  });
+
+  it('should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        popconfirm={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <Popconfirm
+          title="Test"
+          description="Content"
+          open
+          styles={semanticRootStylePriority.styles}
+          overlayStyle={semanticRootStylePriority.style}
+        >
+          <span>Test</span>
+        </Popconfirm>
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-popover'));
   });
 });

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -4,7 +4,7 @@ import { omit, useControlledState } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { RenderFunction } from '../_util/getRenderPropValue';
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { devUseWarning } from '../_util/warning';
 import type { ButtonProps, LegacyButtonType } from '../button/Button';
@@ -126,13 +126,16 @@ const InternalPopconfirm = React.forwardRef<TooltipRef, PopconfirmProps>((props,
     classNames,
   };
 
-  const [mergedClassNames, mergedStyles] = useMergeSemantic(
-    [contextClassNames, classNames],
-    [contextStyles, styles],
-    {
-      props: mergedProps,
-    },
-  );
+  const contextStyleRoot = useSemanticRootStyle(contextStyle);
+  const overlayStyleRoot = useSemanticRootStyle(overlayStyle);
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    PopconfirmSemanticAllType['classNames'],
+    PopconfirmSemanticAllType['styles'],
+    PopconfirmProps
+  >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles, overlayStyleRoot], {
+    props: mergedProps,
+  });
 
   const rootClassNames = clsx(prefixCls, contextClassName, overlayClassName, mergedClassNames.root);
 
@@ -153,7 +156,7 @@ const InternalPopconfirm = React.forwardRef<TooltipRef, PopconfirmProps>((props,
         arrow: mergedClassNames.arrow,
       }}
       styles={{
-        root: { ...contextStyle, ...mergedStyles.root, ...overlayStyle },
+        root: mergedStyles.root,
         container: mergedStyles.container,
         arrow: mergedStyles.arrow,
       }}

--- a/components/popover/__tests__/semantic.test.tsx
+++ b/components/popover/__tests__/semantic.test.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 
 import Popover from '..';
 import { render } from '../../../tests/utils';
+import {
+  expectSemanticRootStylePriority,
+  semanticRootStylePriority,
+} from '../../../tests/shared/semanticStylePriority';
+import ConfigProvider from '../../config-provider';
 
 describe('Popover.Semantic', () => {
   it('should support static classNames and styles', () => {
@@ -53,5 +58,28 @@ describe('Popover.Semantic', () => {
     expect(contentElement).toHaveClass('custom-container');
     expect(popoverElement).toHaveStyle({ backgroundColor: 'rgb(0, 0, 255)' });
     expect(contentElement).toHaveStyle({ padding: '16px' });
+  });
+
+  it('should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        popover={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <Popover
+          open
+          title="Test"
+          content="Content"
+          styles={semanticRootStylePriority.styles}
+          overlayStyle={semanticRootStylePriority.style}
+        >
+          <span>Test</span>
+        </Popover>
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-popover'));
   });
 });

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -4,7 +4,7 @@ import { clsx } from 'clsx';
 
 import type { RenderFunction } from '../_util/getRenderPropValue';
 import { getRenderPropValue } from '../_util/getRenderPropValue';
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { isReactRenderable } from '../_util/is';
 import { getTransitionName } from '../_util/motion';
@@ -96,13 +96,16 @@ const InternalPopover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) 
     classNames,
   };
 
-  const [mergedClassNames, mergedStyles] = useMergeSemantic(
-    [contextClassNames, classNames],
-    [contextStyles, styles],
-    {
-      props: mergedProps,
-    },
-  );
+  const contextStyleRoot = useSemanticRootStyle(contextStyle);
+  const overlayStyleRoot = useSemanticRootStyle(overlayStyle);
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    PopoverSemanticAllType['classNames'],
+    PopoverSemanticAllType['styles'],
+    PopoverProps
+  >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles, overlayStyleRoot], {
+    props: mergedProps,
+  });
 
   const rootClassNames = clsx(
     overlayClassName,
@@ -138,7 +141,7 @@ const InternalPopover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) 
         arrow: mergedClassNames.arrow,
       }}
       styles={{
-        root: { ...mergedStyles.root, ...contextStyle, ...overlayStyle },
+        root: mergedStyles.root,
         container: mergedStyles.container,
         arrow: mergedStyles.arrow,
       }}

--- a/components/qr-code/__tests__/semantic.test.tsx
+++ b/components/qr-code/__tests__/semantic.test.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 
 import QRCode from '..';
 import { render } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
+import {
+  expectSemanticRootStylePriority,
+  semanticRootStylePriority,
+} from '../../../tests/shared/semanticStylePriority';
 
 describe('QRCode.Semantic', () => {
   it('should apply custom styles to QRCode', () => {
@@ -73,5 +78,24 @@ describe('QRCode.Semantic', () => {
     const coverStyle = cover?.getAttribute('style');
     expect(coverStyle).toContain('background-color: rgba(255, 0, 0, 0.8)');
     expect(coverStyle).toContain('color: white');
+  });
+
+  it('should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        qrcode={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <QRCode
+          value="antd"
+          styles={semanticRootStylePriority.styles}
+          style={semanticRootStylePriority.style}
+        />
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-qrcode'));
   });
 });

--- a/components/qr-code/index.tsx
+++ b/components/qr-code/index.tsx
@@ -3,13 +3,19 @@ import { QRCodeCanvas, QRCodeSVG } from '@rc-component/qrcode';
 import { omit, pickAttrs } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import { isNumber } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import { useLocale } from '../locale';
 import { useToken } from '../theme/internal';
-import type { QRCodeProps, QRProps, QRPropsCanvas, QRPropsSvg } from './interface';
+import type {
+  QRCodeProps,
+  QRCodeSemanticAllType,
+  QRProps,
+  QRPropsCanvas,
+  QRPropsSvg,
+} from './interface';
 import QRcodeStatus from './QrcodeStatus';
 import useStyle from './style/index';
 
@@ -60,13 +66,16 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
     errorLevel,
   };
 
-  const [mergedClassNames, mergedStyles] = useMergeSemantic(
-    [contextClassNames, classNames],
-    [contextStyles, styles],
-    {
-      props: mergedProps,
-    },
-  );
+  const contextStyleRoot = useSemanticRootStyle(contextStyle);
+  const styleRoot = useSemanticRootStyle(style);
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    QRCodeSemanticAllType['classNames'],
+    QRCodeSemanticAllType['styles'],
+    QRCodeProps
+  >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles, styleRoot], {
+    props: mergedProps,
+  });
 
   const prefixCls = getPrefixCls('qrcode', customizePrefixCls);
 
@@ -136,8 +145,6 @@ const QRCode: React.FC<QRCodeProps> = (props) => {
   const rootStyle: React.CSSProperties = {
     backgroundColor: bgColor,
     ...mergedStyles.root,
-    ...contextStyle,
-    ...style,
     width: style?.width ?? size,
     height: style?.height ?? size,
   };

--- a/components/space/__tests__/semantic.test.tsx
+++ b/components/space/__tests__/semantic.test.tsx
@@ -3,6 +3,11 @@ import React from 'react';
 import Space from '..';
 import type { SpaceProps } from '..';
 import { render } from '../../../tests/utils';
+import {
+  expectSemanticRootStylePriority,
+  semanticRootStylePriority,
+} from '../../../tests/shared/semanticStylePriority';
+import ConfigProvider from '../../config-provider';
 
 describe('Space.Semantic', () => {
   it('should support classNames as object', () => {
@@ -81,5 +86,22 @@ describe('Space.Semantic', () => {
     expect(stylesFn.mock.calls[0][0].props.size).toBe('large');
     const spaceElement = container.querySelector('.ant-space');
     expect(spaceElement).toHaveStyle('background-color: rgb(0, 0, 255)');
+  });
+
+  it('should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        space={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <Space styles={semanticRootStylePriority.styles} style={semanticRootStylePriority.style}>
+          <span>Item</span>
+        </Space>
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-space'));
   });
 });

--- a/components/space/index.tsx
+++ b/components/space/index.tsx
@@ -5,7 +5,7 @@ import { clsx } from 'clsx';
 import { isPresetSize, isValidGapNumber } from '../_util/gapSize';
 import { useOrientation } from '../_util/hooks';
 import type { Orientation } from '../_util/hooks';
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
@@ -117,13 +117,16 @@ const InternalSpace = React.forwardRef<HTMLDivElement, SpaceProps>((props, ref) 
     align: mergedAlign,
   };
 
-  const [mergedClassNames, mergedStyles] = useMergeSemantic(
-    [contextClassNames, classNames],
-    [contextStyles, styles],
-    {
-      props: mergedProps,
-    },
-  );
+  const contextStyleRoot = useSemanticRootStyle(contextStyle);
+  const styleRoot = useSemanticRootStyle(style);
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    SpaceSemanticAllType['classNames'],
+    SpaceSemanticAllType['styles'],
+    SpaceProps
+  >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles, styleRoot], {
+    props: mergedProps,
+  });
 
   const rootClassNames = clsx(
     prefixCls,
@@ -205,7 +208,7 @@ const InternalSpace = React.forwardRef<HTMLDivElement, SpaceProps>((props, ref) 
     <div
       ref={ref}
       className={rootClassNames}
-      style={{ ...gapStyle, ...mergedStyles.root, ...contextStyle, ...style }}
+      style={{ ...gapStyle, ...mergedStyles.root }}
       {...restProps}
     >
       <SpaceContextProvider value={memoizedSpaceContext}>{renderedItems}</SpaceContextProvider>

--- a/components/spin/__tests__/semantic.test.tsx
+++ b/components/spin/__tests__/semantic.test.tsx
@@ -3,6 +3,11 @@ import React from 'react';
 import { render } from '../../../tests/utils';
 import Spin from '..';
 import type { SpinProps } from '..';
+import {
+  expectSemanticRootStylePriority,
+  semanticRootStylePriority,
+} from '../../../tests/shared/semanticStylePriority';
+import ConfigProvider from '../../config-provider';
 
 describe('Spin.Semantic', () => {
   it('supports object classNames and styles for default mode', () => {
@@ -168,5 +173,24 @@ describe('Spin.Semantic', () => {
     expect(container.querySelector('.ant-spin-description')).toHaveClass('custom-tip');
     expect(container.querySelector('.ant-spin-description')).toHaveStyle(styles.tip);
     expect(indicator).toHaveStyle(styles.indicator);
+  });
+
+  it('should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        spin={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <Spin
+          spinning
+          styles={semanticRootStylePriority.styles}
+          style={semanticRootStylePriority.style}
+        />
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-spin'));
   });
 });

--- a/components/spin/index.tsx
+++ b/components/spin/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { clsx } from 'clsx';
 import { debounce } from 'throttle-debounce';
 
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
@@ -160,13 +160,15 @@ const Spin: SpinType = (props) => {
   };
 
   // ========================= Style ==========================
-  const [mergedClassNames, mergedStyles] = useMergeSemantic(
-    [contextClassNames, classNames],
-    [contextStyles, styles],
-    {
-      props: mergedProps,
-    },
-  );
+  const contextStyleRoot = useSemanticRootStyle(contextStyle);
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    SpinSemanticAllType['classNames'],
+    SpinSemanticAllType['styles'],
+    SpinProps
+  >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles], {
+    props: mergedProps,
+  });
 
   // ======================== Warning =========================
   if (process.env.NODE_ENV !== 'production') {
@@ -246,7 +248,6 @@ const Spin: SpinType = (props) => {
         ...mergedStyles.root,
         ...(!isNested ? mergedStyles.section : {}),
         ...(fullscreen ? mergedStyles.mask : {}),
-        ...contextStyle,
         ...style,
       }}
       aria-live="polite"

--- a/components/tag/__tests__/semantic.test.tsx
+++ b/components/tag/__tests__/semantic.test.tsx
@@ -129,6 +129,22 @@ describe('Tag.Semantic', () => {
     expect(closeElement).toHaveClass('close-filled');
     expect(closeElement).toHaveStyle({ color: 'rgb(0, 0, 255)' });
   });
+  it('should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        tag={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <Tag styles={semanticRootStylePriority.styles} style={semanticRootStylePriority.style}>
+          Bamboo
+        </Tag>
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-tag'));
+  });
   it('checkableTagGroup support classNames and styles as objects', () => {
     const { container } = render(
       <Tag.CheckableTagGroup

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -5,7 +5,7 @@ import { clsx } from 'clsx';
 import type { PresetColorType, PresetStatusColorType } from '../_util/colors';
 import { pickClosable, useClosable } from '../_util/hooks';
 import type { ClosableType } from '../_util/hooks';
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { isFunction } from '../_util/is';
 import { cloneElement, replaceElement } from '../_util/reactNode';
@@ -127,23 +127,26 @@ const InternalTag = React.forwardRef<HTMLSpanElement | HTMLAnchorElement, TagPro
     };
 
     // ====================== Styles ======================
-    const [mergedClassNames, mergedStyles] = useMergeSemantic(
-      [contextClassNames, classNames],
-      [contextStyles, styles],
-      {
-        props: mergedProps,
-      },
-    );
+    const contextStyleRoot = useSemanticRootStyle(contextStyle);
+    const styleRoot = useSemanticRootStyle(style);
+
+    const [mergedClassNames, mergedStyles] = useMergeSemantic<
+      TagSemanticAllType['classNames'],
+      TagSemanticAllType['styles'],
+      TagProps
+    >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles, styleRoot], {
+      props: mergedProps,
+    });
 
     const tagStyle = React.useMemo(() => {
-      let nextTagStyle: React.CSSProperties = { ...mergedStyles.root, ...contextStyle, ...style };
+      let nextTagStyle: React.CSSProperties = mergedStyles.root;
 
       if (!mergedDisabled) {
         nextTagStyle = { ...customTagStyle, ...nextTagStyle };
       }
 
       return nextTagStyle;
-    }, [mergedStyles.root, contextStyle, style, customTagStyle, mergedDisabled]);
+    }, [mergedStyles.root, customTagStyle, mergedDisabled]);
 
     const prefixCls = getPrefixCls('tag', customizePrefixCls);
     const [hashId, cssVarCls] = useStyle(prefixCls);

--- a/components/time-picker/__tests__/semantic.test.tsx
+++ b/components/time-picker/__tests__/semantic.test.tsx
@@ -5,6 +5,11 @@ import type { TimePickerProps } from '..';
 import TimePicker from '..';
 import type { GetProp } from '../../_util/type';
 import { render } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
+import {
+  expectSemanticRootStylePriority,
+  semanticRootStylePriority,
+} from '../../../tests/shared/semanticStylePriority';
 
 describe('TimePicker.Semantic', () => {
   it('should support semantic classNames and styles with useMergeSemantic', () => {
@@ -51,5 +56,23 @@ describe('TimePicker.Semantic', () => {
     const popupRoot = container.querySelector('.ant-picker-dropdown');
     expect(popupRoot).toHaveClass('semantic-popup-root');
     expect(popupRoot).toHaveStyle('border-radius: 8px');
+  });
+
+  it('should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        timePicker={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <TimePicker
+          styles={semanticRootStylePriority.styles}
+          style={semanticRootStylePriority.style}
+        />
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-picker'));
   });
 });

--- a/components/tooltip/__tests__/semantic.test.tsx
+++ b/components/tooltip/__tests__/semantic.test.tsx
@@ -3,6 +3,11 @@ import React from 'react';
 import Tooltip from '..';
 import type { TooltipProps } from '..';
 import { render } from '../../../tests/utils';
+import {
+  expectSemanticRootStylePriority,
+  semanticRootStylePriority,
+} from '../../../tests/shared/semanticStylePriority';
+import ConfigProvider from '../../config-provider';
 
 describe('Tooltip.Semantic', () => {
   it('should support static classNames and styles', () => {
@@ -64,5 +69,27 @@ describe('Tooltip.Semantic', () => {
 
     expect(tooltipElement).toHaveClass('blue-tooltip');
     expect(tooltipContainer).toHaveStyle('font-size: 16px');
+  });
+
+  it('should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        tooltip={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <Tooltip
+          title="Test tooltip"
+          open
+          styles={semanticRootStylePriority.styles}
+          overlayStyle={semanticRootStylePriority.style}
+        >
+          Test
+        </Tooltip>
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-tooltip'));
   });
 });

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -8,7 +8,7 @@ import type { PresetColorType } from '../_util/colors';
 import ContextIsolator from '../_util/ContextIsolator';
 import type { RenderFunction } from '../_util/getRenderPropValue';
 import { useZIndex } from '../_util/hooks';
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { isFunction } from '../_util/is';
 import { getTransitionName } from '../_util/motion';
@@ -295,13 +295,16 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
     destroyOnHidden: mergedDestroyOnHidden,
   };
 
-  const [mergedClassNames, mergedStyles] = useMergeSemantic(
-    [contextClassNames, classNames],
-    [contextStyles, styles],
-    {
-      props: mergedProps,
-    },
-  );
+  const contextStyleRoot = useSemanticRootStyle(contextStyle);
+  const overlayStyleRoot = useSemanticRootStyle(overlayStyle);
+
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    TooltipSemanticAllType['classNames'],
+    TooltipSemanticAllType['styles'],
+    TooltipProps
+  >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles, overlayStyleRoot], {
+    props: mergedProps,
+  });
 
   const prefixCls = getPrefixCls('tooltip', customizePrefixCls);
 
@@ -371,8 +374,6 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
         root: {
           ...arrowContentStyle,
           ...mergedStyles.root,
-          ...contextStyle,
-          ...overlayStyle,
         },
         container: containerStyle,
         uniqueContainer: containerStyle,

--- a/components/typography/__tests__/semantic.test.tsx
+++ b/components/typography/__tests__/semantic.test.tsx
@@ -5,6 +5,10 @@ import Typography from '..';
 import type { TypographyProps } from '..';
 import type { GetProp } from '../../_util/type';
 import { render } from '../../../tests/utils';
+import {
+  expectSemanticRootStylePriority,
+  semanticRootStylePriority,
+} from '../../../tests/shared/semanticStylePriority';
 import ConfigProvider from '../../config-provider';
 
 describe('Typography.Semantic', () => {
@@ -150,5 +154,25 @@ describe('Typography.Semantic', () => {
     const textarea = container.querySelector<HTMLTextAreaElement>('textarea');
     expect(textarea).toHaveClass('custom-textarea-class');
     expect(textarea).toHaveStyle({ fontSize: '20px' });
+  });
+
+  it('should follow root style priority', () => {
+    render(
+      <ConfigProvider
+        typography={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <Typography.Paragraph
+          styles={semanticRootStylePriority.styles}
+          style={semanticRootStylePriority.style}
+        >
+          Test Typography
+        </Typography.Paragraph>
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(document.querySelector('.ant-typography'));
   });
 });

--- a/components/typography/hooks/useTypographySemantic.ts
+++ b/components/typography/hooks/useTypographySemantic.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { useMergeSemantic } from '../../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../../_util/hooks/useMergeSemantic';
 import type { DirectionType } from '../../config-provider';
 import { useComponentConfig } from '../../config-provider/context';
 import type { BaseTypographyProps, TypographySemanticAllType } from '../Base';
@@ -34,14 +34,15 @@ export const useTypographySemantic = (
     () => ({ root: contextClassName }),
     [contextClassName],
   );
-  const contextStylesObject = useMemo<TypographySemanticAllType['styles']>(
-    () => ({ root: contextStyle }),
-    [contextStyle],
-  );
+  const contextStyleRoot = useSemanticRootStyle(contextStyle);
 
-  const [mergedClassNames, mergedStyles] = useMergeSemantic(
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    TypographySemanticAllType['classNames'],
+    TypographySemanticAllType['styles'],
+    BaseTypographyProps
+  >(
     [contextClassNamesObject, contextClassNames, classNames],
-    [contextStylesObject, contextStyles, styles],
+    [contextStyles, contextStyleRoot, styles],
     {
       props: mergedProps,
     },


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

ref #58470

### 💡 需求背景和解决方案

部分组件根节点同时支持 ConfigProvider 的 `styles.root`、ConfigProvider 的 `style`、组件自身的 `styles.root` 和组件自身的 `style` 时，合并顺序不一致，可能导致组件本地 `styles.root` 被全局 `style` 覆盖。

本 PR 延续已合并 PR 的处理方式，将 ConfigProvider `style` 与组件 `style` 转为 semantic root style 后交由 `useMergeSemantic` 合并，保证根节点样式优先级为：ConfigProvider `styles.root` -> ConfigProvider `style` -> 组件 `styles.root` -> 组件 `style`。

本 PR 覆盖以下组件：

- Calendar
- ColorPicker
- DatePicker / TimePicker
- Divider
- Dropdown
- Input.Search / Input.Password
- Masonry
- Popover / Popconfirm
- QRCode
- Space
- Spin
- Tag
- Tooltip
- Typography

同时补充对应组件的根节点样式优先级测试。DatePicker 的 RangePicker 额外避免错误复用 DatePicker 的全局 `style` 配置。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix root style priority for Calendar, ColorPicker, DatePicker, Divider, Dropdown, Input.Search, Input.Password, Masonry, Popover, Popconfirm, QRCode, Space, Spin, Tag, Tooltip, Typography and TimePicker. |
| 🇨🇳 中文 | 🐞 修复 Calendar、ColorPicker、DatePicker、Divider、Dropdown、Input.Search、Input.Password、Masonry、Popover、Popconfirm、QRCode、Space、Spin、Tag、Tooltip、Typography 和 TimePicker 根节点样式优先级问题。 |
