### PR TITLE
fix(tag): improve filled variant visibility in dark mode

### DIFF
--- a/components/tag/style/presetCmp.ts
+++ b/components/tag/style/presetCmp.ts
@@ -1,11 +1,15 @@
 // Style as status component
+import { FastColor } from '@ant-design/fast-color';
+
 import { prepareComponentToken, prepareToken } from '.';
 import type { TagToken } from '.';
 import { genPresetColor, genSubStyleComponent } from '../../theme/internal';
 
 // ============================== Preset ==============================
-const genPresetStyle = (token: TagToken) =>
-  genPresetColor(token, (colorKey, { textColor, lightBorderColor, lightColor, darkColor }) => ({
+const genPresetStyle = (token: TagToken) => {
+  const isDarkMode = new FastColor(token.colorBgBase).toHsl().l < 0.5;
+
+  return genPresetColor(token, (colorKey, { textColor, lightBorderColor, lightColor, darkColor }) => ({
     [`${token.componentCls}${token.componentCls}-${colorKey}:not(${token.componentCls}-disabled)`]:
       {
         [`&${token.componentCls}-outlined`]: {
@@ -18,12 +22,18 @@ const genPresetStyle = (token: TagToken) =>
           borderColor: darkColor,
           color: token.colorTextLightSolid,
         },
-        [`&${token.componentCls}-filled`]: {
-          backgroundColor: lightColor,
-          color: textColor,
-        },
+        [`&${token.componentCls}-filled`]: isDarkMode
+          ? {
+              backgroundColor: new FastColor(darkColor).setA(0.15).toRgbString(),
+              color: darkColor,
+            }
+          : {
+              backgroundColor: lightColor,
+              color: textColor,
+            },
       },
   }));
+};
 
 // ============================== Export ==============================
 export default genSubStyleComponent<'Tag'>(


### PR DESCRIPTION
## What does this PR do?

Fixes the filled variant of `<Tag>` being nearly invisible in dark mode.

## Problem

In dark mode, preset-color filled tags (e.g. `<Tag color="blue" variant="filled">`) used palette-1 (`lightColor`) as background and palette-7 (`textColor`) as text. These palette indices are reversed in the dark algorithm — `lightColor` becomes very dark (close to the container background), and `textColor` becomes a mid-tone that doesn't contrast well.

**Before (dark mode):** Tags appear as dark blobs that blend into the `#141414` container.

## Solution

Detect dark mode via `token.colorBgBase` lightness (< 0.5 = dark) and conditionally apply different styling:

- **Dark mode:** Use `darkColor` (palette-6, the saturated base color) at 15% alpha as background, with opaque `darkColor` as text. This creates a visible tint against any dark background.
- **Light mode:** Unchanged — uses original `lightColor` / `textColor` pairing.

## Changes

- `components/tag/style/presetCmp.ts`: Import `FastColor`, add dark mode detection, conditionally apply filled variant colors.

## Verification

- API usage (`.setA()`, `.toHsl().l`, `colorBgBase`) verified against existing codebase patterns
- Light mode behavior is preserved (no change to the `isDarkMode = false` branch)
- CI will validate TypeScript compilation and visual snapshot tests

Closes #56339