### PR TITLE
fix(Table): sync controlled filter state while open

### DIFF
--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -3169,5 +3169,61 @@ describe('Table.filter', () => {
       fireEvent.click(container.querySelector('.ant-dropdown-trigger')!);
       expect(container.querySelector('.ant-dropdown-placement-topLeft')).toBeTruthy();
     });
+
+    it('should sync selected keys while controlled dropdown stays open', async () => {
+      const getTable = (filteredValue: React.Key[]) =>
+        createTable({
+          columns: [
+            {
+              ...column,
+              filterMultiple: false,
+              filteredValue,
+              filterDropdownProps: {
+                open: true,
+              },
+            },
+          ],
+        });
+
+      const { container, rerender } = render(getTable(['boy']));
+
+      await waitFor(() => {
+        expect(container.querySelectorAll<HTMLInputElement>('input[type="radio"]')[0]).toBeChecked();
+      });
+
+      rerender(getTable(['girl']));
+
+      await waitFor(() => {
+        expect(container.querySelectorAll<HTMLInputElement>('input[type="radio"]')[1]).toBeChecked();
+      });
+    });
+
+    it('should clear search when controlled dropdown closes', async () => {
+      const getTable = (open: boolean) =>
+        createTable({
+          columns: [
+            {
+              ...column,
+              filterSearch: true,
+              filterDropdownProps: {
+                open,
+              },
+            },
+          ],
+        });
+
+      const { container, rerender } = render(getTable(true));
+      const searchInput = container.querySelector<HTMLInputElement>('.ant-input')!;
+
+      fireEvent.change(searchInput, { target: { value: 'boy' } });
+      expect(searchInput).toHaveValue('boy');
+
+      rerender(getTable(false));
+      rerender(getTable(true));
+
+      await waitFor(() => {
+        expect(container.querySelector('.ant-input')).toHaveValue('');
+      });
+    });
   });
 });

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -241,11 +241,11 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
   };
 
   React.useEffect(() => {
-    if (!visible) {
+    if (!mergedVisible) {
       return;
     }
     onSelectKeys({ selectedKeys: wrapStringListType(propFilteredKeys) });
-  }, [propFilteredKeys, visible]);
+  }, [propFilteredKeys, mergedVisible]);
 
   // ====================== Open Keys ======================
   const [openKeys, setOpenKeys] = React.useState<string[]>([]);
@@ -267,10 +267,10 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
   };
   // clear search value after close filter dropdown
   React.useEffect(() => {
-    if (!visible) {
+    if (!mergedVisible) {
       setSearchValue('');
     }
-  }, [visible]);
+  }, [mergedVisible]);
 
   // ======================= Submit ========================
   const internalTriggerFilter = (keys?: string[]) => {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Follow-up to #58657.

### 💡 需求背景和解决方案

Table 筛选面板由 `filterDropdownProps.open` 控制并保持打开时，外部更新 `filteredValue` 后，表格数据已经变化，但面板里的选中项仍停留在旧值。

[CodeSandbox 复现](https://codesandbox.io/s/h6fvtp)

1. 面板保持打开，初始选中 `Boy`。
2. 点击 “Control value: Girl”。
3. 表格切换为 Lucy，但面板仍选中 `Boy`。

本次统一使用最终合并后的打开状态同步选中项，并在受控关闭时清空搜索词。两种场景都补充了回归测试。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Table controlled filters showing stale selections while open. |
| 🇨🇳 中文 | 修复 Table 受控筛选面板保持打开时显示旧选中项的问题。 |
