### PR TITLE
fix: fix missing styles when using StyleProvider layer

### DIFF
--- a/components/config-provider/__tests__/nonce.test.tsx
+++ b/components/config-provider/__tests__/nonce.test.tsx
@@ -86,6 +86,32 @@ describe('ConfigProvider.Icon', () => {
     expect(container.querySelector('#zero-runtime')?.innerHTML).toBe('true');
   });
 
+  it('does not rewrite icon runtime style when cssinjs layer is enabled', () => {
+    render(<SmileOutlined />);
+
+    const runtimeStyle = document.querySelector<HTMLStyleElement>(
+      'style[rc-util-key="@ant-design-icons"]',
+    );
+
+    expect(runtimeStyle).toBeTruthy();
+    expect(runtimeStyle?.innerHTML).not.toContain('@layer antd');
+
+    render(
+      <StyleProvider layer cache={createCache()}>
+        <ConfigProvider>
+          <SmileOutlined />
+        </ConfigProvider>
+      </StyleProvider>,
+    );
+
+    expect(runtimeStyle?.innerHTML).not.toContain('@layer antd');
+    expect(
+      Array.from(document.querySelectorAll('style')).some(
+        (style) => style.innerHTML.includes('@layer antd') && style.innerHTML.includes('.anticon'),
+      ),
+    ).toBeTruthy();
+  });
+
   it('cssinjs should support nonce', () => {
     render(
       <StyleProvider cache={createCache()}>

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -641,7 +641,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
       prefixCls: iconPrefixCls,
       csp,
       layer: layer ? 'antd' : undefined,
-      zeroRuntime: mergedTheme?.zeroRuntime,
+      zeroRuntime: layer || mergedTheme?.zeroRuntime,
     }),
     [iconPrefixCls, csp, layer, mergedTheme?.zeroRuntime],
   );

--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -641,7 +641,7 @@ const ProviderChildren: React.FC<ProviderChildrenProps> = (props) => {
       prefixCls: iconPrefixCls,
       csp,
       layer: layer ? 'antd' : undefined,
-      zeroRuntime: layer || mergedTheme?.zeroRuntime,
+      zeroRuntime: !!layer || mergedTheme?.zeroRuntime,
     }),
     [iconPrefixCls, csp, layer, mergedTheme?.zeroRuntime],
   );

--- a/package.json
+++ b/package.json
@@ -221,8 +221,6 @@
     "@types/semver": "^7.7.1",
     "@types/spinnies": "^0.5.3",
     "@types/throttle-debounce": "^5.0.2",
-    "@umijs/bundler-utils": "^4.6.68",
-    "@umijs/utils": "^4.6.68",
     "adm-zip": "^0.5.17",
     "ajv": "^8.20.0",
     "ali-oss": "^6.23.0",


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

closes: #58553

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix missing styles in some components when ConfigProvider is used with StyleProvider `layer`. |
| 🇨🇳 Chinese | 🐞 修复 ConfigProvider 配合 StyleProvider `layer` 使用时，部分组件样式可能丢失的问题。 |
