### PR TITLE
style(Button): align loading icon styles

### DIFF
--- a/components/button/style/index.ts
+++ b/components/button/style/index.ts
@@ -53,7 +53,6 @@ const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => {
       [`${componentCls}-icon`]: {
         display: 'inline-flex',
         alignItems: 'center',
-        justifyContent: 'center',
 
         [iconCls]: {
           verticalAlign: 'middle',
@@ -101,8 +100,6 @@ const genSharedButtonStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => {
       },
 
       [`${componentCls}-loading-icon`]: {
-        display: 'block',
-
         transition: ['width', 'opacity', 'margin']
           .map((prop) => `${prop} ${motionDurationSlow} ${motionEaseInOut}`)
           .join(','),


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 💄 组件样式/交互改进

### 🔗 相关 Issue

[#58690](https://github.com/ant-design/ant-design/pull/58690) 的后续调优。

### 💡 需求背景和解决方案

在 [#58690](https://github.com/ant-design/ant-design/pull/58690) 中，为修复 Button Loading 动画跳动，Loading icon 单独设置了 `display: block`。

进一步验证发现，Loading icon 可以直接复用普通 icon 的 `inline-flex` 布局。本次调优移除 Loading icon 的独立 display 样式及普通 icon 冗余的水平居中样式，使两者保持一致。

Button 单测全部通过：67 tests、25 snapshots。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | - |
| 🇨🇳 中文 | - |
