### PR TITLE
fix: mask OTP values when mask is true

### DIFF
--- a/components/input/OTP/OTPInput.tsx
+++ b/components/input/OTP/OTPInput.tsx
@@ -15,11 +15,14 @@ export interface OTPInputProps extends Omit<InputProps, 'onChange'> {
   mask?: boolean | string;
 }
 
+const DEFAULT_MASK_VALUE = '•';
+
 const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
-  const { className, value, onChange, onActiveChange, index, mask, onFocus, ...restProps } = props;
+  const { className, value, onChange, onActiveChange, index, mask, onFocus, type, ...restProps } =
+    props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('otp');
-  const maskValue = typeof mask === 'string' ? mask : value;
+  const maskValue = typeof mask === 'string' ? mask : DEFAULT_MASK_VALUE;
 
   // ========================== Ref ===========================
   const inputRef = React.useRef<InputRef>(null);
@@ -75,8 +78,8 @@ const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
 
       <Input
         aria-label={`OTP Input ${index + 1}`}
-        type={mask === true ? 'password' : 'text'}
         {...restProps}
+        type={type ?? (mask === true ? 'password' : 'text')}
         ref={inputRef}
         value={value}
         onInput={onInternalChange}

--- a/components/input/__tests__/otp.test.tsx
+++ b/components/input/__tests__/otp.test.tsx
@@ -160,6 +160,16 @@ describe('Input.OTP', () => {
     const { container, rerender } = render(<OTP defaultValue="bamboo" />);
     expect(getText(container)).toBe('bamboo');
 
+    // support true
+    rerender(<OTP defaultValue="bamboo" mask />);
+    expect(getText(container)).toBe('bamboo');
+    expect(
+      Array.from(container.querySelectorAll('.ant-otp-mask-icon'))
+        .map((node) => node.textContent)
+        .join(''),
+    ).toBe('••••••');
+    expect(container.querySelector('input')).toHaveAttribute('type', 'password');
+
     // support string
     rerender(<OTP defaultValue="bamboo" mask="*" />);
     expect(getText(container)).toBe('bamboo');


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Fixes #58781.

### 💡 Background and Solution

`Input.OTP` currently renders the raw cell value into the visible mask layer when `mask` is `true`, so values like `123456` can still be displayed.

This changes the boolean mask path to render a default mask character (`•`) in the mask layer instead of the original value. String masks continue to render the provided mask character, and the default boolean mask input type is kept as `password` when no explicit `type` prop is provided.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Input.OTP `mask={true}` displaying the original value instead of a masked character. |
| 🇨🇳 Chinese | 🐞 修复 Input.OTP 在 `mask={true}` 时显示原始值而非遮罩字符的问题。 |
