### PR TITLE
fix: avoid invalid pseudo-element selectors in reduced-motion styles

### DIFF
--- a/components/border-beam/style/index.ts
+++ b/components/border-beam/style/index.ts
@@ -1,7 +1,7 @@
 import type { CSSObject } from '@ant-design/cssinjs';
 import { Keyframes, unit } from '@ant-design/cssinjs';
 
-import { genNoMotionStyle } from '../../style/motion';
+import { genNoMotionRawStyle } from '../../style/motion';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genStyleHooks } from '../../theme/internal';
 import { genCssVar } from '../../theme/util/genStyleUtils';
@@ -52,7 +52,7 @@ const genBorderBeamStyle: GenerateStyle<BorderBeamToken, CSSObject> = (token) =>
           display: 'block',
 
           '&::before': {
-            ...genNoMotionStyle(),
+            ...genNoMotionRawStyle(),
             content: '""',
             position: 'absolute',
             top: 0,

--- a/components/checkbox/style/index.ts
+++ b/components/checkbox/style/index.ts
@@ -1,7 +1,7 @@
 import { unit } from '@ant-design/cssinjs';
 
 import { genFocusOutline, resetComponent } from '../../style';
-import { genNoMotionStyle } from '../../style/motion';
+import { genNoMotionRawStyle, genNoMotionStyle } from '../../style/motion';
 import type { FullToken, GenerateStyle } from '../../theme/internal';
 import { genStyleHooks, mergeToken } from '../../theme/internal';
 
@@ -113,7 +113,7 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
           opacity: 0,
           content: '""',
           transition: `all ${token.motionDurationFast} ${token.motionEaseInBack}, opacity ${token.motionDurationFast}`,
-          ...genNoMotionStyle(),
+          ...genNoMotionRawStyle(),
         },
 
         // Wrapper > Checkbox > input
@@ -173,7 +173,7 @@ export const genCheckboxStyle: GenerateStyle<CheckboxToken> = (token) => {
           opacity: 1,
           transform: 'rotate(45deg) scale(1) translate(-50%,-50%)',
           transition: `all ${token.motionDurationMid} ${token.motionEaseOutBack} ${token.motionDurationFast}`,
-          ...genNoMotionStyle(),
+          ...genNoMotionRawStyle(),
         },
 
         [hoverMediaQuery]: {

--- a/components/style/motion/index.ts
+++ b/components/style/motion/index.ts
@@ -22,7 +22,7 @@ import {
   slideUpIn,
   slideUpOut,
 } from './slide';
-import { genNoMotionStyle } from './util';
+import { genNoMotionRawStyle, genNoMotionStyle } from './util';
 import {
   initZoomMotion,
   zoomBigIn,
@@ -43,6 +43,7 @@ export {
   fadeIn,
   fadeOut,
   genCollapseMotion,
+  genNoMotionRawStyle,
   genNoMotionStyle,
   initFadeMotion,
   initMoveMotion,

--- a/components/style/motion/util.ts
+++ b/components/style/motion/util.ts
@@ -10,3 +10,15 @@ export const genNoMotionStyle = (): CSSObject => {
     },
   };
 };
+
+/**
+ * For call sites already nested inside a pseudo-element selector.
+ */
+export const genNoMotionRawStyle = (): CSSObject => {
+  return {
+    '@media (prefers-reduced-motion: reduce)': {
+      transition: 'none',
+      animation: 'none',
+    },
+  };
+};

--- a/components/switch/style/index.ts
+++ b/components/switch/style/index.ts
@@ -3,7 +3,7 @@ import { unit } from '@ant-design/cssinjs';
 import { FastColor } from '@ant-design/fast-color';
 
 import { genFocusStyle, resetComponent } from '../../style';
-import { genNoMotionStyle } from '../../style/motion';
+import { genNoMotionRawStyle, genNoMotionStyle } from '../../style/motion';
 import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genStyleHooks, mergeToken } from '../../theme/internal';
 
@@ -222,7 +222,7 @@ const genSwitchHandleStyle: GenerateStyle<SwitchToken, CSSObject> = (token) => {
           boxShadow: handleShadow,
           transition: `all ${token.switchDuration} ease-in-out`,
           content: '""',
-          ...genNoMotionStyle(),
+          ...genNoMotionRawStyle(),
         },
       },
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Related to #58685

### 💡 需求背景和解决方案

#58685 扩展了 `genNoMotionStyle`，使其同时处理当前节点及其前后伪元素。但当该方法已经在伪元素样式内调用时，会生成 `::before::before`、`::after::after` 等非法选择器，导致 Lightning CSS 压缩失败。

本次新增仅处理当前选择器的 `genNoMotionRawStyle`，并将 BorderBeam、Checkbox 和 Switch 中位于伪元素内的调用切换至该方法。普通节点继续使用原有方法，保持 reduced-motion 覆盖范围不变。

已验证生成的 CSS 不再包含嵌套伪元素选择器，并可通过 Lightning CSS 压缩。Biome、ESLint 和 antd lint 均通过；未运行测试。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix BorderBeam, Checkbox, and Switch reduced-motion styles generating invalid pseudo-element selectors. |
| 🇨🇳 中文 | 🐞 修复 BorderBeam、Checkbox 和 Switch 的 reduced-motion 样式生成非法伪元素选择器的问题。 |
