### PR TITLE
fix(Segmented): respect ConfigProvider disabled state

### DIFF
--- a/components/segmented/__tests__/index.test.tsx
+++ b/components/segmented/__tests__/index.test.tsx
@@ -6,6 +6,7 @@ import Segmented from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render, waitFor } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
 
 // Make CSSMotion working without transition
 jest.mock('@rc-component/motion/lib/util/motion', () => ({
@@ -181,6 +182,24 @@ describe('Segmented', () => {
     fireEvent.click(container.querySelectorAll(`.${prefixCls}-item-input`)[2]);
     expect(handleValueChange).not.toHaveBeenCalled();
 
+    expectMatchChecked(container, [true, false, false]);
+  });
+
+  it('should respect ConfigProvider componentDisabled', () => {
+    const handleValueChange = jest.fn();
+    const { container } = render(
+      <ConfigProvider componentDisabled>
+        <Segmented
+          options={['Daily', 'Weekly', 'Monthly']}
+          onChange={(value) => handleValueChange(value)}
+        />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector(`.${prefixCls}`)).toHaveClass(`${prefixCls}-disabled`);
+
+    fireEvent.click(container.querySelectorAll(`.${prefixCls}-item-input`)[1]);
+    expect(handleValueChange).not.toHaveBeenCalled();
     expectMatchChecked(container, [true, false, false]);
   });
 

--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -15,6 +15,7 @@ import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeS
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { isPlainObject } from '../_util/is';
 import { useComponentConfig } from '../config-provider/context';
+import DisabledContext from '../config-provider/DisabledContext';
 import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';
 import Tooltip from '../tooltip';
@@ -96,6 +97,7 @@ const InternalSegmented = React.forwardRef<HTMLDivElement, SegmentedProps>((prop
     style,
     vertical,
     orientation,
+    disabled: customDisabled,
     shape = 'default',
     name = defaultName,
     styles,
@@ -112,9 +114,14 @@ const InternalSegmented = React.forwardRef<HTMLDivElement, SegmentedProps>((prop
     styles: contextStyles,
   } = useComponentConfig('segmented');
 
+  // ===================== Disabled =====================
+  const disabled = React.useContext(DisabledContext);
+  const mergedDisabled = customDisabled ?? disabled;
+
   const mergedProps: SegmentedProps = {
     ...props,
     options,
+    disabled: mergedDisabled,
     size: customSize,
     shape,
   };
@@ -194,6 +201,7 @@ const InternalSegmented = React.forwardRef<HTMLDivElement, SegmentedProps>((prop
   return (
     <RcSegmented
       {...restProps}
+      disabled={mergedDisabled}
       name={name}
       className={cls}
       style={mergedStyles.root}


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] ✅ 测试用例

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

`Segmented` 未合并 `ConfigProvider` 的 `componentDisabled` 状态，导致全局禁用时仍然可以切换选项并触发 `onChange`。

本次将组件自身的 `disabled` 与 `DisabledContext` 合并，并保持组件显式配置的优先级。同时补充回归测试，验证全局禁用后选项无法切换且不会触发 `onChange`。

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | 🐞 Fix Segmented not respecting ConfigProvider `componentDisabled`. |
| 🇨🇳 中文 | 🐞 修复 Segmented 未响应 ConfigProvider `componentDisabled` 的问题。 |