### PR TITLE
site: add "All" filter to icon search

### DIFF
--- a/.dumi/theme/builtins/IconSearch/CopyableIcon.tsx
+++ b/.dumi/theme/builtins/IconSearch/CopyableIcon.tsx
@@ -131,9 +131,12 @@ const CopyableIcon: React.FC<CopyableIconProps> = (props) => {
       message.error(locale.errMessage);
     }
   };
+  // Derive the theme from the icon name so the correct hover style applies even
+  // in the "All" view, where a single list mixes icons of different themes.
+  const themeClass = name.match(/(Outlined|Filled|TwoTone)$/)?.[0] ?? theme;
   return (
     <li
-      className={clsx(theme, styles.iconItem, { copied: justCopied === name })}
+      className={clsx(themeClass, styles.iconItem, { copied: justCopied === name })}
       onClick={() => onCopy(`<${name} />`)}
       style={{ cursor: 'pointer' }}
     >

--- a/.dumi/theme/builtins/IconSearch/IconSearch.tsx
+++ b/.dumi/theme/builtins/IconSearch/IconSearch.tsx
@@ -15,10 +15,20 @@ import type { IconName, IconsMeta } from './meta';
 import { FilledIcon, OutlinedIcon, TwoToneIcon } from './themeIcons';
 
 export enum ThemeType {
+  All = 'All',
   Filled = 'Filled',
   Outlined = 'Outlined',
   TwoTone = 'TwoTone',
 }
+
+// Preference order used by the "All" view to pick the single variant shown for
+// each icon. Outlined first keeps the default look; Filled surfaces logos that
+// only ship as Filled and would otherwise stay hidden on the Outlined tab.
+const THEME_ORDER: ReadonlyArray<ThemeType> = [
+  ThemeType.Outlined,
+  ThemeType.Filled,
+  ThemeType.TwoTone,
+];
 
 const allIcons: { [key: string]: any } = AntdIcons;
 
@@ -61,7 +71,7 @@ const IconSearch: React.FC = () => {
   const intl = useIntl();
   const [displayState, setDisplayState] = useState<IconSearchState>({
     searchKey: '',
-    theme: ThemeType.Outlined,
+    theme: ThemeType.All,
   });
   const token = useTheme();
 
@@ -117,9 +127,7 @@ const IconSearch: React.FC = () => {
     const merged = mergeCategory(namedMatchedCategoryObj, tagMatchedCategoryObj);
     const matchedCategories = Object.values(merged)
       .map((item) => {
-        const icons = item.icons
-          .map((iconName) => iconName + theme)
-          .filter((iconName) => allIcons[iconName]);
+        const icons = item.icons.flatMap((iconName) => resolveIconNames(iconName, theme));
 
         item.icons = item.category === 'logo' ? groupNewIcons(icons) : icons;
 
@@ -154,6 +162,11 @@ const IconSearch: React.FC = () => {
 
   const memoizedOptions = React.useMemo<SegmentedOptions<ThemeType>>(
     () => [
+      {
+        value: ThemeType.All,
+        icon: <AntdIcons.AppstoreOutlined />,
+        label: intl.formatMessage({ id: 'app.docs.components.icon.all' }),
+      },
       {
         value: ThemeType.Outlined,
         icon: <Icon component={OutlinedIcon} />,
@@ -208,6 +221,17 @@ type MatchedCategory = {
   category: string;
   icons: string[];
 };
+
+// Map a base icon name to the concrete component name(s) to render for a theme.
+// "All" resolves to a single variant (see THEME_ORDER); a specific theme resolves
+// to that variant only when it exists.
+function resolveIconNames(baseName: string, theme: ThemeType): string[] {
+  if (theme === ThemeType.All) {
+    const matched = THEME_ORDER.find((item) => allIcons[baseName + item]);
+    return matched ? [baseName + matched] : [];
+  }
+  return allIcons[baseName + theme] ? [baseName + theme] : [];
+}
 
 function groupNewIcons(icons: string[]) {
   const firstNewIconIndex = icons.findIndex((iconName) => NEW_ICON_ORDER.has(iconName));

--- a/.dumi/theme/locales/en-US.json
+++ b/.dumi/theme/locales/en-US.json
@@ -118,6 +118,7 @@
   "app.docs.color.pick-primary": "Pick your primary color",
   "app.docs.color.pick-background": "Pick your background color",
   "app.docs.components.icon.search.placeholder": "Search {total} icons here, click icon to copy code",
+  "app.docs.components.icon.all": "All",
   "app.docs.components.icon.outlined": "Outlined",
   "app.docs.components.icon.filled": "Filled",
   "app.docs.components.icon.two-tone": "Two Tone",

--- a/.dumi/theme/locales/zh-CN.json
+++ b/.dumi/theme/locales/zh-CN.json
@@ -117,6 +117,7 @@
   "app.docs.color.pick-primary": "选择你的主色",
   "app.docs.color.pick-background": "选择你的背景色",
   "app.docs.components.icon.search.placeholder": "在此搜索 {total} 个图标，点击图标可复制代码",
+  "app.docs.components.icon.all": "全部",
   "app.docs.components.icon.outlined": "线框风格",
   "app.docs.components.icon.filled": "实底风格",
   "app.docs.components.icon.two-tone": "双色风格",


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

N/A — self-identified discoverability gap on the Icon page.

### 💡 Background and Solution

**Problem.** The icon search on the Icon page filters within a single theme at a time and defaults to **Outlined**. Any icon that ships in only one theme is therefore silently absent from search when that theme isn't the active tab — with no hint it exists elsewhere. This hits **brand / logo icons hardest: 49 icons exist only as `Filled`** (e.g. `Anthropic`, `Claude`, `Gemini`, `DeepSeek`, `HuggingFace`, `GoogleSquare`), so searching e.g. `anthropic` on a freshly opened page returns an empty **"No data"** state even though the icon exists.

**Solution.** Add an **`All`** segment, selected by default. In `All` mode each icon resolves to a single variant using the preference order **Outlined → Filled → TwoTone**, so:

- multi-theme icons keep their familiar Outlined look;
- single-theme icons (the 49 Filled-only logos, plus any Outlined-only) are now surfaced by default;
- the existing `Outlined` / `Filled` / `TwoTone` tabs are completely unchanged.

Result: the default view now surfaces **all 496 icons** (was 447 on the Outlined default) — the **49 previously-hidden logos become discoverable without switching tabs**.

**Before / after** (search `anthropic`):

| Tab | Result |
| --- | --- |
| `Outlined` (old default) | **No data** — `AnthropicFilled` / `ClaudeFilled` hidden |
| `All` (new default) | `AnthropicFilled` + `ClaudeFilled` shown under Brand and Logos |

Implementation notes:

- `IconSearch.tsx`: `All` added to `ThemeType`, made the default segment (`AppstoreOutlined` glyph); a small `resolveIconNames(base, theme)` helper maps a base name to the concrete component name(s) — the preferred existing variant for `All`, or the exact variant for a specific theme.
- `CopyableIcon.tsx`: the hover style is now derived from the icon-name suffix, so a mixed `All` list still styles `TwoTone` correctly.
- New i18n label `app.docs.components.icon.all` → `All` / `全部`.

### 📝 Change Log

> Site-only change (Icon docs page); no impact on the published `antd` package.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Icon search now defaults to an `All` filter so icons are discoverable regardless of theme (site only). |
| 🇨🇳 Chinese | 图标搜索新增并默认使用「全部」筛选，无需切换主题即可搜索到所有图标（仅站点）。 |
