### PR TITLE
fix(Transfer): preserve custom action disabled state

### DIFF
--- a/components/transfer/Actions.tsx
+++ b/components/transfer/Actions.tsx
@@ -60,12 +60,16 @@ const Action: React.FC<ActionProps> = ({
 
   if (React.isValidElement(button)) {
     const element = button as ButtonElementType;
+    const mergedDisabled = element.props.disabled || disabled || !active;
     const onClick: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement> = (event) => {
+      if (mergedDisabled) {
+        return;
+      }
       element?.props?.onClick?.(event);
       moveHandler?.(event);
     };
     return React.cloneElement(element, {
-      disabled: element.props.disabled || disabled || !active,
+      disabled: mergedDisabled,
       onClick,
     });
   }

--- a/components/transfer/Actions.tsx
+++ b/components/transfer/Actions.tsx
@@ -65,7 +65,7 @@ const Action: React.FC<ActionProps> = ({
       moveHandler?.(event);
     };
     return React.cloneElement(element, {
-      disabled: disabled || !active,
+      disabled: element.props.disabled || disabled || !active,
       onClick,
     });
   }

--- a/components/transfer/Actions.tsx
+++ b/components/transfer/Actions.tsx
@@ -63,6 +63,7 @@ const Action: React.FC<ActionProps> = ({
     const mergedDisabled = element.props.disabled || disabled || !active;
     const onClick: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement> = (event) => {
       if (mergedDisabled) {
+        event.preventDefault();
         return;
       }
       element?.props?.onClick?.(event);

--- a/components/transfer/__tests__/actions.test.tsx
+++ b/components/transfer/__tests__/actions.test.tsx
@@ -43,6 +43,28 @@ describe('Actions', () => {
     expect(handleChange).toHaveBeenCalled();
   });
 
+  it('should preserve custom button disabled state', () => {
+    const handleChange = jest.fn();
+    const { getByRole } = render(
+      <Transfer
+        {...listCommonProps}
+        onChange={handleChange}
+        oneWay
+        actions={[
+          <Button key="test" disabled>
+            Custom Button
+          </Button>,
+        ]}
+      />,
+    );
+
+    const button = getByRole('button', { name: 'Custom Button' });
+    expect(button).toBeDisabled();
+
+    fireEvent.click(button);
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
   it('should accept multiple actions >= 3', () => {
     const { getByText } = render(
       <Transfer

--- a/components/transfer/__tests__/actions.test.tsx
+++ b/components/transfer/__tests__/actions.test.tsx
@@ -18,6 +18,18 @@ const listCommonProps: {
   targetKeys: ['b'],
 };
 
+const CustomLink = ({
+  disabled,
+  onClick,
+}: {
+  disabled?: boolean;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+}) => (
+  <a href="#target" aria-disabled={disabled} onClick={onClick}>
+    Custom Link
+  </a>
+);
+
 describe('Actions', () => {
   it('should handle custom button click correctly via actions', () => {
     const handleChange = jest.fn();
@@ -43,36 +55,39 @@ describe('Actions', () => {
     expect(handleChange).toHaveBeenCalled();
   });
 
-  it('should preserve custom button disabled state', () => {
-    const handleChange = jest.fn();
-    const customButtonClick = jest.fn();
-
-    const CustomButton = ({
-      disabled,
-      onClick,
-    }: {
-      disabled?: boolean;
-      onClick?: React.MouseEventHandler<HTMLButtonElement>;
-    }) => (
-      <button type="button" aria-disabled={disabled} onClick={onClick}>
-        Custom Button
-      </button>
+  it('should preserve disabled state of custom actions', () => {
+    const { getByRole } = render(
+      <Transfer {...listCommonProps} oneWay actions={[<CustomLink key="test" disabled />]} />,
     );
+
+    const link = getByRole('link', { name: 'Custom Link' });
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should prevent default behavior of disabled custom actions', () => {
+    const { getByRole } = render(
+      <Transfer {...listCommonProps} oneWay actions={[<CustomLink key="test" disabled />]} />,
+    );
+
+    const link = getByRole('link', { name: 'Custom Link' });
+    expect(fireEvent.click(link)).toBe(false);
+  });
+
+  it('should prevent click handlers of disabled custom actions', () => {
+    const handleChange = jest.fn();
+    const customActionClick = jest.fn();
 
     const { getByRole } = render(
       <Transfer
         {...listCommonProps}
         onChange={handleChange}
         oneWay
-        actions={[<CustomButton key="test" disabled onClick={customButtonClick} />]}
+        actions={[<CustomLink key="test" disabled onClick={customActionClick} />]}
       />,
     );
 
-    const button = getByRole('button', { name: 'Custom Button' });
-    expect(button).toHaveAttribute('aria-disabled', 'true');
-
-    fireEvent.click(button);
-    expect(customButtonClick).not.toHaveBeenCalled();
+    fireEvent.click(getByRole('link', { name: 'Custom Link' }));
+    expect(customActionClick).not.toHaveBeenCalled();
     expect(handleChange).not.toHaveBeenCalled();
   });
 

--- a/components/transfer/__tests__/actions.test.tsx
+++ b/components/transfer/__tests__/actions.test.tsx
@@ -45,23 +45,34 @@ describe('Actions', () => {
 
   it('should preserve custom button disabled state', () => {
     const handleChange = jest.fn();
+    const customButtonClick = jest.fn();
+
+    const CustomButton = ({
+      disabled,
+      onClick,
+    }: {
+      disabled?: boolean;
+      onClick?: React.MouseEventHandler<HTMLButtonElement>;
+    }) => (
+      <button type="button" aria-disabled={disabled} onClick={onClick}>
+        Custom Button
+      </button>
+    );
+
     const { getByRole } = render(
       <Transfer
         {...listCommonProps}
         onChange={handleChange}
         oneWay
-        actions={[
-          <Button key="test" disabled>
-            Custom Button
-          </Button>,
-        ]}
+        actions={[<CustomButton key="test" disabled onClick={customButtonClick} />]}
       />,
     );
 
     const button = getByRole('button', { name: 'Custom Button' });
-    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-disabled', 'true');
 
     fireEvent.click(button);
+    expect(customButtonClick).not.toHaveBeenCalled();
     expect(handleChange).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

`d671e38f2e` 为 Transfer 的 `actions` 属性增加了 ReactNode 数组支持，并允许自定义操作按钮通过 `disabled` 属性控制禁用状态。

当前实现克隆自定义按钮时，仅根据 Transfer 的全局禁用状态和是否存在可移动项重新计算 `disabled`。当存在可移动项时，计算结果会以 `false` 覆盖自定义按钮原有的 `disabled={true}`，导致按钮重新变为可点击状态，并可能继续移动数据、触发 `onChange`。

本次修改在计算禁用状态时同时保留自定义按钮自身的 `disabled`。以下任一条件满足时，按钮都会保持禁用：

- 自定义按钮显式设置 `disabled`。
- Transfer 整体处于禁用状态。
- 当前没有可移动的选中项。

新增回归测试覆盖“内部存在可移动项，但自定义操作按钮显式禁用”的场景，验证按钮保持禁用且不会触发 `onChange`。

API 和默认操作按钮行为没有变化。

验证结果：

- antd lint 通过
- Biome 通过
- ESLint 通过
- 未运行组件测试

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Transfer custom action buttons not preserving their `disabled` state. |
| 🇨🇳 中文 | 🐞 修复 Transfer 自定义操作按钮的 `disabled` 状态被覆盖的问题。 |
