### PR TITLE
fix(space): support Compact nativeElement ref

### DIFF
--- a/components/space/Compact.tsx
+++ b/components/space/Compact.tsx
@@ -64,6 +64,10 @@ export interface SpaceCompactProps extends React.HTMLAttributes<HTMLDivElement> 
   rootClassName?: string;
 }
 
+export interface SpaceCompactRef {
+  nativeElement: HTMLDivElement;
+}
+
 const CompactItem: React.FC<React.PropsWithChildren<SpaceCompactItemContextType>> = (props) => {
   const { children, ...others } = props;
   return (
@@ -75,7 +79,7 @@ const CompactItem: React.FC<React.PropsWithChildren<SpaceCompactItemContextType>
   );
 };
 
-const Compact: React.FC<SpaceCompactProps> = (props) => {
+const Compact = React.forwardRef<SpaceCompactRef, SpaceCompactProps>((props, ref) => {
   const { getPrefixCls, direction: directionConfig } = React.useContext(ConfigContext);
 
   const {
@@ -116,6 +120,12 @@ const Compact: React.FC<SpaceCompactProps> = (props) => {
 
   const compactItemContext = React.useContext(SpaceCompactItemContext);
 
+  const nativeElementRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
+
   const childNodes = toArray(children);
 
   const nodes = React.useMemo(
@@ -145,10 +155,10 @@ const Compact: React.FC<SpaceCompactProps> = (props) => {
   }
 
   return (
-    <div className={clx} {...restProps}>
+    <div ref={nativeElementRef} className={clx} {...restProps}>
       {nodes}
     </div>
   );
-};
+});
 
 export default Compact;

--- a/components/space/__tests__/space-compact.test.tsx
+++ b/components/space/__tests__/space-compact.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Space from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import { render } from '../../../tests/utils';
+import { fireEvent, render } from '../../../tests/utils';
 import AutoComplete from '../../auto-complete';
 import Button from '../../button';
 import Cascader from '../../cascader';
@@ -14,6 +14,7 @@ import Dropdown from '../../dropdown';
 import Input from '../../input';
 import InputNumber from '../../input-number';
 import Modal from '../../modal';
+import Popover from '../../popover';
 import Select from '../../select';
 import TimePicker from '../../time-picker';
 import Tooltip from '../../tooltip';
@@ -38,6 +39,30 @@ describe('Space.Compact', () => {
     const { container } = render(<Space.Compact />);
 
     expect(container.children.length).toBe(0);
+  });
+
+  it('should ref work', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Space.Compact>>();
+    const { container } = render(
+      <Space.Compact ref={ref}>
+        <Input />
+      </Space.Compact>,
+    );
+
+    expect(ref.current?.nativeElement).toBe(container.firstChild);
+  });
+
+  it('should work as Popover trigger', () => {
+    const { container } = render(
+      <Popover trigger="click" content="123">
+        <Space.Compact>
+          <Input />
+        </Space.Compact>
+      </Popover>,
+    );
+
+    fireEvent.click(container.querySelector('.ant-space-compact')!);
+    expect(document.body.querySelector('.ant-popover')).toBeTruthy();
   });
 
   it('block className', () => {


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `Space.Compact`.
- Adds direct ref coverage for `Space.Compact`.
- Adds the Popover trigger regression coverage for `Space.Compact`.

Validation:
- `git diff --check`