### PR TITLE
fix: correct ja-JP Typography expand/collapse labels

### DIFF
--- a/components/locale/ja_JP.ts
+++ b/components/locale/ja_JP.ts
@@ -82,8 +82,8 @@ const localeValues: Locale = {
     edit: '編集',
     copy: 'コピー',
     copied: 'コピーされました',
-    expand: '拡大する',
-    collapse: '崩壊',
+    expand: '展開する',
+    collapse: '折り畳む',
   },
   Form: {
     optional: '(オプション)',


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] 🌐 Internationalization

### 🔗 Related Issues

No issue. The two values were introduced in #48704 (locale: add missing japanese translation).

### 💡 Background and Solution

In `components/locale/ja_JP.ts` the Typography (`Text`) expand/collapse labels use the wrong sense of the English homographs:

- `expand` was `拡大する`, which means "enlarge / zoom in".
- `collapse` was `崩壊`, which means a structural or systemic collapse (a building or a system falling apart).

These labels are the show-more / fold-up toggle of an ellipsized Typography (`ellipsis={{ expandable: 'collapsible' }}`), so neither sense fits. The same package's Table component already uses the correct terms for the identical expand/fold action: `Table.expand` is `展開する` and `Table.collapse` is `折り畳む`. The other locales agree on the unfold / fold-up meaning: en-US `Expand`/`Collapse`, zh-CN `展开`/`收起`, ko-KR `확장`.

This PR aligns `Text.expand`/`Text.collapse` with the existing Table labels. Only the two `ja_JP` values change; no keys are added or removed, so locale key parity across all language files is unchanged.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🇯🇵 Fix the wrong Japanese (ja-JP) labels for Typography expand and collapse. |
| 🇨🇳 Chinese | 🇯🇵 修复 Typography 展开和折叠的日语（ja-JP）文案错误。 |
