### PR TITLE
fix(descriptions): support nativeElement ref

### DIFF
--- a/components/descriptions/__tests__/index.test.tsx
+++ b/components/descriptions/__tests__/index.test.tsx
@@ -23,6 +23,15 @@ describe('Descriptions', () => {
     errorSpy.mockRestore();
   });
 
+  it('should support nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Descriptions>>();
+    const { container } = render(
+      <Descriptions ref={ref} items={[{ key: 'name', label: 'Name', children: 'Ant Design' }]} />,
+    );
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-descriptions'));
+  });
+
   it('when max-width: 575px, column=1', () => {
     const wrapper = render(
       <Descriptions>

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -90,7 +90,11 @@ export interface DescriptionsProps extends Omit<React.HTMLAttributes<HTMLDivElem
   items?: DescriptionsItemType[];
 }
 
-const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) => {
+export interface DescriptionsRef {
+  nativeElement: HTMLDivElement;
+}
+
+const Descriptions = React.forwardRef<DescriptionsRef, DescriptionsProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
     title,
@@ -199,9 +203,16 @@ const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) 
     ],
   );
 
+  const nativeElementRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
+
   return (
     <DescriptionsContext.Provider value={memoizedValue}>
       <div
+        ref={nativeElementRef}
         className={clsx(
           prefixCls,
           contextClassName,
@@ -263,7 +274,8 @@ const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) 
       </div>
     </DescriptionsContext.Provider>
   );
-};
+}) as React.ForwardRefExoticComponent<DescriptionsProps & React.RefAttributes<DescriptionsRef>> &
+  CompoundedComponent;
 
 if (process.env.NODE_ENV !== 'production') {
   Descriptions.displayName = 'Descriptions';

--- a/components/index.ts
+++ b/components/index.ts
@@ -53,7 +53,7 @@ export type { ConfigProviderProps, ThemeConfig } from './config-provider';
 export { default as DatePicker } from './date-picker';
 export type { DatePickerProps } from './date-picker';
 export { default as Descriptions } from './descriptions';
-export type { DescriptionsProps } from './descriptions';
+export type { DescriptionsProps, DescriptionsRef } from './descriptions';
 export { default as Divider } from './divider';
 export type { DividerProps } from './divider';
 export { default as Drawer } from './drawer';


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `Descriptions`.
- Exports the new ref type through the descriptions entry and package entry.
- Adds component-level ref coverage.

Validation:
- `git diff --check`