### PR TITLE
fix(divider): support nativeElement ref

### DIFF
--- a/components/divider/__tests__/index.test.tsx
+++ b/components/divider/__tests__/index.test.tsx
@@ -10,6 +10,13 @@ import ConfigProvider from '../../config-provider';
 describe('Divider', () => {
   mountTest(Divider);
 
+  it('should support nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Divider>>();
+    const { container } = render(<Divider ref={ref} />);
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-divider'));
+  });
+
   it('not show children when vertical', () => {
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -61,7 +61,11 @@ export interface DividerProps {
   styles?: DividerSemanticAllType['stylesAndFn'];
 }
 
-const Divider: React.FC<DividerProps> = (props) => {
+export interface DividerRef {
+  nativeElement: HTMLDivElement;
+}
+
+const Divider = React.forwardRef<DividerRef, DividerProps>((props, ref) => {
   const {
     getPrefixCls,
     direction,
@@ -178,6 +182,12 @@ const Divider: React.FC<DividerProps> = (props) => {
     marginInlineEnd: hasMarginEnd ? memoizedPlacementMargin : undefined,
   };
 
+  const nativeElementRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
+
   // =================== Warning =====================
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('Divider');
@@ -198,6 +208,7 @@ const Divider: React.FC<DividerProps> = (props) => {
 
   return (
     <div
+      ref={nativeElementRef}
       className={classString}
       style={{
         ...mergedStyles.root,
@@ -227,7 +238,7 @@ const Divider: React.FC<DividerProps> = (props) => {
       )}
     </div>
   );
-};
+});
 
 if (process.env.NODE_ENV !== 'production') {
   Divider.displayName = 'Divider';

--- a/components/index.ts
+++ b/components/index.ts
@@ -55,7 +55,7 @@ export type { DatePickerProps } from './date-picker';
 export { default as Descriptions } from './descriptions';
 export type { DescriptionsProps } from './descriptions';
 export { default as Divider } from './divider';
-export type { DividerProps } from './divider';
+export type { DividerProps, DividerRef } from './divider';
 export { default as Drawer } from './drawer';
 export type { DrawerProps } from './drawer';
 export { default as Dropdown } from './dropdown';


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `Divider`.
- Exports the new ref type through the divider entry and package entry.
- Adds component-level ref coverage.

Validation:
- `git diff --check`