### PR TITLE
fix(watermark): support nativeElement ref

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -181,7 +181,13 @@ export { default as Upload } from './upload';
 export type { DraggerProps, UploadFile, UploadProps } from './upload';
 export { default as version } from './version';
 export { default as Watermark } from './watermark';
-export type { WatermarkContent, WatermarkFont, WatermarkProps, WatermarkText } from './watermark';
+export type {
+  WatermarkContent,
+  WatermarkFont,
+  WatermarkProps,
+  WatermarkRef,
+  WatermarkText,
+} from './watermark';
 
 export const unstableSetRender: any = () => {
   warning(

--- a/components/watermark/__tests__/index.test.tsx
+++ b/components/watermark/__tests__/index.test.tsx
@@ -33,6 +33,15 @@ describe('Watermark', () => {
     mockSrcSet.mockRestore();
   });
 
+  it('should support nativeElement ref', () => {
+    const ref = React.createRef<React.ComponentRef<typeof Watermark>>();
+    const { container } = render(
+      <Watermark ref={ref} className="watermark-ref" content="Ant Design" />,
+    );
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.watermark-ref'));
+  });
+
   it('The watermark should render successfully', () => {
     const { container } = render(<Watermark className="watermark" content="Ant Design" />);
     expect(container.querySelector('.watermark div')).toBeTruthy();

--- a/components/watermark/index.tsx
+++ b/components/watermark/index.tsx
@@ -50,6 +50,10 @@ export interface WatermarkProps {
   onRemove?: () => void;
 }
 
+export interface WatermarkRef {
+  nativeElement: HTMLDivElement;
+}
+
 /**
  * Only return `next` when size changed.
  * This is only used for elements compare, not a shallow equal!
@@ -67,7 +71,7 @@ const fixedStyle: React.CSSProperties = {
   overflow: 'hidden',
 };
 
-const Watermark: React.FC<WatermarkProps> = (props) => {
+const Watermark = React.forwardRef<WatermarkRef, WatermarkProps>((props, ref) => {
   const {
     zIndex,
     rotate = -22,
@@ -160,6 +164,16 @@ const Watermark: React.FC<WatermarkProps> = (props) => {
   }, [mergedZIndex, offsetLeft, gapXCenter, offsetTop, gapYCenter]);
 
   const [container, setContainer] = React.useState<HTMLDivElement | null>();
+  const nativeElementRef = React.useRef<HTMLDivElement>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
+
+  const setContainerRef = React.useCallback((node: HTMLDivElement | null) => {
+    nativeElementRef.current = node;
+    setContainer(node);
+  }, []);
 
   // Used for nest case like Modal, Drawer
   const [subElements, setSubElements] = React.useState(() => new Set<HTMLElement>());
@@ -334,14 +348,14 @@ const Watermark: React.FC<WatermarkProps> = (props) => {
 
   return (
     <div
-      ref={setContainer}
+      ref={setContainerRef}
       className={clsx(className, contextClassName, rootClassName)}
       style={mergedStyle}
     >
       {childNode}
     </div>
   );
-};
+});
 
 if (process.env.NODE_ENV !== 'production') {
   Watermark.displayName = 'Watermark';

--- a/components/watermark/index.tsx
+++ b/components/watermark/index.tsx
@@ -163,7 +163,7 @@ const Watermark = React.forwardRef<WatermarkRef, WatermarkProps>((props, ref) =>
     return mergedMarkStyle;
   }, [mergedZIndex, offsetLeft, gapXCenter, offsetTop, gapYCenter]);
 
-  const [container, setContainer] = React.useState<HTMLDivElement | null>(null);
+  const [container, setContainer] = React.useState<HTMLDivElement | null>();
 
   const nativeElementRef = React.useRef<HTMLDivElement>(null);
 

--- a/components/watermark/index.tsx
+++ b/components/watermark/index.tsx
@@ -164,17 +164,18 @@ const Watermark = React.forwardRef<WatermarkRef, WatermarkProps>((props, ref) =>
   }, [mergedZIndex, offsetLeft, gapXCenter, offsetTop, gapYCenter]);
 
   const [container, setContainer] = React.useState<HTMLDivElement | null>(null);
+
   const nativeElementRef = React.useRef<HTMLDivElement>(null);
 
-  React.useImperativeHandle(
-    ref,
-    () => ({
-      nativeElement: nativeElementRef.current!,
-    }),
-    [container],
-  );
+  React.useImperativeHandle(ref, () => ({
+    nativeElement: nativeElementRef.current!,
+  }));
 
-  const setContainerRef = useComposeRef(nativeElementRef, setContainer);
+  const setContainerRef = React.useCallback((node: HTMLDivElement) => {
+    setContainer(node);
+  }, []);
+
+  const mergedRef = useComposeRef(nativeElementRef, setContainerRef);
 
   // Used for nest case like Modal, Drawer
   const [subElements, setSubElements] = React.useState(() => new Set<HTMLElement>());
@@ -349,7 +350,7 @@ const Watermark = React.forwardRef<WatermarkRef, WatermarkProps>((props, ref) =>
 
   return (
     <div
-      ref={setContainerRef}
+      ref={mergedRef}
       className={clsx(className, contextClassName, rootClassName)}
       style={mergedStyle}
     >

--- a/components/watermark/index.tsx
+++ b/components/watermark/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useMutateObserver } from '@rc-component/mutate-observer';
-import { useEvent } from '@rc-component/util';
+import { useComposeRef, useEvent } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useComponentConfig } from '../config-provider/context';
@@ -163,17 +163,18 @@ const Watermark = React.forwardRef<WatermarkRef, WatermarkProps>((props, ref) =>
     return mergedMarkStyle;
   }, [mergedZIndex, offsetLeft, gapXCenter, offsetTop, gapYCenter]);
 
-  const [container, setContainer] = React.useState<HTMLDivElement | null>();
+  const [container, setContainer] = React.useState<HTMLDivElement | null>(null);
   const nativeElementRef = React.useRef<HTMLDivElement>(null);
 
-  React.useImperativeHandle(ref, () => ({
-    nativeElement: nativeElementRef.current!,
-  }));
+  React.useImperativeHandle(
+    ref,
+    () => ({
+      nativeElement: nativeElementRef.current!,
+    }),
+    [container],
+  );
 
-  const setContainerRef = React.useCallback((node: HTMLDivElement | null) => {
-    nativeElementRef.current = node;
-    setContainer(node);
-  }, []);
+  const setContainerRef = useComposeRef(nativeElementRef, setContainer);
 
   // Used for nest case like Modal, Drawer
   const [subElements, setSubElements] = React.useState(() => new Set<HTMLElement>());

--- a/components/watermark/index.tsx
+++ b/components/watermark/index.tsx
@@ -171,11 +171,7 @@ const Watermark = React.forwardRef<WatermarkRef, WatermarkProps>((props, ref) =>
     nativeElement: nativeElementRef.current!,
   }));
 
-  const setContainerRef = React.useCallback((node: HTMLDivElement) => {
-    setContainer(node);
-  }, []);
-
-  const mergedRef = useComposeRef(nativeElementRef, setContainerRef);
+  const mergedRef = useComposeRef<HTMLDivElement>(nativeElementRef, setContainer);
 
   // Used for nest case like Modal, Drawer
   const [subElements, setSubElements] = React.useState(() => new Set<HTMLElement>());


### PR DESCRIPTION
Extracted from #58627.

Changes:
- Adds `nativeElement` ref support for `Watermark`.
- Exports the new ref type through the watermark entry and package entry.
- Adds component-level ref coverage.

Validation:
- `git diff --check`