### PR TITLE
chore: avoid post-publish tag hanging when tag.gpgSign is enabled

### DIFF
--- a/scripts/post-publish.ts
+++ b/scripts/post-publish.ts
@@ -34,7 +34,9 @@ const SAFE_DAYS_DIFF = 1000 * 60 * 60 * 24 * 3; // 3 days not update seems to be
   // git tag
   const spinner = ora(chalk.cyan(`Tagging ${packageVersion}`)).start();
   try {
-    execSync(`git tag ${packageVersion}`);
+    // `--no-sign` keeps the tag lightweight even if local `tag.gpgSign` is enabled,
+    // which would otherwise wait for an editor and hang `execSync`
+    execSync(`git tag --no-sign ${packageVersion}`);
     execSync(`git push origin ${packageVersion}:${packageVersion}`);
     spinner.succeed(
       chalk.cyan(


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [x] ⏩ 工作流程

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

当发布者本地 git 配置了 `tag.gpgSign = true` 时，post-publish 脚本中的 `git tag ${version}` 会变成创建签名 tag。签名 tag 必须携带注释信息，而脚本未传 `-m`，git 会尝试拉起编辑器等待输入；但该命令运行在 `execSync`（stdio 为 pipe）中，编辑器无法交互，脚本便永久卡死在 "Tagging x.x.x" 阶段。

解决方案：为 `git tag` 显式添加 `--no-sign`，使其不受本地 `tag.gpgSign` 配置影响，始终创建与现有发布 tag 一致的轻量 tag。

### 📝 更新日志

| 语言    | 更新描述     |
| ------- | ------------ |
| 🇺🇸 英文 | N/A          |
| 🇨🇳 中文 | 无需更新日志 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)