### PR TITLE
fix(transfer): support nativeElement ref

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -166,7 +166,7 @@ export type { TooltipProps } from './tooltip';
 export { default as Tour } from './tour';
 export type { TourProps, TourStepProps } from './tour/interface';
 export { default as Transfer } from './transfer';
-export type { TransferProps } from './transfer';
+export type { TransferProps, TransferRef } from './transfer';
 export { default as Tree } from './tree';
 export type {
   DataNode as TreeDataNode,

--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -102,6 +102,13 @@ describe('Transfer', () => {
   mountTest(Transfer);
   rtlTest(Transfer);
 
+  it('should support nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Transfer>>();
+    const { container } = render(<Transfer ref={ref} dataSource={[]} targetKeys={[]} />);
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-transfer'));
+  });
+
   it('should render correctly', () => {
     const wrapper = render(<Transfer {...listCommonProps} />);
     expect(wrapper.container.firstChild).toMatchSnapshot();

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -141,10 +141,8 @@ export interface TransferSearchOption {
   defaultValue?: string;
 }
 
-export interface TransferProps<RecordType = any> extends Omit<
-  React.HTMLAttributes<HTMLDivElement>,
-  'onChange' | 'onScroll' | 'children'
-> {
+export interface TransferProps<RecordType = any>
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'onScroll' | 'children'> {
   prefixCls?: string;
   className?: string;
   rootClassName?: string;
@@ -191,8 +189,13 @@ export interface TransferProps<RecordType = any> extends Omit<
   selectionsIcon?: React.ReactNode;
 }
 
-const Transfer = <RecordType extends TransferItem = TransferItem>(
+export interface TransferRef {
+  nativeElement: HTMLDivElement;
+}
+
+const InternalTransfer = <RecordType extends TransferItem = TransferItem>(
   props: TransferProps<RecordType>,
+  ref: React.ForwardedRef<TransferRef>,
 ) => {
   const {
     prefixCls: customizePrefixCls,
@@ -595,6 +598,12 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
     data: true,
   });
 
+  const nativeElementRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
+
   // ===================== Warning ======================
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('Transfer');
@@ -612,7 +621,7 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
 
   // ====================== Render ======================
   return (
-    <div {...rootProps} className={cls} style={mergedStyles.root}>
+    <div ref={nativeElementRef} {...rootProps} className={cls} style={mergedStyles.root}>
       <Section<KeyWise<RecordType>>
         prefixCls={prefixCls}
         style={handleListStyle('left')}
@@ -685,6 +694,19 @@ const Transfer = <RecordType extends TransferItem = TransferItem>(
     </div>
   );
 };
+
+const Transfer = React.forwardRef(InternalTransfer) as unknown as (<
+  RecordType extends TransferItem = TransferItem,
+>(
+  props: TransferProps<RecordType> & {
+    ref?: React.ForwardedRef<TransferRef>;
+  },
+) => ReturnType<typeof InternalTransfer>) &
+  Pick<React.FC, 'displayName'> & {
+    List: typeof Section;
+    Search: typeof Search;
+    Operation: typeof Actions;
+  };
 
 if (process.env.NODE_ENV !== 'production') {
   Transfer.displayName = 'Transfer';


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `Transfer`.
- Exports the new ref type through the transfer entry and package entry.
- Adds component-level ref coverage.

Validation:
- `git diff --check`