### PR TITLE
fix(Input.Search): sync custom button disabled and loading states

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -8,7 +8,7 @@ import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { cloneElement } from '../_util/reactNode';
 import Button from '../button/Button';
-import type { ButtonSemanticType } from '../button/Button';
+import type { ButtonProps, ButtonSemanticType } from '../button/Button';
 import { useComponentConfig } from '../config-provider/context';
 import useSize from '../config-provider/hooks/useSize';
 import Compact, { useCompactItemContext } from '../space/Compact';
@@ -165,9 +165,13 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
   const isAntdButton =
     enterButtonAsElement.type && (enterButtonAsElement.type as typeof Button).__ANT_BUTTON === true;
   if (isAntdButton || enterButtonAsElement.type === 'button') {
-    const enterButtonProps = enterButtonAsElement.props as { className?: string };
+    const enterButtonProps = enterButtonAsElement.props as Pick<
+      ButtonProps,
+      'className' | 'disabled' | 'loading'
+    >;
 
     button = cloneElement(enterButtonAsElement, {
+      disabled: disabled || (!isAntdButton && loading) || enterButtonProps.disabled,
       onMouseDown,
       onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
         (
@@ -178,7 +182,13 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
         onSearch(e);
       },
       key: 'enterButton',
-      ...(isAntdButton ? { className: clsx(btnClassName, enterButtonProps.className), size } : {}),
+      ...(isAntdButton
+        ? {
+            className: clsx(btnClassName, enterButtonProps.className),
+            loading: loading || enterButtonProps.loading,
+            size,
+          }
+        : {}),
     });
   } else {
     button = (

--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -9,6 +9,7 @@ import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticT
 import { cloneElement } from '../_util/reactNode';
 import Button from '../button/Button';
 import type { ButtonProps, ButtonSemanticType } from '../button/Button';
+import DisabledContext from '../config-provider/DisabledContext';
 import { useComponentConfig } from '../config-provider/context';
 import useSize from '../config-provider/hooks/useSize';
 import Compact, { useCompactItemContext } from '../space/Compact';
@@ -93,6 +94,9 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
     searchIcon: contextSearchIcon,
   } = useComponentConfig('inputSearch');
 
+  const contextDisabled = React.useContext(DisabledContext);
+  const mergedDisabled = disabled ?? contextDisabled;
+
   const mergedProps: SearchProps = {
     ...props,
     enterButton,
@@ -171,7 +175,7 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
     >;
 
     button = cloneElement(enterButtonAsElement, {
-      disabled: disabled || (!isAntdButton && loading) || enterButtonProps.disabled,
+      disabled: mergedDisabled || enterButtonProps.disabled || (!isAntdButton && loading),
       onMouseDown,
       onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
         (

--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -51,6 +51,68 @@ describe('Input.Search', () => {
     expect(container.querySelectorAll('.ant-btn[disabled]')).toHaveLength(1);
   });
 
+  it('should disable custom Button when disabled prop is true', () => {
+    const onSearch = jest.fn();
+    const { getByRole } = render(
+      <Search disabled enterButton={<Button>ok</Button>} onSearch={onSearch} />,
+    );
+
+    const button = getByRole('button');
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it('should disable custom native button when disabled prop is true', () => {
+    const onSearch = jest.fn();
+    const { getByRole } = render(
+      <Search disabled enterButton={<button type="button">ok</button>} onSearch={onSearch} />,
+    );
+
+    const button = getByRole('button');
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it('should preserve disabled context for custom Button', () => {
+    const onSearch = jest.fn();
+    const { getByRole } = render(
+      <ConfigProvider componentDisabled>
+        <Search enterButton={<Button>ok</Button>} onSearch={onSearch} />
+      </ConfigProvider>,
+    );
+
+    const button = getByRole('button');
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it('should set custom Button to loading when loading prop is true', () => {
+    const onSearch = jest.fn();
+    const { getByLabelText, getByRole } = render(
+      <Search loading enterButton={<Button>ok</Button>} onSearch={onSearch} />,
+    );
+
+    const button = getByRole('button');
+    expect(getByLabelText('loading')).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it('should disable custom native button when loading prop is true', () => {
+    const onSearch = jest.fn();
+    const { getByRole } = render(
+      <Search loading enterButton={<button type="button">ok</button>} onSearch={onSearch} />,
+    );
+
+    const button = getByRole('button');
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
   it('should disable search icon when disabled prop is true', () => {
     const onSearch = jest.fn();
     const { container } = render(

--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -89,6 +89,20 @@ describe('Input.Search', () => {
     expect(onSearch).not.toHaveBeenCalled();
   });
 
+  it('should disable custom native button with disabled context', () => {
+    const onSearch = jest.fn();
+    const { getByRole } = render(
+      <ConfigProvider componentDisabled>
+        <Search enterButton={<button type="button">ok</button>} onSearch={onSearch} />
+      </ConfigProvider>,
+    );
+
+    const button = getByRole('button');
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
   it('should set custom Button to loading when loading prop is true', () => {
     const onSearch = jest.fn();
     const { getByLabelText, getByRole } = render(


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Input.Search 使用自定义 `enterButton` 时，组件自身的 `disabled` 和 `loading` 状态不会同步到自定义按钮，导致输入框已经禁用或处于加载状态时，自定义按钮仍可点击并触发搜索。

本次改动：

- 将 `disabled` 状态同步到自定义 antd Button 和原生 button。
- 将 `loading` 状态同步到自定义 antd Button；原生 button 在加载时禁用。
- 保留自定义按钮自身已有的 `disabled`、`loading` 以及全局禁用状态。
- 补充禁用、加载和 `componentDisabled` 场景的回归测试。

提交钩子中的 Biome 与 ESLint 检查已通过，未运行组件测试。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Input.Search custom enter buttons not respecting disabled and loading states. |
| 🇨🇳 中文 | 🐞 修复 Input.Search 自定义确认按钮未响应禁用和加载状态的问题。 |
