### PR TITLE
site: add progress colors for theme preview

### DIFF
--- a/.dumi/pages/index/components/ThemePreview/previewThemes/blossomTheme.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/blossomTheme.ts
@@ -36,7 +36,11 @@ const useBlossomTheme = () => {
           Select: {},
           Input: {},
           Switch: {},
-          Progress: {},
+          Progress: {
+            circleTextColor: '#3f2330',
+            defaultColor: '#ED4192',
+            remainingColor: 'rgba(237, 65, 146, 0.14)',
+          },
           Steps: {},
           Slider: {},
           ColorPicker: {},

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/bootstrapTheme.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/bootstrapTheme.ts
@@ -152,8 +152,8 @@ const useBootstrapTheme: UseTheme = () => {
           Switch: {},
           Progress: {
             circleTextColor: '#212529',
-            defaultColor: '#3a87ad',
-            remainingColor: '#e9ecef',
+            defaultColor: '#337ab7',
+            remainingColor: '#f5f5f5',
           },
           Steps: {},
           Slider: {},

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/bootstrapTheme.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/bootstrapTheme.ts
@@ -150,7 +150,11 @@ const useBootstrapTheme: UseTheme = () => {
           Select: {},
           Input: {},
           Switch: {},
-          Progress: {},
+          Progress: {
+            circleTextColor: '#212529',
+            defaultColor: '#3a87ad',
+            remainingColor: '#e9ecef',
+          },
           Steps: {},
           Slider: {},
           ColorPicker: {},

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/cartoonTheme.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/cartoonTheme.ts
@@ -93,7 +93,11 @@ const useCartoonTheme = () => {
           Radio: {},
           Input: {},
           Switch: {},
-          Progress: {},
+          Progress: {
+            circleTextColor: '#51463B',
+            defaultColor: '#225555',
+            remainingColor: '#CBC4AF',
+          },
           Steps: {},
           Slider: {},
           ColorPicker: {},

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/geekTheme.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/geekTheme.ts
@@ -147,7 +147,11 @@ const useGeekTheme = () => {
           Select: {},
           Input: {},
           Switch: {},
-          Progress: {},
+          Progress: {
+            circleTextColor: '#39ff14',
+            defaultColor: '#39ff14',
+            remainingColor: 'rgba(57, 255, 20, 0.18)',
+          },
           Steps: {},
           Slider: {},
           ColorPicker: {},

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/glassTheme.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/glassTheme.ts
@@ -207,7 +207,11 @@ const useGlassTheme = () => {
           Select: {},
           Input: {},
           Switch: {},
-          Progress: {},
+          Progress: {
+            circleTextColor: 'rgba(0, 0, 0, 0.88)',
+            defaultColor: '#1677ff',
+            remainingColor: 'rgba(255, 255, 255, 0.28)',
+          },
           Steps: {},
           Slider: {},
           ColorPicker: {},

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/illustrationTheme.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/illustrationTheme.ts
@@ -138,7 +138,11 @@ const useIllustrationTheme = () => {
           Radio: {},
           Input: {},
           Switch: {},
-          Progress: {},
+          Progress: {
+            circleTextColor: '#2C2C2C',
+            defaultColor: '#52C41A',
+            remainingColor: '#D9F7BE',
+          },
           Steps: {},
           ColorPicker: {},
         },

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/index.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/index.ts
@@ -96,7 +96,11 @@ const previewThemeComponents: NonNullable<ThemeConfig['components']> = {
   Select: {},
   Input: {},
   Switch: {},
-  Progress: {},
+  Progress: {
+    circleTextColor: 'rgba(0, 0, 0, 0.88)',
+    defaultColor: DEFAULT_COLOR,
+    remainingColor: 'rgba(0, 0, 0, 0.06)',
+  },
   Steps: {},
   Slider: {},
   ColorPicker: {},
@@ -123,6 +127,12 @@ const darkPreviewMenuToken: NonNullable<ThemeConfig['components']>['Menu'] = {
   darkSubMenuItemBg: 'transparent',
 };
 
+const darkPreviewProgressToken: NonNullable<ThemeConfig['components']>['Progress'] = {
+  circleTextColor: 'rgba(255, 255, 255, 0.88)',
+  defaultColor: DEFAULT_COLOR,
+  remainingColor: 'rgba(255, 255, 255, 0.12)',
+};
+
 const isDarkAlgorithm = (algorithm: ThemeConfig['algorithm']) => {
   const algorithms = Array.isArray(algorithm) ? algorithm : algorithm ? [algorithm] : [];
 
@@ -137,6 +147,7 @@ const getBasePreviewThemeProps = (algorithm: ThemeConfig['algorithm']): ConfigPr
           ...previewThemeComponents,
           Layout: darkPreviewLayoutToken,
           Menu: darkPreviewMenuToken,
+          Progress: darkPreviewProgressToken,
         }
       : previewThemeComponents,
   },

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/larkTheme.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/larkTheme.ts
@@ -36,7 +36,11 @@ const useLarkTheme = () => {
           Select: {},
           Input: {},
           Switch: {},
-          Progress: {},
+          Progress: {
+            circleTextColor: '#1f2329',
+            defaultColor: '#00B96B',
+            remainingColor: 'rgba(0, 185, 107, 0.12)',
+          },
           Steps: {},
           Slider: {},
           ColorPicker: {},

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/muiTheme.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/muiTheme.ts
@@ -245,6 +245,7 @@ const useMuiTheme = () => {
             borderRadiusLG: 4,
           },
           Progress: {
+            circleTextColor: 'rgba(33, 33, 33, 0.87)',
             defaultColor: '#1976d2',
             remainingColor: 'rgba(25, 118, 210, 0.12)',
           },

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/shadcnTheme.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/shadcnTheme.ts
@@ -179,6 +179,7 @@ const useShadcnTheme = () => {
             borderRadiusLG: 12,
           },
           Progress: {
+            circleTextColor: '#262626',
             defaultColor: '#18181b',
             remainingColor: '#f4f4f5',
           },

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/v4Theme.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/v4Theme.ts
@@ -37,7 +37,12 @@ const useV4Theme = () => {
           Select: {},
           Input: {},
           Switch: {},
-          Progress: {},
+          Progress: {
+            ...defaultTheme.components?.Progress,
+            circleTextColor: '#000000d9',
+            defaultColor: defaultTheme.token?.colorPrimary ?? '#1890ff',
+            remainingColor: '#f5f5f5',
+          },
           Steps: {},
           Slider: {},
           ColorPicker: {},


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

主题预览里的多个主题缺少 Progress 组件的颜色 token 配置，导致进度条在不同主题下无法充分体现对应视觉风格。

本次为默认、暗色以及各个自定义主题补充 Progress 的颜色相关 token：`defaultColor`、`remainingColor`、`circleTextColor`。仅配置颜色，不覆盖尺寸、圆角或字体大小等非颜色 token。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | N/A |