### PR TITLE
fix(calendar): support nativeElement ref

### DIFF
--- a/components/calendar/__tests__/index.test.tsx
+++ b/components/calendar/__tests__/index.test.tsx
@@ -68,6 +68,13 @@ describe('Calendar', () => {
     fireEvent.click(findSelectItem(wrapper)[index]);
   }
 
+  it('should support nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Calendar>>();
+    const { container } = render(<Calendar ref={ref} fullscreen={false} />);
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-picker-calendar'));
+  });
+
   // https://github.com/ant-design/ant-design/issues/30392
   it('should be able to set undefined or null', () => {
     expect(() => {

--- a/components/calendar/generateCalendar.tsx
+++ b/components/calendar/generateCalendar.tsx
@@ -85,6 +85,10 @@ export interface CalendarProps<DateType> {
   onSelect?: (date: DateType, selectInfo: SelectInfo) => void;
 }
 
+export interface CalendarRef {
+  nativeElement: HTMLDivElement;
+}
+
 const isSameYear = <T extends AnyObject>(date1: T, date2: T, config: GenerateConfig<T>) => {
   const { getYear } = config;
   return date1 && date2 && getYear(date1) === getYear(date2);
@@ -101,7 +105,10 @@ const isSameDate = <T extends AnyObject>(date1: T, date2: T, config: GenerateCon
 };
 
 const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateConfig<DateType>) => {
-  const Calendar: React.FC<Readonly<CalendarProps<DateType>>> = (props) => {
+  const InternalCalendar = (
+    props: Readonly<CalendarProps<DateType>>,
+    ref: React.ForwardedRef<CalendarRef>,
+  ) => {
     const {
       prefixCls: customizePrefixCls,
       className,
@@ -354,8 +361,15 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
       }
     };
 
+    const nativeElementRef = React.useRef<HTMLDivElement>(null);
+
+    React.useImperativeHandle(ref, () => ({
+      nativeElement: nativeElementRef.current!,
+    }));
+
     return (
       <div
+        ref={nativeElementRef}
         className={clsx(
           calendarPrefixCls,
           {
@@ -416,6 +430,10 @@ const generateCalendar = <DateType extends AnyObject>(generateConfig: GenerateCo
       </div>
     );
   };
+
+  const Calendar = React.forwardRef(InternalCalendar) as React.ForwardRefExoticComponent<
+    Readonly<CalendarProps<DateType>> & React.RefAttributes<CalendarRef>
+  >;
 
   if (process.env.NODE_ENV !== 'production') {
     Calendar.displayName = 'Calendar';

--- a/components/calendar/index.tsx
+++ b/components/calendar/index.tsx
@@ -3,7 +3,7 @@ import type { Dayjs } from 'dayjs';
 
 import generateCalendar from './generateCalendar';
 
-export type { CalendarMode, CalendarProps } from './generateCalendar';
+export type { CalendarMode, CalendarProps, CalendarRef } from './generateCalendar';
 
 const Calendar = generateCalendar<Dayjs>(dayjsGenerateConfig);
 

--- a/components/index.ts
+++ b/components/index.ts
@@ -26,7 +26,7 @@ export type { BreadcrumbItemProps, BreadcrumbProps } from './breadcrumb';
 export { default as Button } from './button';
 export type { ButtonProps } from './button';
 export { default as Calendar } from './calendar';
-export type { CalendarMode, CalendarProps } from './calendar';
+export type { CalendarMode, CalendarProps, CalendarRef } from './calendar';
 export { default as Card } from './card';
 export type { CardProps } from './card';
 export type { CardMetaProps } from './card/CardMeta';


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `Calendar`.
- Exports the new ref type through the calendar entry and package entry.
- Adds component-level ref coverage.

Validation:
- `git diff --check`