### PR TITLE
fix(Splitter): correct percentage-based ARIA ranges

### DIFF
--- a/components/splitter/Splitter.tsx
+++ b/components/splitter/Splitter.tsx
@@ -229,11 +229,13 @@ const Splitter: React.FC<React.PropsWithChildren<SplitterProps>> = (props) => {
 
           const resizableInfo = resizableInfos[idx];
           if (resizableInfo) {
-            const ariaMinStart = (stackSizes[idx - 1] || 0) + itemPtgMinSizes[idx];
-            const ariaMinEnd = (stackSizes[idx + 1] || 100) - itemPtgMaxSizes[idx + 1];
+            const prevStackSize = Number.isFinite(stackSizes[idx - 1]) ? stackSizes[idx - 1] : 0;
+            const nextStackSize = Number.isFinite(stackSizes[idx + 1]) ? stackSizes[idx + 1] : 1;
+            const ariaMinStart = prevStackSize + itemPtgMinSizes[idx];
+            const ariaMinEnd = nextStackSize - itemPtgMaxSizes[idx + 1];
 
-            const ariaMaxStart = (stackSizes[idx - 1] || 0) + itemPtgMaxSizes[idx];
-            const ariaMaxEnd = (stackSizes[idx + 1] || 100) - itemPtgMinSizes[idx + 1];
+            const ariaMaxStart = prevStackSize + itemPtgMaxSizes[idx];
+            const ariaMaxEnd = nextStackSize - itemPtgMinSizes[idx + 1];
 
             splitBar = (
               <SplitBar

--- a/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1540,7 +1540,7 @@ Array [
       <div
         aria-disabled="true"
         aria-orientation="vertical"
-        aria-valuemax="9980"
+        aria-valuemax="80"
         aria-valuemin="0"
         aria-valuenow="0"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"

--- a/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
@@ -1527,7 +1527,7 @@ Array [
       <div
         aria-disabled="true"
         aria-orientation="vertical"
-        aria-valuemax="9980"
+        aria-valuemax="80"
         aria-valuemin="0"
         aria-valuenow="0"
         class="ant-splitter-bar-dragger ant-splitter-bar-dragger-disabled"

--- a/components/splitter/__tests__/index.test.tsx
+++ b/components/splitter/__tests__/index.test.tsx
@@ -483,6 +483,19 @@ describe('Splitter', () => {
         'NaN',
       );
     });
+
+    it('should render percentage-based aria value range before resize', () => {
+      const { container } = render(
+        <SplitterDemo
+          items={[{ defaultSize: 100, min: 100, max: 200 }, { min: 100, max: 200 }, { min: '20%' }]}
+        />,
+      );
+
+      expect(container.querySelectorAll('.ant-splitter-bar-dragger')[1]).toHaveAttribute(
+        'aria-valuemax',
+        '80',
+      );
+    });
   });
 
   // ============================= Collapsible =============================

--- a/components/splitter/__tests__/lazy.test.tsx
+++ b/components/splitter/__tests__/lazy.test.tsx
@@ -141,6 +141,37 @@ describe('Splitter lazy', () => {
     expect(container.querySelector('.ant-splitter-mask')).toBeFalsy();
   });
 
+  it('should not move preview when adjacent panels have zero size', async () => {
+    const onResize = jest.fn();
+    const onResizeEnd = jest.fn();
+    const { container } = render(
+      <SplitterDemo
+        items={[{ defaultSize: 0 }, { defaultSize: 0 }, {}]}
+        onResize={onResize}
+        onResizeEnd={onResizeEnd}
+        lazy
+      />,
+    );
+
+    await resizeSplitter();
+
+    const dragger = container.querySelector<HTMLElement>('.ant-splitter-bar-dragger')!;
+    const downEvent = createEvent.mouseDown(dragger);
+    Object.defineProperty(downEvent, 'pageX', { value: 0 });
+    fireEvent(dragger, downEvent);
+
+    const moveEvent = createEvent.mouseMove(window);
+    Object.defineProperty(moveEvent, 'pageX', { value: 1000 });
+    fireEvent(window, moveEvent);
+
+    const preview = container.querySelector<HTMLElement>('.ant-splitter-bar-preview')!;
+    expect(preview.style.getPropertyValue('--ant-splitter-bar-preview-offset')).toBe('0px');
+    expect(onResize).not.toHaveBeenCalled();
+
+    fireEvent.mouseUp(window);
+    expect(onResizeEnd).toHaveBeenCalledWith([0, 0, 100]);
+  });
+
   it('should work with touch events when lazy', async () => {
     const onResize = jest.fn();
     const onResizeEnd = jest.fn();


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [x] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Splitter 内部使用 0～1 的比例计算分隔条位置，但容器尚未完成尺寸测量时，累计尺寸的兜底值错误地使用了 100，导致 `aria-valuemax` 等 ARIA 范围可能被放大 100 倍，例如由 80 误算为 9980。

本次改动统一使用百分比比例进行兜底，仅对非有限累计尺寸采用默认边界，并保留合法的零尺寸。这样同时保证了 ARIA 范围和 lazy 拖拽预览边界与实际面板尺寸一致。

新增了初始化 ARIA 范围和相邻零尺寸面板 lazy 拖拽的回归用例。无 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Splitter incorrect percentage-based ARIA value ranges before container measurement. |
| 🇨🇳 中文 | 🐞 修复 Splitter 在容器尺寸测量前百分比 ARIA 取值范围异常的问题。 |
