### PR TITLE
docs(Grid): add flex number vs string type description

### DIFF
--- a/components/grid/index.en-US.md
+++ b/components/grid/index.en-US.md
@@ -71,7 +71,7 @@ If the Ant Design grid layout component does not meet your needs, you can use th
 
 | Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
 | --- | --- | --- | --- | --- | --- |
-| flex | Flex layout style, number for `flex: n n auto`, string for `flex: n 1 0` | string \| number | - |  | × |
+| flex | Flex layout style. Number for 'flex: n n auto', string is applied directly (e.g. pure number string 'n' for 'flex: n 1 0') | string \| number | - |  | × |
 | offset | The number of cells to offset Col from the left | number | 0 |  | × |
 | order | Raster order | number | 0 |  | × |
 | pull | The number of cells that raster is moved to the left | number | 0 |  | × |

--- a/components/grid/index.en-US.md
+++ b/components/grid/index.en-US.md
@@ -71,7 +71,7 @@ If the Ant Design grid layout component does not meet your needs, you can use th
 
 | Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
 | --- | --- | --- | --- | --- | --- |
-| flex | Flex layout style | string \| number | - |  | × |
+| flex | Flex layout style, number for `flex: n n auto`, string for `flex: n 1 0` | string \| number | - |  | × |
 | offset | The number of cells to offset Col from the left | number | 0 |  | × |
 | order | Raster order | number | 0 |  | × |
 | pull | The number of cells that raster is moved to the left | number | 0 |  | × |

--- a/components/grid/index.zh-CN.md
+++ b/components/grid/index.zh-CN.md
@@ -70,7 +70,7 @@ Ant Design 的布局组件若不能满足你的需求，你也可以直接使用
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
 | --- | --- | --- | --- | --- | --- |
-| flex | flex 布局属性 | string \| number | - |  | × |
+| flex | flex 布局属性，数字类型对应 `flex: n n auto`，字符串类型对应 `flex: n 1 0` | string \| number | - |  | × |
 | offset | 栅格左侧的间隔格数，间隔内不可以有栅格 | number | 0 |  | × |
 | order | 栅格顺序 | number | 0 |  | × |
 | pull | 栅格向左移动格数 | number | 0 |  | × |

--- a/components/grid/index.zh-CN.md
+++ b/components/grid/index.zh-CN.md
@@ -70,7 +70,7 @@ Ant Design 的布局组件若不能满足你的需求，你也可以直接使用
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
 | --- | --- | --- | --- | --- | --- |
-| flex | flex 布局属性，数字类型对应 `flex: n n auto`，字符串类型对应 `flex: n 1 0` | string \| number | - |  | × |
+| flex | flex 布局属性。数字类型对应 'flex: n n auto'；字符串类型直接透传（例如纯数字字符串 'n' 对应 'flex: n 1 0'） | string \| number | - |  | × |
 | offset | 栅格左侧的间隔格数，间隔内不可以有栅格 | number | 0 |  | × |
 | order | 栅格顺序 | number | 0 |  | × |
 | pull | 栅格向左移动格数 | number | 0 |  | × |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

  - [x] 📝 站点、文档改进


  ### 🔗 相关 Issue

  fix #29831

  ### 💡 需求背景和解决方案

  修复 issue #29831：Col 组件的 flex 属性在使用数字和字符串时行为不同
  - 数字类型 `flex={n}` 对应 CSS `flex: n n auto` (flex-basis 为 auto)
  - 字符串类型 `flex="n"` 对应 CSS `flex: n 1 0` (flex-basis 为 0)
  在文档中增加说明，让用户了解两者区别

  ### 📝 更新日志

  | 语言    | 更新描述 |
  | ------- | -------- |
  | 🇺🇸 英文 | 无需更新日志 |
  | 🇨🇳 中文 | 无需更新日志 |