### PR TITLE
fix(card): support Card.Meta nativeElement ref

### DIFF
--- a/components/card/CardMeta.tsx
+++ b/components/card/CardMeta.tsx
@@ -35,7 +35,11 @@ export interface CardMetaProps {
   styles?: CardMetaSemanticAllType['stylesAndFn'];
 }
 
-const CardMeta: React.FC<CardMetaProps> = (props) => {
+export interface CardMetaRef {
+  nativeElement: HTMLDivElement;
+}
+
+const CardMeta = React.forwardRef<CardMetaRef, CardMetaProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
     className,
@@ -110,13 +114,19 @@ const CardMeta: React.FC<CardMetaProps> = (props) => {
       </div>
     ) : null;
 
+  const nativeElementRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
+
   return (
-    <div {...restProps} className={rootClassNames} style={rootStyles}>
+    <div ref={nativeElementRef} {...restProps} className={rootClassNames} style={rootStyles}>
       {avatarDom}
       {MetaDetail}
     </div>
   );
-};
+});
 
 if (process.env.NODE_ENV !== 'production') {
   CardMeta.displayName = 'CardMeta';

--- a/components/card/__tests__/index.test.tsx
+++ b/components/card/__tests__/index.test.tsx
@@ -149,6 +149,13 @@ describe('Card', () => {
     expect(container.querySelector('.ant-tabs-nav-add')).toBeTruthy();
   });
 
+  it('should support Card.Meta nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Card.Meta>>();
+    const { container } = render(<Card.Meta ref={ref} title="Title" />);
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-card-meta'));
+  });
+
   it('correct pass tabList props', () => {
     const { container } = render(
       <Card

--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -5,6 +5,7 @@ import CardMeta from './CardMeta';
 export type { CardProps, CardTabListType } from './Card';
 export type { CardGridProps } from './CardGrid';
 export type { CardMetaProps } from './CardMeta';
+export type { CardMetaRef } from './CardMeta';
 
 type InternalCardType = typeof InternalCard;
 

--- a/components/index.ts
+++ b/components/index.ts
@@ -30,6 +30,7 @@ export type { CalendarMode, CalendarProps } from './calendar';
 export { default as Card } from './card';
 export type { CardProps } from './card';
 export type { CardMetaProps } from './card/CardMeta';
+export type { CardMetaRef } from './card/CardMeta';
 export { default as Carousel } from './carousel';
 export type { CarouselProps } from './carousel';
 export { default as Cascader } from './cascader';


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `Card.Meta`.
- Exports the new ref type through the card entry and package entry.
- Adds only the `Card.Meta` ref test from the shared card test file.

Validation:
- `git diff --check`