### PR TITLE
feat(Input): support global variant config for subcomponents

### DIFF
--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -256,15 +256,15 @@ export type InputConfig = ComponentStyleConfig &
   Pick<InputProps, 'autoComplete' | 'classNames' | 'styles' | 'allowClear' | 'variant'>;
 
 export type InputPasswordConfig = ComponentStyleConfig &
-  Pick<PasswordProps, 'classNames' | 'styles' | 'iconRender'>;
+  Pick<PasswordProps, 'classNames' | 'styles' | 'iconRender' | 'variant'>;
 
 export type InputSearchConfig = ComponentStyleConfig &
-  Pick<SearchProps, 'classNames' | 'styles' | 'searchIcon'>;
+  Pick<SearchProps, 'classNames' | 'styles' | 'searchIcon' | 'variant'>;
 
 export type TextAreaConfig = ComponentStyleConfig &
   Pick<TextAreaProps, 'autoComplete' | 'classNames' | 'styles' | 'allowClear' | 'variant'>;
 
-export type OTPConfig = ComponentStyleConfig & Pick<OTPProps, 'classNames' | 'styles'>;
+export type OTPConfig = ComponentStyleConfig & Pick<OTPProps, 'classNames' | 'styles' | 'variant'>;
 
 export type ButtonConfig = ComponentStyleConfig &
   Pick<ButtonProps, 'classNames' | 'styles' | 'autoInsertSpace' | 'variant' | 'color' | 'shape'> & {

--- a/components/form/hooks/useVariants.ts
+++ b/components/form/hooks/useVariants.ts
@@ -7,6 +7,9 @@ import { VariantContext } from '../context';
 type VariantComponents = keyof Pick<
   ConfigProviderProps,
   | 'input'
+  | 'inputPassword'
+  | 'inputSearch'
+  | 'otp'
   | 'inputNumber'
   | 'textArea'
   | 'mentions'
@@ -26,10 +29,19 @@ const useVariant = (
   component: VariantComponents,
   variant?: Variant,
   legacyBordered?: boolean,
-): [Variant, boolean] => {
-  const { variant: configVariant, [component]: componentConfig } = React.useContext(ConfigContext);
+  fallbackComponent?: VariantComponents,
+): [Variant, boolean, boolean] => {
+  const config = React.useContext(ConfigContext);
+  const { variant: configVariant, [component]: componentConfig } = config;
   const ctxVariant = React.useContext(VariantContext);
-  const configComponentVariant = componentConfig?.variant;
+  const fallbackComponentConfig = fallbackComponent ? config[fallbackComponent] : undefined;
+  const configComponentVariant = componentConfig?.variant ?? fallbackComponentConfig?.variant;
+  const isVariantConfigured =
+    typeof variant !== 'undefined' ||
+    legacyBordered === false ||
+    typeof ctxVariant !== 'undefined' ||
+    typeof configComponentVariant !== 'undefined' ||
+    typeof configVariant !== 'undefined';
 
   let mergedVariant: Variant;
   if (typeof variant !== 'undefined') {
@@ -37,12 +49,12 @@ const useVariant = (
   } else if (legacyBordered === false) {
     mergedVariant = 'borderless';
   } else {
-    // form variant > component global variant > global variant
+    // form variant > component global variant > fallback component global variant > global variant
     mergedVariant = ctxVariant ?? configComponentVariant ?? configVariant ?? 'outlined';
   }
 
   const enableVariantCls = Variants.includes(mergedVariant);
-  return [mergedVariant, enableVariantCls];
+  return [mergedVariant, enableVariantCls, isVariantConfigured];
 };
 
 export default useVariant;

--- a/components/input/OTP/index.tsx
+++ b/components/input/OTP/index.tsx
@@ -14,6 +14,7 @@ import useSize from '../../config-provider/hooks/useSize';
 import type { SizeType } from '../../config-provider/SizeContext';
 import { FormItemInputContext } from '../../form/context';
 import type { FormItemStatusContextProps } from '../../form/context';
+import useVariant from '../../form/hooks/useVariants';
 import type { InputRef } from '../Input';
 import useStyle from '../style/otp';
 import OTPInput from './OTPInput';
@@ -110,7 +111,7 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
     onChange,
     formatter,
     separator,
-    variant,
+    variant: customizeVariant,
     disabled,
     status: customStatus,
     autoFocus,
@@ -145,10 +146,12 @@ const OTP = React.forwardRef<OTPRef, OTPProps>((props, ref) => {
     className: contextClassName,
   } = useComponentConfig('otp');
   const prefixCls = getPrefixCls('otp', customizePrefixCls);
+  const [variant] = useVariant('otp', customizeVariant, undefined, 'input');
 
   const mergedProps: OTPProps = {
     ...props,
     length,
+    variant,
   };
 
   const contextStyleRoot = useSemanticRootStyle(contextStyle);

--- a/components/input/Password.tsx
+++ b/components/input/Password.tsx
@@ -9,6 +9,7 @@ import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeS
 import { isPlainObject } from '../_util/is';
 import { useComponentConfig } from '../config-provider/context';
 import DisabledContext from '../config-provider/DisabledContext';
+import useVariant from '../form/hooks/useVariants';
 import { useLocale } from '../locale';
 import useRemovePasswordTimeout from './hooks/useRemovePasswordTimeout';
 import type { InputProps, InputRef, InputSemanticAllType } from './Input';
@@ -52,6 +53,7 @@ const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
     style,
     classNames,
     styles,
+    variant: customizeVariant,
     ...restProps
   } = props;
 
@@ -64,6 +66,8 @@ const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
     iconRender: contextIconRender,
   } = useComponentConfig('inputPassword');
 
+  const [variant] = useVariant('inputPassword', customizeVariant, props.bordered, 'input');
+
   const [locale] = useLocale('global');
 
   // ===================== Disabled =====================
@@ -74,6 +78,7 @@ const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
   const mergedProps: PasswordProps = {
     ...props,
     disabled: mergedDisabled,
+    variant,
   };
 
   const contextStyleRoot = useSemanticRootStyle(contextStyle);
@@ -181,6 +186,7 @@ const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
     className: inputClassName,
     classNames: mergedClassNames,
     styles: mergedStyles,
+    variant,
   };
 
   return <Input ref={composeRef(ref, inputRef)} {...inputProps} />;

--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -9,9 +9,10 @@ import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticT
 import { cloneElement } from '../_util/reactNode';
 import Button from '../button/Button';
 import type { ButtonProps, ButtonSemanticType } from '../button/Button';
-import DisabledContext from '../config-provider/DisabledContext';
 import { useComponentConfig } from '../config-provider/context';
+import DisabledContext from '../config-provider/DisabledContext';
 import useSize from '../config-provider/hooks/useSize';
+import useVariant from '../form/hooks/useVariants';
 import Compact, { useCompactItemContext } from '../space/Compact';
 import type { InputProps, InputRef } from './Input';
 import Input from './Input';
@@ -76,7 +77,7 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
     onChange: customOnChange,
     onCompositionStart,
     onCompositionEnd,
-    variant,
+    variant: customizeVariant,
     onPressEnter: customOnPressEnter,
     classNames,
     styles,
@@ -96,10 +97,18 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
 
   const contextDisabled = React.useContext(DisabledContext);
   const mergedDisabled = disabled ?? contextDisabled;
+  const [mergedVariant, , isVariantConfigured] = useVariant(
+    'inputSearch',
+    customizeVariant,
+    props.bordered,
+  );
+  const variant = isVariantConfigured ? mergedVariant : undefined;
+  const [inputVariant] = useVariant('inputSearch', customizeVariant, props.bordered, 'input');
 
   const mergedProps: SearchProps = {
     ...props,
     enterButton,
+    variant,
   };
 
   const contextStyleRoot = useSemanticRootStyle(contextStyle);
@@ -270,7 +279,7 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
       prefixCls: inputPrefixCls,
       type: 'search',
       size,
-      variant,
+      variant: inputVariant,
       onPressEnter,
       onCompositionStart: handleOnCompositionStart,
       onCompositionEnd: handleOnCompositionEnd,

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -11610,6 +11610,591 @@ Array [
 
 exports[`renders components/input/demo/search-input-loading.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/input/demo/search-variant-debug.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-large ant-flex-vertical"
+>
+  <div
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+  >
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <strong>
+        Input.Search
+      </strong>
+    </span>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        ConfigProvider input
+      </code>
+    </span>
+    <div
+      class="ant-space-compact ant-input-search css-var-test-id"
+    >
+      <input
+        class="ant-input ant-input-filled css-var-test-id ant-input-css-var ant-input-compact-item ant-input-compact-first-item"
+        placeholder="Filled"
+        type="search"
+        value=""
+      />
+      <button
+        class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-last-item ant-input-search-btn"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="search"
+            class="anticon anticon-search"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="search"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+              />
+            </svg>
+          </span>
+        </span>
+      </button>
+    </div>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        ConfigProvider inputSearch
+      </code>
+    </span>
+    <div
+      class="ant-space-compact ant-input-search css-var-test-id"
+    >
+      <input
+        class="ant-input ant-input-filled css-var-test-id ant-input-css-var ant-input-compact-item ant-input-compact-first-item"
+        placeholder="Filled"
+        type="search"
+        value=""
+      />
+      <button
+        class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-icon-only ant-btn-compact-item ant-btn-compact-last-item ant-input-search-btn ant-input-search-btn-filled"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="search"
+            class="anticon anticon-search"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="search"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+              />
+            </svg>
+          </span>
+        </span>
+      </button>
+    </div>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        Component prop
+      </code>
+    </span>
+    <div
+      class="ant-space-compact ant-input-search css-var-test-id"
+    >
+      <input
+        class="ant-input ant-input-filled css-var-test-id ant-input-css-var ant-input-compact-item ant-input-compact-first-item"
+        placeholder="Filled"
+        type="search"
+        value=""
+      />
+      <button
+        class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-icon-only ant-btn-compact-item ant-btn-compact-last-item ant-input-search-btn ant-input-search-btn-filled"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="search"
+            class="anticon anticon-search"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="search"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+              />
+            </svg>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+  >
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <strong>
+        Input.Password
+      </strong>
+    </span>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        ConfigProvider input
+      </code>
+    </span>
+    <span
+      class="ant-input-affix-wrapper ant-input-filled ant-input-password css-var-test-id ant-input-css-var"
+    >
+      <input
+        class="ant-input"
+        placeholder="Filled"
+        type="password"
+        value=""
+      />
+      <span
+        class="ant-input-suffix"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Show"
+          aria-pressed="false"
+          class="ant-input-password-icon"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            aria-label="eye-invisible"
+            class="anticon anticon-eye-invisible"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="eye-invisible"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
+              />
+              <path
+                d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
+              />
+            </svg>
+          </span>
+        </span>
+      </span>
+    </span>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        ConfigProvider inputPassword
+      </code>
+    </span>
+    <span
+      class="ant-input-affix-wrapper ant-input-filled ant-input-password css-var-test-id ant-input-css-var"
+    >
+      <input
+        class="ant-input"
+        placeholder="Filled"
+        type="password"
+        value=""
+      />
+      <span
+        class="ant-input-suffix"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Show"
+          aria-pressed="false"
+          class="ant-input-password-icon"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            aria-label="eye-invisible"
+            class="anticon anticon-eye-invisible"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="eye-invisible"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
+              />
+              <path
+                d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
+              />
+            </svg>
+          </span>
+        </span>
+      </span>
+    </span>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        Component prop
+      </code>
+    </span>
+    <span
+      class="ant-input-affix-wrapper ant-input-filled ant-input-password css-var-test-id ant-input-css-var"
+    >
+      <input
+        class="ant-input"
+        placeholder="Filled"
+        type="password"
+        value=""
+      />
+      <span
+        class="ant-input-suffix"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Show"
+          aria-pressed="false"
+          class="ant-input-password-icon"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            aria-label="eye-invisible"
+            class="anticon anticon-eye-invisible"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="eye-invisible"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
+              />
+              <path
+                d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
+              />
+            </svg>
+          </span>
+        </span>
+      </span>
+    </span>
+  </div>
+  <div
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+  >
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <strong>
+        Input.OTP
+      </strong>
+    </span>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        ConfigProvider input
+      </code>
+    </span>
+    <div
+      class="ant-otp css-var-test-id"
+      role="group"
+    >
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 1"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="1"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 2"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="1"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 3"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="1"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 4"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="1"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 5"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="1"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 6"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="1"
+        />
+      </span>
+    </div>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        ConfigProvider otp
+      </code>
+    </span>
+    <div
+      class="ant-otp css-var-test-id"
+      role="group"
+    >
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 1"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="2"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 2"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="2"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 3"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="2"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 4"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="2"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 5"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="2"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 6"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="2"
+        />
+      </span>
+    </div>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        Component prop
+      </code>
+    </span>
+    <div
+      class="ant-otp css-var-test-id"
+      role="group"
+    >
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 1"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="3"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 2"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="3"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 3"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="3"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 4"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="3"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 5"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="3"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 6"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="3"
+        />
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/input/demo/search-variant-debug.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/input/demo/show-count.tsx extend context correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"

--- a/components/input/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.tsx.snap
@@ -4847,6 +4847,589 @@ Array [
 ]
 `;
 
+exports[`renders components/input/demo/search-variant-debug.tsx correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-large ant-flex-vertical"
+>
+  <div
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+  >
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <strong>
+        Input.Search
+      </strong>
+    </span>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        ConfigProvider input
+      </code>
+    </span>
+    <div
+      class="ant-space-compact ant-input-search css-var-test-id"
+    >
+      <input
+        class="ant-input ant-input-filled css-var-test-id ant-input-css-var ant-input-compact-item ant-input-compact-first-item"
+        placeholder="Filled"
+        type="search"
+        value=""
+      />
+      <button
+        class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-last-item ant-input-search-btn"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="search"
+            class="anticon anticon-search"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="search"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+              />
+            </svg>
+          </span>
+        </span>
+      </button>
+    </div>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        ConfigProvider inputSearch
+      </code>
+    </span>
+    <div
+      class="ant-space-compact ant-input-search css-var-test-id"
+    >
+      <input
+        class="ant-input ant-input-filled css-var-test-id ant-input-css-var ant-input-compact-item ant-input-compact-first-item"
+        placeholder="Filled"
+        type="search"
+        value=""
+      />
+      <button
+        class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-icon-only ant-btn-compact-item ant-btn-compact-last-item ant-input-search-btn ant-input-search-btn-filled"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="search"
+            class="anticon anticon-search"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="search"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+              />
+            </svg>
+          </span>
+        </span>
+      </button>
+    </div>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        Component prop
+      </code>
+    </span>
+    <div
+      class="ant-space-compact ant-input-search css-var-test-id"
+    >
+      <input
+        class="ant-input ant-input-filled css-var-test-id ant-input-css-var ant-input-compact-item ant-input-compact-first-item"
+        placeholder="Filled"
+        type="search"
+        value=""
+      />
+      <button
+        class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-icon-only ant-btn-compact-item ant-btn-compact-last-item ant-input-search-btn ant-input-search-btn-filled"
+        type="button"
+      >
+        <span
+          class="ant-btn-icon"
+        >
+          <span
+            aria-label="search"
+            class="anticon anticon-search"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="search"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M909.6 854.5L649.9 594.8C690.2 542.7 712 479 712 412c0-80.2-31.3-155.4-87.9-212.1-56.6-56.7-132-87.9-212.1-87.9s-155.5 31.3-212.1 87.9C143.2 256.5 112 331.8 112 412c0 80.1 31.3 155.5 87.9 212.1C256.5 680.8 331.8 712 412 712c67 0 130.6-21.8 182.7-62l259.7 259.6a8.2 8.2 0 0011.6 0l43.6-43.5a8.2 8.2 0 000-11.6zM570.4 570.4C528 612.7 471.8 636 412 636s-116-23.3-158.4-65.6C211.3 528 188 471.8 188 412s23.3-116.1 65.6-158.4C296 211.3 352.2 188 412 188s116.1 23.2 158.4 65.6S636 352.2 636 412s-23.3 116.1-65.6 158.4z"
+              />
+            </svg>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+  >
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <strong>
+        Input.Password
+      </strong>
+    </span>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        ConfigProvider input
+      </code>
+    </span>
+    <span
+      class="ant-input-affix-wrapper ant-input-filled ant-input-password css-var-test-id ant-input-css-var"
+    >
+      <input
+        class="ant-input"
+        placeholder="Filled"
+        type="password"
+        value=""
+      />
+      <span
+        class="ant-input-suffix"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Show"
+          aria-pressed="false"
+          class="ant-input-password-icon"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            aria-label="eye-invisible"
+            class="anticon anticon-eye-invisible"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="eye-invisible"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
+              />
+              <path
+                d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
+              />
+            </svg>
+          </span>
+        </span>
+      </span>
+    </span>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        ConfigProvider inputPassword
+      </code>
+    </span>
+    <span
+      class="ant-input-affix-wrapper ant-input-filled ant-input-password css-var-test-id ant-input-css-var"
+    >
+      <input
+        class="ant-input"
+        placeholder="Filled"
+        type="password"
+        value=""
+      />
+      <span
+        class="ant-input-suffix"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Show"
+          aria-pressed="false"
+          class="ant-input-password-icon"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            aria-label="eye-invisible"
+            class="anticon anticon-eye-invisible"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="eye-invisible"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
+              />
+              <path
+                d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
+              />
+            </svg>
+          </span>
+        </span>
+      </span>
+    </span>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        Component prop
+      </code>
+    </span>
+    <span
+      class="ant-input-affix-wrapper ant-input-filled ant-input-password css-var-test-id ant-input-css-var"
+    >
+      <input
+        class="ant-input"
+        placeholder="Filled"
+        type="password"
+        value=""
+      />
+      <span
+        class="ant-input-suffix"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Show"
+          aria-pressed="false"
+          class="ant-input-password-icon"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            aria-label="eye-invisible"
+            class="anticon anticon-eye-invisible"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="eye-invisible"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M942.2 486.2Q889.47 375.11 816.7 305l-50.88 50.88C807.31 395.53 843.45 447.4 874.7 512 791.5 684.2 673.4 766 512 766q-72.67 0-133.87-22.38L323 798.75Q408 838 512 838q288.3 0 430.2-300.3a60.29 60.29 0 000-51.5zm-63.57-320.64L836 122.88a8 8 0 00-11.32 0L715.31 232.2Q624.86 186 512 186q-288.3 0-430.2 300.3a60.3 60.3 0 000 51.5q56.69 119.4 136.5 191.41L112.48 835a8 8 0 000 11.31L155.17 889a8 8 0 0011.31 0l712.15-712.12a8 8 0 000-11.32zM149.3 512C232.6 339.8 350.7 258 512 258c54.54 0 104.13 9.36 149.12 28.39l-70.3 70.3a176 176 0 00-238.13 238.13l-83.42 83.42C223.1 637.49 183.3 582.28 149.3 512zm246.7 0a112.11 112.11 0 01146.2-106.69L401.31 546.2A112 112 0 01396 512z"
+              />
+              <path
+                d="M508 624c-3.46 0-6.87-.16-10.25-.47l-52.82 52.82a176.09 176.09 0 00227.42-227.42l-52.82 52.82c.31 3.38.47 6.79.47 10.25a111.94 111.94 0 01-112 112z"
+              />
+            </svg>
+          </span>
+        </span>
+      </span>
+    </span>
+  </div>
+  <div
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+  >
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <strong>
+        Input.OTP
+      </strong>
+    </span>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        ConfigProvider input
+      </code>
+    </span>
+    <div
+      class="ant-otp css-var-test-id"
+      role="group"
+    >
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 1"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="1"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 2"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="1"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 3"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="1"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 4"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="1"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 5"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="1"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 6"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="1"
+        />
+      </span>
+    </div>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        ConfigProvider otp
+      </code>
+    </span>
+    <div
+      class="ant-otp css-var-test-id"
+      role="group"
+    >
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 1"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="2"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 2"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="2"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 3"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="2"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 4"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="2"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 5"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="2"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 6"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="2"
+        />
+      </span>
+    </div>
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      <code>
+        Component prop
+      </code>
+    </span>
+    <div
+      class="ant-otp css-var-test-id"
+      role="group"
+    >
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 1"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="3"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 2"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="3"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 3"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="3"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 4"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="3"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 5"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="3"
+        />
+      </span>
+      <span
+        class="ant-otp-input-wrapper"
+        role="presentation"
+      >
+        <input
+          aria-label="OTP Input 6"
+          class="ant-input ant-input-filled ant-otp-input css-var-test-id ant-input-css-var"
+          size="1"
+          type="text"
+          value="3"
+        />
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/input/demo/show-count.tsx correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"

--- a/components/input/demo/search-variant-debug.md
+++ b/components/input/demo/search-variant-debug.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+对比 Input 子组件通过 `input`、子组件全局配置和组件属性设置变体的效果。
+
+## en-US
+
+Compare Input subcomponent variants configured through `input`, subcomponent global config, and component props.

--- a/components/input/demo/search-variant-debug.tsx
+++ b/components/input/demo/search-variant-debug.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { ConfigProvider, Flex, Input, Typography } from 'antd';
+
+const App: React.FC = () => (
+  <Flex vertical gap="large">
+    <Flex vertical gap="small">
+      <Typography.Text strong>Input.Search</Typography.Text>
+      <Typography.Text code>ConfigProvider input</Typography.Text>
+      <ConfigProvider input={{ variant: 'filled' }}>
+        <Input.Search placeholder="Filled" />
+      </ConfigProvider>
+      <Typography.Text code>ConfigProvider inputSearch</Typography.Text>
+      <ConfigProvider inputSearch={{ variant: 'filled' }}>
+        <Input.Search placeholder="Filled" />
+      </ConfigProvider>
+      <Typography.Text code>Component prop</Typography.Text>
+      <Input.Search placeholder="Filled" variant="filled" />
+    </Flex>
+
+    <Flex vertical gap="small">
+      <Typography.Text strong>Input.Password</Typography.Text>
+      <Typography.Text code>ConfigProvider input</Typography.Text>
+      <ConfigProvider input={{ variant: 'filled' }}>
+        <Input.Password placeholder="Filled" />
+      </ConfigProvider>
+      <Typography.Text code>ConfigProvider inputPassword</Typography.Text>
+      <ConfigProvider inputPassword={{ variant: 'filled' }}>
+        <Input.Password placeholder="Filled" />
+      </ConfigProvider>
+      <Typography.Text code>Component prop</Typography.Text>
+      <Input.Password placeholder="Filled" variant="filled" />
+    </Flex>
+
+    <Flex vertical gap="small">
+      <Typography.Text strong>Input.OTP</Typography.Text>
+      <Typography.Text code>ConfigProvider input</Typography.Text>
+      <ConfigProvider input={{ variant: 'filled' }}>
+        <Input.OTP defaultValue="111111" />
+      </ConfigProvider>
+      <Typography.Text code>ConfigProvider otp</Typography.Text>
+      <ConfigProvider otp={{ variant: 'filled' }}>
+        <Input.OTP defaultValue="222222" />
+      </ConfigProvider>
+      <Typography.Text code>Component prop</Typography.Text>
+      <Input.OTP defaultValue="333333" variant="filled" />
+    </Flex>
+  </Flex>
+);
+
+export default App;

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -20,6 +20,7 @@ demo:
 <code src="./demo/basic.tsx">Basic usage</code>
 <code src="./demo/size.tsx">Three sizes of Input</code>
 <code src="./demo/variant.tsx" version="5.13.0">Variants</code>
+<code src="./demo/search-variant-debug.tsx" debug>Variant Config Debug</code>
 <code src="./demo/filled-debug.tsx" debug>Filled Debug</code>
 <code src="./demo/addon.tsx" debug>Pre / Post tab</code>
 <code src="./demo/compact-style.tsx">Compact Style</code>
@@ -116,6 +117,7 @@ The rest of the props of `Input.TextArea` are the same as the original [textarea
 | onSearch | The callback function triggered when you click on the search-icon, the clear-icon or press the Enter key | function(value, event, { source: "input" \| "clear" }) | - |  | × |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-search), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-search), CSSProperties> | - | 6.0.0 | 6.0.0 |
 | searchIcon | Customize the search icon | ReactNode | - | 6.4.0 | 6.4.0 |
+| variant | Variants of Input | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 | 6.6.0 |
 
 Supports all props of `Input`.
 
@@ -126,6 +128,7 @@ Supports all props of `Input`.
 | classNames | Semantic DOM class | Record<[SemanticDOM](#semantic-password), string> | - | 5.4.0 | 6.4.0 |
 | iconRender | Custom toggle button | (visible) => ReactNode | (visible) => (visible ? &lt;EyeOutlined /> : &lt;EyeInvisibleOutlined />) | 4.3.0 | 6.4.0 |
 | styles | Semantic DOM style | Record<[SemanticDOM](#semantic-password), CSSProperties> | - | 5.4.0 | 6.4.0 |
+| variant | Variants of Input | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 | 6.6.0 |
 | visibilityToggle | Whether show toggle button or control password visible | boolean \| [VisibilityToggle](#visibilitytoggle) | true |  | × |
 
 ### Input.OTP
@@ -149,7 +152,7 @@ Added in `5.16.0`.
 | length | The number of input elements | number | 6 |  | × |
 | status | Set validation status | 'error' \| 'warning' | - |  | × |
 | size | The size of the input box | `small` \| `medium` \| `large` | `medium` |  | × |
-| variant | Variants of Input | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | `underlined`: 5.24.0 | × |
+| variant | Variants of Input | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | `underlined`: 5.24.0 | 6.6.0 |
 | value | The input content value | string | - |  | × |
 | onChange | Trigger when all the fields are filled | (value: string) => void | - |  | × |
 | onInput | Trigger when the input value changes | (value: string[]) => void | - | `5.22.0` | × |

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -21,6 +21,7 @@ demo:
 <code src="./demo/basic.tsx">基本使用</code>
 <code src="./demo/size.tsx">三种大小</code>
 <code src="./demo/variant.tsx" version="5.13.0">形态变体</code>
+<code src="./demo/search-variant-debug.tsx" debug>变体配置 Debug</code>
 <code src="./demo/filled-debug.tsx" debug>面性变体 Debug</code>
 <code src="./demo/addon.tsx" debug>前置/后置标签</code>
 <code src="./demo/compact-style.tsx">紧凑模式</code>
@@ -117,6 +118,7 @@ interface CountConfig {
 | onSearch | 点击搜索图标、清除图标，或按下回车键时的回调 | function(value, event, { source: "input" \| "clear" }) | - |  | × |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-search) , CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-search) , CSSProperties> | - | 6.0.0 | 6.0.0 |
 | searchIcon | 自定义搜索图标 | ReactNode | - | 6.4.0 | 6.4.0 |
+| variant | 形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 | 6.6.0 |
 
 其余属性和 Input 一致。
 
@@ -127,6 +129,7 @@ interface CountConfig {
 | classNames | 语义化结构 class | Record<[SemanticDOM](#semantic-password), string> | - | 5.4.0 | 6.4.0 |
 | iconRender | 自定义切换按钮 | (visible) => ReactNode | (visible) => (visible ? &lt;EyeOutlined /> : &lt;EyeInvisibleOutlined />) | 4.3.0 | 6.4.0 |
 | styles | 语义化结构 style | Record<[SemanticDOM](#semantic-password), CSSProperties> | - | 5.4.0 | 6.4.0 |
+| variant | 形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 | 6.6.0 |
 | visibilityToggle | 是否显示切换按钮或者控制密码显隐 | boolean \| [VisibilityToggle](#visibilitytoggle) | true |  | × |
 
 ### Input.OTP
@@ -150,7 +153,7 @@ interface CountConfig {
 | status | 设置校验状态 | 'error' \| 'warning' | - |  | × |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-otp) , CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-otp) , CSSProperties> | - | 6.0.0 | 6.0.0 |
 | size | 输入框大小 | `small` \| `medium` \| `large` | `medium` |  | × |
-| variant | 形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | `underlined`: 5.24.0 | × |
+| variant | 形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | `underlined`: 5.24.0 | 6.6.0 |
 | value | 输入框内容 | string | - |  | × |
 | onChange | 当输入框内容全部填充时触发回调 | (value: string) => void | - |  | × |
 | onInput | 输入值变化时触发的回调 | (value: string[]) => void | - | `5.22.0` | × |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [x] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

ConfigProvider 的 `inputSearch`、`inputPassword` 和 `otp` 配置此前未支持 `variant`。

本次新增对应的全局配置能力，并保持组件属性、Form variant、子组件配置、`input` fallback 和顶层 variant 的优先级。对于 Input.Search，`input.variant` 仅影响输入框，`inputSearch.variant` 同时影响输入框和搜索按钮。

同时补充中英文 API 文档、debug demo 和对应快照。

验证结果：Input demo 测试 57 项通过，78 个快照通过；ESLint、Prettier 和 antd lint 通过。

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | 🆕 Support Input.Search, Input.Password, and Input.OTP global `variant` configuration. |
| 🇨🇳 中文 | 🆕 支持 Input.Search、Input.Password 和 Input.OTP 全局配置 `variant`。 |