### PR TITLE
docs(Image): add wheel prop for mouse wheel zoom control

### DIFF
--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -90,6 +90,7 @@ Other Property ref [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/
 | scaleStep | Each step's zoom multiplier is 1 + scaleStep | number | 0.5 |  |
 | src | Custom preview src | string | - |  |
 | styles | Custom semantic structure styles | Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
+| wheel | Whether to enable mouse wheel zoom | boolean | true | 6.6.0 |
 | ~~toolbarRender~~ | Custom toolbar; please use 'actionsRender' instead | (originalNode: React.ReactElement, info: Omit<ToolbarRenderInfoType, 'current' \| 'total'>) => React.ReactNode | - |  |
 | ~~visible~~ | Whether to show; please use 'open' instead | boolean | - |  |
 | onOpenChange | Callback when preview open state changes | (visible: boolean) => void | - |  |
@@ -125,6 +126,7 @@ Other Property ref [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/
 | open | Whether to display preview | boolean | - |  |
 | ~~rootClassName~~ | Root DOM class name for preview; applies to both image and preview wrapper. Use 'classNames.root' instead | string | - |  |
 | styles | Custom semantic structure styles | Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
+| wheel | Whether to enable mouse wheel zoom | boolean | true | 6.6.0 |
 | scaleStep | Each step's zoom multiplier is 1 + scaleStep | number | 0.5 |  |
 | ~~toolbarRender~~ | Custom toolbar; please use 'actionsRender' instead | (originalNode: React.ReactElement, info: ToolbarRenderInfoType) => React.ReactNode | - |  |
 | ~~visible~~ | Whether to show; please use 'open' instead | boolean | - |  |

--- a/components/image/index.zh-CN.md
+++ b/components/image/index.zh-CN.md
@@ -91,6 +91,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | scaleStep | `1 + scaleStep` 为缩放放大的每步倍数 | number | 0.5 |  |
 | src | 自定义预览 src | string | - |  |
 | styles | 自定义语义化结构样式 | Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
+| wheel | 是否启用鼠标滚轮缩放 | boolean | true | 6.6.0 |
 | ~~toolbarRender~~ | 自定义工具栏，请使用 `actionsRender` 替换 | (originalNode: React.ReactElement, info: Omit<ToolbarRenderInfoType, 'current' \| 'total'>) => React.ReactNode | - |  |
 | ~~visible~~ | 是否显示，请使用 `open` 替换 | boolean | - |  |
 | onOpenChange | 预览打开状态变化的回调 | (visible: boolean) => void | - |  |
@@ -126,6 +127,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | open | 是否显示预览 | boolean | - |  |
 | ~~rootClassName~~ | 预览图的根 DOM 类名，会同时作用在图片和预览层最外侧，请使用 `classNames.root` 替换 | string | - |  |
 | styles | 自定义语义化结构样式 | Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  |
+| wheel | 是否启用鼠标滚轮缩放 | boolean | true | 6.6.0 |
 | scaleStep | `1 + scaleStep` 为缩放放大的每步倍数 | number | 0.5 |  |
 | ~~toolbarRender~~ | 自定义工具栏，请使用 `actionsRender` 替换 | (originalNode: React.ReactElement, info: ToolbarRenderInfoType) => React.ReactNode | - |  |
 | ~~visible~~ | 是否显示，请使用 `open` 替换 | boolean | - |  |

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@rc-component/drawer": "~1.4.2",
     "@rc-component/dropdown": "~1.0.3",
     "@rc-component/form": "~1.8.5",
-    "@rc-component/image": "~1.9.0",
+    "@rc-component/image": "~1.10.0",
     "@rc-component/input": "~1.3.1",
     "@rc-component/input-number": "~1.6.2",
     "@rc-component/mentions": "~1.11.0",


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动

### 🔗 相关 Issue

> close #29068
> 对应 rc-component/image PR: https://github.com/react-component/image/pull/521

### 💡 需求背景和解决方案

> 1. 用户需要能够在图片预览时禁用鼠标滚轮缩放功能
> 2. 在 `PreviewType` 和 `PreviewGroupType` 中添加 `wheel` 属性
> 3. 默认值为 `true`（保持向后兼容）
> 4. 设置为 `false` 时，鼠标滚轮将不会触发图片缩放，但通过预览工具栏按钮缩放仍可正常工作

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇨🇳 中文 | 🆕 Image 组件新增 `preview.wheel` 属性，可控制预览时是否启用鼠标滚轮缩放 |
| 🇺🇸 英文 | 🆕 Add `preview.wheel` prop to Image component for controlling mouse wheel zoom |