### PR TITLE
fix(splitter): support nativeElement ref

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -135,7 +135,7 @@ export type { SpaceProps } from './space';
 export { default as Spin } from './spin';
 export type { SpinProps } from './spin';
 export { default as Splitter } from './splitter';
-export type { SplitterProps } from './splitter';
+export type { SplitterProps, SplitterRef } from './splitter';
 export { default as Statistic } from './statistic';
 export type { CountdownProps, StatisticProps, StatisticTimerProps } from './statistic';
 export { default as Steps } from './steps';

--- a/components/splitter/Splitter.tsx
+++ b/components/splitter/Splitter.tsx
@@ -20,7 +20,14 @@ import { InternalPanel } from './Panel';
 import SplitBar from './SplitBar';
 import useStyle from './style';
 
-const Splitter: React.FC<React.PropsWithChildren<SplitterProps>> = (props) => {
+export interface SplitterRef {
+  nativeElement: HTMLDivElement;
+}
+
+const InternalSplitter = (
+  props: React.PropsWithChildren<SplitterProps>,
+  ref: React.ForwardedRef<SplitterRef>,
+) => {
   const {
     prefixCls: customizePrefixCls,
     className,
@@ -188,6 +195,12 @@ const Splitter: React.FC<React.PropsWithChildren<SplitterProps>> = (props) => {
     hashId,
   );
 
+  const nativeElementRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
+
   // ======================== Render ========================
   const maskCls = `${prefixCls}-mask`;
 
@@ -206,7 +219,7 @@ const Splitter: React.FC<React.PropsWithChildren<SplitterProps>> = (props) => {
 
   return (
     <ResizeObserver onResize={onContainerResize}>
-      <div style={mergedStyles.root} className={containerClassName}>
+      <div ref={nativeElementRef} style={mergedStyles.root} className={containerClassName}>
         {items.map((item, idx) => {
           const panelProps = {
             ...item,
@@ -287,6 +300,8 @@ const Splitter: React.FC<React.PropsWithChildren<SplitterProps>> = (props) => {
     </ResizeObserver>
   );
 };
+
+const Splitter = React.forwardRef(InternalSplitter);
 
 if (process.env.NODE_ENV !== 'production') {
   Splitter.displayName = 'Splitter';

--- a/components/splitter/__tests__/index.test.tsx
+++ b/components/splitter/__tests__/index.test.tsx
@@ -75,6 +75,18 @@ describe('Splitter', () => {
     jest.useRealTimers();
   });
 
+  it('should support nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Splitter>>();
+    const { container } = render(
+      <Splitter ref={ref}>
+        <Splitter.Panel>First</Splitter.Panel>
+        <Splitter.Panel>Second</Splitter.Panel>
+      </Splitter>,
+    );
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-splitter'));
+  });
+
   it('should correct render', () => {
     const { container } = render(<SplitterDemo />);
     expect(container.querySelector('.ant-splitter')).toBeTruthy();

--- a/components/splitter/index.tsx
+++ b/components/splitter/index.tsx
@@ -2,6 +2,7 @@ import Panel from './Panel';
 import SplitterComp from './Splitter';
 
 export type { SplitterProps } from './interface';
+export type { SplitterRef } from './Splitter';
 
 type CompoundedComponent = typeof SplitterComp & {
   Panel: typeof Panel;


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `Splitter`.
- Exports the new ref type through the splitter entry and package entry.
- Adds component-level ref coverage.

Validation:
- `git diff --check`