### PR TITLE
fix(result): support nativeElement ref

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -119,7 +119,7 @@ export type { RadioChangeEvent, RadioGroupProps, RadioProps } from './radio';
 export { default as Rate } from './rate';
 export type { RateProps } from './rate';
 export { default as Result } from './result';
-export type { ResultProps } from './result';
+export type { ResultProps, ResultRef } from './result';
 export { default as Row } from './row';
 export type { RowProps } from './row';
 export { default as Segmented } from './segmented';

--- a/components/result/__tests__/index.test.tsx
+++ b/components/result/__tests__/index.test.tsx
@@ -31,6 +31,13 @@ describe('Result', () => {
   mountTest(Result);
   rtlTest(Result);
 
+  it('should support nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Result>>();
+    const { container } = render(<Result ref={ref} />);
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-result'));
+  });
+
   it('🙂  successPercent should decide the progress status when it exists', () => {
     const { container } = render(
       <Result

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -70,6 +70,10 @@ export interface ResultProps extends HTMLAriaDataAttributes {
   styles?: ResultSemanticAllType['stylesAndFn'];
 }
 
+export interface ResultRef {
+  nativeElement: HTMLDivElement;
+}
+
 // ExceptionImageMap keys
 const ExceptionStatus = Object.keys(ExceptionMap);
 
@@ -138,13 +142,14 @@ const Extra: React.FC<ExtraProps> = ({ className, extra, style }) => {
   );
 };
 
-export interface ResultType extends React.FC<ResultProps> {
+export interface ResultType
+  extends React.ForwardRefExoticComponent<ResultProps & React.RefAttributes<ResultRef>> {
   PRESENTED_IMAGE_404: React.FC;
   PRESENTED_IMAGE_403: React.FC;
   PRESENTED_IMAGE_500: React.FC;
 }
 
-const Result: ResultType = (props) => {
+const Result = React.forwardRef<ResultRef, ResultProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
     className: customizeClassName,
@@ -224,8 +229,14 @@ const Result: ResultType = (props) => {
 
   const restProps = pickAttrs(rest, { aria: true, data: true });
 
+  const nativeElementRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
+
   return (
-    <div {...restProps} className={rootClassNames} style={rootStyles}>
+    <div ref={nativeElementRef} {...restProps} className={rootClassNames} style={rootStyles}>
       <Icon className={iconClassNames} style={mergedStyles.icon} status={status} icon={icon} />
       {isReactRenderable(title) && (
         <div className={titleClassNames} style={mergedStyles.title}>
@@ -245,7 +256,7 @@ const Result: ResultType = (props) => {
       )}
     </div>
   );
-};
+}) as ResultType;
 
 Result.PRESENTED_IMAGE_403 = ExceptionMap['403'];
 Result.PRESENTED_IMAGE_404 = ExceptionMap['404'];


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `Result`.
- Exports the new ref type through the result entry and package entry.
- Adds component-level ref coverage.

Validation:
- `git diff --check`