### PR TITLE
fix(Slider): prevent duplicate focus and blur callbacks

### DIFF
--- a/components/slider/__tests__/index.test.tsx
+++ b/components/slider/__tests__/index.test.tsx
@@ -37,6 +37,19 @@ describe('Slider', () => {
     jest.useRealTimers();
   });
 
+  it('should trigger focus and blur events once', () => {
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    const { container } = render(<Slider onFocus={onFocus} onBlur={onBlur} />);
+    const handle = container.querySelector('.ant-slider-handle')!;
+
+    fireEvent.focus(handle);
+    expect(onFocus).toHaveBeenCalledTimes(1);
+
+    fireEvent.blur(handle);
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+
   it('should show tooltip when hovering slider handler', async () => {
     const { container } = render(<Slider defaultValue={30} />);
 

--- a/components/slider/__tests__/tooltip.test.tsx
+++ b/components/slider/__tests__/tooltip.test.tsx
@@ -65,6 +65,20 @@ describe('Slider.Tooltip', () => {
     expect(tooltipProps().open).toBeTruthy();
   });
 
+  it('range should show tooltip when handle is focused', async () => {
+    const { container } = render(<Slider range defaultValue={[0, 100]} />);
+
+    const handleEle = container.querySelector('.ant-slider-handle')!;
+
+    fireEvent.focus(handleEle);
+    await waitFakeTimer();
+    expect(tooltipProps().open).toBeTruthy();
+
+    fireEvent.blur(handleEle);
+    await waitFakeTimer();
+    expect(tooltipProps().open).toBeFalsy();
+  });
+
   it('tooltip should not display when formatter is null or open is false', async () => {
     // https://github.com/ant-design/ant-design/issues/48668
     const { container: container1 } = render(

--- a/components/slider/index.tsx
+++ b/components/slider/index.tsx
@@ -307,12 +307,7 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
       function proxyEvent(
         eventName: keyof React.DOMAttributes<HTMLElement>,
         event: React.SyntheticEvent,
-        triggerRestPropsEvent?: boolean,
       ) {
-        if (triggerRestPropsEvent) {
-          (restProps as any)[eventName]?.(event);
-        }
-
         (nodeProps as any)[eventName]?.(event);
       }
 
@@ -333,13 +328,11 @@ const Slider = React.forwardRef<SliderRef, SliderSingleProps | SliderRangeProps>
         },
         onFocus: (e) => {
           setFocusOpen(true);
-          restProps.onFocus?.(e);
-          proxyEvent('onFocus', e, true);
+          proxyEvent('onFocus', e);
         },
         onBlur: (e) => {
           setFocusOpen(false);
-          restProps.onBlur?.(e);
-          proxyEvent('onBlur', e, true);
+          proxyEvent('onBlur', e);
         },
       };
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Slider 当前会将用户传入的 `onFocus` 和 `onBlur` 回调重复触发三次。对相关代码的历史进行回溯后，事件链的演变如下：

1. `321dfd8cc9` 首次支持 Slider handle 聚焦时显示 Tooltip。
2. `b888f69152` 为修复 React 16 下的测试问题，改为克隆 handle 并手动管理聚焦状态。由于当时没有继续转发原始节点的事件，因此显式调用 `restProps.onFocus/onBlur` 是必要的，用于保留用户回调。
3. `c321492eeb` 为修复 Range Slider 交换位置时 Tooltip 闪烁的问题，引入 `activeHandleRender` 并开始转发 `nodeProps.onFocus/onBlur`，但旧的 `restProps` 调用仍被保留。此时原始节点事件已经包含 rc-slider 的 active handle 状态更新和用户回调。
4. `832cffcdf9` 在 ColorPicker 渐变色改造中抽取 `proxyEvent`，又通过 `triggerRestPropsEvent` 调用了一次 `restProps`，最终使用户回调被触发三次。ColorPicker 使用独立的 context `handleRender`，不会进入该默认 Slider 事件分支。
5. `2247db09a8` 仅将依赖迁移至 `@rc-component/slider`，重复调用逻辑被原样保留。

当前 `@rc-component/slider@1.1.1` 中，`nodeProps.onFocus` 会先更新 rc 的 active handle 状态，再调用用户的 `onFocus`；`nodeProps.onBlur` 也会调用用户的 `onBlur`。

本次修改保留 `setFocusOpen` 和完整的 `nodeProps` 事件链，仅移除额外的 `restProps` 调用，使用户回调恢复为每次事件触发一次，同时保持 Single、Range Tooltip 和 ColorPicker 的既有行为。

新增测试覆盖：

- `onFocus` 和 `onBlur` 每次只触发一次。
- Range Slider 聚焦时 Tooltip 正常打开，失焦时正常关闭。

验证结果：

`npm test -- components/slider`

- 9 个测试套件通过
- 77 个测试通过，1 个跳过
- 49 个快照通过

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Slider triggering `onFocus` and `onBlur` callbacks multiple times. |
| 🇨🇳 中文 | 🐞 修复 Slider 的 `onFocus` 和 `onBlur` 回调被重复触发的问题。 |
