### PR TITLE
fix: avoid popup root drop-shadow filter

### DIFF
--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 import { warning } from '@rc-component/util';
 
 import Popover from '..';
@@ -255,5 +256,26 @@ describe('Popover', () => {
 
     const arrow = container.querySelector('.ant-popover-arrow');
     expect(arrow).not.toHaveStyle({ background: 'red' });
+  });
+
+  it('uses container pseudo element to hold popup drop shadow', () => {
+    const cache = createCache();
+
+    render(
+      <StyleProvider cache={cache}>
+        <Popover content="hello" open>
+          <span>Show</span>
+        </Popover>
+      </StyleProvider>,
+    );
+
+    const styleText = extractStyle(cache, { plain: true });
+
+    expect(styleText).not.toMatch(
+      /\.ant-popover\{[^}]*filter\s*:\s*var\(--ant-drop-shadow-popover\)/,
+    );
+    expect(styleText).toMatch(
+      /\.ant-popover-container::before\{[^}]*filter\s*:\s*var\(--ant-drop-shadow-popover\)/,
+    );
   });
 });

--- a/components/popover/style/index.ts
+++ b/components/popover/style/index.ts
@@ -108,7 +108,6 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
         textAlign: 'start',
         cursor: 'auto',
         userSelect: 'text',
-        filter: dropShadowPopover,
 
         // When use `autoArrow`, origin will follow the arrow position
         [varName('valid-offset-x')]: varRef('arrow-offset-x', 'var(--arrow-x)'),
@@ -137,7 +136,19 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
           backgroundColor: popoverBg,
           backgroundClip: 'padding-box',
           borderRadius: borderRadiusLG,
+          position: 'relative',
           padding: innerPadding,
+
+          '&::before': {
+            position: 'absolute',
+            inset: 0,
+            zIndex: -1,
+            borderRadius: 'inherit',
+            background: 'inherit',
+            content: '""',
+            filter: dropShadowPopover,
+            pointerEvents: 'none',
+          },
         },
 
         [`${componentCls}-title`]: {

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 import { spyElementPrototype, warning } from '@rc-component/util';
 
 import type { TooltipPlacement } from '..';
@@ -656,5 +657,29 @@ describe('Tooltip', () => {
 
     const arrow = container.querySelector('.ant-tooltip-arrow');
     expect(arrow).toHaveStyle({ background: 'red' });
+  });
+
+  it('uses container pseudo elements to hold popup drop shadow', () => {
+    const cache = createCache();
+
+    render(
+      <StyleProvider cache={cache}>
+        <Tooltip title="hello" open>
+          <span>Hover me</span>
+        </Tooltip>
+      </StyleProvider>,
+    );
+
+    const styleText = extractStyle(cache, { plain: true });
+
+    expect(styleText).not.toMatch(
+      /\.ant-tooltip\{[^}]*filter\s*:\s*var\(--ant-drop-shadow-popover\)/,
+    );
+    expect(styleText).toMatch(
+      /\.ant-tooltip-container::before\{[^}]*filter\s*:\s*var\(--ant-drop-shadow-popover\)/,
+    );
+    expect(styleText).toMatch(
+      /\.ant-tooltip-unique-container::before\{[^}]*filter\s*:\s*var\(--ant-drop-shadow-popover\)/,
+    );
   });
 });

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -68,6 +68,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
   const centerAlignMinWidth = calc(tooltipBorderRadius).mul(2).add(sizePopupArrow).equal();
 
   const sharedBodyStyle: CSSObject = {
+    position: 'relative',
     minWidth: centerAlignMinWidth,
     minHeight: controlHeight,
     padding: `${unit(token.calc(paddingSM).div(2).equal())} ${unit(paddingXS)}`,
@@ -78,6 +79,17 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
     backgroundColor: tooltipBg,
     borderRadius: tooltipBorderRadius,
     boxSizing: 'border-box',
+
+    '&::before': {
+      position: 'absolute',
+      inset: 0,
+      zIndex: -1,
+      borderRadius: 'inherit',
+      background: 'inherit',
+      content: '""',
+      filter: dropShadowPopover,
+      pointerEvents: 'none',
+    },
   };
 
   const sharedTransformOrigin: CSSObject = {
@@ -99,7 +111,6 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
         width: 'max-content',
         maxWidth: tooltipMaxWidth,
         visibility: 'visible',
-        filter: dropShadowPopover,
 
         ...sharedTransformOrigin,
 
@@ -185,7 +196,6 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
         ...sharedTransformOrigin,
         position: 'absolute',
         zIndex: calc(zIndexPopup).sub(1).equal(),
-        filter: dropShadowPopover,
 
         '&-hidden': {
           display: 'none',


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close #58384
close #58466

### 💡 Background and Solution

#57988 moved Tooltip and Popover elevation to `filter: drop-shadow(...)` on the popup root, which keeps the arrow and popup body sharing one shadow. However, a non-`none` root filter also creates a filtered ancestor for popup content, so descendant `backdrop-filter` styles on Popover/Tooltip content stop blurring the page behind the popup.

This PR removes the direct root `filter` from Tooltip and Popover. The existing `dropShadowPopover` elevation is now applied by container `::before` pseudo elements instead, so the shadow remains outside the popup content ancestor chain while popup content can still use `backdrop-filter`. Tooltip unique containers use the same pseudo-element path.

Validation:

- `./node_modules/.bin/jest --config .jest.js --no-cache components/popover/__tests__/index.test.tsx components/tooltip/__tests__/tooltip.test.tsx`
- `./node_modules/.bin/biome check components/popover/__tests__/index.test.tsx components/popover/style/index.ts components/tooltip/__tests__/tooltip.test.tsx components/tooltip/style/index.ts`
- `./node_modules/.bin/eslint components/popover/__tests__/index.test.tsx components/popover/style/index.ts components/tooltip/__tests__/tooltip.test.tsx components/tooltip/style/index.ts`
- `git diff --check`

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Tooltip and Popover root drop-shadow filter blocking `backdrop-filter` on popup content. |
| 🇨🇳 Chinese | 🐞 修复 Tooltip 和 Popover 根节点 drop-shadow filter 导致弹层内容 `backdrop-filter` 失效的问题。 |