### PR TITLE
fix(Table): preserve nested table top border inside custom content

### DIFF
--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -22175,6 +22175,254 @@ Array [
 
 exports[`renders components/table/demo/nested-table.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/table/demo/nested-table-in-tabs-debug.tsx extend context correctly 1`] = `
+<div
+  class="css-var-test-id ant-table-css-var ant-table-wrapper"
+>
+  <div
+    aria-busy="false"
+    aria-live="polite"
+    class="ant-spin css-var-test-id"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <div
+        class="ant-table css-var-test-id ant-table-css-var"
+      >
+        <div
+          class="ant-table-container"
+        >
+          <div
+            class="ant-table-content"
+          >
+            <table
+              style="table-layout: auto;"
+            >
+              <colgroup>
+                <col
+                  class="ant-table-expand-icon-col"
+                />
+              </colgroup>
+              <thead
+                class="ant-table-thead"
+              >
+                <tr>
+                  <th
+                    class="ant-table-cell ant-table-row-expand-icon-cell"
+                  />
+                  <th
+                    class="ant-table-cell"
+                    scope="col"
+                  >
+                    Name
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="ant-table-tbody"
+              >
+                <tr
+                  class="ant-table-row ant-table-row-level-0"
+                  data-row-key="0"
+                >
+                  <td
+                    class="ant-table-cell ant-table-row-expand-icon-cell"
+                  >
+                    <button
+                      aria-expanded="true"
+                      aria-label="Collapse row"
+                      class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
+                      type="button"
+                    />
+                  </td>
+                  <td
+                    class="ant-table-cell"
+                  >
+                    Jack
+                  </td>
+                </tr>
+                <tr
+                  class="ant-table-expanded-row ant-table-expanded-row-level-1"
+                >
+                  <td
+                    class="ant-table-cell"
+                    colspan="2"
+                  >
+                    <div
+                      class="ant-tabs ant-tabs-top css-var-test-id ant-tabs-css-var"
+                    >
+                      <div
+                        aria-orientation="horizontal"
+                        class="ant-tabs-nav"
+                        role="tablist"
+                      >
+                        <div
+                          class="ant-tabs-nav-wrap"
+                        >
+                          <div
+                            class="ant-tabs-nav-list"
+                            style="transform: translate(0px, 0px);"
+                          >
+                            <div
+                              class="ant-tabs-tab ant-tabs-tab-active"
+                              data-node-key="1"
+                            >
+                              <div
+                                aria-controls="rc-tabs-test-panel-1"
+                                aria-selected="true"
+                                class="ant-tabs-tab-btn"
+                                id="rc-tabs-test-tab-1"
+                                role="tab"
+                                tabindex="0"
+                              >
+                                Tab 1
+                              </div>
+                            </div>
+                            <div
+                              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+                            />
+                          </div>
+                        </div>
+                        <div
+                          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+                        >
+                          <button
+                            aria-controls="rc-tabs-test-more-popup"
+                            aria-expanded="false"
+                            aria-haspopup="listbox"
+                            class="ant-tabs-nav-more"
+                            id="rc-tabs-test-more"
+                            style="visibility: hidden; order: 1;"
+                            type="button"
+                          >
+                            <span
+                              aria-label="ellipsis"
+                              class="anticon anticon-ellipsis"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="ellipsis"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                                />
+                              </svg>
+                            </span>
+                          </button>
+                          <div
+                            class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-tabs-css-var ant-tabs-dropdown-placement-bottomLeft"
+                            style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+                          >
+                            <ul
+                              aria-label="expanded dropdown"
+                              class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+                              data-menu-list="true"
+                              id="rc-tabs-test-more-popup"
+                              role="listbox"
+                              tabindex="-1"
+                            />
+                            <div
+                              aria-hidden="true"
+                              style="display: none;"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="ant-tabs-body-holder"
+                      >
+                        <div
+                          class="ant-tabs-body ant-tabs-body-top"
+                        >
+                          <div
+                            aria-hidden="false"
+                            aria-labelledby="rc-tabs-test-tab-1"
+                            class="ant-tabs-content ant-tabs-content-active"
+                            id="rc-tabs-test-panel-1"
+                            role="tabpanel"
+                            tabindex="0"
+                          >
+                            <div
+                              class="css-var-test-id ant-table-css-var ant-table-wrapper"
+                            >
+                              <div
+                                aria-busy="false"
+                                aria-live="polite"
+                                class="ant-spin css-var-test-id"
+                              >
+                                <div
+                                  class="ant-spin-container"
+                                >
+                                  <div
+                                    class="ant-table ant-table-bordered css-var-test-id ant-table-css-var"
+                                  >
+                                    <div
+                                      class="ant-table-container"
+                                    >
+                                      <div
+                                        class="ant-table-content"
+                                      >
+                                        <table
+                                          style="table-layout: auto;"
+                                        >
+                                          <thead
+                                            class="ant-table-thead"
+                                          >
+                                            <tr>
+                                              <th
+                                                class="ant-table-cell"
+                                                scope="col"
+                                              >
+                                                Name
+                                              </th>
+                                            </tr>
+                                          </thead>
+                                          <tbody
+                                            class="ant-table-tbody"
+                                          >
+                                            <tr
+                                              class="ant-table-row ant-table-row-level-0"
+                                              data-row-key="0"
+                                            >
+                                              <td
+                                                class="ant-table-cell"
+                                              >
+                                                Jack
+                                              </td>
+                                            </tr>
+                                          </tbody>
+                                        </table>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/table/demo/nested-table-in-tabs-debug.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/table/demo/order-column.tsx extend context correctly 1`] = `
 <div
   class="css-var-test-id ant-table-css-var ant-table-wrapper"

--- a/components/table/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.ts.snap
@@ -20508,6 +20508,231 @@ Array [
 ]
 `;
 
+exports[`renders components/table/demo/nested-table-in-tabs-debug.tsx correctly 1`] = `
+<div
+  class="css-var-test-id ant-table-css-var ant-table-wrapper"
+>
+  <div
+    aria-busy="false"
+    aria-live="polite"
+    class="ant-spin css-var-test-id"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <div
+        class="ant-table css-var-test-id ant-table-css-var"
+      >
+        <div
+          class="ant-table-container"
+        >
+          <div
+            class="ant-table-content"
+          >
+            <table
+              style="table-layout:auto"
+            >
+              <colgroup>
+                <col
+                  class="ant-table-expand-icon-col"
+                />
+              </colgroup>
+              <thead
+                class="ant-table-thead"
+              >
+                <tr>
+                  <th
+                    class="ant-table-cell ant-table-row-expand-icon-cell"
+                  />
+                  <th
+                    class="ant-table-cell"
+                    scope="col"
+                  >
+                    Name
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="ant-table-tbody"
+              >
+                <tr
+                  class="ant-table-row ant-table-row-level-0"
+                  data-row-key="0"
+                >
+                  <td
+                    class="ant-table-cell ant-table-row-expand-icon-cell"
+                  >
+                    <button
+                      aria-expanded="true"
+                      aria-label="Collapse row"
+                      class="ant-table-row-expand-icon ant-table-row-expand-icon-expanded"
+                      type="button"
+                    />
+                  </td>
+                  <td
+                    class="ant-table-cell"
+                  >
+                    Jack
+                  </td>
+                </tr>
+                <tr
+                  class="ant-table-expanded-row ant-table-expanded-row-level-1"
+                >
+                  <td
+                    class="ant-table-cell"
+                    colspan="2"
+                  >
+                    <div
+                      class="ant-tabs ant-tabs-top css-var-test-id ant-tabs-css-var"
+                    >
+                      <div
+                        aria-orientation="horizontal"
+                        class="ant-tabs-nav"
+                        role="tablist"
+                      >
+                        <div
+                          class="ant-tabs-nav-wrap"
+                        >
+                          <div
+                            class="ant-tabs-nav-list"
+                            style="transform:translate(0px, 0px)"
+                          >
+                            <div
+                              class="ant-tabs-tab ant-tabs-tab-active"
+                              data-node-key="1"
+                            >
+                              <div
+                                aria-selected="true"
+                                class="ant-tabs-tab-btn"
+                                role="tab"
+                                tabindex="0"
+                              >
+                                Tab 1
+                              </div>
+                            </div>
+                            <div
+                              class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+                            />
+                          </div>
+                        </div>
+                        <div
+                          class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+                        >
+                          <button
+                            aria-controls="null-more-popup"
+                            aria-expanded="false"
+                            aria-haspopup="listbox"
+                            class="ant-tabs-nav-more"
+                            id="null-more"
+                            style="visibility:hidden;order:1"
+                            type="button"
+                          >
+                            <span
+                              aria-label="ellipsis"
+                              class="anticon anticon-ellipsis"
+                              role="img"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                data-icon="ellipsis"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="64 64 896 896"
+                                width="1em"
+                              >
+                                <path
+                                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                                />
+                              </svg>
+                            </span>
+                          </button>
+                        </div>
+                      </div>
+                      <div
+                        class="ant-tabs-body-holder"
+                      >
+                        <div
+                          class="ant-tabs-body ant-tabs-body-top"
+                        >
+                          <div
+                            aria-hidden="false"
+                            class="ant-tabs-content ant-tabs-content-active"
+                            role="tabpanel"
+                            tabindex="0"
+                          >
+                            <div
+                              class="css-var-test-id ant-table-css-var ant-table-wrapper"
+                            >
+                              <div
+                                aria-busy="false"
+                                aria-live="polite"
+                                class="ant-spin css-var-test-id"
+                              >
+                                <div
+                                  class="ant-spin-container"
+                                >
+                                  <div
+                                    class="ant-table ant-table-bordered css-var-test-id ant-table-css-var"
+                                  >
+                                    <div
+                                      class="ant-table-container"
+                                    >
+                                      <div
+                                        class="ant-table-content"
+                                      >
+                                        <table
+                                          style="table-layout:auto"
+                                        >
+                                          <thead
+                                            class="ant-table-thead"
+                                          >
+                                            <tr>
+                                              <th
+                                                class="ant-table-cell"
+                                                scope="col"
+                                              >
+                                                Name
+                                              </th>
+                                            </tr>
+                                          </thead>
+                                          <tbody
+                                            class="ant-table-tbody"
+                                          >
+                                            <tr
+                                              class="ant-table-row ant-table-row-level-0"
+                                              data-row-key="0"
+                                            >
+                                              <td
+                                                class="ant-table-cell"
+                                              >
+                                                Jack
+                                              </td>
+                                            </tr>
+                                          </tbody>
+                                        </table>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/table/demo/order-column.tsx correctly 1`] = `
 <div
   class="css-var-test-id ant-table-css-var ant-table-wrapper"

--- a/components/table/demo/nested-table-in-tabs-debug.md
+++ b/components/table/demo/nested-table-in-tabs-debug.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+带边框的表格嵌套在展开行的 Tabs 中时应保留上边框。
+
+## en-US
+
+A bordered table nested in Tabs inside an expanded row should retain its top border.

--- a/components/table/demo/nested-table-in-tabs-debug.tsx
+++ b/components/table/demo/nested-table-in-tabs-debug.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import type { TableColumnsType, TabsProps } from 'antd';
+import { Table, Tabs } from 'antd';
+
+interface DataType {
+  key: string;
+  name: string;
+}
+
+const columns: TableColumnsType<DataType> = [{ title: 'Name', dataIndex: 'name' }];
+
+const dataSource: DataType[] = [{ key: '0', name: 'Jack' }];
+
+const items: TabsProps['items'] = [
+  {
+    key: '1',
+    label: 'Tab 1',
+    children: (
+      <Table<DataType> bordered columns={columns} dataSource={dataSource} pagination={false} />
+    ),
+  },
+];
+
+const expandedRowRender = () => <Tabs defaultActiveKey="1" items={items} />;
+
+const App: React.FC = () => (
+  <Table<DataType>
+    columns={columns}
+    dataSource={dataSource}
+    expandable={{ expandedRowRender, defaultExpandedRowKeys: ['0'] }}
+    pagination={false}
+  />
+);
+
+export default App;

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -105,6 +105,7 @@ const columns = [
 <code src="./demo/virtual-list.tsx" version="5.9.0">Virtual list</code>
 <code src="./demo/responsive.tsx">Responsive</code>
 <code src="./demo/nest-table-border-debug.tsx" debug>Nested Bordered Table Debug</code>
+<code src="./demo/nested-table-in-tabs-debug.tsx" debug>Nested Table in Tabs Debug</code>
 <code src="./demo/pagination.tsx">Pagination Settings</code>
 <code src="./demo/row-selection-custom-debug.tsx" debug>Custom selection group</code>
 <code src="./demo/sticky.tsx">Fixed header and scroll bar with the page</code>

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -107,6 +107,7 @@ const columns = [
 <code src="./demo/virtual-list.tsx" version="5.9.0">虚拟列表</code>
 <code src="./demo/responsive.tsx">响应式</code>
 <code src="./demo/nest-table-border-debug.tsx" debug>嵌套带边框的表格 Debug</code>
+<code src="./demo/nested-table-in-tabs-debug.tsx" debug>Tabs 中的嵌套表格 Debug</code>
 <code src="./demo/pagination.tsx">分页设置</code>
 <code src="./demo/row-selection-custom-debug.tsx" debug>自定义选择项组</code>
 <code src="./demo/sticky.tsx">随页面滚动的固定表头和滚动条</code>

--- a/components/table/style/bordered.ts
+++ b/components/table/style/bordered.ts
@@ -2,10 +2,12 @@ import { unit } from '@ant-design/cssinjs';
 import type { CSSObject } from '@ant-design/cssinjs';
 
 import type { GenerateStyle } from '../../theme/internal';
+import { genCssVar } from '../../theme/util/genStyleUtils';
 import type { TableToken } from './index';
 
 const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
   const {
+    antCls,
     componentCls,
     lineWidth,
     lineType,
@@ -16,6 +18,7 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
     calc,
   } = token;
   const tableBorder = `${unit(lineWidth)} ${lineType} ${tableBorderColor}`;
+  const [varName, varRef] = genCssVar(antCls, 'table');
 
   const getSizeBorderStyle = (
     size: 'small' | 'medium',
@@ -38,6 +41,8 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
 
   return {
     [`${componentCls}-wrapper`]: {
+      [varName('nested-border-top')]: tableBorder,
+
       [`${componentCls}${componentCls}-bordered`]: {
         // ============================ Title =============================
         [`> ${componentCls}-title`]: {
@@ -49,6 +54,10 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
         [`> ${componentCls}-container`]: {
           borderInlineStart: tableBorder,
           borderTop: tableBorder,
+
+          '&:first-child': {
+            borderTop: varRef('nested-border-top', tableBorder),
+          },
 
           [`> ${componentCls}-header${componentCls}-sticky-holder`]: {
             marginTop: calc(lineWidth).mul(-1).equal(),
@@ -144,9 +153,11 @@ const genBorderedStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
 
       // ============================ Nested ============================
       [`${componentCls}-cell`]: {
-        [`${componentCls}-container:first-child`]: {
-          // :first-child to avoid the case when bordered and title is set
-          borderTop: 0,
+        [`
+          > ${componentCls}-wrapper:only-child,
+          > ${componentCls}-expanded-row-fixed > ${componentCls}-wrapper:only-child
+        `]: {
+          [varName('nested-border-top')]: 0,
         },
         // https://github.com/ant-design/ant-design/issues/35577
         '&-scrollbar:not([rowspan])': {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #58744

### 💡 需求背景和解决方案

Table 为避免直接嵌套时出现重复边框，会移除嵌套表格的上边框。原有选择器影响了单元格内所有层级的 Table，导致 Table 被 Tabs 或用户自定义内容包裹时也错误地丢失上边框。

本次通过 CSS 变量只标记作为单元格唯一直接子元素的 Table wrapper：

- 直接嵌套的 Table 继续移除上边框，保留原有行为。
- 被 Tabs 或自定义内容包裹的 bordered Table 保留上边框。
- 不依赖枚举 Tabs、Spin 等 Ant Design 内部结构。
- 新增展开行中嵌套 Tabs 和 bordered Table 的 debug demo。
- 已更新并验证对应 demo 快照。

验证结果：2 个测试套件通过，91 个测试通过，130 个快照通过。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Table missing top border when a bordered nested table is wrapped by Tabs or custom content. |
| 🇨🇳 中文 | 🐞 修复 Table 带边框的嵌套表格被 Tabs 或自定义内容包裹时缺少上边框的问题。 |
