### PR TITLE
fix(InputNumber): display suffix with form feedback

### DIFF
--- a/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2155,6 +2155,145 @@ exports[`renders components/input-number/demo/disabled-hover-debug.tsx extend co
 
 exports[`renders components/input-number/demo/disabled-hover-debug.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/input-number/demo/feedback-suffix-debug.tsx extend context correctly 1`] = `
+<form
+  class="ant-form ant-form-vertical css-var-test-id ant-form-css-var"
+  style="max-width: 320px;"
+>
+  <div
+    class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-has-feedback ant-form-item-has-success ant-form-item-vertical"
+  >
+    <div
+      class="ant-row ant-form-item-row css-var-test-id"
+    >
+      <div
+        class="ant-col ant-form-item-label css-var-test-id"
+      >
+        <label
+          class=""
+          title="Suffix with feedback"
+        >
+          Suffix with feedback
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control css-var-test-id"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-status-success ant-input-number-has-feedback ant-input-number-outlined ant-input-number-in-form-item"
+              style="width: 100%;"
+            >
+              <input
+                aria-valuenow="100"
+                autocomplete="off"
+                class="ant-input-number-input"
+                role="spinbutton"
+                step="1"
+                value="100"
+              />
+              <div
+                class="ant-input-number-suffix"
+              >
+                RMB
+                <span
+                  class="ant-form-item-feedback-icon ant-form-item-feedback-icon-success"
+                >
+                  <span
+                    aria-label="check-circle"
+                    class="anticon anticon-check-circle"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="check-circle"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+              <div
+                class="ant-input-number-actions"
+              >
+                <span
+                  aria-disabled="false"
+                  aria-label="Increase Value"
+                  class="ant-input-number-action ant-input-number-action-up"
+                  role="button"
+                  unselectable="on"
+                >
+                  <span
+                    aria-label="up"
+                    class="anticon anticon-up"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="up"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+                <span
+                  aria-disabled="false"
+                  aria-label="Decrease Value"
+                  class="ant-input-number-action ant-input-number-action-down"
+                  role="button"
+                  unselectable="on"
+                >
+                  <span
+                    aria-label="down"
+                    class="anticon anticon-down"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="down"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`renders components/input-number/demo/feedback-suffix-debug.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/input-number/demo/filled-debug.tsx extend context correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"

--- a/components/input-number/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input-number/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1682,6 +1682,143 @@ exports[`renders components/input-number/demo/disabled-hover-debug.tsx correctly
 </div>
 `;
 
+exports[`renders components/input-number/demo/feedback-suffix-debug.tsx correctly 1`] = `
+<form
+  class="ant-form ant-form-vertical css-var-test-id ant-form-css-var"
+  style="max-width:320px"
+>
+  <div
+    class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-has-feedback ant-form-item-has-success ant-form-item-vertical"
+  >
+    <div
+      class="ant-row ant-form-item-row css-var-test-id"
+    >
+      <div
+        class="ant-col ant-form-item-label css-var-test-id"
+      >
+        <label
+          class=""
+          title="Suffix with feedback"
+        >
+          Suffix with feedback
+        </label>
+      </div>
+      <div
+        class="ant-col ant-form-item-control css-var-test-id"
+      >
+        <div
+          class="ant-form-item-control-input"
+        >
+          <div
+            class="ant-form-item-control-input-content"
+          >
+            <div
+              class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-status-success ant-input-number-has-feedback ant-input-number-outlined ant-input-number-in-form-item"
+              style="width:100%"
+            >
+              <input
+                aria-valuenow="100"
+                autocomplete="off"
+                class="ant-input-number-input"
+                role="spinbutton"
+                step="1"
+                value="100"
+              />
+              <div
+                class="ant-input-number-suffix"
+              >
+                RMB
+                <span
+                  class="ant-form-item-feedback-icon ant-form-item-feedback-icon-success"
+                >
+                  <span
+                    aria-label="check-circle"
+                    class="anticon anticon-check-circle"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="check-circle"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+              <div
+                class="ant-input-number-actions"
+              >
+                <span
+                  aria-disabled="false"
+                  aria-label="Increase Value"
+                  class="ant-input-number-action ant-input-number-action-up"
+                  role="button"
+                  unselectable="on"
+                >
+                  <span
+                    aria-label="up"
+                    class="anticon anticon-up"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="up"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+                <span
+                  aria-disabled="false"
+                  aria-label="Decrease Value"
+                  class="ant-input-number-action ant-input-number-action-down"
+                  role="button"
+                  unselectable="on"
+                >
+                  <span
+                    aria-label="down"
+                    class="anticon anticon-down"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="down"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`renders components/input-number/demo/filled-debug.tsx correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"

--- a/components/input-number/demo/feedback-suffix-debug.tsx
+++ b/components/input-number/demo/feedback-suffix-debug.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Form, InputNumber } from 'antd';
+
+const App: React.FC = () => (
+  <Form layout="vertical" style={{ maxWidth: 320 }}>
+    <Form.Item label="Suffix with feedback" validateStatus="success" hasFeedback>
+      <InputNumber defaultValue={100} suffix="RMB" style={{ width: '100%' }} />
+    </Form.Item>
+  </Form>
+);
+
+export default App;

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -175,7 +175,12 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
 
     const [variant, enableVariantCls] = useVariant('inputNumber', customVariant, bordered);
 
-    const suffixNode = hasFeedback && <>{feedbackIcon}</>;
+    const suffixNode = (hasFeedback || suffix) && (
+      <>
+        {suffix}
+        {hasFeedback && feedbackIcon}
+      </>
+    );
 
     // =========== Merged Props for Semantic ==========
     const mergedProps: InputNumberProps = {
@@ -225,7 +230,7 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
         readOnly={readOnly}
         controls={controlsTemp}
         prefix={prefix}
-        suffix={suffixNode || suffix}
+        suffix={suffixNode}
         classNames={mergedClassNames}
         styles={mergedStyles}
         {...others}


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

InputNumber 在 Form.Item 开启 `hasFeedback` 时，会优先使用反馈图标生成的后缀节点，导致组件自身配置的 `suffix` 无法显示。

本次改动参考 Input 的现有处理方式，将用户传入的 `suffix` 与 Form 反馈图标合并渲染，使两者能够同时显示。新增 debug demo 并更新对应快照，防止该问题回归。无 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix InputNumber not displaying `suffix` when Form feedback is enabled. |
| 🇨🇳 中文 | 🐞 修复 InputNumber 在 Form 开启反馈状态时不显示 `suffix` 的问题。 |