### PR TITLE
feat(Carousel): support nativeElement ref

### DIFF
--- a/components/carousel/__tests__/index.test.tsx
+++ b/components/carousel/__tests__/index.test.tsx
@@ -30,6 +30,17 @@ describe('Carousel', () => {
     expect(typeof innerSlider.slickNext).toBe('function');
   });
 
+  it('should support nativeElement ref', () => {
+    const ref = React.createRef<CarouselRef>();
+    const { container } = render(
+      <Carousel ref={ref}>
+        <div />
+      </Carousel>,
+    );
+
+    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-carousel'));
+  });
+
   it('should support id property', () => {
     const { container } = render(
       <Carousel id="my-carousel">

--- a/components/carousel/__tests__/index.test.tsx
+++ b/components/carousel/__tests__/index.test.tsx
@@ -37,8 +37,9 @@ describe('Carousel', () => {
         <div />
       </Carousel>,
     );
-
-    expect(ref.current?.nativeElement).toBe(container.querySelector('.ant-carousel'));
+    expect(ref.current?.nativeElement).toBe(
+      container.querySelector<HTMLDivElement>('.ant-carousel'),
+    );
   });
 
   it('should support id property', () => {
@@ -302,19 +303,19 @@ describe('Carousel', () => {
         { placement: 'end', expectedVertical: true },
         { placement: 'top', expectedVertical: false },
         { placement: 'bottom', expectedVertical: false },
-      ])('should set vertical=$expectedVertical for $placement', ({
-        placement,
-        expectedVertical,
-      }) => {
-        const { container } = render(<Demo dotPlacement={placement} />);
-        const carousel = container.querySelector('.ant-carousel-vertical');
+      ])(
+        'should set vertical=$expectedVertical for $placement',
+        ({ placement, expectedVertical }) => {
+          const { container } = render(<Demo dotPlacement={placement} />);
+          const carousel = container.querySelector('.ant-carousel-vertical');
 
-        if (expectedVertical) {
-          expect(carousel).toBeTruthy();
-        } else {
-          expect(carousel).toBeFalsy();
-        }
-      });
+          if (expectedVertical) {
+            expect(carousel).toBeTruthy();
+          } else {
+            expect(carousel).toBeFalsy();
+          }
+        },
+      );
     });
   });
   describe('RTL Direction', () => {

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -101,12 +101,12 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>((props, ref) => {
   React.useImperativeHandle(
     ref,
     () => ({
-      nativeElement: nativeElementRef.current!,
       goTo,
       autoPlay: slickRef.current.innerSlider.autoPlay,
       innerSlider: slickRef.current.innerSlider,
       prev: slickRef.current.slickPrev,
       next: slickRef.current.slickNext,
+      nativeElement: nativeElementRef.current!,
     }),
     [slickRef.current],
   );

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -30,6 +30,7 @@ export interface CarouselProps extends Omit<Settings, 'dots' | 'dotsClass' | 'au
   autoplay?: boolean | { dotDuration?: boolean };
 }
 export interface CarouselRef {
+  nativeElement: HTMLDivElement;
   goTo: (slide: number, dontAnimate?: boolean) => void;
   next: () => void;
   prev: () => void;
@@ -91,6 +92,7 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>((props, ref) => {
     style: contextStyle,
   } = useComponentConfig('carousel');
   const slickRef = React.useRef<any>(null);
+  const nativeElementRef = React.useRef<HTMLDivElement>(null);
 
   const goTo = (slide: number, dontAnimate = false) => {
     slickRef.current.slickGoTo(slide, dontAnimate);
@@ -99,6 +101,7 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>((props, ref) => {
   React.useImperativeHandle(
     ref,
     () => ({
+      nativeElement: nativeElementRef.current!,
       goTo,
       autoPlay: slickRef.current.innerSlider.autoPlay,
       innerSlider: slickRef.current.innerSlider,
@@ -167,7 +170,7 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>((props, ref) => {
     : {};
 
   return (
-    <div className={className} id={id} style={dotDurationStyle}>
+    <div ref={nativeElementRef} className={className} id={id} style={dotDurationStyle}>
       <SlickCarousel
         ref={slickRef}
         {...newProps}


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [x] 🤖 TypeScript 定义更新
- [x] ✅ 测试用例

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Carousel 的 ref 目前只暴露轮播控制方法，无法获取组件根 DOM 节点。

为 Carousel ref 新增 nativeElement，指向外层 .ant-carousel，并保留现有的 goTo、prev、next、autoPlay 和 innerSlider API。已补充对应测试。

验证：Biome 检查通过。Jest 因本地 @ant-design/cssinjs 缺少 lib/util/extractStyle 未能启动；全量 TypeScript 检查被既有 Mentions 与 Typography 错误阻断。

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | 🆕 Add Carousel nativeElement to access its root DOM node. |
| 🇨🇳 中文 | 🆕 新增 Carousel nativeElement，用于获取根 DOM 节点。 |