### PR TITLE
fix(tag): fix preset filled variant low contrast in dark mode

### DIFF
--- a/components/tag/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tag/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -949,6 +949,240 @@ exports[`renders components/tag/demo/customize.tsx extend context correctly 1`] 
 
 exports[`renders components/tag/demo/customize.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/tag/demo/dark.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start ant-divider-plain"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      Filled
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <div
+    class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-center ant-flex-gap-small"
+  >
+    <span
+      class="ant-tag ant-tag-filled ant-tag-magenta css-var-test-id"
+    >
+      magenta
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-red css-var-test-id"
+    >
+      red
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-volcano css-var-test-id"
+    >
+      volcano
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-orange css-var-test-id"
+    >
+      orange
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-gold css-var-test-id"
+    >
+      gold
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-lime css-var-test-id"
+    >
+      lime
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-green css-var-test-id"
+    >
+      green
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-cyan css-var-test-id"
+    >
+      cyan
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-blue css-var-test-id"
+    >
+      blue
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-geekblue css-var-test-id"
+    >
+      geekblue
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-purple css-var-test-id"
+    >
+      purple
+    </span>
+  </div>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start ant-divider-plain"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      Solid
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <div
+    class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-center ant-flex-gap-small"
+  >
+    <span
+      class="ant-tag ant-tag-solid ant-tag-magenta css-var-test-id"
+    >
+      magenta
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-red css-var-test-id"
+    >
+      red
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-volcano css-var-test-id"
+    >
+      volcano
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-orange css-var-test-id"
+    >
+      orange
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-gold css-var-test-id"
+    >
+      gold
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-lime css-var-test-id"
+    >
+      lime
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-green css-var-test-id"
+    >
+      green
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-cyan css-var-test-id"
+    >
+      cyan
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-blue css-var-test-id"
+    >
+      blue
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-geekblue css-var-test-id"
+    >
+      geekblue
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-purple css-var-test-id"
+    >
+      purple
+    </span>
+  </div>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start ant-divider-plain"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      Outlined
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <div
+    class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-center ant-flex-gap-small"
+  >
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-magenta css-var-test-id"
+    >
+      magenta
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-red css-var-test-id"
+    >
+      red
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-volcano css-var-test-id"
+    >
+      volcano
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-orange css-var-test-id"
+    >
+      orange
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-gold css-var-test-id"
+    >
+      gold
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-lime css-var-test-id"
+    >
+      lime
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-green css-var-test-id"
+    >
+      green
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-cyan css-var-test-id"
+    >
+      cyan
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-blue css-var-test-id"
+    >
+      blue
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-geekblue css-var-test-id"
+    >
+      geekblue
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-purple css-var-test-id"
+    >
+      purple
+    </span>
+  </div>
+</div>
+`;
+
+exports[`renders components/tag/demo/dark.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/tag/demo/disabled.tsx extend context correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"

--- a/components/tag/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/tag/__tests__/__snapshots__/demo.test.tsx.snap
@@ -961,6 +961,238 @@ exports[`renders components/tag/demo/customize.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/tag/demo/dark.tsx correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start ant-divider-plain"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      Filled
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <div
+    class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-center ant-flex-gap-small"
+  >
+    <span
+      class="ant-tag ant-tag-filled ant-tag-magenta css-var-test-id"
+    >
+      magenta
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-red css-var-test-id"
+    >
+      red
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-volcano css-var-test-id"
+    >
+      volcano
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-orange css-var-test-id"
+    >
+      orange
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-gold css-var-test-id"
+    >
+      gold
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-lime css-var-test-id"
+    >
+      lime
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-green css-var-test-id"
+    >
+      green
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-cyan css-var-test-id"
+    >
+      cyan
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-blue css-var-test-id"
+    >
+      blue
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-geekblue css-var-test-id"
+    >
+      geekblue
+    </span>
+    <span
+      class="ant-tag ant-tag-filled ant-tag-purple css-var-test-id"
+    >
+      purple
+    </span>
+  </div>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start ant-divider-plain"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      Solid
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <div
+    class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-center ant-flex-gap-small"
+  >
+    <span
+      class="ant-tag ant-tag-solid ant-tag-magenta css-var-test-id"
+    >
+      magenta
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-red css-var-test-id"
+    >
+      red
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-volcano css-var-test-id"
+    >
+      volcano
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-orange css-var-test-id"
+    >
+      orange
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-gold css-var-test-id"
+    >
+      gold
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-lime css-var-test-id"
+    >
+      lime
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-green css-var-test-id"
+    >
+      green
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-cyan css-var-test-id"
+    >
+      cyan
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-blue css-var-test-id"
+    >
+      blue
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-geekblue css-var-test-id"
+    >
+      geekblue
+    </span>
+    <span
+      class="ant-tag ant-tag-solid ant-tag-purple css-var-test-id"
+    >
+      purple
+    </span>
+  </div>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start ant-divider-plain"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      Outlined
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <div
+    class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-center ant-flex-gap-small"
+  >
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-magenta css-var-test-id"
+    >
+      magenta
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-red css-var-test-id"
+    >
+      red
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-volcano css-var-test-id"
+    >
+      volcano
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-orange css-var-test-id"
+    >
+      orange
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-gold css-var-test-id"
+    >
+      gold
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-lime css-var-test-id"
+    >
+      lime
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-green css-var-test-id"
+    >
+      green
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-cyan css-var-test-id"
+    >
+      cyan
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-blue css-var-test-id"
+    >
+      blue
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-geekblue css-var-test-id"
+    >
+      geekblue
+    </span>
+    <span
+      class="ant-tag ant-tag-outlined ant-tag-purple css-var-test-id"
+    >
+      purple
+    </span>
+  </div>
+</div>
+`;
+
 exports[`renders components/tag/demo/disabled.tsx correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"

--- a/components/tag/demo/dark.md
+++ b/components/tag/demo/dark.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+暗色模式下的标签样式。
+
+## en-US
+
+Tag styles in dark mode.

--- a/components/tag/demo/dark.tsx
+++ b/components/tag/demo/dark.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { ConfigProvider, Divider, Flex, Tag, theme } from 'antd';
+
+const presets = [
+  'magenta',
+  'red',
+  'volcano',
+  'orange',
+  'gold',
+  'lime',
+  'green',
+  'cyan',
+  'blue',
+  'geekblue',
+  'purple',
+];
+
+const App: React.FC = () => (
+  <ConfigProvider theme={{ algorithm: theme.darkAlgorithm }}>
+    <Flex vertical gap="small">
+      <Divider titlePlacement="left" plain>
+        Filled
+      </Divider>
+      <Flex gap="small" align="center" wrap>
+        {presets.map((color) => (
+          <Tag key={color} color={color} variant="filled">
+            {color}
+          </Tag>
+        ))}
+      </Flex>
+      <Divider titlePlacement="left" plain>
+        Solid
+      </Divider>
+      <Flex gap="small" align="center" wrap>
+        {presets.map((color) => (
+          <Tag key={color} color={color} variant="solid">
+            {color}
+          </Tag>
+        ))}
+      </Flex>
+      <Divider titlePlacement="left" plain>
+        Outlined
+      </Divider>
+      <Flex gap="small" align="center" wrap>
+        {presets.map((color) => (
+          <Tag key={color} color={color} variant="outlined">
+            {color}
+          </Tag>
+        ))}
+      </Flex>
+    </Flex>
+  </ConfigProvider>
+);
+
+export default App;

--- a/components/tag/index.en-US.md
+++ b/components/tag/index.en-US.md
@@ -27,6 +27,7 @@ demo:
 <code src="./demo/status.tsx">Status Tag</code>
 <code src="./demo/customize.tsx" debug>Customize close</code>
 <code src="./demo/draggable.tsx">Draggable Tag</code>
+<code src="./demo/dark.tsx" debug>Dark Mode</code>
 <code src="./demo/component-token.tsx" debug>Component Token</code>
 <code src="./demo/disabled.tsx" debug>Disabled</code>
 <code src="./demo/style-class.tsx" version="6.0.0">Custom semantic dom styling</code>

--- a/components/tag/index.zh-CN.md
+++ b/components/tag/index.zh-CN.md
@@ -27,6 +27,7 @@ demo:
 <code src="./demo/status.tsx">预设状态的标签</code>
 <code src="./demo/customize.tsx" debug>自定义关闭按钮</code>
 <code src="./demo/draggable.tsx">可拖拽标签</code>
+<code src="./demo/dark.tsx" debug>暗色模式</code>
 <code src="./demo/component-token.tsx" debug>组件 Token</code>
 <code src="./demo/disabled.tsx" debug>禁用标签</code>
 <code src="./demo/style-class.tsx" version="6.0.0">自定义语义结构的样式和类</code>

--- a/components/tag/style/index.ts
+++ b/components/tag/style/index.ts
@@ -8,8 +8,16 @@ import { isBright } from '../../color-picker/components/ColorPresets';
 import { resetComponent } from '../../style';
 import type { FullToken, GenerateStyle, GenStyleFn, GetDefaultToken } from '../../theme/internal';
 import { genStyleHooks, mergeToken } from '../../theme/internal';
+import { PresetColors } from '../../theme/interface';
+import type { PresetColorKey } from '../../theme/interface';
 
-export interface ComponentToken {
+// Per-preset-color background for the `filled` variant, one flat token per color (e.g.
+// `blueFilledBg`, `purpleFilledBg`). Must stay flat: `cssVar` theming turns every top-level
+// `ComponentToken` key into its own `var(...)` reference, so a single key holding a nested
+// object cannot survive the round trip.
+type PresetFilledBgComponentToken = Partial<Record<`${PresetColorKey}FilledBg`, string>>;
+
+export interface ComponentToken extends PresetFilledBgComponentToken {
   /**
    * @desc 默认背景色
    * @descEN Default background color
@@ -224,12 +232,33 @@ export const prepareComponentToken: GetDefaultToken<'Tag'> = (token) => {
     ? '#000'
     : '#fff';
 
+  // In dark mode, preset palette index 1 (the filled variant's light-mode background) resolves
+  // to a near-black tint that barely stands out against `colorBgContainer`, so filled tags need
+  // a background derived from the saturated palette-6 step instead. This must be computed here
+  // (not in the style-generation function) because under `cssVar` theming, color tokens are
+  // already `var(...)` reference strings by the time the style function runs and can no longer
+  // be parsed/blended by FastColor — `prepareComponentToken` still receives real values. Each
+  // color's result is returned as its own flat token (e.g. `blueFilledBg`) — in light mode this
+  // is just the unchanged `lightColor` passthrough, keeping light mode pixel-identical.
+  const isDarkMode = new FastColor(token.colorBgContainer).isDark();
+  const presetFilledBg = PresetColors.reduce<Record<string, string>>((prev, colorKey) => {
+    const lightColor = token[`${colorKey}1`];
+    const darkColor = token[`${colorKey}6`];
+    if (lightColor && darkColor) {
+      prev[`${colorKey}FilledBg`] = isDarkMode
+        ? new FastColor(darkColor).setA(0.15).onBackground(token.colorBgContainer).toHexString()
+        : lightColor;
+    }
+    return prev;
+  }, {});
+
   return {
     defaultBg: new FastColor(token.colorFillTertiary)
       .onBackground(token.colorBgContainer)
       .toHexString(),
     defaultColor: token.colorText,
     solidTextColor,
+    ...presetFilledBg,
   };
 };
 

--- a/components/tag/style/presetCmp.ts
+++ b/components/tag/style/presetCmp.ts
@@ -19,7 +19,10 @@ const genPresetStyle = (token: TagToken) =>
           color: token.colorTextLightSolid,
         },
         [`&${token.componentCls}-filled`]: {
-          backgroundColor: lightColor,
+          // Resolved in `prepareComponentToken` (dark-mode-aware there; a plain passthrough of
+          // `lightColor` in light mode), since color math can't safely happen in this function
+          // under `cssVar` theming — see the comment in `prepareComponentToken`.
+          backgroundColor: token[`${colorKey}FilledBg`] ?? lightColor,
           color: textColor,
         },
       },


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

close #56339

### 💡 Background and Solution

In dark mode, `<Tag color="..." variant="filled">` used preset palette index 1 as its background, which resolves to a near-black tint nearly identical in luminance to `colorBgContainer` — so the tag rendered as an almost invisible blob instead of a distinct chip.

Fixed by deriving the filled variant's dark-mode background from the palette's saturated step instead (15% alpha blended onto `colorBgContainer`), computed in `prepareComponentToken` so it resolves correctly under both standard and CSS-variable (`cssVar`) theming — doing the color math directly in the style-generation function breaks under `cssVar`, since token values there are `var(...)` reference strings rather than real colors. Light mode is unchanged (verified via unchanged Jest snapshots).

**Before (dark mode):**
<img width="470" height="117" alt="before" src="https://github.com/user-attachments/assets/55c450ec-2f1c-4ecc-8338-a86458a46f34" />



**After (dark mode):**
<img width="541" height="152" alt="after" src="https://github.com/user-attachments/assets/fef2987f-2669-4a49-b6e9-c5ff75c579b5" />


**Light mode (unchanged):**
<img width="548" height="150" alt="Screenshot 2026-07-11 184711" src="https://github.com/user-attachments/assets/0fc52c61-ab58-4f83-b627-b90282eb44df" />


The visual difference is most apparent for `purple` and `geekblue` text legibility specifically — these were the two colors whose text-on-background contrast fell below the WCAG 3:1 minimum before this fix (2.08:1 and 2.37:1). The overall tag-vs-page boundary contrast is a separate, harder problem this PR does not attempt to solve (see discussion above).


Note: #58590 also targets this issue. This PR's approach additionally fixes two contrast failures present in that PR's implementation (text-on-background contrast for `purple` and `geekblue` preset colors fell below the WCAG 3:1 minimum there).

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | 🐞 Fix Tag low contrast for preset color `filled` variant tags in dark mode. |
| 🇨🇳 Chinese | 🐞 修复 Tag 预设颜色 `filled` 变体标签在暗色模式下对比度过低的问题。 |
