### PR TITLE
fix(empty): support nativeElement ref

### DIFF
--- a/components/empty/__tests__/index.test.tsx
+++ b/components/empty/__tests__/index.test.tsx
@@ -11,6 +11,13 @@ describe('Empty', () => {
   mountTest(Empty);
   rtlTest(Empty);
 
+  it('should support nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Empty>>();
+    const { container } = render(<Empty ref={ref} />);
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-empty'));
+  });
+
   it('image size should change', () => {
     const { container } = render(<Empty styles={{ image: { height: 20 } }} />);
     expect(container.querySelector<HTMLDivElement>('.ant-empty-image')).toHaveStyle({

--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -48,12 +48,18 @@ export interface EmptyProps {
   styles?: EmptySemanticAllType['stylesAndFn'];
 }
 
-type CompoundedComponent = React.FC<EmptyProps> & {
+export interface EmptyRef {
+  nativeElement: HTMLDivElement;
+}
+
+type CompoundedComponent = React.ForwardRefExoticComponent<
+  EmptyProps & React.RefAttributes<EmptyRef>
+> & {
   PRESENTED_IMAGE_DEFAULT: React.ReactNode;
   PRESENTED_IMAGE_SIMPLE: React.ReactNode;
 };
 
-const Empty: CompoundedComponent = (props) => {
+const Empty = React.forwardRef<EmptyRef, EmptyProps>((props, ref) => {
   const {
     className,
     rootClassName,
@@ -116,8 +122,15 @@ const Empty: CompoundedComponent = (props) => {
     });
   }
 
+  const nativeElementRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
+
   return (
     <div
+      ref={nativeElementRef}
       className={clsx(
         hashId,
         cssVarCls,
@@ -158,7 +171,7 @@ const Empty: CompoundedComponent = (props) => {
       )}
     </div>
   );
-};
+}) as CompoundedComponent;
 
 Empty.PRESENTED_IMAGE_DEFAULT = defaultEmptyImg;
 Empty.PRESENTED_IMAGE_SIMPLE = simpleEmptyImg;

--- a/components/index.ts
+++ b/components/index.ts
@@ -67,7 +67,7 @@ export type {
   DropdownProps,
 } from './dropdown';
 export { default as Empty } from './empty';
-export type { EmptyProps } from './empty';
+export type { EmptyProps, EmptyRef } from './empty';
 export { default as Flex } from './flex';
 export type { FlexProps } from './flex/interface';
 export { default as FloatButton } from './float-button';


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `Empty`.
- Exports the new ref type through the empty entry and package entry.
- Adds component-level ref coverage.

Validation:
- `git diff --check`