### PR TITLE
fix(Collapse): respect border design tokens in borderless styles

### DIFF
--- a/components/collapse/style/index.ts
+++ b/components/collapse/style/index.ts
@@ -301,7 +301,7 @@ const genBorderlessStyle: GenerateStyle<CollapseToken, CSSObject> = (token) => {
       border: 0,
 
       [`> ${componentCls}-item`]: {
-        borderBottom: `1px solid ${colorBorder}`,
+        borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${colorBorder}`,
       },
 
       [`


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 💄 组件样式/交互改进

### 🔗 相关 Issue

None

### 💡 需求背景和解决方案

Collapse 无边框模式的项目分隔线使用了硬编码的 `1px solid`，无法响应主题中的 `lineWidth` 和 `lineType`。本 PR 改为使用对应 Design Token，不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Make Collapse borderless separators respect `lineWidth` and `lineType`. |
| 🇨🇳 中文 | 使 Collapse 无边框模式分隔线支持 `lineWidth` 和 `lineType`。 |