### PR TITLE
docs(Table): mention React DevTools in FAQ

### DIFF
--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -394,6 +394,10 @@ In order to improve user experience, Pagination show size changer by default whe
 
 Table can not tell what state used in `columns.render`, so it always need fully render to avoid sync issue. You can use `column.shouldCellUpdate` to control render.
 
+### How should I troubleshoot Table performance issues? {#faq-table-performance}
+
+React DevTools may add extra overhead when profiling complex tables, especially with many rows or cells. If you notice obvious lag, please try disabling React DevTools or testing in a clean browser environment first. If the performance issue can still be reproduced in a normal runtime, feel free to provide a minimal reproduction so we can continue to investigate.
+
 ### How to handle fixed column display over the mask layout? {#faq-fixed-column-zindex}
 
 Fixed column use `z-index` to make it over other columns. You will find sometimes fixed columns also over your mask layout. You can set `z-index` on your mask layout to resolve.

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -394,6 +394,10 @@ return <Table rowKey={(record) => record.uid} />;
 
 由于 `columns` 支持 `render` 方法，因而 Table 无法知道哪些单元会受到影响。你可以通过 `column.shouldCellUpdate` 来控制单元格的渲染。
 
+### 如何排查 Table 性能问题？ {#faq-table-performance}
+
+React DevTools 在分析复杂表格时可能带来额外开销，尤其是行列数量较多的场景。若你遇到明显卡顿，建议先关闭 React DevTools，或在干净的浏览器环境中重新测试。如果在正常运行环境下仍能稳定复现性能问题，欢迎提供最小复现以便我们继续排查。
+
 ### 固定列穿透到最上层该怎么办？ {#faq-fixed-column-zindex}
 
 固定列通过 `z-index` 属性将其悬浮于非固定列之上，这使得有时候你会发现在 Table 上放置遮罩层时固定列会被透过的情况。为遮罩层设置更高的 `z-index` 覆盖住固定列即可。


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Close #46980

Related comment: https://github.com/ant-design/ant-design/issues/46980#issuecomment-4841462171

### 💡 Background and Solution

Add a Table FAQ entry that gently suggests disabling React DevTools, or testing in a clean browser environment, before judging complex Table performance issues. The note also asks for a minimal reproduction if the issue is still reproducible in a normal runtime.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 📝 Add Table FAQ note for React DevTools performance troubleshooting. |
| 🇨🇳 Chinese | 📝 补充 Table FAQ 中关于 React DevTools 性能排查的说明。 |
