### PR TITLE
feat(Mentions): support popupRender to customize dropdown menu

### DIFF
--- a/components/mentions/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/mentions/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -382,6 +382,20 @@ exports[`renders components/mentions/demo/placement.tsx extend context correctly
 
 exports[`renders components/mentions/demo/placement.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/mentions/demo/popupRender.tsx extend context correctly 1`] = `
+<div
+  class="ant-mentions ant-mentions-outlined ant-mentions css-var-test-id ant-mentions-css-var"
+  style="width: 100%;"
+>
+  <textarea
+    class="rc-textarea"
+    rows="1"
+  />
+</div>
+`;
+
+exports[`renders components/mentions/demo/popupRender.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/mentions/demo/prefix.tsx extend context correctly 1`] = `
 <div
   class="ant-mentions ant-mentions-outlined ant-mentions css-var-test-id ant-mentions-css-var"

--- a/components/mentions/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/mentions/__tests__/__snapshots__/demo.test.tsx.snap
@@ -360,6 +360,18 @@ exports[`renders components/mentions/demo/placement.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/mentions/demo/popupRender.tsx correctly 1`] = `
+<div
+  class="ant-mentions ant-mentions-outlined ant-mentions css-var-test-id ant-mentions-css-var"
+  style="width:100%"
+>
+  <textarea
+    class="rc-textarea"
+    rows="1"
+  />
+</div>
+`;
+
 exports[`renders components/mentions/demo/prefix.tsx correctly 1`] = `
 <div
   class="ant-mentions ant-mentions-outlined ant-mentions css-var-test-id ant-mentions-css-var"

--- a/components/mentions/demo/popupRender.md
+++ b/components/mentions/demo/popupRender.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+使用 `popupRender` 对下拉菜单进行自定义渲染。
+
+## en-US
+
+Customize the dropdown menu rendering via `popupRender`.

--- a/components/mentions/demo/popupRender.tsx
+++ b/components/mentions/demo/popupRender.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Mentions } from 'antd';
+
+const App: React.FC = () => (
+  <Mentions
+    style={{ width: '100%' }}
+    popupRender={(menu) => (
+      <div className="custom-popup">
+        <div className="custom-header">Custom Header</div>
+        {menu}
+      </div>
+    )}
+    options={[
+      {
+        value: 'afc163',
+        label: 'afc163',
+      },
+      {
+        value: 'zombieJ',
+        label: 'zombieJ',
+      },
+      {
+        value: 'yesmeck',
+        label: 'yesmeck',
+      },
+    ]}
+  />
+);
+
+export default App;

--- a/components/mentions/demo/popupRender.tsx
+++ b/components/mentions/demo/popupRender.tsx
@@ -1,30 +1,42 @@
 import React from 'react';
-import { Mentions } from 'antd';
+import { Divider, Mentions, theme } from 'antd';
 
-const App: React.FC = () => (
-  <Mentions
-    style={{ width: '100%' }}
-    popupRender={(menu) => (
-      <div className="custom-popup">
-        <div className="custom-header">Custom Header</div>
-        {menu}
-      </div>
-    )}
-    options={[
-      {
-        value: 'afc163',
-        label: 'afc163',
-      },
-      {
-        value: 'zombieJ',
-        label: 'zombieJ',
-      },
-      {
-        value: 'yesmeck',
-        label: 'yesmeck',
-      },
-    ]}
-  />
-);
+const App: React.FC = () => {
+  const { token } = theme.useToken();
+  return (
+    <Mentions
+      style={{ width: '100%' }}
+      popupRender={(menu) => (
+        <>
+          <div
+            style={{
+              padding: '8px 12px',
+              fontWeight: 'bold',
+              color: token.colorTextDescription,
+            }}
+          >
+            Custom Header
+          </div>
+          <Divider style={{ margin: '4px 0' }} />
+          {menu}
+        </>
+      )}
+      options={[
+        {
+          value: 'afc163',
+          label: 'afc163',
+        },
+        {
+          value: 'zombieJ',
+          label: 'zombieJ',
+        },
+        {
+          value: 'yesmeck',
+          label: 'yesmeck',
+        },
+      ]}
+    />
+  );
+};
 
 export default App;

--- a/components/mentions/demo/popupRender.tsx
+++ b/components/mentions/demo/popupRender.tsx
@@ -10,14 +10,14 @@ const App: React.FC = () => {
         <>
           <div
             style={{
-              padding: '8px 12px',
-              fontWeight: 'bold',
+              padding: `${token.paddingXS}px ${token.paddingSM}px`,
+              fontWeight: token.fontWeightStrong,
               color: token.colorTextDescription,
             }}
           >
             Custom Header
           </div>
-          <Divider style={{ margin: '4px 0' }} />
+          <Divider style={{ margin: `${token.marginXXS}px 0` }} />
           {menu}
         </>
       )}

--- a/components/mentions/index.en-US.md
+++ b/components/mentions/index.en-US.md
@@ -49,6 +49,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | getPopupContainer | Set the mount HTML node for suggestions | () => HTMLElement | - |  | × |
 | notFoundContent | Set mentions content when not match | ReactNode | `Not Found` |  | × |
 | placement | Set popup placement | `top` \| `bottom` | `bottom` |  | × |
+| popupRender | Customize the dropdown menu rendering | (menu: React.ReactElement) => ReactNode | - | 6.5.0 | × |
 | prefix | Set trigger prefix keyword | string \| string\[] | `@` |  | × |
 | split | Set split string before and after selected mention | string | ` ` |  | × |
 | size | The size of the input box | `large` \| `medium` \| `small` | - |  | × |
@@ -64,7 +65,6 @@ Common props ref：[Common props](/docs/react/common-props)
 | onSearch | Trigger when prefix hit | (text: string, prefix: string) => void | - |  | × |
 | onSelect | Trigger when user select the option | (option: OptionProps, prefix: string) => void | - |  | × |
 | onPopupScroll | Trigger when mentions scroll | (e: Event) => void | - | 5.23.0 | × |
-| popupRender | Customize the dropdown menu rendering | (menu: React.ReactElement) => ReactNode | - | 6.5.0 | × |
 | options | Option Configuration | [Options](#option) | \[] | 5.1.0 | × |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
 

--- a/components/mentions/index.en-US.md
+++ b/components/mentions/index.en-US.md
@@ -24,6 +24,7 @@ When you need to mention someone or something.
 <code src="./demo/prefix.tsx">Customize Trigger Token</code>
 <code src="./demo/readonly.tsx">disabled or readOnly</code>
 <code src="./demo/placement.tsx">Placement</code>
+<code src="./demo/popupRender.tsx">Customize Popup</code>
 <code src="./demo/allowClear.tsx">With clear icon</code>
 <code src="./demo/autoSize.tsx">autoSize</code>
 <code src="./demo/autosize-textarea-debug.tsx" debug>debug autoSize</code>
@@ -63,6 +64,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | onSearch | Trigger when prefix hit | (text: string, prefix: string) => void | - |  | × |
 | onSelect | Trigger when user select the option | (option: OptionProps, prefix: string) => void | - |  | × |
 | onPopupScroll | Trigger when mentions scroll | (e: Event) => void | - | 5.23.0 | × |
+| popupRender | Customize the dropdown menu rendering | (menu: React.ReactElement) => ReactNode | - | 6.5.0 | × |
 | options | Option Configuration | [Options](#option) | \[] | 5.1.0 | × |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
 

--- a/components/mentions/index.en-US.md
+++ b/components/mentions/index.en-US.md
@@ -49,7 +49,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | getPopupContainer | Set the mount HTML node for suggestions | () => HTMLElement | - |  | × |
 | notFoundContent | Set mentions content when not match | ReactNode | `Not Found` |  | × |
 | placement | Set popup placement | `top` \| `bottom` | `bottom` |  | × |
-| popupRender | Customize the dropdown menu rendering | (menu: React.ReactElement) => ReactNode | - | 6.5.0 | × |
+| popupRender | Customize the dropdown menu rendering | (menu: React.ReactElement) => ReactNode | - | 6.6.0 | × |
 | prefix | Set trigger prefix keyword | string \| string\[] | `@` |  | × |
 | split | Set split string before and after selected mention | string | ` ` |  | × |
 | size | The size of the input box | `large` \| `medium` \| `small` | - |  | × |

--- a/components/mentions/index.tsx
+++ b/components/mentions/index.tsx
@@ -24,6 +24,7 @@ import { FormItemInputContext } from '../form/context';
 import useVariant from '../form/hooks/useVariants';
 import Spin from '../spin';
 import useStyle from './style';
+import usePopupRender from '../select/usePopupRender';
 
 export const { Option } = RcMentions;
 
@@ -108,6 +109,7 @@ const InternalMentions = React.forwardRef<MentionsRef, MentionProps>((props, ref
     classNames,
     styles,
     size: customSize,
+    popupRender,
     ...restProps
   } = props;
   const [focused, setFocused] = React.useState(false);
@@ -240,6 +242,8 @@ const InternalMentions = React.forwardRef<MentionsRef, MentionProps>((props, ref
     },
   );
 
+  const mergedPopupRender = usePopupRender(popupRender);
+
   return (
     <RcMentions
       silent={loading}
@@ -250,6 +254,7 @@ const InternalMentions = React.forwardRef<MentionsRef, MentionProps>((props, ref
       allowClear={mergedAllowClear}
       direction={direction}
       style={mergedStyles.root}
+      popupRender={mergedPopupRender}
       {...restProps}
       filterOption={mentionsfilterOption}
       onFocus={onFocus}

--- a/components/mentions/index.zh-CN.md
+++ b/components/mentions/index.zh-CN.md
@@ -50,6 +50,7 @@ demo:
 | getPopupContainer | 指定建议框挂载的 HTML 节点 | () => HTMLElement | - |  | × |
 | notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | `Not Found` |  | × |
 | placement | 弹出层展示位置 | `top` \| `bottom` | `bottom` |  | × |
+| popupRender | 自定义下拉菜单渲染 | (menu: React.ReactElement) => ReactNode | - | 6.5.0 | × |
 | prefix | 设置触发关键字 | string \| string\[] | `@` |  | × |
 | split | 设置选中项前后分隔符 | string | ` ` |  | × |
 | size | 控件大小 | `large` \| `medium` \| `small` | - |  | × |
@@ -65,7 +66,6 @@ demo:
 | onSearch | 搜索时触发 | (text: string, prefix: string) => void | - |  | × |
 | onSelect | 选择选项时触发 | (option: OptionProps, prefix: string) => void | - |  | × |
 | onPopupScroll | 滚动时触发 | (event: Event) => void | - | 5.23.0 | × |
-| popupRender | 自定义下拉菜单渲染 | (menu: React.ReactElement) => ReactNode | - | 6.5.0 | × |
 | options | 选项配置 | [Options](#option) | [] | 5.1.0 | × |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
 

--- a/components/mentions/index.zh-CN.md
+++ b/components/mentions/index.zh-CN.md
@@ -50,7 +50,7 @@ demo:
 | getPopupContainer | 指定建议框挂载的 HTML 节点 | () => HTMLElement | - |  | × |
 | notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | `Not Found` |  | × |
 | placement | 弹出层展示位置 | `top` \| `bottom` | `bottom` |  | × |
-| popupRender | 自定义下拉菜单渲染 | (menu: React.ReactElement) => ReactNode | - | 6.5.0 | × |
+| popupRender | 自定义下拉菜单渲染 | (menu: React.ReactElement) => ReactNode | - | 6.6.0 | × |
 | prefix | 设置触发关键字 | string \| string\[] | `@` |  | × |
 | split | 设置选中项前后分隔符 | string | ` ` |  | × |
 | size | 控件大小 | `large` \| `medium` \| `small` | - |  | × |

--- a/components/mentions/index.zh-CN.md
+++ b/components/mentions/index.zh-CN.md
@@ -25,6 +25,7 @@ demo:
 <code src="./demo/prefix.tsx">自定义触发字符</code>
 <code src="./demo/readonly.tsx">无效或只读</code>
 <code src="./demo/placement.tsx">向上展开</code>
+<code src="./demo/popupRender.tsx">自定义弹出层</code>
 <code src="./demo/allowClear.tsx">带移除图标</code>
 <code src="./demo/autoSize.tsx">自动大小</code>
 <code src="./demo/autosize-textarea-debug.tsx" debug>debug 自动大小</code>
@@ -64,6 +65,7 @@ demo:
 | onSearch | 搜索时触发 | (text: string, prefix: string) => void | - |  | × |
 | onSelect | 选择选项时触发 | (option: OptionProps, prefix: string) => void | - |  | × |
 | onPopupScroll | 滚动时触发 | (event: Event) => void | - | 5.23.0 | × |
+| popupRender | 自定义下拉菜单渲染 | (menu: React.ReactElement) => ReactNode | - | 6.5.0 | × |
 | options | 选项配置 | [Options](#option) | [] | 5.1.0 | × |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
 

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@rc-component/image": "~1.9.0",
     "@rc-component/input": "~1.3.1",
     "@rc-component/input-number": "~1.6.2",
-    "@rc-component/mentions": "~1.10.0",
+    "@rc-component/mentions": "~1.11.0",
     "@rc-component/menu": "~1.4.1",
     "@rc-component/motion": "^1.3.3",
     "@rc-component/mutate-observer": "^2.0.1",


### PR DESCRIPTION
### 🤔 这个变动的性质是？

  - [x] 🆕 新特性提交

  ### 🔗 相关 Issue

  > close #31193

  ### 💡 需求背景和解决方案

  为 Mentions 组件添加 `popupRender` 属性，允许用户自定义下拉菜单的渲染，与 Select 组件保持一致。

  由于 `@rc-component/mentions` 已于 `~1.11.0` 版本支持该属性，而 antd 的 `MentionProps extends Omit<RcMentionsProps,
  ...>` 已继承该类型，因此只需添加文档和示例即可。

  ### 📝 更新日志

  | 语言    | 更新描述 |
  | ------- | -------- |
  | 🇺🇸 英文 | 🆕 Mentions component adds `popupRender` prop for customizing dropdown menu rendering |
  | 🇨🇳 中文 | 🆕 Mentions 组件新增 `popupRender` 属性，支持自定义下拉菜单渲染 |