### PR TITLE
fix(breadcrumb): support nativeElement ref

### DIFF
--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -90,6 +90,10 @@ export interface BreadcrumbProps<T extends AnyObject = AnyObject> {
   itemRender?: (route: ItemType, params: T, routes: ItemType[], paths: string[]) => React.ReactNode;
 }
 
+export interface BreadcrumbRef {
+  nativeElement: HTMLElement;
+}
+
 const getPath = <T extends AnyObject = AnyObject>(params: T, path?: string) => {
   if (path === undefined) {
     return path;
@@ -101,7 +105,10 @@ const getPath = <T extends AnyObject = AnyObject>(params: T, path?: string) => {
   return mergedPath;
 };
 
-const Breadcrumb = <T extends AnyObject = AnyObject>(props: BreadcrumbProps<T>) => {
+const InternalBreadcrumb = <T extends AnyObject = AnyObject>(
+  props: BreadcrumbProps<T>,
+  ref: React.ForwardedRef<BreadcrumbRef>,
+) => {
   const {
     prefixCls: customizePrefixCls,
     separator,
@@ -286,14 +293,32 @@ const Breadcrumb = <T extends AnyObject = AnyObject>(props: BreadcrumbProps<T>) 
     [mergedClassNames, mergedStyles],
   );
 
+  const nativeElementRef = React.useRef<HTMLElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
+
   return (
     <BreadcrumbContext.Provider value={memoizedValue}>
-      <nav className={breadcrumbClassName} style={mergedStyle} {...restProps}>
+      <nav
+        ref={nativeElementRef}
+        className={breadcrumbClassName}
+        style={mergedStyle}
+        {...restProps}
+      >
         <ol>{crumbs}</ol>
       </nav>
     </BreadcrumbContext.Provider>
   );
 };
+
+const Breadcrumb = React.forwardRef(InternalBreadcrumb) as (<T extends AnyObject = AnyObject>(
+  props: BreadcrumbProps<T> & {
+    ref?: React.ForwardedRef<BreadcrumbRef>;
+  },
+) => ReturnType<typeof InternalBreadcrumb>) &
+  Pick<React.FC, 'displayName'>;
 
 if (process.env.NODE_ENV !== 'production') {
   Breadcrumb.displayName = 'Breadcrumb';

--- a/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -24,6 +24,13 @@ describe('Breadcrumb', () => {
     errorSpy.mockRestore();
   });
 
+  it('should support nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Breadcrumb>>();
+    const { container } = render(<Breadcrumb ref={ref} items={[{ title: 'Home' }]} />);
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-breadcrumb'));
+  });
+
   it('warns on non-Breadcrumb.Item and non-Breadcrumb.Separator children', () => {
     const MyCom: React.FC = () => <div>foo</div>;
     render(

--- a/components/breadcrumb/index.tsx
+++ b/components/breadcrumb/index.tsx
@@ -2,7 +2,7 @@ import InternalBreadcrumb from './Breadcrumb';
 import BreadcrumbItem from './BreadcrumbItem';
 import BreadcrumbSeparator from './BreadcrumbSeparator';
 
-export type { BreadcrumbProps } from './Breadcrumb';
+export type { BreadcrumbProps, BreadcrumbRef } from './Breadcrumb';
 export type { BreadcrumbItemProps, SeparatorType } from './BreadcrumbItem';
 
 type CompoundedComponent = typeof InternalBreadcrumb & {

--- a/components/index.ts
+++ b/components/index.ts
@@ -22,7 +22,7 @@ export type { BadgeProps } from './badge';
 export { default as BorderBeam } from './border-beam';
 export type { BorderBeamColor, BorderBeamGradient, BorderBeamProps } from './border-beam';
 export { default as Breadcrumb } from './breadcrumb';
-export type { BreadcrumbItemProps, BreadcrumbProps } from './breadcrumb';
+export type { BreadcrumbItemProps, BreadcrumbProps, BreadcrumbRef } from './breadcrumb';
 export { default as Button } from './button';
 export type { ButtonProps } from './button';
 export { default as Calendar } from './calendar';


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `Breadcrumb`.
- Exports the new ref type through the breadcrumb entry and package entry.
- Adds component-level ref coverage.

Validation:
- `git diff --check`