### PR TITLE
fix(float-button): support FloatButton.Group nativeElement ref

### DIFF
--- a/components/float-button/FloatButtonGroup.tsx
+++ b/components/float-button/FloatButtonGroup.tsx
@@ -64,7 +64,14 @@ export interface FloatButtonGroupProps extends Omit<FloatButtonProps, 'className
   placement?: 'top' | 'left' | 'right' | 'bottom';
 }
 
-const FloatButtonGroup: React.FC<Readonly<FloatButtonGroupProps>> = (props) => {
+export interface FloatButtonGroupRef {
+  nativeElement: HTMLDivElement;
+}
+
+const InternalFloatButtonGroup = (
+  props: Readonly<FloatButtonGroupProps>,
+  ref: React.ForwardedRef<FloatButtonGroupRef>,
+) => {
   const {
     prefixCls: customizePrefixCls,
     className,
@@ -116,6 +123,10 @@ const FloatButtonGroup: React.FC<Readonly<FloatButtonGroupProps>> = (props) => {
 
   // ============================= Refs =============================
   const floatButtonGroupRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: floatButtonGroupRef.current!,
+  }));
 
   // ========================== Placement ==========================
   const mergedPlacement = ['top', 'left', 'right', 'bottom'].includes(placement!)
@@ -327,5 +338,7 @@ const FloatButtonGroup: React.FC<Readonly<FloatButtonGroupProps>> = (props) => {
     </GroupContext.Provider>
   );
 };
+
+const FloatButtonGroup = React.forwardRef(InternalFloatButtonGroup);
 
 export default FloatButtonGroup;

--- a/components/float-button/__tests__/group.test.tsx
+++ b/components/float-button/__tests__/group.test.tsx
@@ -6,6 +6,17 @@ import { fireEvent, render } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
 
 describe('FloatButtonGroup', () => {
+  it('should support nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof FloatButton.Group>>();
+    const { container } = render(
+      <FloatButton.Group ref={ref}>
+        <FloatButton />
+      </FloatButton.Group>,
+    );
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-float-btn-group'));
+  });
+
   it('should correct render', () => {
     const { container } = render(
       <FloatButton.Group>

--- a/components/float-button/index.tsx
+++ b/components/float-button/index.tsx
@@ -4,7 +4,7 @@ import FloatButtonGroup from './FloatButtonGroup';
 import PurePanel from './PurePanel';
 
 export type { FloatButtonProps, FloatButtonRef } from './FloatButton';
-export type { FloatButtonGroupProps } from './FloatButtonGroup';
+export type { FloatButtonGroupProps, FloatButtonGroupRef } from './FloatButtonGroup';
 
 FloatButton.BackTop = BackTop;
 FloatButton.Group = FloatButtonGroup;

--- a/components/index.ts
+++ b/components/index.ts
@@ -71,7 +71,12 @@ export type { EmptyProps } from './empty';
 export { default as Flex } from './flex';
 export type { FlexProps } from './flex/interface';
 export { default as FloatButton } from './float-button';
-export type { FloatButtonGroupProps, FloatButtonProps, FloatButtonRef } from './float-button';
+export type {
+  FloatButtonGroupProps,
+  FloatButtonGroupRef,
+  FloatButtonProps,
+  FloatButtonRef,
+} from './float-button';
 export { default as Form } from './form';
 export type {
   FormInstance,


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `FloatButton.Group`.
- Exports the new ref type through the float-button entry and package entry.
- Adds component-level ref coverage.

Validation:
- `git diff --check`