### PR TITLE
docs: add AdaptTable to Third-Party Libraries (Table enhancement)

### DIFF
--- a/docs/react/recommendation.en-US.md
+++ b/docs/react/recommendation.en-US.md
@@ -30,6 +30,7 @@ title: Third-Party Libraries
 | Code highlight | [react-syntax-highlighter](https://github.com/conorhastings/react-syntax-highlighter) |
 | Markdown renderer | [react-markdown](https://remarkjs.github.io/react-markdown/) |
 | Infinite Scroll | [@rc-component/virtual-list](https://github.com/react-component/virtual-list/) [react-infinite-scroll-component](https://github.com/ankeetmaini/react-infinite-scroll-component) |
+| Table enhancement | [AdaptTable](https://github.com/orwa-mahmoud/adapttable) |
 | Map | [google-map-react](https://github.com/istarkov/google-map-react) [@uiw/react-amap](https://github.com/uiwjs/react-amap) |
 | Video | [react-player](https://github.com/CookPete/react-player) [video-react](https://github.com/video-react/video-react) [video.js](https://docs.videojs.com/tutorial-react.html) |
 | Context Menu | [react-contexify](https://github.com/fkhadra/react-contexify) |

--- a/docs/react/recommendation.zh-CN.md
+++ b/docs/react/recommendation.zh-CN.md
@@ -31,6 +31,7 @@ title: 社区精选组件
 | 代码高亮 | [react-syntax-highlighter](https://github.com/conorhastings/react-syntax-highlighter) |
 | Markdown 渲染 | [react-markdown](https://remarkjs.github.io/react-markdown/) |
 | 无限滚动 | [@rc-component/virtual-list](https://github.com/react-component/virtual-list/) [react-infinite-scroll-component](https://github.com/ankeetmaini/react-infinite-scroll-component) |
+| 表格增强 | [AdaptTable](https://github.com/orwa-mahmoud/adapttable) |
 | 地图 | [google-map-react](https://github.com/istarkov/google-map-react) [@uiw/react-amap 高德地图](https://github.com/uiwjs/react-amap) |
 | 视频播放 | [react-player](https://github.com/CookPete/react-player) [video-react](https://github.com/video-react/video-react) [video.js](https://docs.videojs.com/tutorial-react.html) |
 | 右键菜单 | [react-contexify](https://github.com/fkhadra/react-contexify) |


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Documentation improvement

### 💡 Background and solution

Adds **AdaptTable** as a "Table enhancement" entry to the Third-Party Libraries recommendation page (both `en-US` and `zh-CN`).

Why it fits this list: AdaptTable's antd adapter (`@adapttable/antd`) does **not replace** antd's Table — it **drives antd's own high-level `<Table>`** (native sorters, checkboxes, pagination, virtual mode) and adds the batteries around it: URL-synced state (shareable/refresh-safe filters, sort, page), a declarative filter drawer/popover with removable chips, one contract for client- and server-side data, column show/hide/reorder/pin/resize, saved views, and i18n incl. a `zh` locale preset. In spirit it is close to existing entries like `antd-img-crop` and `antd-phone-input` — community packages that enhance an antd component rather than compete with it.

MIT · TypeScript strict · per-adapter test suites (95%+ coverage in CI) incl. axe a11y + Playwright.

- Repo: https://github.com/orwa-mahmoud/adapttable
- Live antd demo: https://orwa-mahmoud.github.io/adapttable/demo/

Disclosure: I am the author of AdaptTable. Happy to adjust the category name/row placement if the team prefers — or to close if third-party table tooling is out of scope for this page.

### 📝 Change log

| Language | Changelog |
| -------- | --------- |
| 🇺🇸 English | docs only |
| 🇨🇳 Chinese | 仅文档更新 |