### PR TITLE
site: prevent version selector from shifting page scroll

### DIFF
--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -149,6 +149,9 @@ const useStyle = createStyles(({ cssVar, token, css }) => {
       width: 88px;
       min-width: 88px; // 这个宽度需要和 Empty 状态的宽度保持一致
       margin-inline-end: 6px;
+      input {
+        scroll-margin-top: 0;
+      }
       .rc-virtual-list {
         .rc-virtual-list-holder {
           scrollbar-width: thin;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Ant Design 文档站会为所有带有 `id` 的元素设置 `scroll-margin-top`，确保 hash 锚点及 `scrollIntoView()` 定位时，目标内容不会被固定 Header 遮挡。

Header 中的版本 Select 展开时会正常聚焦内部 input。该 input 同样带有自动生成的 `id`，因此命中了全局锚点样式。浏览器在处理焦点滚动时会考虑 `scroll-margin-top`，导致已经滚动过的页面向上移动约一个 Header 的高度。

Select 聚焦内部 input 是键盘操作和无障碍支持所需的正常行为；全局 `[id]` 样式也被文档 hash、IconSearch 和 Form `scrollToField` 等场景使用，因此不应修改组件行为或缩小全局选择器范围。

本次修复保留全局 `[id]` 样式不变，仅在 Header 的版本 Select 范围内将内部 input 的 `scroll-margin-top` 重置为 `0`。这样既能避免展开版本下拉时页面跳动，也不会影响站点其他锚点及程序化滚动行为。

已完成以下静态检查：

- ESLint
- antd lint
- `git diff --check`

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | 无需更新日志 |