### PR TITLE
fix(Typography): restore interactive ellipsis tooltip

### DIFF
--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -64,6 +64,7 @@ const InternalPopconfirm = React.forwardRef<TooltipRef, PopconfirmProps>((props,
     styles,
     arrow: popconfirmArrow,
     classNames,
+    disabled = false,
     ...restProps
   } = props;
   const {
@@ -107,7 +108,6 @@ const InternalPopconfirm = React.forwardRef<TooltipRef, PopconfirmProps>((props,
   };
 
   const onInternalOpenChange: PopoverProps['onOpenChange'] = (value) => {
-    const { disabled = false } = props;
     if (disabled) {
       return;
     }

--- a/components/typography/Base/EllipsisTooltip.tsx
+++ b/components/typography/Base/EllipsisTooltip.tsx
@@ -7,15 +7,14 @@ export interface EllipsisTooltipProps {
   tooltipProps?: TooltipProps;
   enableEllipsis: boolean;
   isEllipsis?: boolean;
-  /** When true, show the ellipsis tooltip; when false, hide it. Fully controlled so tooltip re-opens when moving from copy button back to text. */
-  open: boolean;
+  disabled: boolean;
   children: React.ReactElement;
 }
 
 const EllipsisTooltip: React.FC<EllipsisTooltipProps> = ({
   enableEllipsis,
   isEllipsis,
-  open,
+  disabled,
   children,
   tooltipProps,
 }) => {
@@ -23,9 +22,8 @@ const EllipsisTooltip: React.FC<EllipsisTooltipProps> = ({
     return children;
   }
 
-  const mergedOpen = open && isEllipsis;
   return (
-    <Tooltip open={mergedOpen} {...tooltipProps}>
+    <Tooltip open={isEllipsis ? undefined : false} {...tooltipProps} disabled={disabled}>
       {children}
     </Tooltip>
   );

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -323,7 +323,6 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
 
   const [ellipsisWidth, setEllipsisWidth] = React.useState(0);
   const [isHoveringOperations, setIsHoveringOperations] = React.useState(false);
-  const [isHoveringTypography, setIsHoveringTypography] = React.useState(false);
   const onResize = ({ offsetWidth }: { offsetWidth: number }) => {
     setEllipsisWidth(offsetWidth);
   };
@@ -525,17 +524,11 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
           tooltipProps={tooltipProps}
           enableEllipsis={mergedEnableEllipsis}
           isEllipsis={isMergedEllipsis}
-          open={isHoveringTypography && !isHoveringOperations}
+          disabled={isHoveringOperations}
         >
           <InternalTypography
-            onMouseEnter={(e) => {
-              setIsHoveringTypography(true);
-              onMouseEnter?.(e);
-            }}
-            onMouseLeave={(e) => {
-              setIsHoveringTypography(false);
-              onMouseLeave?.(e);
-            }}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
             className={clsx(
               {
                 [`${prefixCls}-${type}`]: type,

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "@rc-component/switch": "~1.0.3",
     "@rc-component/table": "~1.10.4",
     "@rc-component/tabs": "~1.11.0",
-    "@rc-component/tooltip": "~1.4.0",
+    "@rc-component/tooltip": "~1.5.0",
     "@rc-component/tour": "~2.4.0",
     "@rc-component/tree": "~1.3.2",
     "@rc-component/tree-select": "~1.13.0",


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

Close #57290

### 💡 需求背景和解决方案

Typography ellipsis Tooltip 目前使用完全受控的 `open` 状态，导致鼠标从文字移动到弹层时 Tooltip 立即关闭，无法选择或复制弹层中的文本。

本次调整：

- 升级 `@rc-component/tooltip` 至 `~1.5.0`。
- 恢复 ellipsis Tooltip 自身的 hover 行为。
- 鼠标进入复制、编辑或展开操作区时，通过内部 `disabled` 临时关闭 ellipsis Tooltip，避免多个 Tooltip 同时显示。
- Popconfirm 在组件内部消费 `disabled`，不再将其传递给底层 Tooltip。
- `disabled` 仅作为内部能力使用，不在 Tooltip 文档中公开。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Typography ellipsis tooltip closing when moving the pointer to its popup. |
| 🇨🇳 中文 | 🐞 修复 Typography 省略提示在鼠标移入弹层时关闭的问题。 |