### PR TITLE
fix(Tree): respect border design tokens in tree styles

### DIFF
--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -173,7 +173,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
           [`${treeNodeCls}.dragging:after`]: {
             position: 'absolute',
             inset: 0,
-            border: `1px solid ${token.colorPrimary}`,
+            border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorPrimary}`,
             opacity: 0,
             animationName: treeNodeFX,
             animationDuration: token.motionDurationSlow,
@@ -358,7 +358,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
             insetInlineEnd: token.calc(switcherSize).div(2).equal(),
             bottom: token.calc(treeNodePadding).mul(-1).equal(),
             marginInlineStart: -1,
-            borderInlineEnd: `1px solid ${token.colorBorder}`,
+            borderInlineEnd: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
             content: '""',
           },
 
@@ -366,7 +366,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
             position: 'absolute',
             width: token.calc(token.calc(switcherSize).div(2).equal()).mul(0.8).equal(),
             height: token.calc(titleHeight).div(2).equal(),
-            borderBottom: `1px solid ${token.colorBorder}`,
+            borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
             content: '""',
           },
         },
@@ -435,7 +435,7 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
             top: 0,
             insetInlineEnd: token.calc(switcherSize).div(2).equal(),
             bottom: token.calc(treeNodePadding).mul(-1).equal(),
-            borderInlineEnd: `1px solid ${token.colorBorder}`,
+            borderInlineEnd: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
             content: '""',
           },
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 💄 组件样式/交互改进

### 🔗 相关 Issue

None

### 💡 需求背景和解决方案

Tree 的拖拽边框和树形连接线使用了硬编码的 `1px solid`，无法响应主题中的 `lineWidth` 和 `lineType`。本 PR 改为使用对应 Design Token，不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Make Tree drag borders and connector lines respect `lineWidth` and `lineType`. |
| 🇨🇳 中文 | 使 Tree 拖拽边框和连接线支持 `lineWidth` 和 `lineType`。 |