### PR TITLE
fix(Tag): improve filled variant visibility in dark mode

### DIFF
--- a/components/tag/style/index.ts
+++ b/components/tag/style/index.ts
@@ -8,8 +8,16 @@ import { isBright } from '../../color-picker/components/ColorPresets';
 import { resetComponent } from '../../style';
 import type { FullToken, GenerateStyle, GenStyleFn, GetDefaultToken } from '../../theme/internal';
 import { genStyleHooks, mergeToken } from '../../theme/internal';
+import { PresetColors } from '../../theme/interface';
+import type { PresetColorKey } from '../../theme/interface';
 
-export interface ComponentToken {
+// Per-preset-color background for the `filled` variant, one flat token per color (e.g.
+// `blueFilledBg`, `purpleFilledBg`). Must stay flat: `cssVar` theming turns every top-level
+// `ComponentToken` key into its own `var(...)` reference, so a single key holding a nested
+// object cannot survive the round trip.
+type PresetFilledBgComponentToken = Partial<Record<`${PresetColorKey}FilledBg`, string>>;
+
+export interface ComponentToken extends PresetFilledBgComponentToken {
   /**
    * @desc 默认背景色
    * @descEN Default background color
@@ -238,12 +246,31 @@ export const prepareComponentToken: GetDefaultToken<'Tag'> = (token) => {
     ? '#000'
     : '#fff';
 
+  // In dark mode, preset palette index 1 (the filled variant's light-mode background) resolves
+  // to a near-black tint that barely stands out against `colorBgContainer`, so filled tags need
+  // a background derived from the saturated palette-6 step instead. This must be computed here
+  // (not in the style-generation function) because under `cssVar` theming, color tokens are
+  // already `var(...)` reference strings by the time the style function runs and can no longer
+  // be parsed/blended by FastColor — `prepareComponentToken` still receives real values.
+  const isDarkMode = new FastColor(token.colorBgBase).toHsl().l < 0.5;
+  const presetFilledBg = PresetColors.reduce<Record<string, string>>((prev, colorKey) => {
+    const lightColor = token[`${colorKey}1`];
+    const darkColor = token[`${colorKey}6`];
+    if (lightColor && darkColor) {
+      prev[`${colorKey}FilledBg`] = isDarkMode
+        ? new FastColor(darkColor).setA(0.15).onBackground(token.colorBgContainer).toHexString()
+        : lightColor;
+    }
+    return prev;
+  }, {});
+
   return {
     defaultBg: new FastColor(token.colorFillTertiary)
       .onBackground(token.colorBgContainer)
       .toHexString(),
     defaultColor: token.colorText,
     solidTextColor,
+    ...presetFilledBg,
   };
 };
 

--- a/components/tag/style/presetCmp.ts
+++ b/components/tag/style/presetCmp.ts
@@ -19,7 +19,10 @@ const genPresetStyle = (token: TagToken) =>
           color: token.colorTextLightSolid,
         },
         [`&${token.componentCls}-filled`]: {
-          backgroundColor: lightColor,
+          // `xxxFilledBg` is resolved in `prepareComponentToken` (dark-mode-aware there;
+          // a plain passthrough of `lightColor` in light mode), since color math can't
+          // safely happen in this function under `cssVar` theming.
+          backgroundColor: token[`${colorKey}FilledBg`] ?? lightColor,
           color: textColor,
         },
       },


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] 💄 Component style improvement

### 🔗 Related Issues

close #56339

### 💡 Background and Solution

In dark mode, preset-color `filled` variant tags (e.g. `<Tag color="blue" variant="filled">`) used palette index 1 as background, which resolves to a near-black tint nearly identical to `colorBgContainer` — making the tag almost invisible.

**Solution:**
- In `prepareComponentToken`, detect dark mode via `colorBgBase` lightness and precompute a `xxxFilledBg` token for each preset color.
- Dark mode: use palette-6 (saturated color) at 15% alpha blended onto `colorBgContainer` as the filled background.
- Light mode: unchanged — passes through the original `lightColor` directly.
- Computed in `prepareComponentToken` (not the style function) to stay compatible with `cssVar` theming, since color tokens are already `var(...)` references by the time the style function runs.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Tag preset-color `filled` variant being nearly invisible in dark mode. |
| 🇨🇳 Chinese | 修复 Tag 预设颜色 `filled` 变体标签在暗色模式下几乎不可见的问题。 |
