### PR TITLE
fix(avatar): support Avatar.Group nativeElement ref

### DIFF
--- a/components/avatar/AvatarGroup.tsx
+++ b/components/avatar/AvatarGroup.tsx
@@ -51,7 +51,11 @@ export interface AvatarGroupProps {
   shape?: 'circle' | 'square';
 }
 
-const AvatarGroup: React.FC<AvatarGroupProps> = (props) => {
+export interface AvatarGroupRef {
+  nativeElement: HTMLDivElement;
+}
+
+const AvatarGroup = React.forwardRef<AvatarGroupRef, AvatarGroupProps>((props, ref) => {
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
   const {
     prefixCls: customizePrefixCls,
@@ -104,6 +108,12 @@ const AvatarGroup: React.FC<AvatarGroupProps> = (props) => {
     }),
   );
 
+  const nativeElementRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
+
   const mergeCount = max?.count || maxCount;
   const numOfChildren = childrenWithProps.length;
   if (mergeCount && mergeCount < numOfChildren) {
@@ -130,7 +140,7 @@ const AvatarGroup: React.FC<AvatarGroupProps> = (props) => {
 
     return (
       <AvatarContextProvider shape={shape} size={size}>
-        <div className={cls} style={style}>
+        <div ref={nativeElementRef} className={cls} style={style}>
           {childrenShow}
         </div>
       </AvatarContextProvider>
@@ -139,11 +149,11 @@ const AvatarGroup: React.FC<AvatarGroupProps> = (props) => {
 
   return (
     <AvatarContextProvider shape={shape} size={size}>
-      <div className={cls} style={style}>
+      <div ref={nativeElementRef} className={cls} style={style}>
         {childrenWithProps}
       </div>
     </AvatarContextProvider>
   );
-};
+});
 
 export default AvatarGroup;

--- a/components/avatar/__tests__/Avatar.test.tsx
+++ b/components/avatar/__tests__/Avatar.test.tsx
@@ -35,6 +35,17 @@ describe('Avatar Render', () => {
     });
   });
 
+  it('should support Avatar.Group nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Avatar.Group>>();
+    const { container } = render(
+      <Avatar.Group ref={ref}>
+        <Avatar />
+      </Avatar.Group>,
+    );
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-avatar-group'));
+  });
+
   it('Render long string correctly', () => {
     const { container } = render(<Avatar>TestString</Avatar>);
     expect(container.querySelectorAll('.ant-avatar-string').length).toBe(1);

--- a/components/avatar/index.tsx
+++ b/components/avatar/index.tsx
@@ -3,6 +3,7 @@ import type { AvatarGroupProps } from './AvatarGroup';
 import AvatarGroup from './AvatarGroup';
 
 export type { AvatarProps } from './Avatar';
+export type { AvatarGroupRef } from './AvatarGroup';
 
 /** @deprecated Please use `AvatarGroupProps` */
 export type GroupProps = AvatarGroupProps;

--- a/components/index.ts
+++ b/components/index.ts
@@ -14,7 +14,7 @@ export type { AppProps } from './app';
 export { default as AutoComplete } from './auto-complete';
 export type { AutoCompleteProps } from './auto-complete';
 export { default as Avatar } from './avatar';
-export type { AvatarProps } from './avatar';
+export type { AvatarGroupRef, AvatarProps } from './avatar';
 export { default as BackTop } from './back-top';
 export type { BackTopProps } from './back-top';
 export { default as Badge } from './badge';


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `Avatar.Group`.
- Exports the new ref type through the avatar entry and package entry.
- Adds component-level ref coverage.

Validation:
- `git diff --check`