### PR TITLE
refactor(Typography): simplify ellipsis Tooltip control

### DIFF
--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -398,7 +398,7 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
       getTooltipContainer={mergedGetPopupContainer}
       destroyOnHidden={mergedDestroyOnHidden}
     >
-      {tempOpen ? cloneElement(child, { className: childCls }) : child}
+      {tempOpen && !restProps.disabled ? cloneElement(child, { className: childCls }) : child}
     </RcTooltip>
   );
 

--- a/components/typography/Base/EllipsisTooltip.tsx
+++ b/components/typography/Base/EllipsisTooltip.tsx
@@ -23,7 +23,7 @@ const EllipsisTooltip: React.FC<EllipsisTooltipProps> = ({
   }
 
   return (
-    <Tooltip open={isEllipsis ? undefined : false} {...tooltipProps} disabled={disabled}>
+    <Tooltip {...tooltipProps} disabled={!isEllipsis || disabled}>
       {children}
     </Tooltip>
   );

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -507,7 +507,12 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
         })}
         style={mergedStyles.actions}
         onMouseEnter={() => setIsHoveringOperations(true, true)}
-        onMouseLeave={() => setIsHoveringOperations(false)}
+        onMouseLeave={() =>
+          setIsHoveringOperations(false, {
+            // Delay 500ms for better user experience
+            ms: 500,
+          })
+        }
       >
         {expandNode}
         {editNode}

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -3,7 +3,14 @@ import type { JSX } from 'react';
 import EditOutlined from '@ant-design/icons/EditOutlined';
 import type { AutoSizeType } from '@rc-component/input';
 import ResizeObserver from '@rc-component/resize-observer';
-import { composeRef, omit, toArray, useControlledState, useLayoutEffect } from '@rc-component/util';
+import {
+  composeRef,
+  omit,
+  toArray,
+  useControlledState,
+  useDelayState,
+  useLayoutEffect,
+} from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { GenerateSemantic } from '../../_util/hooks/useMergeSemantic/semanticType';
@@ -322,7 +329,8 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
   };
 
   const [ellipsisWidth, setEllipsisWidth] = React.useState(0);
-  const [isHoveringOperations, setIsHoveringOperations] = React.useState(false);
+  const [isHoveringOperations, setIsHoveringOperations] = useDelayState(false);
+
   const onResize = ({ offsetWidth }: { offsetWidth: number }) => {
     setEllipsisWidth(offsetWidth);
   };
@@ -498,7 +506,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
           [`${prefixCls}-actions-start`]: placement === 'start',
         })}
         style={mergedStyles.actions}
-        onMouseEnter={() => setIsHoveringOperations(true)}
+        onMouseEnter={() => setIsHoveringOperations(true, true)}
         onMouseLeave={() => setIsHoveringOperations(false)}
       >
         {expandNode}

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1655,34 +1655,12 @@ Array [
     Ant Design, a design language for background applications, is refined by Ant UED Team. Ant Design, a design language for background applications, is refined by Ant UED Team. Ant Design, a design language for background applications, is refined by Ant UED Team. Ant Design, a design language for background applications, is refined by Ant UED Team. Ant Design, a design language for background applications, is refined by Ant UED Team. Ant Design, a design language for background applications, is refined by Ant UED Team.
   </div>,
   <span
-    aria-describedby="test-id"
     class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line css-var-test-id"
     style="width: 200px;"
   >
     Ant Design, a design language for background applications, is refined by Ant UED Team.
   </span>,
-  <div
-    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-tooltip-placement-top"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-  >
-    <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
-    >
-      <span
-        class="ant-tooltip-arrow-content"
-      />
-    </div>
-    <div
-      class="ant-tooltip-container"
-      id="test-id"
-      role="tooltip"
-    >
-      I am ellipsis now!
-    </div>
-  </div>,
   <span
-    aria-describedby="test-id"
     class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line css-var-test-id"
     style="width: 200px;"
   >
@@ -1690,26 +1668,6 @@ Array [
       Ant Design, a design language for background applications, is refined by Ant UED Team.
     </code>
   </span>,
-  <div
-    class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-tooltip-placement-top"
-    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-  >
-    <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
-    >
-      <span
-        class="ant-tooltip-arrow-content"
-      />
-    </div>
-    <div
-      class="ant-tooltip-container"
-      id="test-id"
-      role="tooltip"
-    >
-      I am ellipsis now!
-    </div>
-  </div>,
 ]
 `;
 
@@ -2246,32 +2204,11 @@ Array [
     style="display: none;"
   >
     <span
-      aria-describedby="test-id"
       class="ant-typography ant-typography-ellipsis ant-typography-ellipsis-single-line css-var-test-id"
       style="width: 100px;"
     >
       默认 display none 样式的超长文字， 悬停 tooltip 失效了
     </span>
-    <div
-      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-tooltip-placement-top"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-    >
-      <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      >
-        <span
-          class="ant-tooltip-arrow-content"
-        />
-      </div>
-      <div
-        class="ant-tooltip-container"
-        id="test-id"
-        role="tooltip"
-      >
-        I am ellipsis now!
-      </div>
-    </div>
   </div>,
   <div
     class="ant-typography ant-typography-ellipsis css-var-test-id"
@@ -2379,7 +2316,6 @@ Array [
       3. Move from copy button back to the text (without leaving the block) → ellipsis tooltip should show again.
     </div>
     <span
-      aria-describedby="test-id"
       aria-label="In the process of internal desktop applications development, many different design specs and implementations would be involved, which might cause designers and developers difficulties and duplication and reduce the efficiency of development."
       class="ant-typography ant-typography-ellipsis css-var-test-id"
       style="width: 280px; display: block;"
@@ -2436,26 +2372,6 @@ Array [
         </div>
       </span>
     </span>
-    <div
-      class="ant-tooltip ant-zoom-big-fast-appear ant-zoom-big-fast-appear-prepare ant-zoom-big-fast ant-tooltip-css-var css-var-test-id ant-tooltip-placement-top"
-      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
-    >
-      <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      >
-        <span
-          class="ant-tooltip-arrow-content"
-        />
-      </div>
-      <div
-        class="ant-tooltip-container"
-        id="test-id"
-        role="tooltip"
-      >
-        In the process of internal desktop applications development, many different design specs and implementations would be involved, which might cause designers and developers difficulties and duplication and reduce the efficiency of development.
-      </div>
-    </div>
   </div>,
 ]
 `;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 💄 组件样式/交互改进
- [x] 🛠 重构

### 🔗 相关 Issue

Follow up #58661

### 💡 需求背景和解决方案

#58661 已通过 Tooltip `disabled` 恢复 ellipsis Tooltip 的弹层交互，并在 hover operations 时临时关闭 Tooltip。

本 PR 在此基础上进一步收敛状态控制：

- 将 ellipsis 状态合并到 `disabled`，移除剩余的受控 `open`
- operations 进入时立即禁用 Tooltip，离开时通过 `useDelayState` 延迟一帧恢复
- disabled 时不再给触发元素添加 open class

不涉及公开 API 变化。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 💄 Improve Typography ellipsis Tooltip hover behavior around action buttons. |
| 🇨🇳 中文 | 💄 优化 Typography 省略 Tooltip 在操作按钮附近的悬浮交互。 |