### PR TITLE
perf(Typography): defer native ellipsis measurement until hover

### DIFF
--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -325,6 +325,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
   const [ellipsisWidth, setEllipsisWidth] = React.useState(0);
   const [isHoveringOperations, setIsHoveringOperations] = React.useState(false);
   const [isHoveringTypography, setIsHoveringTypography] = React.useState(false);
+  const isHoveringTypographyRef = React.useRef(false);
   const onResize = ({ offsetWidth }: { offsetWidth: number }) => {
     setEllipsisWidth(offsetWidth);
   };
@@ -340,24 +341,22 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
   };
 
   // >>>>> Native ellipsis
-  React.useEffect(() => {
+  const measureNativeEllipsis = React.useCallback(() => {
     const textEle = typographyRef.current;
 
     if (enableEllipsis && needNativeEllipsisMeasure && textEle) {
       const currentEllipsis = isEleEllipsis(textEle);
-
-      if (isNativeEllipsis !== currentEllipsis) {
-        setIsNativeEllipsis(currentEllipsis);
-      }
+      setIsNativeEllipsis((prev) => (prev === currentEllipsis ? prev : currentEllipsis));
     }
-  }, [
-    enableEllipsis,
-    needNativeEllipsisMeasure,
-    children,
-    cssLineClamp,
-    isNativeVisible,
-    ellipsisWidth,
-  ]);
+  }, [enableEllipsis, needNativeEllipsisMeasure]);
+
+  // Keep the result current while the Typography is hovered, but do not force every
+  // Typography instance to read layout during a bulk render or resize.
+  React.useEffect(() => {
+    if (isHoveringTypographyRef.current) {
+      measureNativeEllipsis();
+    }
+  }, [measureNativeEllipsis, children, cssLineClamp, isNativeVisible, ellipsisWidth]);
 
   // https://github.com/ant-design/ant-design/issues/36786
   // Use IntersectionObserver to check if element is invisible
@@ -530,10 +529,13 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
         >
           <InternalTypography
             onMouseEnter={(e) => {
+              isHoveringTypographyRef.current = true;
+              measureNativeEllipsis();
               setIsHoveringTypography(true);
               onMouseEnter?.(e);
             }}
             onMouseLeave={(e) => {
+              isHoveringTypographyRef.current = false;
               setIsHoveringTypography(false);
               onMouseLeave?.(e);
             }}

--- a/components/typography/__tests__/ellipsis.test.tsx
+++ b/components/typography/__tests__/ellipsis.test.tsx
@@ -159,6 +159,41 @@ describe('Typography.Ellipsis', () => {
     ellipsisSpy.mockRestore();
   });
 
+  it('should only measure native ellipsis while the typography is hovered', async () => {
+    const ellipsisSpy = jest.spyOn(baseUtil, 'isEleEllipsis').mockReturnValue(true);
+    const ref = React.createRef<HTMLElement>();
+
+    const { baseElement } = render(
+      <Base ellipsis={{ tooltip: true }} component="p" ref={ref}>
+        {fullStr}
+      </Base>,
+    );
+
+    triggerResize(ref.current!);
+    await waitFakeTimer();
+
+    expect(ellipsisSpy).not.toHaveBeenCalled();
+
+    fireEvent.mouseEnter(ref.current!);
+    expect(ellipsisSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(baseElement.querySelector('.ant-tooltip-open')).not.toBeNull();
+    });
+
+    ellipsisSpy.mockReturnValue(false);
+    offsetWidth = 101;
+    triggerResize(ref.current!);
+    await waitFakeTimer();
+    expect(ellipsisSpy).toHaveBeenCalledTimes(2);
+    expect(baseElement.querySelector('.ant-tooltip-open')).toBeNull();
+
+    fireEvent.mouseLeave(ref.current!);
+    triggerResize(ref.current!);
+    await waitFakeTimer();
+    expect(ellipsisSpy).toHaveBeenCalledTimes(2);
+    ellipsisSpy.mockRestore();
+  });
+
   it('string with parentheses', async () => {
     const parenthesesStr = `Ant Design, a design language (for background applications, is refined by
         Ant UED Team. Ant Design, a design language for background applications,
@@ -329,8 +364,9 @@ describe('Typography.Ellipsis', () => {
     });
 
     // https://github.com/ant-design/ant-design/issues/36786
-    it('Tooltip should recheck on parent visible change', () => {
+    it('Tooltip should measure on hover and recheck on parent visible change', () => {
       const originIntersectionObserver = global.IntersectionObserver;
+      const ellipsisSpy = jest.spyOn(baseUtil, 'isEleEllipsis').mockReturnValue(true);
 
       let elementChangeCallback: () => void;
       const observeFn = jest.fn();
@@ -354,14 +390,23 @@ describe('Typography.Ellipsis', () => {
 
       expect(observeFn).toHaveBeenCalled();
 
-      // Hide first
+      const typography = container.querySelector<HTMLElement>('.ant-typography')!;
+      Object.defineProperty(typography, 'offsetParent', {
+        configurable: true,
+        get: () => null,
+      });
+
+      // offsetParent can stay null for a hoverable element, such as fixed positioned content.
       act(() => {
         elementChangeCallback?.();
       });
+      fireEvent.mouseEnter(typography);
+      expect(ellipsisSpy).toHaveBeenCalledTimes(1);
 
       // Trigger visible should trigger recheck
       let getOffsetParent = false;
-      Object.defineProperty(container.querySelector('.ant-typography'), 'offsetParent', {
+      Object.defineProperty(typography, 'offsetParent', {
+        configurable: true,
         get: () => {
           getOffsetParent = true;
           return document.body;
@@ -372,10 +417,12 @@ describe('Typography.Ellipsis', () => {
       });
 
       expect(getOffsetParent).toBeTruthy();
+      expect(ellipsisSpy).toHaveBeenCalledTimes(2);
 
       unmount();
       expect(disconnectFn).toHaveBeenCalled();
 
+      ellipsisSpy.mockRestore();
       global.IntersectionObserver = originIntersectionObserver;
     });
 


### PR DESCRIPTION
# PR: perf(Typography): defer native ellipsis measurement until hover

### 🤔 This is a ...

- [x] ⚡️ Performance optimization
- [x] ✅ Test Case

### 🔗 Related Issues

Fixes #57294

### 💡 Background and Solution

Following #57566, native ellipsis measurement is already skipped when no tooltip is
configured. The remaining CSS ellipsis tooltip path still eagerly called
`isEleEllipsis()` during every mount, content update, and resize. The helper temporarily
appends an element and calls `getBoundingClientRect()` twice, so thousands of paragraphs
repeatedly interleaved DOM writes and synchronous layout reads.

This change:

1. Removes eager native ellipsis layout reads while a Typography node is not hovered.
2. Measures immediately on mouse enter, before the tooltip may open.
3. Keeps remeasurement active for content, visibility, line-clamp, and width changes while
   that Typography node remains hovered.
4. Leaves JavaScript ellipsis, plain CSS ellipsis, ResizeObserver, and IntersectionObserver
   paths unchanged.

The public Issue #57294 structure and a mixed business page with 3,300 declared Ant Design
and icon nodes were reproduced in local benchmark harnesses. These benchmark-only pages
are not included in the production change.

### 📊 Production benchmark

Same machine and browser, production Dumi builds from the same base revision
(`ee9a9ab678`) before the final upstream rebase. Each retained scenario below was repeated
10 times.

| Scenario | Baseline median | Optimized median | Change |
| --- | ---: | ---: | ---: |
| 3,000 remounted ellipsis-tooltip items | 2,525.5 ms | 541.7 ms | **-78.6%** |
| Issue-style update, 3,000 ellipsis-tooltip items | 4,844.3 ms | 514.2 ms | **-89.4%** |
| Real mixed page, 3,300 declared Ant Design/icon nodes, tooltip mode | 141.6 ms | 122.1 ms | -13.7% |

The optimization is intentionally scoped to native ellipsis tooltip measurement. The
final branch was rebased onto the latest `master`, then its tests, lint checks, and
production build were rerun separately.

### ✅ Verification

- Typography tests: 10 suites passed.
- Ellipsis tests: 29 passed, including mount, unhovered resize, first hover, hovered resize,
  visibility changes, tooltip close, and post-mouseleave resize assertions.
- `tsc --noEmit`: passed.
- Targeted ESLint, Biome lint, Remark, and `git diff --check`: passed.
- Baseline and optimized Dumi production builds: passed.
- The baseline and optimized production pages were exercised in the browser with repeated
  timings.

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Improve Typography ellipsis tooltip performance when rendering large lists. |
| 🇨🇳 Chinese | 优化大量渲染 Typography 省略提示时的性能。 |

