### PR TITLE
fix(Spin): correct standalone indicator positioning when nested

### DIFF
--- a/components/spin/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/spin/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -223,6 +223,95 @@ Array [
 
 exports[`renders components/spin/demo/fullscreen.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/spin/demo/list-debug.tsx extend context correctly 1`] = `
+<div
+  class="ant-list ant-list-split css-var-test-id"
+>
+  <div
+    aria-busy="false"
+    aria-live="polite"
+    class="ant-spin css-var-test-id"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <ul
+        class="ant-list-items ant-list-container css-var-test-id"
+      >
+        <li
+          class="ant-list-item"
+        >
+          Apple
+          <div
+            aria-busy="true"
+            aria-live="polite"
+            class="ant-spin ant-spin-sm ant-spin-spinning ant-spin-section css-var-test-id"
+          >
+            <span
+              class="ant-spin-dot-holder"
+            >
+              <span
+                class="ant-spin-dot ant-spin-dot-spin"
+              >
+                <i
+                  class="ant-spin-dot-item"
+                />
+                <i
+                  class="ant-spin-dot-item"
+                />
+                <i
+                  class="ant-spin-dot-item"
+                />
+                <i
+                  class="ant-spin-dot-item"
+                />
+              </span>
+            </span>
+          </div>
+        </li>
+        <li
+          class="ant-list-item"
+        >
+          Banana
+          <div
+            aria-busy="true"
+            aria-live="polite"
+            class="ant-spin ant-spin-sm ant-spin-spinning ant-spin-section css-var-test-id"
+          >
+            <span
+              class="ant-spin-dot-holder"
+            >
+              <span
+                class="ant-spin-dot ant-spin-dot-spin"
+              >
+                <i
+                  class="ant-spin-dot-item"
+                />
+                <i
+                  class="ant-spin-dot-item"
+                />
+                <i
+                  class="ant-spin-dot-item"
+                />
+                <i
+                  class="ant-spin-dot-item"
+                />
+              </span>
+            </span>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/spin/demo/list-debug.tsx extend context correctly 2`] = `
+[
+  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+]
+`;
+
 exports[`renders components/spin/demo/nested.tsx extend context correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"

--- a/components/spin/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/spin/__tests__/__snapshots__/demo.test.ts.snap
@@ -215,6 +215,89 @@ Array [
 ]
 `;
 
+exports[`renders components/spin/demo/list-debug.tsx correctly 1`] = `
+<div
+  class="ant-list ant-list-split css-var-test-id"
+>
+  <div
+    aria-busy="false"
+    aria-live="polite"
+    class="ant-spin css-var-test-id"
+  >
+    <div
+      class="ant-spin-container"
+    >
+      <ul
+        class="ant-list-items ant-list-container css-var-test-id"
+      >
+        <li
+          class="ant-list-item"
+        >
+          Apple
+          <div
+            aria-busy="true"
+            aria-live="polite"
+            class="ant-spin ant-spin-sm ant-spin-spinning ant-spin-section css-var-test-id"
+          >
+            <span
+              class="ant-spin-dot-holder"
+            >
+              <span
+                class="ant-spin-dot ant-spin-dot-spin"
+              >
+                <i
+                  class="ant-spin-dot-item"
+                />
+                <i
+                  class="ant-spin-dot-item"
+                />
+                <i
+                  class="ant-spin-dot-item"
+                />
+                <i
+                  class="ant-spin-dot-item"
+                />
+              </span>
+            </span>
+          </div>
+        </li>
+        <li
+          class="ant-list-item"
+        >
+          Banana
+          <div
+            aria-busy="true"
+            aria-live="polite"
+            class="ant-spin ant-spin-sm ant-spin-spinning ant-spin-section css-var-test-id"
+          >
+            <span
+              class="ant-spin-dot-holder"
+            >
+              <span
+                class="ant-spin-dot ant-spin-dot-spin"
+              >
+                <i
+                  class="ant-spin-dot-item"
+                />
+                <i
+                  class="ant-spin-dot-item"
+                />
+                <i
+                  class="ant-spin-dot-item"
+                />
+                <i
+                  class="ant-spin-dot-item"
+                />
+              </span>
+            </span>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/spin/demo/nested.tsx correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"

--- a/components/spin/demo/list-debug.md
+++ b/components/spin/demo/list-debug.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+List 嵌套独立 Spin 的调试示例。
+
+## en-US
+
+Debug example for standalone Spin components nested in List.

--- a/components/spin/demo/list-debug.tsx
+++ b/components/spin/demo/list-debug.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { List, Spin } from 'antd';
+
+const App: React.FC = () => (
+  <List
+    dataSource={['Apple', 'Banana']}
+    renderItem={(item) => <List.Item extra={<Spin size="small" />}>{item}</List.Item>}
+  />
+);
+
+export default App;

--- a/components/spin/index.en-US.md
+++ b/components/spin/index.en-US.md
@@ -25,6 +25,7 @@ When part of the page is waiting for asynchronous data or during a rendering pro
 <code src="./demo/percent.tsx" version="5.18.0">Progress</code>
 <code src="./demo/style-class.tsx" version="6.0.0">Custom semantic dom styling</code>
 <code src="./demo/fullscreen.tsx">Fullscreen</code>
+<code src="./demo/list-debug.tsx" debug>Nested in List debug</code>
 
 ## API
 

--- a/components/spin/index.zh-CN.md
+++ b/components/spin/index.zh-CN.md
@@ -26,6 +26,7 @@ demo:
 <code src="./demo/percent.tsx" version="5.18.0">进度</code>
 <code src="./demo/style-class.tsx" version="6.0.0">自定义语义结构的样式和类</code>
 <code src="./demo/fullscreen.tsx">全屏</code>
+<code src="./demo/list-debug.tsx" debug>List 嵌套调试</code>
 
 ## API
 

--- a/components/spin/style/index.ts
+++ b/components/spin/style/index.ts
@@ -57,7 +57,7 @@ const genSpinStyle: GenerateStyle<SpinToken, CSSObject> = (token) => {
       },
 
       // ========================== Section ===========================
-      [`&${sectionCls}, ${sectionCls}`]: {
+      [`&${sectionCls}, > ${sectionCls}`]: {
         display: 'flex',
         alignItems: 'center',
         flexDirection: 'column',
@@ -69,7 +69,7 @@ const genSpinStyle: GenerateStyle<SpinToken, CSSObject> = (token) => {
         display: 'inline-flex',
       },
 
-      [sectionCls]: {
+      [`> ${sectionCls}`]: {
         position: 'absolute',
         top: '50%',
         left: {
@@ -141,7 +141,7 @@ const genSpinStyle: GenerateStyle<SpinToken, CSSObject> = (token) => {
           pointerEvents: 'auto',
         },
 
-        [sectionCls]: {
+        [`> ${sectionCls}`]: {
           color: token.colorWhite,
 
           [`${componentCls}-description`]: {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #58796

### 💡 需求背景和解决方案

Spin 语义化结构重构后，section 的后代选择器会命中嵌套 Spin 的 standalone 根节点。List 内部使用 Spin 包裹列表内容时，各列表项中的 Spin 因此会相对同一个外层容器定位并重叠。

本次将 section 的布局、定位及全屏颜色样式限定到当前 Spin 的直属 section，同时保留 standalone Spin 根节点原有样式。新增 List 嵌套 Spin 的 debug demo 及对应快照，不涉及 API 或 DOM 结构变更。

验证：

`npm test -- components/spin/__tests__/demo.test.ts components/spin/__tests__/demo-extend.test.ts --runInBand -u`

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Spin standalone indicators being mispositioned when nested in another Spin. |
| 🇨🇳 中文 | 🐞 修复 Spin 独立加载指示器嵌套使用时定位错乱的问题。 |
