### PR TITLE
demo: fix Menu semantic demo popup behavior

### DIFF
--- a/components/menu/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/menu/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -128,13 +128,13 @@ exports[`renders components/menu/demo/_semantic.tsx correctly 1`] = `
                 tabindex="-1"
               >
                 <span
-                  aria-label="mail"
-                  class="anticon anticon-mail ant-menu-item-icon semantic-mark-itemIcon"
+                  aria-label="appstore"
+                  class="anticon anticon-appstore ant-menu-item-icon semantic-mark-itemIcon"
                   role="img"
                 >
                   <svg
                     aria-hidden="true"
-                    data-icon="mail"
+                    data-icon="appstore"
                     fill="currentColor"
                     focusable="false"
                     height="1em"
@@ -142,14 +142,14 @@ exports[`renders components/menu/demo/_semantic.tsx correctly 1`] = `
                     width="1em"
                   >
                     <path
-                      d="M928 160H96c-17.7 0-32 14.3-32 32v640c0 17.7 14.3 32 32 32h832c17.7 0 32-14.3 32-32V192c0-17.7-14.3-32-32-32zm-40 110.8V792H136V270.8l-27.6-21.5 39.3-50.5 42.8 33.3h643.1l42.8-33.3 39.3 50.5-27.7 21.5zM833.6 232L512 482 190.4 232l-42.8-33.3-39.3 50.5 27.6 21.5 341.6 265.6a55.99 55.99 0 0068.7 0L888 270.8l27.6-21.5-39.3-50.5-42.7 33.2z"
+                      d="M464 144H160c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V160c0-8.8-7.2-16-16-16zm-52 268H212V212h200v200zm452-268H560c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V160c0-8.8-7.2-16-16-16zm-52 268H612V212h200v200zM464 544H160c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V560c0-8.8-7.2-16-16-16zm-52 268H212V612h200v200zm452-268H560c-8.8 0-16 7.2-16 16v304c0 8.8 7.2 16 16 16h304c8.8 0 16-7.2 16-16V560c0-8.8-7.2-16-16-16zm-52 268H612V612h200v200z"
                     />
                   </svg>
                 </span>
                 <span
                   class="ant-menu-title-content"
                 >
-                  Navigation One
+                  Navigation Two
                 </span>
                 <i
                   class="ant-menu-submenu-arrow"
@@ -232,9 +232,9 @@ exports[`renders components/menu/demo/_semantic.tsx correctly 1`] = `
               <div
                 class="ant-menu-item-group-title semantic-mark-itemTitle"
                 role="presentation"
-                title="Group"
+                title="Navigation Three"
               >
-                Group
+                Navigation Three
               </div>
               <ul
                 class="ant-menu-item-group-list semantic-mark-list"
@@ -242,7 +242,7 @@ exports[`renders components/menu/demo/_semantic.tsx correctly 1`] = `
               >
                 <li
                   class="ant-menu-item semantic-mark-item ant-menu-item-only-child"
-                  data-menu-id="rc-menu-uuid-13"
+                  data-menu-id="rc-menu-uuid-3"
                   role="menuitem"
                   style="padding-left: 24px;"
                   tabindex="-1"
@@ -250,12 +250,12 @@ exports[`renders components/menu/demo/_semantic.tsx correctly 1`] = `
                   <span
                     class="ant-menu-title-content semantic-mark-itemContent"
                   >
-                    Option 13
+                    Option 3
                   </span>
                 </li>
                 <li
                   class="ant-menu-item semantic-mark-item ant-menu-item-only-child"
-                  data-menu-id="rc-menu-uuid-14"
+                  data-menu-id="rc-menu-uuid-4"
                   role="menuitem"
                   style="padding-left: 24px;"
                   tabindex="-1"
@@ -263,7 +263,7 @@ exports[`renders components/menu/demo/_semantic.tsx correctly 1`] = `
                   <span
                     class="ant-menu-title-content semantic-mark-itemContent"
                   >
-                    Option 14
+                    Option 4
                   </span>
                 </li>
               </ul>

--- a/components/menu/demo/_semantic.tsx
+++ b/components/menu/demo/_semantic.tsx
@@ -96,6 +96,11 @@ const Block: React.FC<MenuProps & ExternalProps> = (props) => {
     setCurrent(e.key);
   };
 
+  const getPopupContainer = React.useCallback<NonNullable<MenuProps['getPopupContainer']>>(
+    () => divRef.current?.parentElement?.parentElement || divRef.current!,
+    [],
+  );
+
   return (
     <Flex vertical gap="medium" ref={divRef} align="center">
       <Segmented<ModeType> options={['horizontal', 'vertical', 'inline']} onChange={setMode} />
@@ -117,7 +122,7 @@ const Block: React.FC<MenuProps & ExternalProps> = (props) => {
           }}
           {...restProps}
           openKeys={['SubMenu']}
-          getPopupContainer={() => divRef.current!}
+          getPopupContainer={getPopupContainer}
         />
       </div>
     </Flex>

--- a/components/menu/demo/_semantic.tsx
+++ b/components/menu/demo/_semantic.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MailOutlined } from '@ant-design/icons';
+import { AppstoreOutlined, MailOutlined } from '@ant-design/icons';
 import { Flex, Menu, Segmented } from 'antd';
 import type { MenuProps } from 'antd';
 
@@ -50,8 +50,8 @@ const items: MenuItem[] = [
   },
   {
     key: 'SubMenu',
-    label: 'Navigation One',
-    icon: <MailOutlined />,
+    label: 'Navigation Two',
+    icon: <AppstoreOutlined />,
     children: [
       {
         key: 'g1',
@@ -69,11 +69,11 @@ const items: MenuItem[] = [
 const groupItem: MenuItem[] = [
   {
     key: 'grp',
-    label: 'Group',
+    label: 'Navigation Three',
     type: 'group',
     children: [
-      { key: '13', label: 'Option 13' },
-      { key: '14', label: 'Option 14' },
+      { key: '3', label: 'Option 3' },
+      { key: '4', label: 'Option 4' },
     ],
   },
 ];

--- a/components/menu/demo/_semantic.tsx
+++ b/components/menu/demo/_semantic.tsx
@@ -112,7 +112,7 @@ const Block: React.FC<MenuProps & ExternalProps> = (props) => {
           items={item}
           styles={{
             root: {
-              width: mode === 'horizontal' ? 310 : 230,
+              width: mode === 'horizontal' ? 480 : 230,
             },
             popup: {
               root: {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

修复 Menu 语义化 DOM demo 在 `vertical` 模式下展开二级菜单后，页面向上滚动被阻塞的问题。

原因是 demo 之前把 popup 挂载在语义预览左侧容器内，该容器存在裁剪和滚动相关样式，导致 vertical popup 展开后影响页面滚动。现在将 popup 挂载到语义预览外层容器，保留语义标记采集范围，同时避开左侧预览列的布局限制。

同时调整 horizontal 模式宽度，避免菜单项被折叠为省略号，并整理 demo 菜单项文案和 key 顺序，更新对应快照。

验证：

- `npm test -- components/menu/__tests__/demo-semantic.test.tsx -u --runInBand`

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A      |
| 🇨🇳 中文 | N/A      |