### PR TITLE
fix(Switch): center label content instead of aligning it to the text baseline

### DIFF
--- a/components/switch/style/index.ts
+++ b/components/switch/style/index.ts
@@ -278,7 +278,6 @@ const genSwitchInnerStyle: GenerateStyle<SwitchToken, CSSObject> = (token) => {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          gap: token.marginXXS,
           color: token.colorTextLightSolid,
           fontSize: token.fontSizeSM,
           pointerEvents: 'none',

--- a/components/switch/style/index.ts
+++ b/components/switch/style/index.ts
@@ -275,7 +275,10 @@ const genSwitchInnerStyle: GenerateStyle<SwitchToken, CSSObject> = (token) => {
           .join(', '),
         ...genNoMotionStyle(),
         [`${switchInnerCls}-checked, ${switchInnerCls}-unchecked`]: {
-          display: 'block',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: token.marginXXS,
           color: token.colorTextLightSolid,
           fontSize: token.fontSizeSM,
           pointerEvents: 'none',


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- Related: #56315 (third-party SVG icons misaligning in v6 because they lack `.anticon`'s corrections). This PR fixes the root cause for `Switch` only; it does not close that issue.
- Context for the review below: #58428 / #58584 (the `Button` icon-centering saga).

### 💡 Background and Solution

#### The problem

`.ant-switch-inner-checked` / `-unchecked` are `display: block`, so the label content is laid out **on a text baseline** instead of being centered.

A bare `<svg>` is an inline replaced element with **no baseline of its own**, so per CSS 2.1 §10.8.1 it is aligned by its **bottom margin edge** to that baseline — not to the track's center. The icon therefore floats up by:

```
offset = h/2 − (ascent − descent)/2         (h = icon height)
```

The consequence is that **the label's position is a function of the resolved font metrics and the icon height**, rather than being centered. `@ant-design/icons` is not immune — only partially corrected, by `.anticon`'s hardcoded `vertical-align: -0.125em`, which is a constant nudge against a size-dependent error.

Two things follow, and both are measurable today:

1. **The error changes direction depending on the font.** With the font stack that ships in the default theme (ascent 11 / descent 3 at 12px) `<CheckOutlined />` sits **0.50px above** center. On <https://ant.design/components/switch>, where the docs site loads `AlibabaSans` (ascent 14 / descent 4), the very same demo sits **0.50px below** center. The closed form above predicts both, sign included.
2. **The error grows with icon height** (slope exactly ½), then saturates once the icon outgrows the strut.

#### Measured (headless Chromium, standards mode, default tokens, 22px track)

Rendered from this repo's source via `renderToString` + `extractStyle`, so this is the real component with the real cascade — `before` is `origin/master`, `after` is this branch.

| label content | before | after |
| --- | --- | --- |
| `@ant-design/icons` (`<CheckOutlined />`, 12px) | **+0.50px** | **0.00px** |
| bare `<svg>` 10 / 11 / 12 / 13 / 14px | **+1.00 / +1.50 / +2.00 / +2.50 / +3.00px** | **0.00px** |
| bare `<svg>` 16 / 20 / 24px (saturates) | **+3.50px** | **0.00px** |
| `size="small"`, `@ant-design/icons` | **+0.50px** | **0.00px** |
| `size="small"`, bare `<svg>` 11px | **+1.50px** | **0.00px** |
| text only (`"ENABLED"` / `"DISABLED"`) | 0.00px | 0.00px |

`h/2 − 4` fits every bare-`<svg>` row exactly. The slope of ½ is the signature of bottom-edge-on-baseline: any competing *centering* explanation (line-height, padding) would give slope 0. Note the +2.00px cohort is what third-party icon sets (lucide-react, react-icons, phosphor) produce, since they emit a bare `<svg>`.

![before/after](https://raw.githubusercontent.com/mohamedkhaled4053/ant-design/pr-assets-switch-align/switch-before-after.png)

#### The fix

Flex items are blockified and `vertical-align` does not apply to them (CSS Flexbox L1 §4), so centering the label box centers any icon **exactly — at any size, in any font**, and deletes both the bare-`<svg>` baseline offset and `.anticon`'s `-0.125em` nudge in one stroke. This is also what `Button` does for `${componentCls}-icon`.

Every declaration is load-bearing:

| declaration | why |
| --- | --- |
| `display: flex` | **Not `inline-flex`.** `-unchecked` is stacked onto `-checked` with `marginTop: calc(trackHeight).mul(-1)`. `flex` sets only the *inner* display type; the outer box stays block-level, so the negative-margin stacking and the slide transition are untouched (measured: `unchecked.top - checked.top` identical before/after). |
| `align-items: center` | The fix itself. `minHeight: trackHeight` already sizes the box to the track. |
| `justify-content: center` | **Required, not cosmetic.** The label is centered horizontally today only by the `<button>` UA stylesheet's `text-align: center` (`resetComponent` never resets it), which does **not** position flex items. Without it, `checkedChildren="On"` + `unCheckedChildren="Offline!!!"` shifts **14.23px** to the left. |
| `gap: token.marginXXS` | **Prevents a regression this fix would otherwise introduce.** Flex turns each child into its own item and **deletes the anonymous whitespace between them**: `checkedChildren={<><CheckOutlined /> ON</>}` loses its word space entirely (measured 3.34px → **0px**, icon glued to text). `gap` restores it (3.34px → 4px). `Button` carries `gap` for the same reason. |

`size="small"` needs no extra work — its rule only overrides `minHeight`, so it inherits the centering (measured above).

#### "Didn't we try this on Button and revert it twice?"

Yes — and that is the first thing I checked, because it is the strongest argument against this PR:

- #51381 (`inline-block` → `inline-flex`) → reverted by #51588 (regression #51520).
- #57896 (`display: inline-flex` + `align-items` + `justify-content`) → reverted by #58429 (regression #58428: Popconfirm/Modal footer buttons misaligned).
- It only stuck on the third attempt, #58584, *paired with* `&:before { content: "\a0" }` to restore the host's baseline.

**Switch does not have that exposure, for a structural reason.** Button's root is `display: inline-flex` with no `vertical-align`, so it is placed in the parent line box **by its baseline** — and an inline-flex box takes its baseline from its first flex item, which is exactly why flexing the icon box moved the whole Button. Switch's root is `display: inline-block` + **`vertical-align: middle`** (`components/switch/style/index.ts:345,350`): it is placed by its *middle*, so its internal baseline is not observable from outside. Independently, `.ant-switch-inner` is `overflow: hidden`, which severs the inner content from the root's baseline anyway.

Measured, to be sure — a Switch inline in a line of text (`Hello [switch] world`), before vs after:

```
switch.top − reference.top = −2.22px   (before)
switch.top − reference.top = −2.22px   (after)   ← byte-identical, icon and no-icon
```

So no `:before` counter-hack is needed here.

#### Disclosure of behaviour changes

- **`gap` adds 4px where an author wrote no separator at all.** `checkedChildren={<><Icon /><span>ON</span></>}` (no whitespace in the JSX) gains 4px, and the Switch widens accordingly. This is the trade for not silently deleting the space in the far more common `<><Icon /> ON</>`. **Happy to drop `gap` if you prefer** — but then the whitespace regression above ships instead.
- **Element children become flex items** and so shrink-to-fit instead of filling. Only observable if a Switch is given an explicit width *and* an element (not icon/text) child. No demo, doc or test in the repo does this.
- **The visual-regression bot will flag `switch` demos.** That is the intended 0.5px correction in `text.tsx`, and it is the point of the PR.
- Also fixed incidentally: with a 16px icon the block label grew to 23px — taller than the 22px track — so it was clipped by `overflow: hidden` and the two label spans were no longer perfectly superimposed. The flex label stays at 22px.

#### Verification

- `jest --config .jest.js --no-cache components/switch` → **8 suites / 40 tests passed, 20 snapshots passed, 0 written**. The Switch snapshots contain markup only (no CSS), so there is no snapshot churn.
- `tsc --noEmit` clean; `biome check` + `eslint` clean.
- jsdom has no layout engine, so **a unit test cannot cover this bug** — verification is browser-measured, as above.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Switch not vertically centering the icon in `checkedChildren` / `unCheckedChildren`, which was aligned to the text baseline and so shifted with the icon size and the resolved font. |
| 🇨🇳 Chinese | 🐞 修复 Switch 的 `checkedChildren` / `unCheckedChildren` 中图标未垂直居中的问题，此前图标按文字基线对齐，会随图标尺寸和字体度量而偏移。 |
