### PR TITLE
fix: handle Input.OTP IME composition

### DIFF
--- a/components/input/OTP/OTPInput.tsx
+++ b/components/input/OTP/OTPInput.tsx
@@ -16,19 +16,45 @@ export interface OTPInputProps extends Omit<InputProps, 'onChange'> {
 }
 
 const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
-  const { className, value, onChange, onActiveChange, index, mask, onFocus, ...restProps } = props;
+  const {
+    className,
+    value,
+    onChange,
+    onActiveChange,
+    index,
+    mask,
+    onFocus,
+    onCompositionStart,
+    onCompositionEnd,
+    ...restProps
+  } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('otp');
   const maskValue = typeof mask === 'string' ? mask : value;
 
   // ========================== Ref ===========================
   const inputRef = React.useRef<InputRef>(null);
+  const composingRef = React.useRef(false);
 
   React.useImperativeHandle(ref, () => inputRef.current!);
 
   // ========================= Input ==========================
   const onInternalChange: React.InputEventHandler<HTMLInputElement> = (e) => {
+    if (composingRef.current || (e.nativeEvent as InputEvent).isComposing) {
+      return;
+    }
+
     onChange(index, (e.target as HTMLInputElement).value);
+  };
+
+  const onInternalCompositionStart: React.CompositionEventHandler<HTMLInputElement> = (e) => {
+    composingRef.current = true;
+    onCompositionStart?.(e);
+  };
+
+  const onInternalCompositionEnd: React.CompositionEventHandler<HTMLInputElement> = (e) => {
+    composingRef.current = false;
+    onCompositionEnd?.(e);
   };
 
   // ========================= Focus ==========================
@@ -80,6 +106,8 @@ const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
         ref={inputRef}
         value={value}
         onInput={onInternalChange}
+        onCompositionStart={onInternalCompositionStart}
+        onCompositionEnd={onInternalCompositionEnd}
         onFocus={onInternalFocus}
         onKeyDown={onInternalKeyDown}
         onMouseDown={syncSelection}

--- a/components/input/OTP/OTPInput.tsx
+++ b/components/input/OTP/OTPInput.tsx
@@ -35,6 +35,7 @@ const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
   // ========================== Ref ===========================
   const inputRef = React.useRef<InputRef>(null);
   const composingRef = React.useRef(false);
+  const composedValueRef = React.useRef<string | null>(null);
 
   React.useImperativeHandle(ref, () => inputRef.current!);
 
@@ -44,16 +45,41 @@ const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
       return;
     }
 
-    onChange(index, (e.target as HTMLInputElement).value);
+    const nextValue = (e.target as HTMLInputElement).value;
+
+    if (composedValueRef.current !== null) {
+      const composedValue = composedValueRef.current;
+      composedValueRef.current = null;
+
+      if (nextValue === composedValue) {
+        return;
+      }
+    }
+
+    onChange(index, nextValue);
   };
 
   const onInternalCompositionStart: React.CompositionEventHandler<HTMLInputElement> = (e) => {
     composingRef.current = true;
+    composedValueRef.current = null;
     onCompositionStart?.(e);
   };
 
   const onInternalCompositionEnd: React.CompositionEventHandler<HTMLInputElement> = (e) => {
     composingRef.current = false;
+    const nextValue = (e.target as HTMLInputElement).value;
+
+    if (nextValue !== value) {
+      composedValueRef.current = nextValue;
+      onChange(index, nextValue);
+
+      raf(() => {
+        composedValueRef.current = null;
+      });
+    } else {
+      composedValueRef.current = null;
+    }
+
     onCompositionEnd?.(e);
   };
 

--- a/components/input/__tests__/otp.test.tsx
+++ b/components/input/__tests__/otp.test.tsx
@@ -5,6 +5,7 @@ import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { createEvent, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
+import OTPInput from '../OTP/OTPInput';
 import type { OTPProps } from '../OTP';
 
 const { OTP } = Input;
@@ -66,12 +67,105 @@ describe('Input.OTP', () => {
     expect(getText(container)).toBe('');
     expect(onInput).not.toHaveBeenCalled();
 
-    fireEvent.compositionEnd(input);
+    fireEvent.compositionEnd(input, { target: { value: '你' } });
+
+    expect(getText(container)).toBe('你');
+    expect(onInput).toHaveBeenCalledTimes(1);
+    expect(onInput).toHaveBeenCalledWith(['你']);
+  });
+
+  it('should ignore input event marked as composing by native event', () => {
+    const onInput = jest.fn();
+    const { container } = render(<OTP length={4} onInput={onInput} />);
+    const input = container.querySelector('input')!;
+    const inputEvent = createEvent.input(input, { target: { value: 'ni' } });
+
+    Object.defineProperty(inputEvent, 'isComposing', {
+      value: true,
+    });
+    fireEvent(input, inputEvent);
+
+    expect(getText(container)).toBe('');
+    expect(onInput).not.toHaveBeenCalled();
+  });
+
+  it('should not commit twice when input fires right after compositionend', () => {
+    const onInput = jest.fn();
+    const { container } = render(<OTP length={4} onInput={onInput} />);
+    const input = container.querySelector('input')!;
+
+    fireEvent.compositionStart(input);
+    fireEvent.compositionEnd(input, { target: { value: '你' } });
     fireEvent.input(input, { target: { value: '你' } });
 
     expect(getText(container)).toBe('你');
     expect(onInput).toHaveBeenCalledTimes(1);
     expect(onInput).toHaveBeenCalledWith(['你']);
+  });
+
+  it('should still trigger input after composition dedupe', () => {
+    const onInput = jest.fn();
+    const { container } = render(<OTP length={4} onInput={onInput} />);
+    const input = container.querySelector('input')!;
+
+    fireEvent.compositionStart(input);
+    fireEvent.compositionEnd(input, { target: { value: '你' } });
+    fireEvent.input(input, { target: { value: 'a' } });
+
+    expect(getText(container)).toBe('a');
+    expect(onInput).toHaveBeenCalledTimes(2);
+    expect(onInput).toHaveBeenLastCalledWith(['a']);
+  });
+
+  it('should fill multiple cells when composition commits multiple characters', () => {
+    const onInput = jest.fn();
+    const onChange = jest.fn();
+    const { container } = render(<OTP length={2} onChange={onChange} onInput={onInput} />);
+    const input = container.querySelector('input')!;
+
+    fireEvent.compositionStart(input);
+    fireEvent.input(input, { target: { value: 'nihao' } });
+    fireEvent.compositionEnd(input, { target: { value: '你好' } });
+
+    expect(getText(container)).toBe('你好');
+    expect(onInput).toHaveBeenCalledTimes(1);
+    expect(onInput).toHaveBeenCalledWith(['你', '好']);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('你好');
+  });
+
+  it('should not trigger callback when composition is cancelled without change', () => {
+    const onInput = jest.fn();
+    const { container } = render(<OTP length={4} onInput={onInput} />);
+    const input = container.querySelector('input')!;
+
+    fireEvent.compositionStart(input);
+    fireEvent.compositionEnd(input, { target: { value: '' } });
+
+    expect(getText(container)).toBe('');
+    expect(onInput).not.toHaveBeenCalled();
+  });
+
+  it('should forward composition events from OTPInput', () => {
+    const onCompositionStart = jest.fn();
+    const onCompositionEnd = jest.fn();
+    const { container } = render(
+      <OTPInput
+        index={0}
+        value=""
+        onActiveChange={jest.fn()}
+        onChange={jest.fn()}
+        onCompositionStart={onCompositionStart}
+        onCompositionEnd={onCompositionEnd}
+      />,
+    );
+    const input = container.querySelector('input')!;
+
+    fireEvent.compositionStart(input);
+    fireEvent.compositionEnd(input);
+
+    expect(onCompositionStart).toHaveBeenCalledTimes(1);
+    expect(onCompositionEnd).toHaveBeenCalledTimes(1);
   });
 
   it('backspace to delete', async () => {

--- a/components/input/__tests__/otp.test.tsx
+++ b/components/input/__tests__/otp.test.tsx
@@ -117,6 +117,25 @@ describe('Input.OTP', () => {
     expect(onInput).toHaveBeenLastCalledWith(['a']);
   });
 
+  it('should stop deduping input after the frame following compositionend', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <OTPInput index={0} value="" onActiveChange={jest.fn()} onChange={onChange} />,
+    );
+    const input = container.querySelector('input')!;
+
+    fireEvent.compositionStart(input);
+    fireEvent.compositionEnd(input, { target: { value: '你' } });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    jest.runAllTimers();
+    fireEvent.input(input, { target: { value: '你' } });
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange).toHaveBeenLastCalledWith(0, '你');
+  });
+
   it('should fill multiple cells when composition commits multiple characters', () => {
     const onInput = jest.fn();
     const onChange = jest.fn();

--- a/components/input/__tests__/otp.test.tsx
+++ b/components/input/__tests__/otp.test.tsx
@@ -54,6 +54,26 @@ describe('Input.OTP', () => {
     expect(onChange).toHaveBeenCalledWith(CODE);
   });
 
+  it('should ignore IME composition text before commit', () => {
+    const onInput = jest.fn();
+    const { container } = render(<OTP length={4} onInput={onInput} />);
+
+    const input = container.querySelector('input')!;
+
+    fireEvent.compositionStart(input);
+    fireEvent.input(input, { target: { value: 'ni' } });
+
+    expect(getText(container)).toBe('');
+    expect(onInput).not.toHaveBeenCalled();
+
+    fireEvent.compositionEnd(input);
+    fireEvent.input(input, { target: { value: '你' } });
+
+    expect(getText(container)).toBe('你');
+    expect(onInput).toHaveBeenCalledTimes(1);
+    expect(onInput).toHaveBeenCalledWith(['你']);
+  });
+
   it('backspace to delete', async () => {
     const CODE = 'LITTLE';
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] ✅ Test Case

### 🔗 Related Issues

Fix #52093

### 💡 Background and Solution

Input.OTP currently handles every input event immediately. During IME composition, browsers can emit intermediate text such as pinyin before the final committed character. Those intermediate values were treated as OTP input, which could duplicate or split Chinese input across cells.

This PR tracks composition state in each OTP input and ignores input events while composition is active. The committed input event after composition ends is still handled normally, so regular typing, paste, formatter behavior, and focus movement remain unchanged.

A regression test covers the compositionStart -> input intermediate text -> compositionEnd -> committed input flow.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Input.OTP incorrectly handling IME composition text as committed input. |
| 🇨🇳 Chinese | 修复 Input.OTP 在中文输入法合成输入过程中会将中间态文本作为已输入内容处理的问题。 |