### PR TITLE
fix(Input): prevent Search button focus outline from being covered

### DIFF
--- a/components/input/style/search.ts
+++ b/components/input/style/search.ts
@@ -31,6 +31,10 @@ const genSearchStyle: GenerateStyle<InputToken, CSSObject> = (token) => {
       [btnCls]: {
         height: varRef('btn-height'),
 
+        '&:focus-visible': {
+          zIndex: 5,
+        },
+
         [`&${antCls}-btn-icon-only`]: {
           width: varRef('btn-height'),
         },


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [x] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<img width="836" height="318" alt="image" src="https://github.com/user-attachments/assets/7c790c5d-65cd-4546-acac-554c6a817330" />


### 💡 需求背景和解决方案

Input.Search 的搜索按钮处于键盘聚焦态时，如果鼠标 hover 到相邻输入框，输入框的 hover 层级会覆盖按钮的 focus outline。

本次为 Input.Search 的搜索按钮在 `:focus-visible` 状态下提升层级，使按钮聚焦轮廓保持可见，不涉及 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Input.Search button focus outline being covered by adjacent input hover state. |
| 🇨🇳 中文 | 🐞 修复 Input.Search 搜索按钮聚焦轮廓被相邻输入框 hover 态覆盖的问题。 |