### PR TITLE
fix: define virtual scrollbar cursor outside hover styles

### DIFF
--- a/components/select/style/dropdown.ts
+++ b/components/select/style/dropdown.ts
@@ -93,9 +93,12 @@ const genSingleStyle: GenerateStyle<SelectToken> = (token) => {
           display: 'none',
         },
 
-        [`${componentCls}-dropdown-list-scrollbar:hover`]: {
-          backgroundColor: token.colorFillQuaternary,
+        [`${componentCls}-dropdown-list-scrollbar`]: {
           cursor: 'pointer',
+
+          '&:hover': {
+            backgroundColor: token.colorFillQuaternary,
+          },
         },
 
         [selectItemCls]: {

--- a/components/table/style/virtual.ts
+++ b/components/table/style/virtual.ts
@@ -15,9 +15,12 @@ const genVirtualStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
     [`${componentCls}-wrapper`]: {
       // ========================== Row ==========================
       [`${componentCls}-tbody-virtual`]: {
-        [`${componentCls}-tbody-virtual-scrollbar:hover`]: {
-          backgroundColor: token.colorFillQuaternary,
+        [`${componentCls}-tbody-virtual-scrollbar`]: {
           cursor: 'pointer',
+
+          '&:hover': {
+            backgroundColor: token.colorFillQuaternary,
+          },
         },
 
         [`${componentCls}-tbody-virtual-holder-inner`]: {

--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -156,9 +156,12 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
         },
       },
 
-      [`${treeCls}-list-scrollbar:hover`]: {
-        backgroundColor: token.colorFillQuaternary,
+      [`${treeCls}-list-scrollbar`]: {
         cursor: 'pointer',
+
+        '&:hover': {
+          backgroundColor: token.colorFillQuaternary,
+        },
       },
 
       [`${treeCls}-list-holder-inner`]: {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 💄 组件样式/交互改进

### 🔗 相关 Issue

ref #58658

### 💡 需求背景和解决方案

跟进 #58658 的代码审查意见。将 Select、Table 和 Tree 虚拟滚动条的指针光标定义移至基础选择器，悬停状态仅负责轨道背景反馈。不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述              |
| ------- | --------------------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志          |