### PR TITLE
fix(Button): align icon in Card extra

### DIFF
--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -49,6 +49,27 @@ const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => {
       // https://github.com/ant-design/ant-design/issues/51380
       [`${componentCls}-icon > svg`]: resetIcon(),
 
+      // https://github.com/ant-design/ant-design/issues/57727
+      [`${componentCls}-icon`]: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+
+        [iconCls]: {
+          verticalAlign: 'middle',
+
+          // Baseline will align the first element.
+          // So the Button with SVG will make the baseline to be the bottom of the SVG.
+          // Let's use `:before` to add a space to make the baseline to be the center of the Button.
+          // https://github.com/ant-design/ant-design/issues/58428
+          '&:before': {
+            content: '"\\a0"',
+            display: 'inline-block',
+            width: 0,
+          },
+        },
+      },
+
       '> a': {
         color: 'currentColor',
       },

--- a/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -134,6 +134,249 @@ exports[`renders components/card/demo/border-less.tsx extend context correctly 1
 
 exports[`renders components/card/demo/border-less.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/card/demo/button-alignment-debug.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-card ant-card-bordered line-card css-var-test-id"
+  >
+    <div
+      class="ant-card-head"
+    >
+      <div
+        class="ant-card-head-wrapper"
+      >
+        <div
+          class="ant-card-head-title"
+        >
+          #57727 Card extra
+        </div>
+        <div
+          class="ant-card-extra"
+        >
+          <button
+            class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+            type="button"
+          >
+            <span
+              class="ant-btn-icon acss-igvgoe"
+            >
+              <span
+                aria-label="smile"
+                class="anticon anticon-smile"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="smile"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span
+              class="acss-19o9pbo"
+            >
+              Test
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-card-body"
+    >
+      Button in Card extra should be vertically centered with the title.
+    </div>
+  </div>
+  <div
+    class="ant-card ant-card-bordered css-var-test-id"
+  >
+    <div
+      class="ant-card-head"
+    >
+      <div
+        class="ant-card-head-wrapper"
+      >
+        <div
+          class="ant-card-head-title"
+        >
+          #57896 regression minimum case
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-card-body"
+    >
+      <div
+        class="simulate-57896"
+      >
+        <div
+          class="inline-buttons"
+        >
+          <button
+            class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+            type="button"
+          >
+            <span
+              class="acss-19o9pbo"
+            >
+              Cancel
+            </span>
+          </button>
+          <button
+            class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+            type="button"
+          >
+            <span
+              class="ant-btn-icon acss-igvgoe"
+            >
+              <span
+                aria-label="smile"
+                class="anticon anticon-smile"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="smile"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span
+              class="acss-19o9pbo"
+            >
+              Confirm
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-popover ant-popover-pure ant-popover-placement-top ant-popconfirm css-var-test-id"
+  >
+    <div
+      class="ant-popover-arrow"
+    />
+    <div
+      class="ant-popover-container"
+      role="tooltip"
+    >
+      <div
+        class="ant-popover-content"
+      >
+        <div
+          class="ant-popconfirm-inner-content"
+        >
+          <div
+            class="ant-popconfirm-message"
+          >
+            <span
+              class="ant-popconfirm-message-icon"
+            >
+              <span
+                aria-label="exclamation-circle"
+                class="anticon anticon-exclamation-circle"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="exclamation-circle"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <div
+              class="ant-popconfirm-message-text"
+            >
+              <div
+                class="ant-popconfirm-title"
+              >
+                Are you OK?
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-popconfirm-buttons"
+          >
+            <button
+              class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm"
+              type="button"
+            >
+              <span
+                class="acss-19o9pbo"
+              >
+                Cancel
+              </span>
+            </button>
+            <button
+              class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm"
+              type="button"
+            >
+              <span
+                class="ant-btn-icon acss-igvgoe"
+              >
+                <span
+                  aria-label="smile"
+                  class="anticon anticon-smile"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="smile"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              <span
+                class="acss-19o9pbo"
+              >
+                OK
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/card/demo/button-alignment-debug.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/card/demo/component-token.tsx extend context correctly 1`] = `
 Array [
   <div

--- a/components/card/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.ts.snap
@@ -130,6 +130,247 @@ exports[`renders components/card/demo/border-less.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/card/demo/button-alignment-debug.tsx correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-card ant-card-bordered line-card css-var-test-id"
+  >
+    <div
+      class="ant-card-head"
+    >
+      <div
+        class="ant-card-head-wrapper"
+      >
+        <div
+          class="ant-card-head-title"
+        >
+          #57727 Card extra
+        </div>
+        <div
+          class="ant-card-extra"
+        >
+          <button
+            class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+            type="button"
+          >
+            <span
+              class="ant-btn-icon acss-igvgoe"
+            >
+              <span
+                aria-label="smile"
+                class="anticon anticon-smile"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="smile"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span
+              class="acss-19o9pbo"
+            >
+              Test
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-card-body"
+    >
+      Button in Card extra should be vertically centered with the title.
+    </div>
+  </div>
+  <div
+    class="ant-card ant-card-bordered css-var-test-id"
+  >
+    <div
+      class="ant-card-head"
+    >
+      <div
+        class="ant-card-head-wrapper"
+      >
+        <div
+          class="ant-card-head-title"
+        >
+          #57896 regression minimum case
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-card-body"
+    >
+      <div
+        class="simulate-57896"
+      >
+        <div
+          class="inline-buttons"
+        >
+          <button
+            class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+            type="button"
+          >
+            <span
+              class="acss-19o9pbo"
+            >
+              Cancel
+            </span>
+          </button>
+          <button
+            class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+            type="button"
+          >
+            <span
+              class="ant-btn-icon acss-igvgoe"
+            >
+              <span
+                aria-label="smile"
+                class="anticon anticon-smile"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="smile"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span
+              class="acss-19o9pbo"
+            >
+              Confirm
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-popover ant-popover-pure ant-popover-placement-top ant-popconfirm css-var-test-id"
+  >
+    <div
+      class="ant-popover-arrow"
+    />
+    <div
+      class="ant-popover-container"
+      role="tooltip"
+    >
+      <div
+        class="ant-popover-content"
+      >
+        <div
+          class="ant-popconfirm-inner-content"
+        >
+          <div
+            class="ant-popconfirm-message"
+          >
+            <span
+              class="ant-popconfirm-message-icon"
+            >
+              <span
+                aria-label="exclamation-circle"
+                class="anticon anticon-exclamation-circle"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="exclamation-circle"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+                  />
+                </svg>
+              </span>
+            </span>
+            <div
+              class="ant-popconfirm-message-text"
+            >
+              <div
+                class="ant-popconfirm-title"
+              >
+                Are you OK?
+              </div>
+            </div>
+          </div>
+          <div
+            class="ant-popconfirm-buttons"
+          >
+            <button
+              class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-sm"
+              type="button"
+            >
+              <span
+                class="acss-19o9pbo"
+              >
+                Cancel
+              </span>
+            </button>
+            <button
+              class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-sm"
+              type="button"
+            >
+              <span
+                class="ant-btn-icon acss-igvgoe"
+              >
+                <span
+                  aria-label="smile"
+                  class="anticon anticon-smile"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="smile"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              <span
+                class="acss-19o9pbo"
+              >
+                OK
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/card/demo/component-token.tsx correctly 1`] = `
 Array [
   <div

--- a/components/card/demo/button-alignment-debug.tsx
+++ b/components/card/demo/button-alignment-debug.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { SmileOutlined } from '@ant-design/icons';
+import { Button, Card, ConfigProvider, Flex, Popconfirm } from 'antd';
+import type { GetProp } from 'antd';
+import { createStyles } from 'antd-style';
+
+const { _InternalPanelDoNotUseOrYouWillBeFired: InternalPopconfirm } = Popconfirm;
+
+const useStyle = createStyles(({ css }) => ({
+  icon: css`
+    background: rgba(255, 0, 0, 0.1);
+
+    span {
+      background: rgba(0, 255, 0, 0.5);
+    }
+  `,
+  content: css`
+    background: rgba(0, 0, 255, 0.1);
+  `,
+}));
+
+const App: React.FC = () => {
+  const { styles } = useStyle();
+
+  const btnCls: GetProp<typeof Button, 'classNames'> = {
+    icon: styles.icon,
+    content: styles.content,
+  };
+
+  return (
+    <ConfigProvider button={{ classNames: btnCls }}>
+      <Flex vertical gap="middle">
+        <Card
+          className="line-card"
+          title="#57727 Card extra"
+          extra={<Button icon={<SmileOutlined />}>Test</Button>}
+        >
+          Button in Card extra should be vertically centered with the title.
+        </Card>
+
+        <Card title="#57896 regression minimum case">
+          <div className="simulate-57896">
+            <div className="inline-buttons">
+              <Button>Cancel</Button>
+              <Button type="primary" icon={<SmileOutlined />}>
+                Confirm
+              </Button>
+            </div>
+          </div>
+        </Card>
+
+        <InternalPopconfirm
+          title="Are you OK?"
+          okButtonProps={{
+            icon: <SmileOutlined />,
+          }}
+        />
+      </Flex>
+    </ConfigProvider>
+  );
+};
+
+export default App;

--- a/components/card/index.en-US.md
+++ b/components/card/index.en-US.md
@@ -26,6 +26,7 @@ A card can be used to display content related to a single subject. The content c
 <code src="./demo/meta.tsx">Support more content configuration</code>
 <code src="./demo/style-class.tsx" version="6.0.0">Custom semantic dom styling</code>
 <code src="./demo/no-body-debug.tsx" debug>Cover and actions without body</code>
+<code src="./demo/button-alignment-debug.tsx" debug>Button alignment</code>
 <code src="./demo/component-token.tsx" debug>Component Token</code>
 
 ## API

--- a/components/card/index.zh-CN.md
+++ b/components/card/index.zh-CN.md
@@ -27,6 +27,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*5WDvQp_H7LUAAA
 <code src="./demo/meta.tsx">支持更多内容配置</code>
 <code src="./demo/style-class.tsx" version="6.0.0">自定义语义结构的样式和类</code>
 <code src="./demo/no-body-debug.tsx" debug>封面和操作区不渲染 body</code>
+<code src="./demo/button-alignment-debug.tsx" debug>按钮对齐</code>
 <code src="./demo/component-token.tsx" debug>组件 Token</code>
 
 ## API


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Fix #57727

### 💡 需求背景和解决方案

修复 Button 图标在 Card extra 场景下的垂直对齐问题。

本次调整 Button 图标容器的对齐方式，并补充 Card debug demo，便于排查 #57727 以及相关回归场景。


### ZombieJ

非 flex 布局的时候元素是通过 baseline 对齐，而 svg 另一个特点是其 baseline 为图片底端。所以会导致对齐的时候让按钮文字和第一个元素也就是 svg 进行对齐：

<img width="626" height="155" alt="截屏2026-07-02 17 46 43" src="https://github.com/user-attachments/assets/a9d12508-5fd3-4a1e-b03d-97e86ff31d84" />

解法为仍然对 icon 使用 flex 布局解决 #57727 问题，同时添加伪类使用文字对齐将 baseline 拉回来:

<img width="1178" height="262" alt="image" src="https://github.com/user-attachments/assets/5db61cbd-8ec8-4474-8c76-0910c49951ec" />




### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Button icon vertical alignment when used in Card extra. |
| 🇨🇳 中文 | 🐞 修复 Button 图标在 Card extra 中垂直对齐的问题。 |
