### PR TITLE
fix(spin): support nativeElement ref

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -133,7 +133,7 @@ export type { SliderSingleProps } from './slider';
 export { default as Space } from './space';
 export type { SpaceProps } from './space';
 export { default as Spin } from './spin';
-export type { SpinProps } from './spin';
+export type { SpinProps, SpinRef } from './spin';
 export { default as Splitter } from './splitter';
 export type { SplitterProps } from './splitter';
 export { default as Statistic } from './statistic';

--- a/components/spin/__tests__/index.test.tsx
+++ b/components/spin/__tests__/index.test.tsx
@@ -19,6 +19,13 @@ describe('Spin', () => {
   mountTest(Spin);
   rtlTest(Spin);
 
+  it('should support nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Spin>>();
+    const { container } = render(<Spin ref={ref} />);
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-spin'));
+  });
+
   it('should only affect the spin element when set style to a nested <Spin>xx</Spin>', () => {
     const { container } = render(
       <Spin style={{ padding: 20 }}>

--- a/components/spin/index.tsx
+++ b/components/spin/index.tsx
@@ -75,7 +75,11 @@ export interface SpinProps {
   styles?: SpinSemanticAllType['stylesAndFn'];
 }
 
-export type SpinType = React.FC<SpinProps> & {
+export interface SpinRef {
+  nativeElement: HTMLDivElement;
+}
+
+export type SpinType = React.ForwardRefExoticComponent<SpinProps & React.RefAttributes<SpinRef>> & {
   setDefaultIndicator: (indicator: React.ReactNode) => void;
 };
 
@@ -86,7 +90,7 @@ function shouldDelay(spinning?: boolean, delay?: number): boolean {
   return !!spinning && !!delay && !Number.isNaN(Number(delay));
 }
 
-const Spin: SpinType = (props) => {
+const Spin = React.forwardRef<SpinRef, SpinProps>((props, ref) => {
   const {
     prefixCls: customizePrefixCls,
     spinning: customSpinning = true,
@@ -224,8 +228,15 @@ const Spin: SpinType = (props) => {
     </>
   );
 
+  const nativeElementRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
+
   return (
     <div
+      ref={nativeElementRef}
       className={clsx(
         prefixCls,
         {
@@ -278,7 +289,7 @@ const Spin: SpinType = (props) => {
       )}
     </div>
   );
-};
+}) as SpinType;
 
 Spin.setDefaultIndicator = (indicator: React.ReactNode) => {
   defaultIndicator = indicator;


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `Spin`.
- Exports the new ref type through the spin entry and package entry.
- Adds component-level ref coverage.

Validation:
- `git diff --check`