### PR TITLE
fix(Upload): isolate default download tabs

### DIFF
--- a/components/upload/UploadList/index.tsx
+++ b/components/upload/UploadList/index.tsx
@@ -97,7 +97,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<UploadListRef, UploadLi
     if (isFunction(onDownload)) {
       onDownload(file);
     } else if (file.url) {
-      window.open(file.url);
+      window.open(file.url, '_blank', 'noopener');
     }
   };
 

--- a/components/upload/__tests__/uploadlist.test.tsx
+++ b/components/upload/__tests__/uploadlist.test.tsx
@@ -415,6 +415,10 @@ describe('Upload List', () => {
   });
 
   it('should support no onDownload', async () => {
+    const url =
+      'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png';
+    open.mockClear();
+
     const { container: wrapper, unmount } = render(
       <Upload
         listType="picture-card"
@@ -423,7 +427,7 @@ describe('Upload List', () => {
             uid: '0',
             name: 'xxx.png',
             status: 'done',
-            url: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+            url,
           },
         ]}
         showUploadList={{
@@ -434,6 +438,7 @@ describe('Upload List', () => {
       </Upload>,
     );
     fireEvent.click(wrapper.querySelectorAll('.anticon-download')[0]);
+    expect(open).toHaveBeenCalledWith(url, '_blank', 'noopener');
 
     unmount();
   });


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

暂无。

### 💡 需求背景和解决方案

Upload 没有传入 `onDownload` 时，会直接用 `window.open(url)` 打开文件。新页面可能保留 `window.opener`，从而能够访问原页面。

[CodeSandbox 复现](https://codesandbox.io/s/9s4ssr)

1. 点击 `report.pdf` 右侧的下载图标。
2. 页面会显示 Upload 调用 `window.open` 时传入的参数。
3. 当前只传入 URL，没有隔离新页面。

本次使用 `_blank` 和 `noopener` 打开默认下载链接，不添加 `noreferrer`，因此不会额外改变 Referer 行为。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Upload default downloads exposing the opener page to the new tab. |
| 🇨🇳 中文 | 修复 Upload 默认下载打开的新页面可访问来源页面的问题。 |
