### PR TITLE
fix(Tree): restore rootStyle compatibility

### DIFF
--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -6,9 +6,10 @@ import type { BasicDataNode, DataNode, TreeProps as RcTreeProps } from '@rc-comp
 import RcTree from '@rc-component/tree';
 import { clsx } from 'clsx';
 
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import initCollapseMotion from '../_util/motion';
+import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import { useComponentConfig } from '../config-provider/context';
 import DisabledContext from '../config-provider/DisabledContext';
@@ -141,11 +142,14 @@ export interface TreeProps<T extends BasicDataNode = DataNode>
     | 'switcherIcon'
     | 'classNames'
     | 'styles'
+    | 'rootStyle'
   > {
   showLine?: boolean | { showLeafIcon: boolean | TreeLeafIcon };
   className?: string;
   classNames?: TreeSemanticAllType['classNamesAndFn'];
   styles?: TreeSemanticAllType['stylesAndFn'];
+  /** @deprecated Please use `styles.root` instead */
+  rootStyle?: React.CSSProperties;
   /** Whether to support multiple selection */
   multiple?: boolean;
   /** Whether to automatically expand the parent node */
@@ -214,10 +218,16 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
     motion: customMotion,
     style,
     rootClassName,
+    rootStyle,
     classNames,
     styles,
     icon,
   } = props;
+
+  if (process.env.NODE_ENV !== 'production') {
+    const warning = devUseWarning('Tree');
+    warning.deprecated(!rootStyle, 'rootStyle', 'styles.root');
+  }
 
   const contextDisabled = React.useContext(DisabledContext);
   const mergedDisabled = disabled ?? contextDisabled;
@@ -241,9 +251,11 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
     motion,
   };
 
+  const rootStyleRoot = useSemanticRootStyle(rootStyle);
+
   const [mergedClassNames, mergedStyles] = useMergeSemantic(
     [contextClassNames, classNames],
-    [contextStyles, styles],
+    [contextStyles, rootStyleRoot, styles],
     {
       props: mergedProps,
     },

--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -253,13 +253,13 @@ const Tree = React.forwardRef<RcTree, TreeProps>((props, ref) => {
 
   const rootStyleRoot = useSemanticRootStyle(rootStyle);
 
-  const [mergedClassNames, mergedStyles] = useMergeSemantic(
-    [contextClassNames, classNames],
-    [contextStyles, rootStyleRoot, styles],
-    {
-      props: mergedProps,
-    },
-  );
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    TreeSemanticAllType['classNames'],
+    TreeSemanticAllType['styles'],
+    TreeProps
+  >([contextClassNames, classNames], [contextStyles, rootStyleRoot, styles], {
+    props: mergedProps,
+  });
 
   const newProps = {
     ...mergedProps,

--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -66,7 +66,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | loadedKeys | (Controlled) Set loaded tree nodes. Need to work with `loadData` | string\[] | \[] |  | × |
 | motion | Custom motion config for the tree | CSSMotionProps | - |  | × |
 | multiple | Allows selecting multiple treeNodes | boolean | false |  | × |
-| rootStyle | Style on the root element | CSSProperties | - | 4.20.0 | × |
+| ~~rootStyle~~ | Style on the root element, please use `styles.root` instead | CSSProperties | - | 4.20.0 | × |
 | selectable | Whether it can be selected | boolean | true |  | × |
 | selectedKeys | (Controlled) Specifies the keys of the selected treeNodes, multiple selection needs to set `multiple` to true | string\[] | - |  | × |
 | showIcon | Controls whether to display the `icon` node (no default style) | boolean | false |  | × |

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -68,7 +68,7 @@ demo:
 | loadedKeys | （受控）已经加载的节点，需要配合 `loadData` 使用 | string\[] | \[] |  | × |
 | motion | 自定义树的动画配置 | CSSMotionProps | - |  | × |
 | multiple | 支持点选多个节点（节点本身） | boolean | false |  | × |
-| rootStyle | 添加在 Tree 最外层的 style | CSSProperties | - | 4.20.0 | × |
+| ~~rootStyle~~ | Tree 最外层样式，请使用 `styles.root` 替代 | CSSProperties | - | 4.20.0 | × |
 | selectable | 是否可选中 | boolean | true |  | × |
 | selectedKeys | （受控）设置选中的树节点，多选需设置 `multiple` 为 true | string\[] | - |  | × |
 | showIcon | 控制是否展示 `icon` 节点，没有默认样式 | boolean | false |  | × |


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

关联引入该回归的 PR：#53174

### 💡 需求背景和解决方案

PR #53174 为 Tree 接入 `classNames` 和 `styles` 时，新增了显式的 `rootStyle={mergedStyles.root}`。此前 `rootStyle` 由 `RcTreeProps` 继承，并通过 `...newProps` 直接透传给 rc-tree；新增的显式属性位于展开属性之后，因此覆盖了原有的 `rootStyle`，未配置 `styles.root` 时也会将其覆盖为 `undefined`。

`rootStyle` 与 `styles.root` 最终都作用于 Tree 最外层的 `.ant-tree` 节点，因此本 PR 将旧的 `rootStyle` 合并到语义样式中，恢复已有用法的兼容行为，并保持组件 `styles.root` 的优先级更高。

同时将 `rootStyle` 标记为废弃，在类型、开发环境警告和中英文文档中推荐使用 `styles.root`。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Tree `rootStyle` not working and deprecate it in favor of `styles.root`. |
| 🇨🇳 中文 | 🐞 修复 Tree `rootStyle` 不生效的问题，并废弃该属性，推荐使用 `styles.root`。 |
