### PR TITLE
fix(badge): support Ribbon nativeElement ref

### DIFF
--- a/components/badge/Ribbon.tsx
+++ b/components/badge/Ribbon.tsx
@@ -39,7 +39,11 @@ export interface RibbonProps {
   styles?: RibbonSemanticAllType['stylesAndFn'];
 }
 
-const Ribbon: React.FC<RibbonProps> = (props) => {
+export interface RibbonRef {
+  nativeElement: HTMLDivElement;
+}
+
+const Ribbon = React.forwardRef<RibbonRef, RibbonProps>((props, ref) => {
   const {
     className,
     prefixCls: customizePrefixCls,
@@ -105,8 +109,16 @@ const Ribbon: React.FC<RibbonProps> = (props) => {
     colorStyle.background = color;
     cornerColorStyle.color = color;
   }
+
+  const nativeElementRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
+
   return (
     <div
+      ref={nativeElementRef}
       className={clsx(wrapperCls, rootClassName, hashId, cssVarCls, mergedClassNames.root)}
       style={mergedStyles.root}
     >
@@ -122,7 +134,7 @@ const Ribbon: React.FC<RibbonProps> = (props) => {
       </div>
     </div>
   );
-};
+});
 
 if (process.env.NODE_ENV !== 'production') {
   Ribbon.displayName = 'Ribbon';

--- a/components/badge/__tests__/ribbon.test.tsx
+++ b/components/badge/__tests__/ribbon.test.tsx
@@ -16,6 +16,17 @@ describe('Ribbon', () => {
   mountTest(Badge.Ribbon);
   rtlTest(Badge.Ribbon);
 
+  it('should support nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Badge.Ribbon>>();
+    const { container } = render(
+      <Badge.Ribbon ref={ref} text="Ribbon">
+        <div />
+      </Badge.Ribbon>,
+    );
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-ribbon-wrapper'));
+  });
+
   describe('placement', () => {
     it('works with `start` & `end` placement', () => {
       const { container: wrapperStart } = render(

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -3,7 +3,7 @@ import Ribbon from './Ribbon';
 
 export type { BadgeProps } from './Badge';
 
-export type { RibbonProps } from './Ribbon';
+export type { RibbonProps, RibbonRef } from './Ribbon';
 
 export type { ScrollNumberProps } from './ScrollNumber';
 

--- a/components/index.ts
+++ b/components/index.ts
@@ -18,7 +18,7 @@ export type { AvatarProps } from './avatar';
 export { default as BackTop } from './back-top';
 export type { BackTopProps } from './back-top';
 export { default as Badge } from './badge';
-export type { BadgeProps } from './badge';
+export type { BadgeProps, RibbonRef } from './badge';
 export { default as BorderBeam } from './border-beam';
 export type { BorderBeamColor, BorderBeamGradient, BorderBeamProps } from './border-beam';
 export { default as Breadcrumb } from './breadcrumb';


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `Badge.Ribbon`.
- Exports the new ref type through the badge entry and package entry.
- Adds component-level ref coverage.

Validation:
- `git diff --check`