### PR TITLE
test(Input.Search): add compact small button height regression test

### DIFF
--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -7,6 +7,7 @@ import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import Button from '../../button';
 import ConfigProvider from '../../config-provider';
+import theme from '../../theme';
 import type { InputRef } from '../Input';
 import Search from '../Search';
 import type { SearchProps } from '../Search';
@@ -412,5 +413,23 @@ describe('Input.Search', () => {
       color: 'rgb(0, 0, 255)',
       backgroundColor: 'rgb(0, 255, 0)',
     });
+  });
+
+  // https://github.com/ant-design/ant-design/issues/54859
+  it('compact small search button height should align with input', () => {
+    const { container } = render(
+      <ConfigProvider theme={{ algorithm: theme.compactAlgorithm }}>
+        <Search placeholder="compact small search" size="small" enterButton="Search" />
+      </ConfigProvider>,
+    );
+
+    const input = container.querySelector('input.ant-input')!;
+    const button = container.querySelector('.ant-input-search-button')!;
+
+    const inputHeight = input.getBoundingClientRect().height;
+    const buttonHeight = button.getBoundingClientRect().height;
+
+    // Button height should be at least equal to input height (not 1px shorter)
+    expect(buttonHeight).toBeGreaterThanOrEqual(inputHeight);
   });
 });

--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -416,20 +416,24 @@ describe('Input.Search', () => {
   });
 
   // https://github.com/ant-design/ant-design/issues/54859
-  it('compact small search button height should align with input', () => {
+  it('compact small search button min-height should not be less than controlHeightSM', () => {
     const { container } = render(
       <ConfigProvider theme={{ algorithm: theme.compactAlgorithm }}>
         <Search placeholder="compact small search" size="small" enterButton="Search" />
       </ConfigProvider>,
     );
 
-    const input = container.querySelector('input.ant-input')!;
-    const button = container.querySelector('.ant-input-search-button')!;
+    const button = container.querySelector<HTMLButtonElement>('.ant-input-search-button')!;
 
-    const inputHeight = input.getBoundingClientRect().height;
-    const buttonHeight = button.getBoundingClientRect().height;
+    // search.ts sets minHeight on the small search button to ensure it aligns
+    // with the input height. In compact algorithm, controlHeightSM is 21px but
+    // the calculated smallButtonHeight should be >= 22px (to cover the input's
+    // font line box + borders). Verify the computed min-height is set and is
+    // greater than the raw controlHeightSM (21px).
+    const buttonMinHeight = getComputedStyle(button).minHeight;
+    expect(buttonMinHeight).not.toBe('0px');
 
-    // Button height should be at least equal to input height (not 1px shorter)
-    expect(buttonHeight).toBeGreaterThanOrEqual(inputHeight);
+    const minHeightValue = parseFloat(buttonMinHeight);
+    expect(minHeightValue).toBeGreaterThanOrEqual(22);
   });
 });


### PR DESCRIPTION
## Summary

- Add a regression test verifying that in `compactAlgorithm` with `size="small"`, the `Input.Search` component button height is aligned with (or greater than) the input height.

## Root Cause

The compact algorithm reduces `controlHeight` from 32px to 28px and derives `controlHeightSM = 28 * 0.75 = 21px`. Compact small inputs render at 22px (12px font * lineHeight + 2px borders), while the search button stays at 21px, causing a 1px mismatch.

The fix (PR #58411) added dynamic button height calculation in `search.ts`. This PR adds the missing regression test.

## Related Issue

Fixes #54859

## Validation

```bash
npm test -- components/input/__tests__/Search.test.tsx --runInBand
