### PR TITLE
fix(Grid): support zero flex values

### DIFF
--- a/components/grid/__tests__/index.test.tsx
+++ b/components/grid/__tests__/index.test.tsx
@@ -64,6 +64,17 @@ describe('Grid', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
+  it('should support zero flex', () => {
+    const { container } = render(<Col flex={0} />);
+    expect(container.firstElementChild).toHaveStyle({ flex: '0 0 auto' });
+  });
+
+  it('should support responsive zero flex', () => {
+    const { container } = render(<Col xs={{ flex: 0 }} />);
+    expect(container.firstElementChild).toHaveClass('ant-col-xs-flex');
+    expect(container.firstElementChild).toHaveStyle({ '--ant-col-xs-flex': '0 0 auto' });
+  });
+
   it('should render Row', () => {
     const { asFragment } = render(<Row />);
     expect(asFragment().firstChild).toMatchSnapshot();

--- a/components/grid/col.tsx
+++ b/components/grid/col.tsx
@@ -104,7 +104,7 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>((props, ref) => {
     };
 
     // Responsive flex layout
-    if (sizeProps.flex) {
+    if (isNumber(sizeProps.flex) || sizeProps.flex) {
       sizeClassObj[`${prefixCls}-${size}-flex`] = true;
       sizeStyle[varName(`${size}-flex`)] = parseFlex(sizeProps.flex);
     }
@@ -133,7 +133,7 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>((props, ref) => {
     mergedStyle.paddingInline = horizontalGutter;
   }
 
-  if (flex) {
+  if (isNumber(flex) || flex) {
     mergedStyle.flex = parseFlex(flex);
 
     // Hack for Firefox to avoid size issue

--- a/components/grid/col.tsx
+++ b/components/grid/col.tsx
@@ -104,7 +104,7 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>((props, ref) => {
     };
 
     // Responsive flex layout
-    if (isNumber(sizeProps.flex) || sizeProps.flex) {
+    if (sizeProps.flex || sizeProps.flex === 0) {
       sizeClassObj[`${prefixCls}-${size}-flex`] = true;
       sizeStyle[varName(`${size}-flex`)] = parseFlex(sizeProps.flex);
     }
@@ -133,7 +133,7 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>((props, ref) => {
     mergedStyle.paddingInline = horizontalGutter;
   }
 
-  if (isNumber(flex) || flex) {
+  if (flex || flex === 0) {
     mergedStyle.flex = parseFlex(flex);
 
     // Hack for Firefox to avoid size issue


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Grid Col 的 `flex` 属性支持数值类型，但现有真值判断会忽略数值 `0`，导致 `flex={0}` 和响应式配置 `xs={{ flex: 0 }}` 无法生效。

本次调整普通与响应式 flex 的判断逻辑，使合法数值 `0` 进入现有 `parseFlex` 转换流程，同时保持空字符串和 `NaN` 等无效值的原有处理方式。补充了普通与响应式场景的回归测试。

验证：Biome、ESLint 提交检查通过；未运行组件测试。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Grid Col ignoring numeric zero values for `flex` and responsive flex. |
| 🇨🇳 中文 | 🐞 修复 Grid Col 的 `flex` 和响应式 flex 忽略数值 `0` 的问题。 |
