### PR TITLE
fix(list): support List.Item.Meta nativeElement ref

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -91,7 +91,7 @@ export type { InputNumberProps } from './input-number';
 export { default as Layout } from './layout';
 export type { LayoutProps, SiderProps } from './layout';
 export { default as List } from './list';
-export type { ListProps } from './list';
+export type { ListItemMetaRef, ListProps } from './list';
 export { default as Masonry } from './masonry';
 export type { MasonryProps } from './masonry';
 export { default as Mentions } from './mentions';

--- a/components/list/Item.tsx
+++ b/components/list/Item.tsx
@@ -43,21 +43,25 @@ export interface ListItemMetaProps {
   title?: ReactNode;
 }
 
+export interface ListItemMetaRef {
+  nativeElement: HTMLDivElement;
+}
+
 type ListItemClassNamesModule = keyof Exclude<ListItemProps['classNames'], undefined>;
 type ListItemStylesModule = keyof Exclude<ListItemProps['styles'], undefined>;
 
-export const Meta: React.FC<ListItemMetaProps> = ({
-  prefixCls: customizePrefixCls,
-  className,
-  avatar,
-  title,
-  description,
-  ...others
-}) => {
+export const Meta = React.forwardRef<ListItemMetaRef, ListItemMetaProps>((props, ref) => {
+  const { prefixCls: customizePrefixCls, className, avatar, title, description, ...others } = props;
   const { getPrefixCls } = useContext(ConfigContext);
 
   const prefixCls = getPrefixCls('list', customizePrefixCls);
   const classString = clsx(`${prefixCls}-item-meta`, className);
+
+  const nativeElementRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
 
   const content = (
     <div className={`${prefixCls}-item-meta-content`}>
@@ -67,12 +71,12 @@ export const Meta: React.FC<ListItemMetaProps> = ({
   );
 
   return (
-    <div {...others} className={classString}>
+    <div ref={nativeElementRef} {...others} className={classString}>
       {avatar && <div className={`${prefixCls}-item-meta-avatar`}>{avatar}</div>}
       {(title || description) && content}
     </div>
   );
-};
+});
 
 const InternalItem = React.forwardRef<HTMLDivElement, ListItemProps>((props, ref) => {
   const {

--- a/components/list/__tests__/Item.test.tsx
+++ b/components/list/__tests__/Item.test.tsx
@@ -20,6 +20,13 @@ describe('List Item Layout', () => {
     },
   ];
 
+  it('should support List.Item.Meta nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof List.Item.Meta>>();
+    const { container } = render(<List.Item.Meta ref={ref} title="Title" />);
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-list-item-meta'));
+  });
+
   it('horizontal itemLayout List which contains string nodes should not be flex container', () => {
     const { container } = render(
       <List

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -24,6 +24,7 @@ import useStyle from './style';
 export type { ListConsumerProps } from './context';
 export type {
   ListItemMetaProps,
+  ListItemMetaRef,
   ListItemProps,
   ListItemSemanticClassNames,
   ListItemSemanticName,


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `List.Item.Meta`.
- Exports the new ref type through the list entry and package entry.
- Adds component-level ref coverage.

Validation:
- `git diff --check`