### PR TITLE
fix: make Table and Sider triggers keyboard accessible

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -25337,9 +25337,10 @@ exports[`ConfigProvider components Table configProvider 1`] = `
                         </div>
                       </span>
                       <span
+                        aria-expanded="true"
                         class="config-dropdown-trigger config-table-filter-trigger config-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -25644,9 +25645,10 @@ exports[`ConfigProvider components Table configProvider componentDisabled 1`] = 
                         </div>
                       </span>
                       <span
+                        aria-expanded="true"
                         class="config-dropdown-trigger config-table-filter-trigger config-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -25953,9 +25955,10 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
                         </div>
                       </span>
                       <span
+                        aria-expanded="true"
                         class="config-dropdown-trigger config-table-filter-trigger config-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -26260,9 +26263,10 @@ exports[`ConfigProvider components Table configProvider componentSize medium 1`]
                         </div>
                       </span>
                       <span
+                        aria-expanded="true"
                         class="config-dropdown-trigger config-table-filter-trigger config-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -26567,9 +26571,10 @@ exports[`ConfigProvider components Table configProvider componentSize small 1`] 
                         </div>
                       </span>
                       <span
+                        aria-expanded="true"
                         class="config-dropdown-trigger config-table-filter-trigger config-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -26874,9 +26879,10 @@ exports[`ConfigProvider components Table normal 1`] = `
                         </div>
                       </span>
                       <span
+                        aria-expanded="true"
                         class="ant-dropdown-trigger ant-table-filter-trigger ant-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -27181,9 +27187,10 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
                         </div>
                       </span>
                       <span
+                        aria-expanded="true"
                         class="ant-dropdown-trigger prefix-Table-filter-trigger ant-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"

--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -188,6 +188,23 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
     handleSetCollapsed(!collapsed, 'clickTrigger');
   };
 
+  const handleTriggerKeyDown: React.KeyboardEventHandler<HTMLElement> = (event) => {
+    if (event.target === event.currentTarget && (event.key === 'Enter' || event.key === ' ')) {
+      event.preventDefault();
+      toggle();
+    }
+  };
+
+  const triggerAccessibilityProps: React.HTMLAttributes<HTMLElement> = !trigger
+    ? {
+        role: 'button',
+        tabIndex: 0,
+        'aria-label': collapsed ? 'Expand sidebar' : 'Collapse sidebar',
+        'aria-expanded': !collapsed,
+        onKeyDown: handleTriggerKeyDown,
+      }
+    : {};
+
   const divProps = omit(otherProps, ['collapsed']);
   const rawWidth = collapsed ? collapsedWidth : width;
   // use "px" as fallback unit for width
@@ -196,6 +213,7 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
   const zeroWidthTrigger =
     Number.parseFloat(String(collapsedWidth || 0)) === 0 ? (
       <span
+        {...triggerAccessibilityProps}
         onClick={toggle}
         className={clsx(
           `${prefixCls}-zero-width-trigger`,
@@ -219,7 +237,12 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
   const triggerDom =
     trigger !== null
       ? zeroWidthTrigger || (
-          <div className={`${prefixCls}-trigger`} onClick={toggle} style={{ width: siderWidth }}>
+          <div
+            {...triggerAccessibilityProps}
+            className={`${prefixCls}-trigger`}
+            onClick={toggle}
+            style={{ width: siderWidth }}
+          >
             {trigger || defaultTrigger}
           </div>
         )

--- a/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2596,7 +2596,11 @@ exports[`renders components/layout/demo/responsive.tsx extend context correctly 
       />
     </div>
     <span
+      aria-expanded="false"
+      aria-label="Expand sidebar"
       class="ant-layout-sider-zero-width-trigger ant-layout-sider-zero-width-trigger-left"
+      role="button"
+      tabindex="0"
     >
       <span
         aria-label="bars"
@@ -3099,8 +3103,12 @@ exports[`renders components/layout/demo/side.tsx extend context correctly 1`] = 
       />
     </div>
     <div
+      aria-expanded="true"
+      aria-label="Collapse sidebar"
       class="ant-layout-sider-trigger"
+      role="button"
       style="width: 200px;"
+      tabindex="0"
     >
       <span
         aria-label="left"

--- a/components/layout/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/layout/__tests__/__snapshots__/demo.test.ts.snap
@@ -1900,8 +1900,12 @@ exports[`renders components/layout/demo/side.tsx correctly 1`] = `
       />
     </div>
     <div
+      aria-expanded="true"
+      aria-label="Collapse sidebar"
       class="ant-layout-sider-trigger"
+      role="button"
       style="width:200px"
+      tabindex="0"
     >
       <span
         aria-label="left"

--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -102,6 +102,71 @@ describe('Layout', () => {
     ).toBe(true);
   });
 
+  it.each([
+    {
+      name: 'default',
+      collapsedWidth: 80,
+      selector: '.ant-layout-sider-trigger',
+      key: 'Enter',
+    },
+    {
+      name: 'zero width',
+      collapsedWidth: 0,
+      selector: '.ant-layout-sider-zero-width-trigger',
+      key: ' ',
+    },
+  ])(
+    'should support keyboard interaction on the $name trigger',
+    ({ collapsedWidth, selector, key }) => {
+      const onCollapse = jest.fn();
+      const { container } = render(
+        <Sider collapsible collapsedWidth={collapsedWidth} onCollapse={onCollapse}>
+          Sider
+        </Sider>,
+      );
+      const trigger = container.querySelector<HTMLElement>(selector)!;
+
+      expect(trigger).toHaveAttribute('role', 'button');
+      expect(trigger).toHaveAttribute('tabindex', '0');
+      expect(trigger).toHaveAttribute('aria-label', 'Collapse sidebar');
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+      fireEvent.keyDown(trigger, { key });
+
+      expect(onCollapse).toHaveBeenCalledWith(true, 'clickTrigger');
+      expect(trigger).toHaveAttribute('aria-label', 'Expand sidebar');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    },
+  );
+
+  it('should leave keyboard handling to a custom interactive trigger', () => {
+    const onCollapse = jest.fn();
+    const { container } = render(
+      <Sider
+        collapsible
+        trigger={
+          <button type="button" className="custom-sider-trigger">
+            Toggle
+          </button>
+        }
+        onCollapse={onCollapse}
+      >
+        Sider
+      </Sider>,
+    );
+    const triggerWrapper = container.querySelector('.ant-layout-sider-trigger')!;
+    const customTrigger = container.querySelector('.custom-sider-trigger')!;
+
+    expect(triggerWrapper).not.toHaveAttribute('role');
+    expect(triggerWrapper).not.toHaveAttribute('tabindex');
+
+    fireEvent.keyDown(customTrigger, { key: 'Enter' });
+    expect(onCollapse).not.toHaveBeenCalled();
+
+    fireEvent.click(customTrigger);
+    expect(onCollapse).toHaveBeenCalledTimes(1);
+  });
+
   it('should have 50% width of sidebar', async () => {
     const { container } = render(
       <Layout>

--- a/components/locale/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/index.test.tsx.snap
@@ -6974,9 +6974,10 @@ exports[`Locale Provider should display the text as ar 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -12210,9 +12211,10 @@ exports[`Locale Provider should display the text as az 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -17446,9 +17448,10 @@ exports[`Locale Provider should display the text as bg 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -22682,9 +22685,10 @@ exports[`Locale Provider should display the text as bn-bd 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -27918,9 +27922,10 @@ exports[`Locale Provider should display the text as by 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -33154,9 +33159,10 @@ exports[`Locale Provider should display the text as ca 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -38390,9 +38396,10 @@ exports[`Locale Provider should display the text as cs 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -43626,9 +43633,10 @@ exports[`Locale Provider should display the text as da 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -48862,9 +48870,10 @@ exports[`Locale Provider should display the text as de 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -54098,9 +54107,10 @@ exports[`Locale Provider should display the text as el 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -59334,9 +59344,10 @@ exports[`Locale Provider should display the text as en 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -64570,9 +64581,10 @@ exports[`Locale Provider should display the text as en-gb 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -69806,9 +69818,10 @@ exports[`Locale Provider should display the text as es 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -75042,9 +75055,10 @@ exports[`Locale Provider should display the text as es-us 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -80278,9 +80292,10 @@ exports[`Locale Provider should display the text as et 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -85514,9 +85529,10 @@ exports[`Locale Provider should display the text as eu 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -90750,9 +90766,10 @@ exports[`Locale Provider should display the text as fa 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -95986,9 +96003,10 @@ exports[`Locale Provider should display the text as fi 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -101222,9 +101240,10 @@ exports[`Locale Provider should display the text as fr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -106458,9 +106477,10 @@ exports[`Locale Provider should display the text as fr 2`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -111694,9 +111714,10 @@ exports[`Locale Provider should display the text as fr 3`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -116930,9 +116951,10 @@ exports[`Locale Provider should display the text as ga 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -122166,9 +122188,10 @@ exports[`Locale Provider should display the text as gl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -127402,9 +127425,10 @@ exports[`Locale Provider should display the text as he 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -132638,9 +132662,10 @@ exports[`Locale Provider should display the text as hi 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -137874,9 +137899,10 @@ exports[`Locale Provider should display the text as hr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -143110,9 +143136,10 @@ exports[`Locale Provider should display the text as hu 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -148346,9 +148373,10 @@ exports[`Locale Provider should display the text as hy-am 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -153582,9 +153610,10 @@ exports[`Locale Provider should display the text as id 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -158818,9 +158847,10 @@ exports[`Locale Provider should display the text as is 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -164054,9 +164084,10 @@ exports[`Locale Provider should display the text as it 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -169290,9 +169321,10 @@ exports[`Locale Provider should display the text as ja 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -174526,9 +174558,10 @@ exports[`Locale Provider should display the text as ka 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -179762,9 +179795,10 @@ exports[`Locale Provider should display the text as kk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -184996,9 +185030,10 @@ exports[`Locale Provider should display the text as km 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -190232,9 +190267,10 @@ exports[`Locale Provider should display the text as kn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -195468,9 +195504,10 @@ exports[`Locale Provider should display the text as ko 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -200704,9 +200741,10 @@ exports[`Locale Provider should display the text as ku 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -205940,9 +205978,10 @@ exports[`Locale Provider should display the text as ku-iq 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -211176,9 +211215,10 @@ exports[`Locale Provider should display the text as lt 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -216412,9 +216452,10 @@ exports[`Locale Provider should display the text as lv 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -221648,9 +221689,10 @@ exports[`Locale Provider should display the text as mk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -226884,9 +226926,10 @@ exports[`Locale Provider should display the text as ml 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -232120,9 +232163,10 @@ exports[`Locale Provider should display the text as mn-mn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -237356,9 +237400,10 @@ exports[`Locale Provider should display the text as mr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -242592,9 +242637,10 @@ exports[`Locale Provider should display the text as ms-my 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -247828,9 +247874,10 @@ exports[`Locale Provider should display the text as my 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -253064,9 +253111,10 @@ exports[`Locale Provider should display the text as nb 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -258300,9 +258348,10 @@ exports[`Locale Provider should display the text as ne-np 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -263536,9 +263585,10 @@ exports[`Locale Provider should display the text as nl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -268772,9 +268822,10 @@ exports[`Locale Provider should display the text as nl-be 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -274008,9 +274059,10 @@ exports[`Locale Provider should display the text as pl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -279244,9 +279296,10 @@ exports[`Locale Provider should display the text as pt 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -284480,9 +284533,10 @@ exports[`Locale Provider should display the text as pt-br 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -289716,9 +289770,10 @@ exports[`Locale Provider should display the text as ro 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -294952,9 +295007,10 @@ exports[`Locale Provider should display the text as ru 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -300188,9 +300244,10 @@ exports[`Locale Provider should display the text as si 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -305424,9 +305481,10 @@ exports[`Locale Provider should display the text as sk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -310660,9 +310718,10 @@ exports[`Locale Provider should display the text as sl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -315896,9 +315955,10 @@ exports[`Locale Provider should display the text as sr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -321132,9 +321192,10 @@ exports[`Locale Provider should display the text as sv 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -326368,9 +326429,10 @@ exports[`Locale Provider should display the text as ta 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -331604,9 +331666,10 @@ exports[`Locale Provider should display the text as th 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -336840,9 +336903,10 @@ exports[`Locale Provider should display the text as tk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -342076,9 +342140,10 @@ exports[`Locale Provider should display the text as tr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -347312,9 +347377,10 @@ exports[`Locale Provider should display the text as uk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -352548,9 +352614,10 @@ exports[`Locale Provider should display the text as ur 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -357784,9 +357851,10 @@ exports[`Locale Provider should display the text as uz-latn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -363020,9 +363088,10 @@ exports[`Locale Provider should display the text as vi 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -368256,9 +368325,10 @@ exports[`Locale Provider should display the text as zh-cn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -373492,9 +373562,10 @@ exports[`Locale Provider should display the text as zh-hk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -378728,9 +378799,10 @@ exports[`Locale Provider should display the text as zh-tw 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"

--- a/components/locale/__tests__/__snapshots__/vitest/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/vitest/index.test.tsx.snap
@@ -1963,9 +1963,10 @@ exports[`Locale Provider > should display the text as ar 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -3913,9 +3914,10 @@ exports[`Locale Provider > should display the text as az 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -5863,9 +5865,10 @@ exports[`Locale Provider > should display the text as bg 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -7813,9 +7816,10 @@ exports[`Locale Provider > should display the text as bn-bd 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -9763,9 +9767,10 @@ exports[`Locale Provider > should display the text as by 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -11713,9 +11718,10 @@ exports[`Locale Provider > should display the text as ca 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -13663,9 +13669,10 @@ exports[`Locale Provider > should display the text as cs 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -15613,9 +15620,10 @@ exports[`Locale Provider > should display the text as da 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -17563,9 +17571,10 @@ exports[`Locale Provider > should display the text as de 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -19513,9 +19522,10 @@ exports[`Locale Provider > should display the text as el 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -21463,9 +21473,10 @@ exports[`Locale Provider > should display the text as en 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -23413,9 +23424,10 @@ exports[`Locale Provider > should display the text as en-gb 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -25363,9 +25375,10 @@ exports[`Locale Provider > should display the text as es 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -27313,9 +27326,10 @@ exports[`Locale Provider > should display the text as es-us 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -29263,9 +29277,10 @@ exports[`Locale Provider > should display the text as et 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -31213,9 +31228,10 @@ exports[`Locale Provider > should display the text as eu 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -33163,9 +33179,10 @@ exports[`Locale Provider > should display the text as fa 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -35113,9 +35130,10 @@ exports[`Locale Provider > should display the text as fi 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -37063,9 +37081,10 @@ exports[`Locale Provider > should display the text as fr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -39013,9 +39032,10 @@ exports[`Locale Provider > should display the text as fr 2`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -40963,9 +40983,10 @@ exports[`Locale Provider > should display the text as fr 3`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -42913,9 +42934,10 @@ exports[`Locale Provider > should display the text as ga 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -44863,9 +44885,10 @@ exports[`Locale Provider > should display the text as gl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -46813,9 +46836,10 @@ exports[`Locale Provider > should display the text as he 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -48763,9 +48787,10 @@ exports[`Locale Provider > should display the text as hi 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -50713,9 +50738,10 @@ exports[`Locale Provider > should display the text as hr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -52663,9 +52689,10 @@ exports[`Locale Provider > should display the text as hu 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -54613,9 +54640,10 @@ exports[`Locale Provider > should display the text as hy-am 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -56563,9 +56591,10 @@ exports[`Locale Provider > should display the text as id 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -58513,9 +58542,10 @@ exports[`Locale Provider > should display the text as is 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -60463,9 +60493,10 @@ exports[`Locale Provider > should display the text as it 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -62413,9 +62444,10 @@ exports[`Locale Provider > should display the text as ja 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -64363,9 +64395,10 @@ exports[`Locale Provider > should display the text as ka 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -66313,9 +66346,10 @@ exports[`Locale Provider > should display the text as kk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -68261,9 +68295,10 @@ exports[`Locale Provider > should display the text as km 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -70211,9 +70246,10 @@ exports[`Locale Provider > should display the text as kn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -72161,9 +72197,10 @@ exports[`Locale Provider > should display the text as ko 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -74111,9 +74148,10 @@ exports[`Locale Provider > should display the text as ku 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -76061,9 +76099,10 @@ exports[`Locale Provider > should display the text as ku-iq 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -78011,9 +78050,10 @@ exports[`Locale Provider > should display the text as lt 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -79961,9 +80001,10 @@ exports[`Locale Provider > should display the text as lv 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -81911,9 +81952,10 @@ exports[`Locale Provider > should display the text as mk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -83861,9 +83903,10 @@ exports[`Locale Provider > should display the text as ml 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -85811,9 +85854,10 @@ exports[`Locale Provider > should display the text as mn-mn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -87761,9 +87805,10 @@ exports[`Locale Provider > should display the text as mr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -89711,9 +89756,10 @@ exports[`Locale Provider > should display the text as ms-my 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -91661,9 +91707,10 @@ exports[`Locale Provider > should display the text as my 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -93611,9 +93658,10 @@ exports[`Locale Provider > should display the text as nb 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -95561,9 +95609,10 @@ exports[`Locale Provider > should display the text as ne-np 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -97511,9 +97560,10 @@ exports[`Locale Provider > should display the text as nl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -99461,9 +99511,10 @@ exports[`Locale Provider > should display the text as nl-be 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -101411,9 +101462,10 @@ exports[`Locale Provider > should display the text as pl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -103361,9 +103413,10 @@ exports[`Locale Provider > should display the text as pt 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -105311,9 +105364,10 @@ exports[`Locale Provider > should display the text as pt-br 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -107261,9 +107315,10 @@ exports[`Locale Provider > should display the text as ro 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -109211,9 +109266,10 @@ exports[`Locale Provider > should display the text as ru 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -111161,9 +111217,10 @@ exports[`Locale Provider > should display the text as si 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -113111,9 +113168,10 @@ exports[`Locale Provider > should display the text as sk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -115061,9 +115119,10 @@ exports[`Locale Provider > should display the text as sl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -117011,9 +117070,10 @@ exports[`Locale Provider > should display the text as sr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -118961,9 +119021,10 @@ exports[`Locale Provider > should display the text as sv 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -120911,9 +120972,10 @@ exports[`Locale Provider > should display the text as ta 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -122861,9 +122923,10 @@ exports[`Locale Provider > should display the text as th 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -124811,9 +124874,10 @@ exports[`Locale Provider > should display the text as tk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -126761,9 +126825,10 @@ exports[`Locale Provider > should display the text as tr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -128711,9 +128776,10 @@ exports[`Locale Provider > should display the text as uk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -130661,9 +130727,10 @@ exports[`Locale Provider > should display the text as ur 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -132611,9 +132678,10 @@ exports[`Locale Provider > should display the text as uz-latn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -134561,9 +134629,10 @@ exports[`Locale Provider > should display the text as vi 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -136511,9 +136580,10 @@ exports[`Locale Provider > should display the text as zh-cn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -138461,9 +138531,10 @@ exports[`Locale Provider > should display the text as zh-hk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -140411,9 +140482,10 @@ exports[`Locale Provider > should display the text as zh-tw 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"

--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -143,6 +143,109 @@ describe('Table.filter', () => {
     });
   });
 
+  it.each(['Enter', ' '])('should open the filter dropdown with the %j key', async (key) => {
+    const { container } = render(createTable());
+    const trigger = container.querySelector<HTMLElement>('.ant-table-filter-trigger')!;
+
+    expect(trigger).toHaveAttribute('role', 'button');
+    expect(trigger).toHaveAttribute('tabindex', '0');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.keyDown(trigger, { key });
+
+    await waitFor(() => {
+      expect(container.querySelector('.ant-table-filter-dropdown')).toBeTruthy();
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+
+  it('should apply filterOnClose when closing the filter dropdown from the keyboard', async () => {
+    const { container } = render(
+      createTable({
+        dataSource: [
+          { key: 'boy', name: 'boy' },
+          { key: 'girl', name: 'girl' },
+        ],
+        columns: [{ ...column, filterMultiple: false }],
+      }),
+    );
+    const trigger = container.querySelector<HTMLElement>('.ant-table-filter-trigger')!;
+
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    await waitFor(() => {
+      expect(container.querySelectorAll<HTMLInputElement>('input[type="radio"]')).toHaveLength(2);
+    });
+
+    fireEvent.click(container.querySelectorAll<HTMLInputElement>('input[type="radio"]')[1]);
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(renderedNames(container)).toEqual(['girl']);
+    });
+  });
+
+  it.each([
+    {
+      name: 'native button',
+      filterIcon: (
+        <button type="button" className="custom-filter-icon">
+          Filter
+        </button>
+      ),
+    },
+    {
+      name: 'native link',
+      filterIcon: (
+        <a href="#filter" className="custom-filter-icon">
+          Filter
+        </a>
+      ),
+    },
+    {
+      name: 'button role',
+      filterIcon: (
+        <span role="button" className="custom-filter-icon">
+          Filter
+        </span>
+      ),
+    },
+    {
+      name: 'explicit tab stop',
+      filterIcon: (
+        <span role="checkbox" aria-checked={false} tabIndex={0} className="custom-filter-icon">
+          Filter
+        </span>
+      ),
+    },
+  ])('should leave keyboard handling to a custom $name filter icon', ({ filterIcon }) => {
+    const onOpenChange = jest.fn();
+    const { container } = render(
+      createTable({
+        columns: [
+          {
+            ...column,
+            filterIcon,
+            filterDropdownProps: {
+              onOpenChange,
+            },
+          },
+        ],
+      }),
+    );
+    const triggerWrapper = container.querySelector('.ant-table-filter-trigger')!;
+    const customFilterIcon = container.querySelector('.custom-filter-icon')!;
+
+    expect(triggerWrapper).not.toHaveAttribute('role');
+    expect(triggerWrapper).not.toHaveAttribute('tabindex');
+    expect(triggerWrapper).not.toHaveAttribute('aria-expanded');
+
+    fireEvent.keyDown(customFilterIcon, { key: 'Enter' });
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    fireEvent.click(customFilterIcon);
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+  });
+
   it('renders empty menu correctly', () => {
     resetWarned();
 
@@ -1942,17 +2045,13 @@ describe('Table.filter', () => {
 
     const { container } = render(<App />);
 
-    expect(container.querySelector('.ant-table-tbody .ant-table-cell')?.textContent).toBe(
-      `${32}`,
-    );
+    expect(container.querySelector('.ant-table-tbody .ant-table-cell')?.textContent).toBe(`${32}`);
     fireEvent.click(container.querySelector('.ant-dropdown-trigger.ant-table-filter-trigger')!);
     fireEvent.click(container.querySelector('.ant-dropdown-menu-item')!);
     fireEvent.click(
       container.querySelector('.ant-btn.ant-btn-color-primary.ant-btn-variant-solid.ant-btn-sm')!,
     );
-    expect(container.querySelector('.ant-table-tbody .ant-table-cell')?.textContent).toBe(
-      `${66}`,
-    );
+    expect(container.querySelector('.ant-table-tbody .ant-table-cell')?.textContent).toBe(`${66}`);
   });
 
   it('Columns with filters should filter correctly after reset it.', () => {
@@ -3008,17 +3107,13 @@ describe('Table.filter', () => {
     fireEvent.click(container.querySelector('input[type="checkbox"]')!);
 
     // The checkbox is now checked.
-    expect(container.querySelector<HTMLInputElement>('input[type="checkbox"]')!.checked).toBe(
-      true,
-    );
+    expect(container.querySelector<HTMLInputElement>('input[type="checkbox"]')!.checked).toBe(true);
     fireEvent.click(container.querySelector('.ant-btn-primary')!);
     // Table data changes while the dropdown is open and a user is setting filters.
     rerender(createTable({ ...tableProps, dataSource: [{ name: 'Foo' }] }));
 
     // The checkbox is still checked.
-    expect(container.querySelector<HTMLInputElement>('input[type="checkbox"]')!.checked).toBe(
-      true,
-    );
+    expect(container.querySelector<HTMLInputElement>('input[type="checkbox"]')!.checked).toBe(true);
   });
 
   it('should not crash when filterDropdown is boolean', () => {

--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -184,68 +184,6 @@ describe('Table.filter', () => {
     });
   });
 
-  it.each([
-    {
-      name: 'native button',
-      filterIcon: (
-        <button type="button" className="custom-filter-icon">
-          Filter
-        </button>
-      ),
-    },
-    {
-      name: 'native link',
-      filterIcon: (
-        <a href="#filter" className="custom-filter-icon">
-          Filter
-        </a>
-      ),
-    },
-    {
-      name: 'button role',
-      filterIcon: (
-        <span role="button" className="custom-filter-icon">
-          Filter
-        </span>
-      ),
-    },
-    {
-      name: 'explicit tab stop',
-      filterIcon: (
-        <span role="checkbox" aria-checked={false} tabIndex={0} className="custom-filter-icon">
-          Filter
-        </span>
-      ),
-    },
-  ])('should leave keyboard handling to a custom $name filter icon', ({ filterIcon }) => {
-    const onOpenChange = jest.fn();
-    const { container } = render(
-      createTable({
-        columns: [
-          {
-            ...column,
-            filterIcon,
-            filterDropdownProps: {
-              onOpenChange,
-            },
-          },
-        ],
-      }),
-    );
-    const triggerWrapper = container.querySelector('.ant-table-filter-trigger')!;
-    const customFilterIcon = container.querySelector('.custom-filter-icon')!;
-
-    expect(triggerWrapper).not.toHaveAttribute('role');
-    expect(triggerWrapper).not.toHaveAttribute('tabindex');
-    expect(triggerWrapper).not.toHaveAttribute('aria-expanded');
-
-    fireEvent.keyDown(customFilterIcon, { key: 'Enter' });
-    expect(onOpenChange).not.toHaveBeenCalled();
-
-    fireEvent.click(customFilterIcon);
-    expect(onOpenChange).toHaveBeenCalledTimes(1);
-  });
-
   it('renders empty menu correctly', () => {
     resetWarned();
 

--- a/components/table/__tests__/__snapshots__/Table.filter.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.filter.test.tsx.snap
@@ -138,9 +138,10 @@ exports[`Table.filter renders custom filter icon as ReactNode 1`] = `
                         Name
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           class="customize-icon"
@@ -244,9 +245,10 @@ exports[`Table.filter renders custom filter icon as string correctly 1`] = `
                         Name
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         string
                       </span>
@@ -356,9 +358,10 @@ exports[`Table.filter renders custom filter icon with right Tooltip title 1`] = 
                         Name
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-describedby="test-id"
@@ -485,9 +488,10 @@ exports[`Table.filter renders filter correctly 1`] = `
                         Name
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2166,9 +2166,10 @@ Array [
                           Address
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -3570,9 +3571,10 @@ Array [
                           Age
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -3980,9 +3982,10 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                         Name
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -4117,9 +4120,10 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                         Age
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -4333,9 +4337,10 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                         </div>
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -6711,9 +6716,10 @@ Array [
                           Address
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -10730,9 +10736,10 @@ exports[`renders components/table/demo/filter-in-tree.tsx extend context correct
                         Name
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -11289,9 +11296,10 @@ exports[`renders components/table/demo/filter-in-tree.tsx extend context correct
                         Address
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -11711,9 +11719,10 @@ exports[`renders components/table/demo/filter-search.tsx extend context correctl
                         Name
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -12068,9 +12077,10 @@ exports[`renders components/table/demo/filter-search.tsx extend context correctl
                         Address
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -13875,9 +13885,10 @@ exports[`renders components/table/demo/grouping-columns.tsx extend context corre
                         Name
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -14252,6 +14263,7 @@ exports[`renders components/table/demo/grouping-columns.tsx extend context corre
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-table-filter-trigger"
                           role="button"
                           tabindex="-1"
@@ -15347,9 +15359,10 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
                         </div>
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -15749,9 +15762,10 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
                         Address
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -16935,9 +16949,10 @@ exports[`renders components/table/demo/measure-row-render.tsx extend context cor
                         Name
                       </span>
                       <span
+                        aria-expanded="true"
                         class="ant-dropdown-trigger ant-table-filter-trigger ant-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -17072,9 +17087,10 @@ exports[`renders components/table/demo/measure-row-render.tsx extend context cor
                         Age
                       </span>
                       <span
+                        aria-expanded="true"
                         class="ant-dropdown-trigger ant-table-filter-trigger ant-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -17367,9 +17383,10 @@ exports[`renders components/table/demo/measure-row-render.tsx extend context cor
                         </div>
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -17532,6 +17549,7 @@ exports[`renders components/table/demo/measure-row-render.tsx extend context cor
                           Name
                         </span>
                         <span
+                          aria-expanded="true"
                           class="ant-table-filter-trigger"
                           role="button"
                           tabindex="-1"
@@ -17574,6 +17592,7 @@ exports[`renders components/table/demo/measure-row-render.tsx extend context cor
                           Age
                         </span>
                         <span
+                          aria-expanded="true"
                           class="ant-table-filter-trigger"
                           role="button"
                           tabindex="-1"
@@ -17692,6 +17711,7 @@ exports[`renders components/table/demo/measure-row-render.tsx extend context cor
                           </div>
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-table-filter-trigger"
                           role="button"
                           tabindex="-1"
@@ -23535,9 +23555,10 @@ Array [
                           </div>
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -23872,9 +23893,10 @@ Array [
                           </div>
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"

--- a/components/table/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.ts.snap
@@ -2143,9 +2143,10 @@ Array [
                           Address
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -3392,9 +3393,10 @@ Array [
                           Age
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -3668,9 +3670,10 @@ exports[`renders components/table/demo/custom-filter-panel.tsx correctly 1`] = `
                         Name
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -3707,9 +3710,10 @@ exports[`renders components/table/demo/custom-filter-panel.tsx correctly 1`] = `
                         Age
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -3804,9 +3808,10 @@ exports[`renders components/table/demo/custom-filter-panel.tsx correctly 1`] = `
                         </div>
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -6008,9 +6013,10 @@ Array [
                           Address
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -9320,9 +9326,10 @@ exports[`renders components/table/demo/filter-in-tree.tsx correctly 1`] = `
                         Name
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -9423,9 +9430,10 @@ exports[`renders components/table/demo/filter-in-tree.tsx correctly 1`] = `
                         Address
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -9673,9 +9681,10 @@ exports[`renders components/table/demo/filter-search.tsx correctly 1`] = `
                         Name
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -9776,9 +9785,10 @@ exports[`renders components/table/demo/filter-search.tsx correctly 1`] = `
                         Address
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -14827,9 +14837,10 @@ exports[`renders components/table/demo/grouping-columns.tsx correctly 1`] = `
                         Name
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -15051,6 +15062,7 @@ exports[`renders components/table/demo/grouping-columns.tsx correctly 1`] = `
                           Name
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-table-filter-trigger"
                           role="button"
                           tabindex="-1"
@@ -15996,9 +16008,10 @@ exports[`renders components/table/demo/head.tsx correctly 1`] = `
                         </div>
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -16100,9 +16113,10 @@ exports[`renders components/table/demo/head.tsx correctly 1`] = `
                         Address
                       </span>
                       <span
+                        aria-expanded="false"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -21826,9 +21840,10 @@ Array [
                           </div>
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -21989,9 +22004,10 @@ Array [
                           </div>
                         </span>
                         <span
+                          aria-expanded="false"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -6,7 +6,7 @@ import { clsx } from 'clsx';
 
 import type { FilterState } from '.';
 import { useSyncState } from '../../../_util/hooks';
-import { isFunction, isNumber } from '../../../_util/is';
+import { isFunction, isNumber, isString } from '../../../_util/is';
 import type { AnyObject } from '../../../_util/type';
 import { devUseWarning } from '../../../_util/warning';
 import Button from '../../../button/Button';
@@ -549,13 +549,34 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
       filterIcon = <FilterFilled />;
     }
 
+    const isInteractiveFilterIcon =
+      React.isValidElement<React.HTMLAttributes<HTMLElement> & { href?: string }>(filterIcon) &&
+      ((isString(filterIcon.type) &&
+        (['button', 'input', 'select', 'textarea'].includes(filterIcon.type) ||
+          (filterIcon.type === 'a' && Boolean(filterIcon.props.href)))) ||
+        ['button', 'link'].includes(filterIcon.props.role || '') ||
+        (isNumber(filterIcon.props.tabIndex) && filterIcon.props.tabIndex >= 0));
+
     return (
       <span
-        role="button"
-        tabIndex={-1}
+        role={isInteractiveFilterIcon ? undefined : 'button'}
+        tabIndex={isInteractiveFilterIcon ? undefined : inMeasureRow ? -1 : 0}
+        aria-expanded={isInteractiveFilterIcon ? undefined : mergedVisible}
         className={clsx(`${prefixCls}-trigger`, { active: filtered })}
         onClick={(e) => {
           e.stopPropagation();
+        }}
+        onKeyDown={(e) => {
+          if (
+            e.target === e.currentTarget &&
+            !isInteractiveFilterIcon &&
+            !inMeasureRow &&
+            (e.key === 'Enter' || e.key === ' ')
+          ) {
+            e.preventDefault();
+            e.stopPropagation();
+            onVisibleChange(!mergedVisible, { source: 'trigger' });
+          }
         }}
       >
         {filterIcon}

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -6,7 +6,7 @@ import { clsx } from 'clsx';
 
 import type { FilterState } from '.';
 import { useSyncState } from '../../../_util/hooks';
-import { isFunction, isNumber, isString } from '../../../_util/is';
+import { isFunction, isNumber } from '../../../_util/is';
 import type { AnyObject } from '../../../_util/type';
 import { devUseWarning } from '../../../_util/warning';
 import Button from '../../../button/Button';
@@ -549,19 +549,11 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
       filterIcon = <FilterFilled />;
     }
 
-    const isInteractiveFilterIcon =
-      React.isValidElement<React.HTMLAttributes<HTMLElement> & { href?: string }>(filterIcon) &&
-      ((isString(filterIcon.type) &&
-        (['button', 'input', 'select', 'textarea'].includes(filterIcon.type) ||
-          (filterIcon.type === 'a' && Boolean(filterIcon.props.href)))) ||
-        ['button', 'link'].includes(filterIcon.props.role || '') ||
-        (isNumber(filterIcon.props.tabIndex) && filterIcon.props.tabIndex >= 0));
-
     return (
       <span
-        role={isInteractiveFilterIcon ? undefined : 'button'}
-        tabIndex={isInteractiveFilterIcon ? undefined : inMeasureRow ? -1 : 0}
-        aria-expanded={isInteractiveFilterIcon ? undefined : mergedVisible}
+        role="button"
+        tabIndex={inMeasureRow ? -1 : 0}
+        aria-expanded={mergedVisible}
         className={clsx(`${prefixCls}-trigger`, { active: filtered })}
         onClick={(e) => {
           e.stopPropagation();
@@ -569,7 +561,6 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
         onKeyDown={(e) => {
           if (
             e.target === e.currentTarget &&
-            !isInteractiveFilterIcon &&
             !inMeasureRow &&
             (e.key === 'Enter' || e.key === ' ')
           ) {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [x] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Related to #37508.

### 💡 需求背景和解决方案

Table 的筛选图标和 Layout.Sider 的默认收起图标无法通过 Tab 聚焦，键盘用户也不能用 Enter 或空格触发。

[CodeSandbox 复现](https://codesandbox.io/s/39tymf)

1. 点击 “Check focusability”，可以看到两个触发器都不是 `tabIndex=0`。
2. 再用 Tab 浏览页面，焦点会跳过它们。

本次为 antd 自己渲染的触发器补充焦点、键盘操作和 ARIA 状态。自定义交互图标仍由使用方自行处理，避免一次按键触发两次；rc-dropdown 内部焦点管理不在本 PR 范围内。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Improve keyboard access for Table filter and Layout.Sider triggers. |
| 🇨🇳 中文 | 改进 Table 筛选和 Layout.Sider 收起触发器的键盘操作。 |
