### PR TITLE
fix(Layout): respect border design tokens in sider styles

### DIFF
--- a/components/layout/style/sider.ts
+++ b/components/layout/style/sider.ts
@@ -120,7 +120,7 @@ const genSiderStyle: GenerateStyle<LayoutToken, CSSObject> = (token) => {
         [`${componentCls}-zero-width-trigger`]: {
           color: lightTriggerColor,
           background: lightTriggerBg,
-          border: `1px solid ${bodyBg}`, // Safe to modify to any other color
+          border: `${unit(token.lineWidth)} ${token.lineType} ${bodyBg}`, // Safe to modify to any other color
           borderInlineStart: 0,
         },
       },


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 💄 组件样式/交互改进

### 🔗 相关 Issue

None

### 💡 需求背景和解决方案

Layout 的亮色零宽 Sider 触发器使用了硬编码的 `1px solid`，无法响应主题中的 `lineWidth` 和 `lineType`。本 PR 改为使用对应 Design Token，不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Make Layout zero-width trigger borders respect `lineWidth` and `lineType`. |
| 🇨🇳 中文 | 使 Layout 零宽触发器边框支持 `lineWidth` 和 `lineType`。 |