### PR TITLE
fix(Typography): respect border design tokens in reset styles

### DIFF
--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -94,7 +94,7 @@ export const getResetStyles: GenerateStyle<TypographyToken, CSSObject> = (token)
     fontSize: '85%',
     fontFamily: token.fontFamilyCode,
     background: 'rgba(150, 150, 150, 0.1)',
-    border: '1px solid rgba(100, 100, 100, 0.2)',
+    border: `${unit(token.lineWidth)} ${token.lineType} rgba(100, 100, 100, 0.2)`,
     borderRadius: 3,
   },
 
@@ -105,7 +105,7 @@ export const getResetStyles: GenerateStyle<TypographyToken, CSSObject> = (token)
     fontSize: '90%',
     fontFamily: token.fontFamilyCode,
     background: 'rgba(150, 150, 150, 0.06)',
-    border: '1px solid rgba(100, 100, 100, 0.2)',
+    border: `${unit(token.lineWidth)} ${token.lineType} rgba(100, 100, 100, 0.2)`,
     borderBottomWidth: 2,
     borderRadius: 3,
   },
@@ -165,7 +165,7 @@ export const getResetStyles: GenerateStyle<TypographyToken, CSSObject> = (token)
     whiteSpace: 'pre-wrap',
     wordWrap: 'break-word',
     background: 'rgba(150, 150, 150, 0.1)',
-    border: '1px solid rgba(100, 100, 100, 0.2)',
+    border: `${unit(token.lineWidth)} ${token.lineType} rgba(100, 100, 100, 0.2)`,
     borderRadius: 3,
     fontFamily: token.fontFamilyCode,
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 💄 组件样式/交互改进

### 🔗 相关 Issue

None

### 💡 需求背景和解决方案

Typography 的 `code`、`kbd` 和 `pre` 重置样式使用了硬编码的 `1px solid`，无法响应主题中的 `lineWidth` 和 `lineType`。本 PR 改为使用对应 Design Token，不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Make Typography code borders respect `lineWidth` and `lineType`. |
| 🇨🇳 中文 | 使 Typography 代码样式边框支持 `lineWidth` 和 `lineType`。 |