### PR TITLE
fix(Anchor): scroll active link into view for vertical direction

### DIFF
--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -224,7 +224,11 @@ const Anchor: React.FC<AnchorProps> = (props) => {
       inkStyle.height = horizontalAnchor ? '' : `${linkNode.clientHeight}px`;
       inkStyle.left = horizontalAnchor ? `${linkNode.offsetLeft}px` : '';
       inkStyle.width = horizontalAnchor ? `${linkNode.clientWidth}px` : '';
-      scrollIntoView(linkNode, { scrollMode: 'if-needed', block: 'nearest' });
+      scrollIntoView(linkNode, {
+        scrollMode: 'if-needed',
+        block: 'nearest',
+        boundary: wrapperRef.current?.parentElement,
+      });
     }
   };
 

--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -224,9 +224,7 @@ const Anchor: React.FC<AnchorProps> = (props) => {
       inkStyle.height = horizontalAnchor ? '' : `${linkNode.clientHeight}px`;
       inkStyle.left = horizontalAnchor ? `${linkNode.offsetLeft}px` : '';
       inkStyle.width = horizontalAnchor ? `${linkNode.clientWidth}px` : '';
-      if (horizontalAnchor) {
-        scrollIntoView(linkNode, { scrollMode: 'if-needed', block: 'nearest' });
-      }
+      scrollIntoView(linkNode, { scrollMode: 'if-needed', block: 'nearest' });
     }
   };
 

--- a/components/anchor/__tests__/Anchor.test.tsx
+++ b/components/anchor/__tests__/Anchor.test.tsx
@@ -871,6 +871,30 @@ describe('Anchor Render', () => {
     });
   });
 
+  describe('scroll active link into view', () => {
+    it('scrollIntoView should be called for vertical anchor', async () => {
+      const hash = getHashUrl();
+      const root = createDiv();
+      render(<h1 id={hash}>Hello</h1>, { container: root });
+      const { container } = render(
+        <Anchor
+          items={[
+            {
+              key: hash,
+              href: `#${hash}`,
+              title: hash,
+            },
+          ]}
+        />,
+      );
+
+      fireEvent.click(container.querySelector(`a[href="#${hash}"]`)!);
+      await waitFakeTimer();
+
+      expect(scrollIntoView).toHaveBeenCalled();
+    });
+  });
+
   describe('deprecated/legacy jsx syntax', () => {
     it('renders jsx correctly', () => {
       const hash = getHashUrl();

--- a/components/anchor/__tests__/Anchor.test.tsx
+++ b/components/anchor/__tests__/Anchor.test.tsx
@@ -891,7 +891,14 @@ describe('Anchor Render', () => {
       fireEvent.click(container.querySelector(`a[href="#${hash}"]`)!);
       await waitFakeTimer();
 
-      expect(scrollIntoView).toHaveBeenCalled();
+      expect(scrollIntoView).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          scrollMode: 'if-needed',
+          block: 'nearest',
+          boundary: expect.anything(),
+        }),
+      );
     });
   });
 

--- a/components/anchor/__tests__/Anchor.test.tsx
+++ b/components/anchor/__tests__/Anchor.test.tsx
@@ -31,7 +31,6 @@ describe('Anchor Render', () => {
     'getBoundingClientRect',
   );
   const getClientRectsMock = jest.spyOn(HTMLHeadingElement.prototype, 'getClientRects');
-  const scrollIntoViewMock = jest.createMockFromModule<any>('scroll-into-view-if-needed');
 
   beforeAll(() => {
     jest.useFakeTimers();
@@ -45,7 +44,6 @@ describe('Anchor Render', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
-    scrollIntoViewMock.mockReset();
   });
 
   afterEach(() => {
@@ -868,37 +866,6 @@ describe('Anchor Render', () => {
         </Anchor>,
       );
       expect(container.querySelectorAll('.ant-anchor-link').length).toBe(3);
-    });
-  });
-
-  describe('scroll active link into view', () => {
-    it('scrollIntoView should be called for vertical anchor', async () => {
-      const hash = getHashUrl();
-      const root = createDiv();
-      render(<h1 id={hash}>Hello</h1>, { container: root });
-      const { container } = render(
-        <Anchor
-          items={[
-            {
-              key: hash,
-              href: `#${hash}`,
-              title: hash,
-            },
-          ]}
-        />,
-      );
-
-      fireEvent.click(container.querySelector(`a[href="#${hash}"]`)!);
-      await waitFakeTimer();
-
-      expect(scrollIntoView).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          scrollMode: 'if-needed',
-          block: 'nearest',
-          boundary: expect.anything(),
-        }),
-      );
     });
   });
 

--- a/components/anchor/__tests__/Anchor.test.tsx
+++ b/components/anchor/__tests__/Anchor.test.tsx
@@ -31,6 +31,7 @@ describe('Anchor Render', () => {
     'getBoundingClientRect',
   );
   const getClientRectsMock = jest.spyOn(HTMLHeadingElement.prototype, 'getClientRects');
+  const scrollIntoViewMock = jest.createMockFromModule<any>('scroll-into-view-if-needed');
 
   beforeAll(() => {
     jest.useFakeTimers();
@@ -44,6 +45,7 @@ describe('Anchor Render', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
+    scrollIntoViewMock.mockReset();
   });
 
   afterEach(() => {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

close https://github.com/ant-design/ant-design/issues/58326

### 💡 Background and Solution

 当激活标题滚出可视区域时，Anchor 的高亮条也会跟着被滚丢

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Fix Anchor ink indicator being scrolled out of view for vertical Anchors placed inside a scrollable container. |
| 🇨🇳 Chinese |      修复垂直 Anchor 被放置在可滚动容器内时，高亮条被滚出可视区域的问题     |
