### PR TITLE
fix: respect line type design token in component borders

### DIFF
--- a/components/button/style/variant.ts
+++ b/components/button/style/variant.ts
@@ -6,7 +6,7 @@ import { genCssVar } from '../../theme/util/genStyleUtils';
 import type { ButtonToken } from './token';
 
 const genVariantStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => {
-  const { componentCls, antCls, lineWidth } = token;
+  const { componentCls, antCls, lineWidth, lineType } = token;
 
   const [varName, varRef] = genCssVar(antCls, 'btn');
 
@@ -24,7 +24,7 @@ const genVariantStyle: GenerateStyle<ButtonToken, CSSObject> = (token) => {
         [varName('border-color-active')]: varRef('border-color'),
         [varName('border-color-disabled')]: varRef('border-color'),
 
-        [varName('border-style')]: 'solid',
+        [varName('border-style')]: lineType,
 
         // Text
         [varName('text-color')]: '#000',

--- a/components/color-picker/style/index.ts
+++ b/components/color-picker/style/index.ts
@@ -99,14 +99,15 @@ const genClearStyle = (
   size: number,
   extraStyle?: CSSObject,
 ): CSSObject => {
-  const { componentCls, borderRadiusSM, lineWidth, colorSplit, colorBorder, red6 } = token;
+  const { componentCls, borderRadiusSM, lineWidth, lineType, colorSplit, colorBorder, red6 } =
+    token;
 
   return {
     [`${componentCls}-clear`]: {
       width: size,
       height: size,
       borderRadius: borderRadiusSM,
-      border: `${unit(lineWidth)} solid ${colorSplit}`,
+      border: `${unit(lineWidth)} ${lineType} ${colorSplit}`,
       position: 'relative',
       overflow: 'hidden',
       cursor: 'inherit',
@@ -228,6 +229,7 @@ const genColorPickerStyle: GenerateStyle<ColorPickerToken> = (token) => {
     colorPickerPresetColorSize,
     colorPickerPreviewSize,
     lineWidth,
+    lineType,
     colorBorder,
     paddingXXS,
     fontSize,
@@ -272,7 +274,7 @@ const genColorPickerStyle: GenerateStyle<ColorPickerToken> = (token) => {
           minWidth: controlHeight,
           minHeight: controlHeight,
           borderRadius,
-          border: `${unit(lineWidth)} solid ${colorBorder}`,
+          border: `${unit(lineWidth)} ${lineType} ${colorBorder}`,
           cursor: 'pointer',
           display: 'inline-flex',
           alignItems: 'flex-start',

--- a/components/select/style/select-input-multiple.ts
+++ b/components/select/style/select-input-multiple.ts
@@ -16,6 +16,7 @@ const genSelectInputMultipleStyle: GenerateStyle<SelectToken, CSSObject> = (toke
     paddingXXS,
     INTERNAL_FIXED_ITEM_MARGIN,
     lineWidth,
+    lineType,
     colorIcon,
     colorIconHover,
     inputPaddingHorizontalBase,
@@ -91,7 +92,7 @@ const genSelectInputMultipleStyle: GenerateStyle<SelectToken, CSSObject> = (toke
 
         [`${componentCls}-selection-item`]: {
           lineHeight: `calc(${varRef('multi-item-height')} - ${lineWidth} * 2)`,
-          border: `${lineWidth} solid ${varRef('multi-item-border-color')}`,
+          border: `${lineWidth} ${lineType} ${varRef('multi-item-border-color')}`,
           display: 'flex',
           marginBlock: INTERNAL_FIXED_ITEM_MARGIN,
           marginInlineEnd: calc(INTERNAL_FIXED_ITEM_MARGIN).mul(2).equal(),

--- a/components/space/style/addon.ts
+++ b/components/space/style/addon.ts
@@ -27,6 +27,7 @@ const genSpaceAddonStyle: GenerateStyle<AddonToken, CSSObject> = (token) => {
     borderRadiusSM,
     colorBgContainerDisabled,
     lineWidth,
+    lineType,
     antCls,
   } = token;
 
@@ -46,7 +47,7 @@ const genSpaceAddonStyle: GenerateStyle<AddonToken, CSSObject> = (token) => {
         paddingInline: paddingSM,
         margin: 0,
         borderWidth: lineWidth,
-        borderStyle: 'solid',
+        borderStyle: lineType,
         borderRadius,
 
         '&:hover': {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 💄 组件样式/交互改进

### 🔗 相关 Issue

None

### 💡 需求背景和解决方案

Button、ColorPicker、Select 多选项和 Space Addon 的部分真实边框仍固定使用 `solid`，无法响应全局 `lineType` Design Token。

本 PR 将这些边框改为使用 `lineType`，同时保留 Button `dashed` variant 和图形型实线的既有语义，不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Make Button, ColorPicker, Select, and Space Addon borders respect `lineType`. |
| 🇨🇳 中文 | 使 Button、ColorPicker、Select 和 Space Addon 的边框支持 `lineType`。 |
