### PR TITLE
fix(Descriptions): prevent collapsed content width

### DIFF
--- a/components/descriptions/style/index.ts
+++ b/components/descriptions/style/index.ts
@@ -154,16 +154,14 @@ const genDescriptionStyles: GenerateStyle<DescriptionsToken, CSSObject> = (token
         fontSize: token.fontSize,
       },
       [`${componentCls}-view`]: {
-        // Use `min-width: 100%` together with `width: 0` instead of
-        // `width: 100%` so the view still fills its container in normal layout,
-        // but won't contribute an extreme intrinsic width when nested inside a
-        // `max-content` sized ancestor (e.g. Table with
-        // `scroll={{ x: 'max-content' }}`). See #54268.
-        width: 0,
-        minWidth: '100%',
+        // #54268 used `width: 0` with `min-width: 100%` to avoid oversized
+        // intrinsic widths in max-content ancestors. Keep the wrapper at
+        // `width: 100%` so it remains measurable in shrink-to-fit containers
+        // like Popover (#58574), while the inner table preserves the minimum.
+        width: '100%',
         borderRadius: token.borderRadiusLG,
         table: {
-          width: '100%',
+          minWidth: '100%',
           tableLayout: 'fixed',
           borderCollapse: 'collapse',
         },


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #58574
ref #54268

### 💡 需求背景和解决方案

修复 Descriptions 放在 Popover 等收缩布局中时，内容列被压缩到接近 0 宽的问题。

将 Descriptions 的 view 恢复为 `width: 100%`，并将内部 table 调整为 `min-width: 100%`，让外层 view 正常撑满容器，同时保持表格最小宽度。这里保留注释说明这和 #54268 相关的宽度处理取舍。

验证：`env TMPDIR=/private/tmp ut test -- components/descriptions/__tests__/index.test.tsx --runInBand`

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Descriptions content column collapsing to near-zero width when nested in Popover. |
| 🇨🇳 中文 | 🐞 修复 Descriptions 嵌套在 Popover 中时内容列宽度塌缩的问题。 |
