### PR TITLE
fix: restore Form.Item help false behavior

### DIFF
--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -68,7 +68,7 @@ const ErrorList: React.FC<ErrorListProps> = ({
   // ref: https://github.com/ant-design/ant-design/issues/36336
   const debounceErrors = useDebounce(errors);
   const debounceWarnings = useDebounce(warnings);
-  const hasHelp = isNonNullable(help) && help !== false;
+  const hasHelp = isNonNullable(help);
 
   const fullKeyList = React.useMemo<ErrorEntity[]>(() => {
     if (hasHelp) {

--- a/components/form/FormItem/ItemHolder.tsx
+++ b/components/form/FormItem/ItemHolder.tsx
@@ -61,7 +61,7 @@ export default function ItemHolder(props: ItemHolderProps) {
   const itemRef = React.useRef<HTMLDivElement>(null);
   const debounceErrors = useDebounce(errors);
   const debounceWarnings = useDebounce(warnings);
-  const hasHelp = isNonNullable(help) && help !== false;
+  const hasHelp = isNonNullable(help);
   const hasError = !!(hasHelp || errors.length || warnings.length);
   const isOnScreen = !!itemRef.current && isVisible(itemRef.current);
   const [marginBottom, setMarginBottom] = React.useState<number | null>(null);

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -790,6 +790,24 @@ describe('Form', () => {
       expect(container.querySelector('.ant-form-item-explain')).toHaveTextContent('');
       expect(container.querySelector('.ant-form-item-with-help')).toBeTruthy();
     });
+
+    // https://github.com/ant-design/ant-design/issues/58557
+    it('false', async () => {
+      const { container } = render(
+        <Form>
+          <Form.Item name="test" help={false} rules={[{ required: true, message: 'message' }]}>
+            <Input />
+          </Form.Item>
+        </Form>,
+      );
+
+      fireEvent.submit(container.querySelector('form')!);
+      await waitFakeTimer();
+
+      expect(container.querySelector('.ant-form-item')).toHaveClass('ant-form-item-has-error');
+      expect(container.querySelector('.ant-form-item-with-help')).toBeTruthy();
+      expect(container.querySelector('.ant-form-item-explain')?.textContent).toBe('');
+    });
   });
 
   // https://github.com/ant-design/ant-design/issues/20706


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #58557

### 💡 需求背景和解决方案

#58160 调整 Form 的 `help` 判断后，`help={false}` 会被当作未配置 `help`，导致校验失败后仍然展示错误提示。

本次将 `ErrorList` 与 `ItemHolder` 中 `help` 是否存在的判断恢复为 `isNonNullable(help)`，保留 `help={false}` 覆盖校验错误提示的历史行为，并补充对应回归测试。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Form.Item `help={false}` still showing validation message. |
| 🇨🇳 中文 | 修复 Form.Item 设置 `help={false}` 时仍展示校验提示的问题。 |