### PR TITLE
fix(card): support Card.Grid nativeElement ref

### DIFF
--- a/components/card/CardGrid.tsx
+++ b/components/card/CardGrid.tsx
@@ -11,14 +11,25 @@ export interface CardGridProps extends React.HTMLAttributes<HTMLDivElement> {
   style?: React.CSSProperties;
 }
 
-const CardGrid: React.FC<CardGridProps> = ({ prefixCls, className, hoverable = true, ...rest }) => {
+export interface CardGridRef {
+  nativeElement: HTMLDivElement;
+}
+
+const CardGrid = React.forwardRef<CardGridRef, CardGridProps>((props, ref) => {
+  const { prefixCls, className, hoverable = true, ...rest } = props;
   const { getPrefixCls } = React.useContext<ConfigConsumerProps>(ConfigContext);
   const prefix = getPrefixCls('card', prefixCls);
   const classString = clsx(`${prefix}-grid`, className, {
     [`${prefix}-grid-hoverable`]: hoverable,
   });
-  return <div {...rest} className={classString} />;
-};
+  const nativeElementRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
+
+  return <div ref={nativeElementRef} {...rest} className={classString} />;
+});
 
 if (process.env.NODE_ENV !== 'production') {
   CardGrid.displayName = 'CardGrid';

--- a/components/card/__tests__/index.test.tsx
+++ b/components/card/__tests__/index.test.tsx
@@ -138,6 +138,13 @@ describe('Card', () => {
     expect(cardRef.current).toHaveClass('ant-card');
   });
 
+  it('should support Card.Grid nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Card.Grid>>();
+    const { container } = render(<Card.Grid ref={ref}>Grid</Card.Grid>);
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-card-grid'));
+  });
+
   it('should show tab when tabList is empty', () => {
     const { container } = render(
       <Card title="Card title" tabList={[]} tabProps={{ type: 'editable-card' }}>

--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -4,6 +4,7 @@ import CardMeta from './CardMeta';
 
 export type { CardProps, CardTabListType } from './Card';
 export type { CardGridProps } from './CardGrid';
+export type { CardGridRef } from './CardGrid';
 export type { CardMetaProps } from './CardMeta';
 
 type InternalCardType = typeof InternalCard;

--- a/components/index.ts
+++ b/components/index.ts
@@ -29,6 +29,7 @@ export { default as Calendar } from './calendar';
 export type { CalendarMode, CalendarProps } from './calendar';
 export { default as Card } from './card';
 export type { CardProps } from './card';
+export type { CardGridRef } from './card';
 export type { CardMetaProps } from './card/CardMeta';
 export { default as Carousel } from './carousel';
 export type { CarouselProps } from './carousel';


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `Card.Grid`.
- Exports the new ref type through the card entry and package entry.
- Adds only the `Card.Grid` ref test from the shared card test file.

Validation:
- `git diff --check`