### PR TITLE
fix(Tag): prevent navigation when closing link tags

### DIFF
--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -6,7 +6,7 @@ import { CheckCircleOutlined, CloseCircleOutlined, LinkedinOutlined } from '@ant
 import Tag from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import { act, fireEvent, render } from '../../../tests/utils';
+import { act, createEvent, fireEvent, render } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
 
 (global as any).isVisible = true;
@@ -64,6 +64,23 @@ describe('Tag', () => {
       jest.runAllTimers();
     });
     expect(container.querySelectorAll('.ant-tag:not(.ant-tag-hidden)').length).toBe(1);
+  });
+
+  it('should prevent navigation when closing a link tag', () => {
+    const onClose = jest.fn();
+    const { container } = render(
+      <Tag href="#target" closable onClose={onClose}>
+        Link
+      </Tag>,
+    );
+    const closeIcon = container.querySelector('.ant-tag-close-icon')!;
+    const clickEvent = createEvent.click(closeIcon);
+
+    fireEvent(closeIcon, clickEvent);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(container.querySelector('.ant-tag-hidden')).toBeTruthy();
   });
 
   it('show close button by closeIcon', () => {

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -176,6 +176,9 @@ const InternalTag = React.forwardRef<HTMLSpanElement | HTMLAnchorElement, TagPro
       if (e.defaultPrevented) {
         return;
       }
+      if (href) {
+        e.preventDefault();
+      }
       setVisible(false);
     };
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] ✅ 测试用例

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

当 Tag 同时配置 `href` 和 `closable` 时，关闭图标位于链接元素内部。点击关闭图标虽然会关闭 Tag，但仍会触发链接的默认导航行为。

本次在 Tag 正常执行关闭操作时阻止链接的默认行为，同时保留 `onClose` 通过 `event.preventDefault()` 阻止关闭的现有能力，并补充回归测试。

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | 🐞 Fix Tag navigating when closing a closable tag with `href`. |
| 🇨🇳 中文 | 🐞 修复 Tag 配置 `href` 时点击关闭图标仍会跳转的问题。 |