### PR TITLE
fix(ConfigProvider): add useTheme memo dependencies

### DIFF
--- a/components/config-provider/hooks/useTheme.ts
+++ b/components/config-provider/hooks/useTheme.ts
@@ -78,7 +78,7 @@ export default function useTheme(
         cssVar: mergedCssVar,
       };
     },
-    [themeConfig, parentThemeConfig],
+    [themeConfig, parentThemeConfig, config?.prefixCls, themeKey],
     (prev, next) =>
       prev.some((prevTheme, index) => {
         const nextTheme = next[index];


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

N/A

### 💡 Background and Solution

The memoized theme configuration did not track primitive values used to build the CSS variable configuration. Add the missing primitive dependencies so the memoized configuration stays current.

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | No changelog required |
| 🇨🇳 Chinese | 无需更新日志 |