### PR TITLE
docs: add Serene preview theme for theme collection (#56936)

### DIFF
--- a/.dumi/pages/index/components/ThemePreview/previewThemes/assets/serene-icon.svg
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/assets/serene-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="Serene theme">
+  <circle cx="32" cy="32" r="31" fill="#f8f6f2" stroke="#e2dcd5" stroke-width="1" />
+  <circle cx="32" cy="30" r="14" stroke="#312721" stroke-width="2" fill="none" />
+  <circle cx="32" cy="46" r="3" fill="#c7a56b" />
+</svg>

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/index.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/index.ts
@@ -23,6 +23,9 @@ import useShadcnTheme from './shadcnTheme';
 import shadcnThemeSource from './shadcnTheme.ts?raw';
 import useV4Theme from './v4Theme';
 import v4ThemeSource from './v4Theme.ts?raw';
+import sereneIcon from './assets/serene-icon.svg';
+import useSereneTheme from './sereneTheme';
+import sereneThemeSource from './sereneTheme.ts?raw';
 
 export type PreviewThemeConfig = {
   icon?: string;
@@ -49,6 +52,7 @@ const locales = {
     lark: '知识协作',
     blossom: '桃花缘',
     v4: 'Ant Design V4',
+    serene: '静谧',
   },
   en: {
     default: 'Ant Design',
@@ -63,6 +67,7 @@ const locales = {
     lark: 'Document',
     blossom: 'Blossom',
     v4: 'Ant Design V4',
+    serene: 'Serene',
   },
 };
 
@@ -186,6 +191,7 @@ const usePreviewThemes = () => {
   const muiTheme = useMuiTheme();
   const shadcnTheme = useShadcnTheme();
   const bootstrapTheme = useBootstrapTheme();
+  const sereneTheme = useSereneTheme();
 
   return React.useMemo<PreviewThemeConfig[]>(() => {
     return [
@@ -282,6 +288,12 @@ const usePreviewThemes = () => {
         name: locale.v4,
         props: v4Theme,
         copyCode: v4ThemeSource,
+      },
+      {
+        name: locale.serene,
+        icon: sereneIcon,
+        props: sereneTheme,
+        copyCode: sereneThemeSource,
       },
     ];
   }, [locale]);

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/sereneTheme.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/sereneTheme.ts
@@ -1,163 +1,8 @@
 import { useMemo } from 'react';
 import { theme } from 'antd';
 import type { ConfigProviderProps } from 'antd';
-import { createStyles } from 'antd-style';
-import clsx from 'clsx';
-
-const useStyles = createStyles(({ css, cssVar }) => {
-  const softShadow = '0 1px 2px rgba(42, 35, 29, 0.04), 0 8px 24px -12px rgba(42, 35, 29, 0.08)';
-  const elevShadow = '0 2px 4px rgba(42, 35, 29, 0.05), 0 24px 48px -16px rgba(42, 35, 29, 0.14)';
-
-  return {
-    buttonPrimary: css({
-      backgroundColor: '#312721',
-      color: '#f8f6f1',
-      border: '1px solid #312721',
-      fontWeight: 500,
-      letterSpacing: '0.02em',
-      boxShadow: 'none',
-      transition: 'all 0.3s ease',
-      '&:hover': {
-        backgroundColor: '#3f342d !important',
-        borderColor: '#3f342d !important',
-      },
-    }),
-    buttonDefault: css({
-      backgroundColor: '#fcfaf8',
-      color: '#2a231d',
-      border: '1px solid #e2dcd5',
-      fontWeight: 500,
-      boxShadow: 'none',
-      transition: 'all 0.3s ease',
-      '&:hover': {
-        backgroundColor: '#f8f6f2 !important',
-        borderColor: '#d9d0c6 !important',
-        color: '#2a231d !important',
-      },
-    }),
-    buttonDanger: css({
-      backgroundColor: '#be4237',
-      color: '#f8f6f1',
-      border: '1px solid #be4237',
-      boxShadow: 'none',
-    }),
-    inputRoot: css({
-      borderColor: '#e2dcd5',
-      backgroundColor: '#fcfaf8',
-      transition: 'all 0.3s ease',
-      '&:hover': {
-        borderColor: '#c7a56b',
-      },
-    }),
-    inputElement: css({
-      color: '#2a231d',
-    }),
-    inputError: css({
-      borderColor: '#be4237',
-    }),
-    cardRoot: css({
-      border: '1px solid color-mix(in srgb, #e2dcd5 70%, transparent)',
-      boxShadow: softShadow,
-      transition: 'box-shadow 0.3s ease',
-      '&:hover': {
-        boxShadow: elevShadow,
-      },
-    }),
-    modalContainer: css({
-      border: '1px solid #e2dcd5',
-      boxShadow: elevShadow,
-    }),
-    modalHeader: css({
-      borderBottom: `1px solid ${cssVar.colorSplit}`,
-    }),
-    modalFooter: css({
-      borderTop: `1px solid ${cssVar.colorSplit}`,
-      backgroundColor: '#f8f6f2',
-    }),
-    notificationRoot: css({
-      '&.ant-notification-notice, & .ant-notification-notice': {
-        border: '1px solid #e2dcd5',
-        borderRadius: 4,
-        boxShadow: softShadow,
-        backgroundColor: '#fcfaf8',
-      },
-    }),
-    notificationTitle: css({
-      fontWeight: 600,
-      color: '#2a231d',
-    }),
-    notificationDescription: css({
-      color: '#766a60',
-    }),
-    selectPopup: css({
-      borderRadius: 4,
-      border: '1px solid #e2dcd5',
-      boxShadow: softShadow,
-    }),
-    menuRoot: css({
-      background: 'transparent !important',
-      borderInlineEnd: 'none !important',
-      paddingBlock: 4,
-
-      '& .ant-menu-item, & .ant-menu-submenu-title': {
-        fontWeight: 300,
-        letterSpacing: '0.04em',
-        borderInlineStart: '2px solid transparent',
-        marginInline: 12,
-        width: 'calc(100% - 24px)',
-        borderRadius: '0 !important',
-      },
-
-      '& .ant-menu-item::after': {
-        display: 'none !important',
-      },
-
-      '& .ant-menu-item': {
-        color: 'rgba(232, 226, 217, 0.7)',
-      },
-
-      '& .ant-menu-item:hover': {
-        color: '#e8e2d9 !important',
-        backgroundColor: 'rgba(60, 51, 42, 0.4) !important',
-      },
-
-      '& .ant-menu-item-selected': {
-        color: '#ebe4d8 !important',
-        backgroundColor: '#3c332a !important',
-        borderInlineStartColor: '#c7a56b !important',
-        fontWeight: 400,
-      },
-
-      '& .ant-menu-submenu-title': {
-        color: 'rgba(232, 226, 217, 0.7)',
-      },
-
-      '& .ant-menu-submenu-title:hover': {
-        color: '#e8e2d9 !important',
-        backgroundColor: 'rgba(60, 51, 42, 0.4) !important',
-      },
-
-      '& .ant-menu-submenu-selected > .ant-menu-submenu-title': {
-        color: '#e8e2d9 !important',
-        backgroundColor: 'transparent !important',
-        borderInlineStartColor: 'transparent !important',
-        fontWeight: 300,
-      },
-
-      '& .ant-menu-sub.ant-menu-inline': {
-        background: 'transparent !important',
-      },
-
-      '& .ant-menu-sub .ant-menu-item': {
-        paddingInlineStart: '40px !important',
-      },
-    }),
-  };
-});
 
 const useSereneTheme = () => {
-  const { styles } = useStyles();
-
   return useMemo<ConfigProviderProps>(
     () => ({
       theme: {
@@ -300,16 +145,27 @@ const useSereneTheme = () => {
             itemMarginInline: 12,
             itemHeight: 40,
           },
-          Card: { borderRadiusLG: 4 },
-          Modal: { borderRadiusLG: 6 },
-          Alert: { borderRadiusLG: 4 },
+          Card: {
+            borderRadiusLG: 4,
+          },
+          Modal: {
+            borderRadiusLG: 6,
+          },
+          Alert: {
+            borderRadiusLG: 4,
+          },
           Progress: {
             circleTextColor: '#2a231d',
             defaultColor: '#312721',
             remainingColor: 'rgba(49, 39, 33, 0.08)',
           },
-          Switch: { trackHeight: 22, trackMinWidth: 44 },
-          Checkbox: { borderRadiusSM: 2 },
+          Switch: {
+            trackHeight: 22,
+            trackMinWidth: 44,
+          },
+          Checkbox: {
+            borderRadiusSM: 2,
+          },
           Slider: {
             trackBg: '#ebe7e0',
             trackHoverBg: '#e2dcd5',
@@ -331,66 +187,28 @@ const useSereneTheme = () => {
           Radio: {},
         },
       },
-      button: {
-        classNames: ({ props }) => ({
-          root: clsx(
-            props.type === 'primary' && styles.buttonPrimary,
-            props.type === 'default' && styles.buttonDefault,
-            props.danger && styles.buttonDanger,
-          ),
-        }),
-      },
-      input: {
-        classNames: ({ props }) => ({
-          root: clsx(styles.inputRoot, props.status === 'error' && styles.inputError),
-          input: styles.inputElement,
-        }),
-      },
-      select: {
-        classNames: {
-          popup: { root: styles.selectPopup },
-        },
-      },
-      card: {
-        classNames: {
-          root: styles.cardRoot,
-        },
-      },
-      modal: {
-        classNames: {
-          container: styles.modalContainer,
-          header: styles.modalHeader,
-          footer: styles.modalFooter,
-        },
-      },
-      notification: {
-        classNames: {
-          root: styles.notificationRoot,
-          title: styles.notificationTitle,
-          description: styles.notificationDescription,
-        },
-      },
-      menu: {
-        classNames: {
-          root: styles.menuRoot,
-        },
-      },
       wave: {},
       app: {},
+      card: {},
+      modal: {},
+      button: {},
       alert: {},
       colorPicker: {},
       checkbox: {},
       dropdown: {},
+      select: {},
       datePicker: {},
+      input: {},
       inputNumber: {},
       popover: {},
       tooltip: {},
+      notification: {},
       switch: {},
       radio: {},
       segmented: {},
       progress: {},
     }),
-    [styles],
+    [],
   );
 };
 

--- a/.dumi/pages/index/components/ThemePreview/previewThemes/sereneTheme.ts
+++ b/.dumi/pages/index/components/ThemePreview/previewThemes/sereneTheme.ts
@@ -1,0 +1,397 @@
+import { useMemo } from 'react';
+import { theme } from 'antd';
+import type { ConfigProviderProps } from 'antd';
+import { createStyles } from 'antd-style';
+import clsx from 'clsx';
+
+const useStyles = createStyles(({ css, cssVar }) => {
+  const softShadow = '0 1px 2px rgba(42, 35, 29, 0.04), 0 8px 24px -12px rgba(42, 35, 29, 0.08)';
+  const elevShadow = '0 2px 4px rgba(42, 35, 29, 0.05), 0 24px 48px -16px rgba(42, 35, 29, 0.14)';
+
+  return {
+    buttonPrimary: css({
+      backgroundColor: '#312721',
+      color: '#f8f6f1',
+      border: '1px solid #312721',
+      fontWeight: 500,
+      letterSpacing: '0.02em',
+      boxShadow: 'none',
+      transition: 'all 0.3s ease',
+      '&:hover': {
+        backgroundColor: '#3f342d !important',
+        borderColor: '#3f342d !important',
+      },
+    }),
+    buttonDefault: css({
+      backgroundColor: '#fcfaf8',
+      color: '#2a231d',
+      border: '1px solid #e2dcd5',
+      fontWeight: 500,
+      boxShadow: 'none',
+      transition: 'all 0.3s ease',
+      '&:hover': {
+        backgroundColor: '#f8f6f2 !important',
+        borderColor: '#d9d0c6 !important',
+        color: '#2a231d !important',
+      },
+    }),
+    buttonDanger: css({
+      backgroundColor: '#be4237',
+      color: '#f8f6f1',
+      border: '1px solid #be4237',
+      boxShadow: 'none',
+    }),
+    inputRoot: css({
+      borderColor: '#e2dcd5',
+      backgroundColor: '#fcfaf8',
+      transition: 'all 0.3s ease',
+      '&:hover': {
+        borderColor: '#c7a56b',
+      },
+    }),
+    inputElement: css({
+      color: '#2a231d',
+    }),
+    inputError: css({
+      borderColor: '#be4237',
+    }),
+    cardRoot: css({
+      border: '1px solid color-mix(in srgb, #e2dcd5 70%, transparent)',
+      boxShadow: softShadow,
+      transition: 'box-shadow 0.3s ease',
+      '&:hover': {
+        boxShadow: elevShadow,
+      },
+    }),
+    modalContainer: css({
+      border: '1px solid #e2dcd5',
+      boxShadow: elevShadow,
+    }),
+    modalHeader: css({
+      borderBottom: `1px solid ${cssVar.colorSplit}`,
+    }),
+    modalFooter: css({
+      borderTop: `1px solid ${cssVar.colorSplit}`,
+      backgroundColor: '#f8f6f2',
+    }),
+    notificationRoot: css({
+      '&.ant-notification-notice, & .ant-notification-notice': {
+        border: '1px solid #e2dcd5',
+        borderRadius: 4,
+        boxShadow: softShadow,
+        backgroundColor: '#fcfaf8',
+      },
+    }),
+    notificationTitle: css({
+      fontWeight: 600,
+      color: '#2a231d',
+    }),
+    notificationDescription: css({
+      color: '#766a60',
+    }),
+    selectPopup: css({
+      borderRadius: 4,
+      border: '1px solid #e2dcd5',
+      boxShadow: softShadow,
+    }),
+    menuRoot: css({
+      background: 'transparent !important',
+      borderInlineEnd: 'none !important',
+      paddingBlock: 4,
+
+      '& .ant-menu-item, & .ant-menu-submenu-title': {
+        fontWeight: 300,
+        letterSpacing: '0.04em',
+        borderInlineStart: '2px solid transparent',
+        marginInline: 12,
+        width: 'calc(100% - 24px)',
+        borderRadius: '0 !important',
+      },
+
+      '& .ant-menu-item::after': {
+        display: 'none !important',
+      },
+
+      '& .ant-menu-item': {
+        color: 'rgba(232, 226, 217, 0.7)',
+      },
+
+      '& .ant-menu-item:hover': {
+        color: '#e8e2d9 !important',
+        backgroundColor: 'rgba(60, 51, 42, 0.4) !important',
+      },
+
+      '& .ant-menu-item-selected': {
+        color: '#ebe4d8 !important',
+        backgroundColor: '#3c332a !important',
+        borderInlineStartColor: '#c7a56b !important',
+        fontWeight: 400,
+      },
+
+      '& .ant-menu-submenu-title': {
+        color: 'rgba(232, 226, 217, 0.7)',
+      },
+
+      '& .ant-menu-submenu-title:hover': {
+        color: '#e8e2d9 !important',
+        backgroundColor: 'rgba(60, 51, 42, 0.4) !important',
+      },
+
+      '& .ant-menu-submenu-selected > .ant-menu-submenu-title': {
+        color: '#e8e2d9 !important',
+        backgroundColor: 'transparent !important',
+        borderInlineStartColor: 'transparent !important',
+        fontWeight: 300,
+      },
+
+      '& .ant-menu-sub.ant-menu-inline': {
+        background: 'transparent !important',
+      },
+
+      '& .ant-menu-sub .ant-menu-item': {
+        paddingInlineStart: '40px !important',
+      },
+    }),
+  };
+});
+
+const useSereneTheme = () => {
+  const { styles } = useStyles();
+
+  return useMemo<ConfigProviderProps>(
+    () => ({
+      theme: {
+        algorithm: theme.defaultAlgorithm,
+        token: {
+          colorPrimary: '#312721',
+          colorSuccess: '#49795d',
+          colorWarning: '#cc9433',
+          colorError: '#be4237',
+          colorInfo: '#507395',
+          colorTextBase: '#2a231d',
+          colorBgBase: '#f8f6f2',
+          colorPrimaryBg: '#f3efe8',
+          colorPrimaryBgHover: '#ebe7e0',
+          colorPrimaryBorder: '#d9d0c6',
+          colorPrimaryBorderHover: '#c7a56b',
+          colorPrimaryHover: '#3f342d',
+          colorPrimaryActive: '#221c18',
+          colorPrimaryText: '#312721',
+          colorPrimaryTextHover: '#3f342d',
+          colorPrimaryTextActive: '#221c18',
+          colorSuccessBg: '#eef5f0',
+          colorSuccessBgHover: '#e0ebe4',
+          colorSuccessBorder: '#b8d4c3',
+          colorSuccessBorderHover: '#8fb9a0',
+          colorSuccessHover: '#3d6a4f',
+          colorSuccessActive: '#335a43',
+          colorSuccessText: '#49795d',
+          colorSuccessTextHover: '#3d6a4f',
+          colorSuccessTextActive: '#335a43',
+          colorWarningBg: '#faf5eb',
+          colorWarningBgHover: '#f3e8d4',
+          colorWarningBorder: '#e8d4a8',
+          colorWarningBorderHover: '#d9bc7a',
+          colorWarningHover: '#b87f2a',
+          colorWarningActive: '#9a6922',
+          colorWarningText: '#cc9433',
+          colorWarningTextHover: '#b87f2a',
+          colorWarningTextActive: '#9a6922',
+          colorErrorBg: '#faf0ee',
+          colorErrorBgHover: '#f5e0dc',
+          colorErrorBorder: '#e8b5ae',
+          colorErrorBorderHover: '#d98f84',
+          colorErrorHover: '#a8382f',
+          colorErrorActive: '#8f2f27',
+          colorErrorText: '#be4237',
+          colorErrorTextHover: '#a8382f',
+          colorErrorTextActive: '#8f2f27',
+          colorInfoBg: '#eef2f6',
+          colorInfoBgHover: '#e0e8ef',
+          colorInfoBorder: '#b8c9d9',
+          colorInfoBorderHover: '#8fa8be',
+          colorInfoHover: '#426178',
+          colorInfoActive: '#365263',
+          colorInfoText: '#507395',
+          colorInfoTextHover: '#426178',
+          colorInfoTextActive: '#365263',
+          colorText: '#2a231d',
+          colorTextSecondary: '#766a60',
+          colorTextTertiary: '#9a8f84',
+          colorTextQuaternary: '#c4bab0',
+          colorTextDisabled: '#c4bab0',
+          colorBgContainer: '#fcfaf8',
+          colorBgElevated: '#fcfaf8',
+          colorBgLayout: '#f8f6f2',
+          colorBgSpotlight: 'rgba(42, 35, 29, 0.85)',
+          colorBgMask: 'rgba(42, 35, 29, 0.45)',
+          colorBorder: '#e2dcd5',
+          colorBorderSecondary: '#eeebe7',
+          fontFamily: `'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`,
+          fontSize: 14,
+          lineHeight: 1.6,
+          borderRadius: 4,
+          borderRadiusXS: 2,
+          borderRadiusSM: 4,
+          borderRadiusLG: 6,
+          padding: 16,
+          paddingSM: 12,
+          paddingLG: 24,
+          margin: 16,
+          marginSM: 12,
+          marginLG: 24,
+          boxShadow: '0 1px 2px rgba(42, 35, 29, 0.04), 0 8px 24px -12px rgba(42, 35, 29, 0.08)',
+          boxShadowSecondary:
+            '0 2px 4px rgba(42, 35, 29, 0.05), 0 24px 48px -16px rgba(42, 35, 29, 0.14)',
+          motionDurationMid: '0.3s',
+          motionEaseInOut: 'ease',
+        },
+        components: {
+          Button: {
+            primaryShadow: 'none',
+            defaultShadow: 'none',
+            dangerShadow: 'none',
+            defaultBorderColor: '#e2dcd5',
+            defaultColor: '#2a231d',
+            defaultBg: '#fcfaf8',
+            defaultHoverBg: '#f8f6f2',
+            defaultHoverBorderColor: '#d9d0c6',
+            defaultHoverColor: '#2a231d',
+            defaultActiveBg: '#ebe7e0',
+            defaultActiveBorderColor: '#d9d0c6',
+            borderRadius: 4,
+            fontWeight: 500,
+          },
+          Input: {
+            activeShadow: 'none',
+            hoverBorderColor: '#c7a56b',
+            activeBorderColor: '#312721',
+            borderRadius: 4,
+            colorBgContainer: '#fcfaf8',
+          },
+          Select: {
+            optionSelectedBg: '#f3efe8',
+            optionActiveBg: '#f8f6f2',
+            optionSelectedFontWeight: 500,
+            borderRadius: 4,
+          },
+          Layout: {
+            bodyBg: '#f8f6f2',
+            footerBg: '#f8f6f2',
+            headerBg: '#fcfaf8',
+            headerColor: '#2a231d',
+            siderBg: '#2c241c',
+            lightSiderBg: '#2c241c',
+            triggerBg: '#3c332a',
+            triggerColor: '#e8e2d9',
+          },
+          Menu: {
+            activeBarWidth: 0,
+            activeBarBorderWidth: 0,
+            itemBg: 'transparent',
+            subMenuItemBg: 'transparent',
+            itemColor: 'rgba(232, 226, 217, 0.7)',
+            itemHoverColor: '#e8e2d9',
+            itemSelectedColor: '#ebe4d8',
+            subMenuItemSelectedColor: 'rgba(232, 226, 217, 0.7)',
+            itemHoverBg: 'rgba(60, 51, 42, 0.4)',
+            itemSelectedBg: '#3c332a',
+            itemBorderRadius: 0,
+            itemMarginInline: 12,
+            itemHeight: 40,
+          },
+          Card: { borderRadiusLG: 4 },
+          Modal: { borderRadiusLG: 6 },
+          Alert: { borderRadiusLG: 4 },
+          Progress: {
+            circleTextColor: '#2a231d',
+            defaultColor: '#312721',
+            remainingColor: 'rgba(49, 39, 33, 0.08)',
+          },
+          Switch: { trackHeight: 22, trackMinWidth: 44 },
+          Checkbox: { borderRadiusSM: 2 },
+          Slider: {
+            trackBg: '#ebe7e0',
+            trackHoverBg: '#e2dcd5',
+            handleColor: '#c7a56b',
+            railSize: 4,
+          },
+          Notification: {
+            colorSuccessBg: '#eef5f0',
+            colorErrorBg: '#faf0ee',
+            colorInfoBg: '#eef2f6',
+            colorWarningBg: '#faf5eb',
+          },
+          Table: {
+            headerBg: '#f3efe8',
+            headerColor: '#766a60',
+            borderColor: '#e2dcd5',
+          },
+          Tooltip: {},
+          Radio: {},
+        },
+      },
+      button: {
+        classNames: ({ props }) => ({
+          root: clsx(
+            props.type === 'primary' && styles.buttonPrimary,
+            props.type === 'default' && styles.buttonDefault,
+            props.danger && styles.buttonDanger,
+          ),
+        }),
+      },
+      input: {
+        classNames: ({ props }) => ({
+          root: clsx(styles.inputRoot, props.status === 'error' && styles.inputError),
+          input: styles.inputElement,
+        }),
+      },
+      select: {
+        classNames: {
+          popup: { root: styles.selectPopup },
+        },
+      },
+      card: {
+        classNames: {
+          root: styles.cardRoot,
+        },
+      },
+      modal: {
+        classNames: {
+          container: styles.modalContainer,
+          header: styles.modalHeader,
+          footer: styles.modalFooter,
+        },
+      },
+      notification: {
+        classNames: {
+          root: styles.notificationRoot,
+          title: styles.notificationTitle,
+          description: styles.notificationDescription,
+        },
+      },
+      menu: {
+        classNames: {
+          root: styles.menuRoot,
+        },
+      },
+      wave: {},
+      app: {},
+      alert: {},
+      colorPicker: {},
+      checkbox: {},
+      dropdown: {},
+      datePicker: {},
+      inputNumber: {},
+      popover: {},
+      tooltip: {},
+      switch: {},
+      radio: {},
+      segmented: {},
+      progress: {},
+    }),
+    [styles],
+  );
+};
+
+export default useSereneTheme;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement

### 🔗 Related Issues

close #56936

### 💡 Background and Solution

Adds **Serene**, a calm Japandi / hospitality-inspired preview theme for the homepage theme collection ([#56936](https://github.com/ant-design/ant-design/issues/56936)).

**Design concept:** warm ivory surfaces (`#f8f6f2`), sumi-ink primary (`#312721`), subtle gold accents (`#c7a56b`), dark charcoal sidebar with gold active indicator on leaf menu items only.

**Implementation:**
- `sereneTheme.ts` — global tokens, component tokens, Semantic DOM `classNames`
- Registered in `previewThemes/index.ts`
- Local preview assets in `previewThemes/assets/` (`serene-icon.svg`) — happy for maintainers to re-host on CDN and update URLs

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Site only |
| 🇨🇳 Chinese | 仅站点更新 |

### Test plan

- [x] `npm run lint` passes locally
- [x] Homepage → Serene chip and warm background display correctly
- [x] Components preview uses Serene palette
- [x] Dashboard: dark sidebar, gold bar on selected leaf item only
- [x] Copy theme code works

### Screenshots

**Components preview**
<img width="1280" height="717" alt="WhatsApp Image 2026-07-06 at 22 04 26" src="https://github.com/user-attachments/assets/766472b5-b01a-4024-bfef-cd0da5d71602" />


**Dashboard preview**
<img width="1280" height="784" alt="WhatsApp Image 2026-07-06 at 22 04 04" src="https://github.com/user-attachments/assets/1349fd0d-a1be-4aa2-9c7f-958c200e8984" />

