### PR TITLE
fix: support Yarn PnP subpath imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,60 @@
   "sideEffects": [
     "*.css"
   ],
+  "exports": {
+    ".": {
+      "types": "./es/index.d.ts",
+      "browser": "./es/index.js",
+      "node": "./lib/index.js",
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "default": "./lib/index.js"
+    },
+    "./es": {
+      "types": "./es/index.d.ts",
+      "browser": "./es/index.js",
+      "node": "./lib/index.js",
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "default": "./es/index.js"
+    },
+    "./es/*.js": "./es/*.js",
+    "./es/*.d.ts": "./es/*.d.ts",
+    "./es/*.css": "./es/*.css",
+    "./es/*.json": "./es/*.json",
+    "./es/*": {
+      "types": "./es/*.d.ts",
+      "browser": "./es/*.js",
+      "node": "./lib/*.js",
+      "import": "./es/*.js",
+      "require": "./lib/*.js",
+      "default": "./es/*.js"
+    },
+    "./lib": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./lib/*.js": "./lib/*.js",
+    "./lib/*.d.ts": "./lib/*.d.ts",
+    "./lib/*.css": "./lib/*.css",
+    "./lib/*.json": "./lib/*.json",
+    "./lib/*": {
+      "types": "./lib/*.d.ts",
+      "default": "./lib/*.js"
+    },
+    "./dist/*": "./dist/*",
+    "./locale": {
+      "types": "./locale/index.d.ts",
+      "default": "./locale/index.js"
+    },
+    "./locale/*.js": "./locale/*.js",
+    "./locale/*.d.ts": "./locale/*.d.ts",
+    "./locale/*": {
+      "types": "./locale/*.d.ts",
+      "default": "./locale/*.js"
+    },
+    "./package.json": "./package.json"
+  },
   "main": "lib/index.js",
   "module": "es/index.js",
   "unpkg": "dist/antd.min.js",
@@ -51,6 +105,7 @@
     "precompile": "npm run prestart",
     "compile": "npm run compileOnly",
     "compileOnly": "npm run clean && antd-tools run compile",
+    "postcompileOnly": "node scripts/generate-index-proxies.js",
     "predeploy": "antd-tools run clean && npm run site && cp CNAME _site && npm run test:site",
     "deploy": "gh-pages -d _site -b gh-pages -f",
     "deploy:china-mirror": "git checkout gh-pages && git pull origin gh-pages && git push git@gitee.com:ant-design/ant-design.git gh-pages -f",

--- a/scripts/generate-index-proxies.js
+++ b/scripts/generate-index-proxies.js
@@ -1,0 +1,82 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+function hasDefaultExport(source) {
+  if (/(?:^|\n)export default\b/m.test(source)) {
+    return true;
+  }
+
+  const reExportPattern = /(?:^|\n)export\s*\{([^}]*)\}\s+from/gm;
+  let match = reExportPattern.exec(source);
+
+  while (match) {
+    const hasDefault = match[1].split(',').some((specifier) => {
+      const normalized = specifier.trim();
+      return normalized === 'default' || /\bas\s+default$/.test(normalized);
+    });
+
+    if (hasDefault) {
+      return true;
+    }
+
+    match = reExportPattern.exec(source);
+  }
+
+  return false;
+}
+
+function generateIndexProxies(outputDir, moduleType) {
+  const outputPath = path.join(process.cwd(), outputDir);
+  const indexFiles = [];
+
+  const collectIndexFiles = (directory) => {
+    fs.readdirSync(directory, { withFileTypes: true }).forEach((entry) => {
+      const entryPath = path.join(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        collectIndexFiles(entryPath);
+      } else if (entry.name === 'index.js' && directory !== outputPath) {
+        indexFiles.push(entryPath);
+      }
+    });
+  };
+
+  collectIndexFiles(outputPath);
+
+  indexFiles.forEach((indexFile) => {
+    const directory = path.dirname(indexFile);
+    const importPath = `./${path.basename(directory)}/index`;
+    const declarationIndex = path.join(directory, 'index.d.ts');
+    const source = fs.readFileSync(indexFile, 'utf8');
+    const directive = source.trimStart().startsWith('"use client";') ? '"use client";\n\n' : '';
+
+    if (moduleType === 'commonjs') {
+      fs.writeFileSync(
+        `${directory}.js`,
+        `${directive}module.exports = require('${importPath}');\n`,
+      );
+    } else {
+      const exports = [`export * from '${importPath}';`];
+
+      if (hasDefaultExport(source)) {
+        exports.push(`export { default } from '${importPath}';`);
+      }
+
+      fs.writeFileSync(`${directory}.js`, `${directive}${exports.join('\n')}\n`);
+    }
+
+    if (fs.existsSync(declarationIndex)) {
+      const declaration = fs.readFileSync(declarationIndex, 'utf8');
+      const exports = [`export * from '${importPath}';`];
+
+      if (hasDefaultExport(declaration)) {
+        exports.push(`export { default } from '${importPath}';`);
+      }
+
+      fs.writeFileSync(`${directory}.d.ts`, `${exports.join('\n')}\n`);
+    }
+  });
+}
+
+generateIndexProxies('es', 'module');
+generateIndexProxies('lib', 'commonjs');

--- a/tests/dekko/exports.test.ts
+++ b/tests/dekko/exports.test.ts
@@ -23,12 +23,50 @@ if (!fs.existsSync(esDir)) {
   process.exit(1);
 }
 
+const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
+
+if (!packageJson.exports) {
+  console.error(chalk.red('`exports` field not found in package.json.'));
+  process.exit(1);
+}
+
+for (const outputDir of ['es', 'lib']) {
+  const outputPath = path.join(rootDir, outputDir);
+
+  const checkIndexProxies = (directory: string) => {
+    fs.readdirSync(directory, { withFileTypes: true }).forEach((entry) => {
+      if (!entry.isDirectory()) {
+        return;
+      }
+
+      const entryPath = path.join(directory, entry.name);
+      const indexPath = path.join(entryPath, 'index.js');
+
+      if (fs.existsSync(indexPath)) {
+        for (const extension of ['.js', '.d.ts']) {
+          if (!fs.existsSync(`${entryPath}${extension}`)) {
+            throw new Error(
+              `Missing ${outputDir} index proxy: ${path.relative(rootDir, entryPath)}${extension}`,
+            );
+          }
+        }
+      }
+
+      checkIndexProxies(entryPath);
+    });
+  };
+
+  checkIndexProxies(outputPath);
+}
+
 const testCases = [
   {
     label: 'directory-based subpath (moduleResolution: bundler)',
     code: [
       `import type { AliasToken } from 'antd/es/theme/interface';`,
+      `import Button from 'antd/es/button';`,
       `const _check: Pick<AliasToken, 'colorText' | 'fontSize' | 'controlHeight' | 'screenXS'> = {} as AliasToken;`,
+      `const _button: typeof Button = Button;`,
     ],
     compilerOptions: { moduleResolution: 'bundler' },
   },
@@ -36,7 +74,9 @@ const testCases = [
     label: 'directory-based subpath (moduleResolution: node16)',
     code: [
       `import type { AliasToken } from 'antd/es/theme/interface';`,
+      `import Button from 'antd/es/button';`,
       `const _check: Pick<AliasToken, 'colorText' | 'fontSize' | 'controlHeight' | 'screenXS'> = {} as AliasToken;`,
+      `const _button: typeof Button = Button;`,
     ],
     compilerOptions: { module: 'node16', moduleResolution: 'node16' },
   },
@@ -44,7 +84,9 @@ const testCases = [
     label: 'file-based subpath (moduleResolution: bundler)',
     code: [
       `import type { ThemeConfig } from 'antd/es/config-provider/context';`,
+      `import Search from 'antd/es/input/Search';`,
       `const _config: ThemeConfig = {};`,
+      `const _search: typeof Search = Search;`,
     ],
     compilerOptions: { moduleResolution: 'bundler' },
   },
@@ -52,7 +94,9 @@ const testCases = [
     label: 'file-based subpath (moduleResolution: node16)',
     code: [
       `import type { ThemeConfig } from 'antd/es/config-provider/context';`,
+      `import Search from 'antd/es/input/Search';`,
       `const _config: ThemeConfig = {};`,
+      `const _search: typeof Search = Search;`,
     ],
     compilerOptions: { module: 'node16', moduleResolution: 'node16' },
   },
@@ -97,6 +141,32 @@ try {
     });
     console.log(chalk.green(`✨ ${label} passed.`));
   }
+
+  execFileSync(
+    process.execPath,
+    [
+      '-e',
+      `[${[
+        'antd',
+        'antd/es',
+        'antd/es/input/Search',
+        'antd/es/theme/interface',
+        'antd/lib',
+        'antd/lib/input/Search',
+        'antd/locale',
+        'antd/locale/en_US',
+        'antd/package.json',
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join(',')}].forEach((entry) => require.resolve(entry));`,
+    ],
+    {
+      cwd: tmpDir,
+      stdio: 'pipe',
+      timeout: 30_000,
+    },
+  );
+  console.log(chalk.green('✨ CommonJS package exports passed.'));
 } catch (error: unknown) {
   const detail =
     (error as { stdout?: Buffer })?.stdout?.toString() ||

--- a/tests/dekko/lib-es.test.ts
+++ b/tests/dekko/lib-es.test.ts
@@ -4,9 +4,7 @@ import chalk from 'chalk';
 $('lib').isDirectory().hasFile('index.js').hasFile('index.d.ts');
 
 $('lib/*')
-  .filter(
-    (filename: string) => !['index.js', 'index.d.ts', '.map'].some((ext) => filename.endsWith(ext)),
-  )
+  .filter((filename: string) => !['.js', '.d.ts', '.map'].some((ext) => filename.endsWith(ext)))
   .isDirectory()
   .filter((filename: string) => !['style', '_util', 'locale'].some((ext) => filename.endsWith(ext)))
   .hasFile('index.js')
@@ -17,9 +15,7 @@ console.log(chalk.green('✨ `lib` directory is valid.'));
 $('es').isDirectory().hasFile('index.js').hasFile('index.d.ts');
 
 $('es/*')
-  .filter(
-    (filename: string) => !['index.js', 'index.d.ts', '.map'].some((ext) => filename.endsWith(ext)),
-  )
+  .filter((filename: string) => !['.js', '.d.ts', '.map'].some((ext) => filename.endsWith(ext)))
   .isDirectory()
   .filter((filename: string) => !['style', '_util', 'locale'].some((ext) => filename.endsWith(ext)))
   .hasFile('index.js')

--- a/tests/dekko/use-client.test.ts
+++ b/tests/dekko/use-client.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 
 const includeUseClient = (filename: string) =>
   fs.readFileSync(filename).toString().includes('"use client"');
+const isIndexProxy = (filename: string) => fs.existsSync(filename.slice(0, -3));
 
 $('dist/*')
   .isFile()
@@ -18,6 +19,7 @@ $('{es,lib}/*/index.js')
 // check tsx files
 $('{es,lib}/typography/*.js')
   .isFile()
+  .filter((filename: string) => !isIndexProxy(filename))
   .assert('contain use client', (filename: string) => includeUseClient(filename));
 
 $('{es,lib}/typography/Base/*.js')


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] ✅ Test Case

### 🔗 Related Issues

Fixes #56858

### 💡 Background and Solution

Yarn PnP cannot use legacy extension and directory lookup for deep imports such as `antd/es/input/Search`. A simple `exports` wildcard fixes that lookup, but breaks TypeScript because the compiled output mixes standalone files with directories containing `index.d.ts`.

This change adds conditional package exports and generates small forwarding entries for directory-based modules after compilation. The proxies preserve named exports, default exports, and `use client` directives, while Node conditions keep using the CommonJS build and browser/import conditions keep using the ES build.

The existing package checks now cover file-based and directory-based subpaths under TypeScript `bundler` and `node16` resolution, CommonJS entry points, and the generated artifacts.

Validation performed:

- `npm run compile`
- `./node_modules/.bin/antd-tools run dist`
- `npm run test:dekko`
- `npm run tsc`
- scoped ESLint and Biome checks
- the public Yarn 4.12 PnP reproduction on Node 22 using a packed local artifact: 2/2 tests passed

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Yarn PnP resolution for Ant Design subpath imports without breaking TypeScript type resolution. |
| 🇨🇳 Chinese | 修复 Yarn PnP 下 Ant Design 子路径导入解析，同时保持 TypeScript 类型解析兼容性。 |