### PR TITLE
demo(Select): keep search text after selecting remote users

### DIFF
--- a/components/select/demo/select-users.tsx
+++ b/components/select/demo/select-users.tsx
@@ -45,7 +45,11 @@ function DebounceSelect<
   return (
     <Select
       labelInValue
-      showSearch={{ filterOption: false, onSearch: debounceFetcher }}
+      showSearch={{
+        autoClearSearchValue: false,
+        filterOption: false,
+        onSearch: debounceFetcher,
+      }}
       notFoundContent={fetching ? <Spin size="small" /> : 'No results found'}
       {...props}
       options={options}


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #58733

### 💡 需求背景和解决方案

Select 远程搜索多选示例在选中用户后会清空搜索词，但仍保留上一次远程搜索返回的选项，导致输入框为空时继续显示已筛选的结果。

将 `showSearch.autoClearSearchValue` 设置为 `false`，使选中用户后搜索词与当前远程搜索结果保持一致。用户可以继续选择相同搜索条件下的其他用户，同时避免额外刷新接口。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A      |
| 🇨🇳 中文 | 无需更新日志 |