### PR TITLE
fix: hide textarea resize handle on touch devices

### DIFF
--- a/components/input/style/textarea.ts
+++ b/components/input/style/textarea.ts
@@ -23,7 +23,7 @@ const genTextAreaStyle: GenerateStyle<InputToken, CSSObject> = (token) => {
       transition: `all ${token.motionDurationSlow}`,
       resize: 'vertical',
 
-      '@media (hover: none), (pointer: coarse)': {
+      '@media (hover: none) and (pointer: coarse)': {
         resize: 'none',
       },
 

--- a/components/input/style/textarea.ts
+++ b/components/input/style/textarea.ts
@@ -23,6 +23,10 @@ const genTextAreaStyle: GenerateStyle<InputToken, CSSObject> = (token) => {
       transition: `all ${token.motionDurationSlow}`,
       resize: 'vertical',
 
+      '@media (hover: none), (pointer: coarse)': {
+        resize: 'none',
+      },
+
       [`&${componentCls}-mouse-active`]: {
         transition: `all ${token.motionDurationSlow}, height 0s, width 0s`,
       },


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] 💄 Component style improvement

### 🔗 Related Issues

Fixes #48341.

### 💡 Background and Solution

On touch devices, Chrome can render the textarea resize affordance as a small dot even though the native resize interaction is not useful there.

This keeps the desktop default of `resize: vertical`, but disables the default TextArea resize affordance for hover-less / coarse-pointer devices. User-provided inline `style={{ resize: ... }}` can still override the component style.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Hide the TextArea resize handle on touch devices to avoid the small dot rendering issue. |
| 🇨🇳 Chinese | 在触摸设备上隐藏 TextArea 的 resize 手柄，避免渲染成异常小点。 |

Verification:

- `npm run test -- components/input/__tests__/textarea.test.tsx --runInBand`
- `npx biome check components/input/style/textarea.ts`
- `git diff --check`
