### PR TITLE
fix: avoid duplicate filled background in AutoComplete custom input

### DIFF
--- a/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1162,6 +1162,192 @@ exports[`renders components/auto-complete/demo/disabled-custom-debug.tsx extend 
 
 exports[`renders components/auto-complete/demo/disabled-custom-debug.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/auto-complete/demo/filled-custom-debug.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap"
+  style="gap: 24px;"
+>
+  <form
+    class="ant-form ant-form-vertical css-var-test-id ant-form-css-var"
+    style="width: 280px;"
+  >
+    <div
+      class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-vertical"
+    >
+      <div
+        class="ant-row ant-form-item-row css-var-test-id"
+      >
+        <div
+          class="ant-col ant-form-item-label css-var-test-id"
+        >
+          <label
+            class=""
+            title="AutoComplete TextArea"
+          >
+            AutoComplete TextArea
+          </label>
+        </div>
+        <div
+          class="ant-col ant-form-item-control css-var-test-id"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <div
+                class="ant-select ant-select-filled ant-select-in-form-item ant-select-auto-complete ant-select-customize css-var-test-id ant-select-css-var ant-select-single ant-select-customize-input ant-select-show-search"
+              >
+                <div
+                  class="ant-select-content"
+                >
+                  <textarea
+                    aria-autocomplete="list"
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    autocomplete="new-password"
+                    class="ant-input ant-input-filled css-var-test-id ant-input-css-var ant-select-input"
+                    id="test-id"
+                    placeholder="Custom TextArea"
+                    role="combobox"
+                    type="text"
+                  />
+                </div>
+              </div>
+              <div
+                class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomLeft"
+                style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+              >
+                <div>
+                  <div
+                    id="test-id_list"
+                    role="listbox"
+                    style="height: 0px; width: 0px; overflow: hidden;"
+                  >
+                    <div
+                      aria-selected="false"
+                      id="test-id_list_0"
+                      role="option"
+                    >
+                      Burnaby
+                    </div>
+                  </div>
+                  <div
+                    class="rc-virtual-list"
+                    style="position: relative;"
+                  >
+                    <div
+                      class="rc-virtual-list-holder"
+                      style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+                    >
+                      <div>
+                        <div
+                          class="rc-virtual-list-holder-inner"
+                          style="display: flex; flex-direction: column;"
+                        >
+                          <div
+                            aria-disabled="false"
+                            class="ant-select-item ant-select-item-option"
+                            title="Burnaby"
+                          >
+                            <div
+                              class="ant-select-item-option-content"
+                            >
+                              Burnaby
+                            </div>
+                            <span
+                              aria-hidden="true"
+                              class="ant-select-item-option-state"
+                              style="user-select: none;"
+                              unselectable="on"
+                            />
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            class="ant-select-item ant-select-item-option"
+                            title="Seattle"
+                          >
+                            <div
+                              class="ant-select-item-option-content"
+                            >
+                              Seattle
+                            </div>
+                            <span
+                              aria-hidden="true"
+                              class="ant-select-item-option-state"
+                              style="user-select: none;"
+                              unselectable="on"
+                            />
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            class="ant-select-item ant-select-item-option"
+                            title="Los Angeles"
+                          >
+                            <div
+                              class="ant-select-item-option-content"
+                            >
+                              Los Angeles
+                            </div>
+                            <span
+                              aria-hidden="true"
+                              class="ant-select-item-option-state"
+                              style="user-select: none;"
+                              unselectable="on"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-vertical"
+    >
+      <div
+        class="ant-row ant-form-item-row css-var-test-id"
+      >
+        <div
+          class="ant-col ant-form-item-label css-var-test-id"
+        >
+          <label
+            class=""
+            title="Input TextArea"
+          >
+            Input TextArea
+          </label>
+        </div>
+        <div
+          class="ant-col ant-form-item-control css-var-test-id"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <textarea
+                class="ant-input ant-input-filled css-var-test-id ant-input-css-var"
+                placeholder="Compare TextArea"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`renders components/auto-complete/demo/filled-custom-debug.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/auto-complete/demo/form-debug.tsx extend context correctly 1`] = `
 <form
   class="ant-form ant-form-horizontal css-var-test-id ant-form-css-var"

--- a/components/auto-complete/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo.test.tsx.snap
@@ -501,6 +501,102 @@ exports[`renders components/auto-complete/demo/disabled-custom-debug.tsx correct
 </div>
 `;
 
+exports[`renders components/auto-complete/demo/filled-custom-debug.tsx correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap"
+  style="gap:24px"
+>
+  <form
+    class="ant-form ant-form-vertical css-var-test-id ant-form-css-var"
+    style="width:280px"
+  >
+    <div
+      class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-vertical"
+    >
+      <div
+        class="ant-row ant-form-item-row css-var-test-id"
+      >
+        <div
+          class="ant-col ant-form-item-label css-var-test-id"
+        >
+          <label
+            class=""
+            title="AutoComplete TextArea"
+          >
+            AutoComplete TextArea
+          </label>
+        </div>
+        <div
+          class="ant-col ant-form-item-control css-var-test-id"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <div
+                class="ant-select ant-select-filled ant-select-in-form-item ant-select-auto-complete ant-select-customize css-var-test-id ant-select-css-var ant-select-single ant-select-customize-input ant-select-show-search"
+              >
+                <div
+                  class="ant-select-content"
+                >
+                  <textarea
+                    aria-autocomplete="list"
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    autocomplete="new-password"
+                    class="ant-input ant-input-filled css-var-test-id ant-input-css-var ant-select-input"
+                    id="test-id"
+                    placeholder="Custom TextArea"
+                    role="combobox"
+                    type="text"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-vertical"
+    >
+      <div
+        class="ant-row ant-form-item-row css-var-test-id"
+      >
+        <div
+          class="ant-col ant-form-item-label css-var-test-id"
+        >
+          <label
+            class=""
+            title="Input TextArea"
+          >
+            Input TextArea
+          </label>
+        </div>
+        <div
+          class="ant-col ant-form-item-control css-var-test-id"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <textarea
+                class="ant-input ant-input-filled css-var-test-id ant-input-css-var"
+                placeholder="Compare TextArea"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+</div>
+`;
+
 exports[`renders components/auto-complete/demo/form-debug.tsx correctly 1`] = `
 <form
   class="ant-form ant-form-horizontal css-var-test-id ant-form-css-var"

--- a/components/auto-complete/demo/filled-custom-debug.md
+++ b/components/auto-complete/demo/filled-custom-debug.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+填充形态自定义输入组件 Debug。
+
+## en-US
+
+Filled custom input debug.

--- a/components/auto-complete/demo/filled-custom-debug.tsx
+++ b/components/auto-complete/demo/filled-custom-debug.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { AutoComplete, Flex, Form, Input } from 'antd';
+
+const options = [{ value: 'Burnaby' }, { value: 'Seattle' }, { value: 'Los Angeles' }];
+
+const App: React.FC = () => (
+  <Flex gap={24} wrap>
+    <Form layout="vertical" variant="filled" style={{ width: 280 }}>
+      <Form.Item label="AutoComplete TextArea">
+        <AutoComplete options={options}>
+          <Input.TextArea placeholder="Custom TextArea" />
+        </AutoComplete>
+      </Form.Item>
+      <Form.Item label="Input TextArea">
+        <Input.TextArea placeholder="Compare TextArea" />
+      </Form.Item>
+    </Form>
+  </Flex>
+);
+
+export default App;

--- a/components/auto-complete/index.en-US.md
+++ b/components/auto-complete/index.en-US.md
@@ -35,6 +35,7 @@ The differences with Select are:
 <code src="./demo/allowClear.tsx">Customize clear button</code>
 <code src="./demo/style-class.tsx" version="6.0.0">Custom semantic dom styling</code>
 <code src="./demo/disabled-custom-debug.tsx" debug>Disabled custom input debug</code>
+<code src="./demo/filled-custom-debug.tsx" debug>Filled custom input debug</code>
 <code src="./demo/form-debug.tsx" debug>Debug in Form</code>
 <code src="./demo/AutoComplete-and-Select.tsx" debug>AutoComplete and Select</code>
 <code src="./demo/render-panel.tsx" debug>_InternalPanelDoNotUseOrYouWillBeFired</code>

--- a/components/auto-complete/index.zh-CN.md
+++ b/components/auto-complete/index.zh-CN.md
@@ -36,6 +36,7 @@ demo:
 <code src="./demo/allowClear.tsx">自定义清除按钮</code>
 <code src="./demo/style-class.tsx" version="6.0.0">自定义语义结构的样式和类</code>
 <code src="./demo/disabled-custom-debug.tsx" debug>禁用自定义输入 Debug</code>
+<code src="./demo/filled-custom-debug.tsx" debug>填充形态自定义输入 Debug</code>
 <code src="./demo/form-debug.tsx" debug>在 Form 中 Debug</code>
 <code src="./demo/AutoComplete-and-Select.tsx" debug>AutoComplete 和 Select</code>
 <code src="./demo/render-panel.tsx" debug>\_InternalPanelDoNotUseOrYouWillBeFired</code>

--- a/components/select/style/select-input-customize.ts
+++ b/components/select/style/select-input-customize.ts
@@ -37,6 +37,10 @@ const genSelectInputCustomizeStyle: GenerateStyle<SelectToken, CSSObject> = (tok
         },
       },
 
+      [`&${componentCls}-filled ${componentCls}-content`]: {
+        [`${antCls}-input-filled`]: transparentBackground,
+      },
+
       [`&${componentCls}-disabled ${componentCls}-content`]: {
         [disabledCustomizedInputSelector]: transparentBackground,
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #58668

### 💡 需求背景和解决方案

AutoComplete 使用自定义输入组件并处于 Form `variant="filled"` 下时，外层 Select selector 和内层 Input.TextArea 都会渲染 filled 背景，导致背景色重复叠加变深。

本次在 Select customize 模式下，为 filled variant 的内层 `.ant-input-filled` 设置透明背景，避免双层背景叠加；同时补充 AutoComplete debug demo 和对应快照。

验证：`npm test -- components/auto-complete/__tests__/demo.test.tsx components/auto-complete/__tests__/demo-extend.test.ts -u`

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix AutoComplete custom input background being rendered twice in filled variant. |
| 🇨🇳 中文 | 修复 AutoComplete 自定义输入组件在填充形态下背景色重复叠加的问题。 |
