### PR TITLE
feat: support autoAdjustOverflow for Select & treeselect & cascader & autoComplete

### DIFF
--- a/components/_util/placements.ts
+++ b/components/_util/placements.ts
@@ -17,12 +17,12 @@ export interface PlacementsConfig {
   visibleFirst?: boolean;
 }
 
-export function getOverflowOptions(
-  placement: string,
-  arrowOffset: ReturnType<typeof getArrowOffsetToken>,
-  arrowWidth: number,
+type Overflow = NonNullable<AlignType['overflow']>;
+
+export function getMergedOverflow(
+  baseOverflow: Overflow,
   autoAdjustOverflow?: boolean | AdjustOverflow,
-) {
+): Overflow {
   if (autoAdjustOverflow === false) {
     return {
       adjustX: false,
@@ -30,9 +30,23 @@ export function getOverflowOptions(
     };
   }
 
-  const overflow = isPlainObject(autoAdjustOverflow) ? autoAdjustOverflow : {};
+  return {
+    ...baseOverflow,
+    ...(isPlainObject(autoAdjustOverflow) ? autoAdjustOverflow : {}),
+  };
+}
 
-  const baseOverflow: AlignType['overflow'] = {};
+export function getOverflowOptions(
+  placement: string,
+  arrowOffset: ReturnType<typeof getArrowOffsetToken>,
+  arrowWidth: number,
+  autoAdjustOverflow?: boolean | AdjustOverflow,
+) {
+  if (autoAdjustOverflow === false) {
+    return getMergedOverflow({}, autoAdjustOverflow);
+  }
+
+  const baseOverflow: Overflow = {};
 
   switch (placement) {
     case 'top':
@@ -50,10 +64,7 @@ export function getOverflowOptions(
       break;
   }
 
-  const mergedOverflow = {
-    ...baseOverflow,
-    ...overflow,
-  };
+  const mergedOverflow = getMergedOverflow(baseOverflow, autoAdjustOverflow);
 
   // Support auto shift
   if (!mergedOverflow.shiftX) {

--- a/components/auto-complete/index.en-US.md
+++ b/components/auto-complete/index.en-US.md
@@ -47,6 +47,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | allowClear | Show clear button | boolean \| { clearIcon?: ReactNode } | false | 5.8.0: Support Object type |
+| autoAdjustOverflow | Whether to adjust popup placement automatically when popup is off screen | boolean \| AdjustOverflow | true | 6.6.0 |
 | backfill | If backfill selected item the input when using keyboard | boolean | false |  |
 | children | Customize input element | HTMLInputElement \| HTMLTextAreaElement \| React.ReactElement&lt;InputProps> | &lt;Input /> |  |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |

--- a/components/auto-complete/index.zh-CN.md
+++ b/components/auto-complete/index.zh-CN.md
@@ -48,6 +48,7 @@ demo:
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | allowClear | 支持清除 | boolean \| { clearIcon?: ReactNode } | false | 5.8.0: 支持对象形式 |
+| autoAdjustOverflow | 浮层被遮挡时自动调整位置 | boolean \| AdjustOverflow | true | 6.6.0 |
 | backfill | 使用键盘选择选项的时候把选中项回填到输入框中 | boolean | false |  |
 | children | 自定义输入框 | HTMLInputElement \| HTMLTextAreaElement \| React.ReactElement&lt;InputProps> | &lt;Input /> |  |
 | classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  |

--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -53,6 +53,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
 | --- | --- | --- | --- | --- | --- |
 | allowClear | Show clear button | boolean \| { clearIcon?: ReactNode } | true | 5.8.0: Support object type | `clearIcon`: 6.4.0 |
+| autoAdjustOverflow | Whether to adjust popup placement automatically when popup is off screen | boolean \| AdjustOverflow | true | 6.6.0 | × |
 | ~~autoClearSearchValue~~ | Whether the current search will be cleared on selecting an item. Only applies when `multiple` is `true` | boolean | true | 5.9.0 | × |
 | ~~bordered~~ | Whether has border style, please use `variant` instead | boolean | true | - | × |
 | changeOnSelect | Change value on each selection if set to true, see above demo for details | boolean | false |  | × |

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -16,6 +16,7 @@ import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticT
 import { isNumber, isPlainObject, isString } from '../_util/is';
 import type { SelectCommonPlacement } from '../_util/motion';
 import { getTransitionName } from '../_util/motion';
+import type { AdjustOverflow } from '../_util/placements';
 import genPurePanel from '../_util/PurePanel';
 import type { InputStatus } from '../_util/statusUtils';
 import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';
@@ -189,6 +190,7 @@ export interface CascaderProps<
   variant?: Variant;
   classNames?: CascaderSemanticAllType['classNamesAndFn'];
   styles?: CascaderSemanticAllType['stylesAndFn'];
+  autoAdjustOverflow?: boolean | AdjustOverflow;
 }
 
 export type CascaderAutoProps<
@@ -242,6 +244,7 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
     clearIcon,
     removeIcon,
     suffixIcon,
+    autoAdjustOverflow,
     ...restProps
   } = props;
 
@@ -474,7 +477,11 @@ const Cascader = React.forwardRef<CascaderRef, CascaderProps<any>>((props, ref) 
       classNames={mergedClassNames}
       styles={mergedStyles}
       {...(restProps as any)}
-      builtinPlacements={mergedBuiltinPlacements(builtinPlacements, popupOverflow)}
+      builtinPlacements={mergedBuiltinPlacements({
+        builtinPlacements,
+        popupOverflow,
+        autoAdjustOverflow,
+      })}
       direction={mergedDirection}
       placement={memoPlacement}
       notFoundContent={mergedNotFoundContent}

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -54,6 +54,7 @@ demo:
 | 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
 | --- | --- | --- | --- | --- | --- |
 | allowClear | 支持清除 | boolean \| { clearIcon?: ReactNode } | true | 5.8.0: 支持对象形式 | `clearIcon`: 6.4.0 |
+| autoAdjustOverflow | 浮层被遮挡时自动调整位置 | boolean \| AdjustOverflow | true | 6.6.0 | × |
 | ~~autoClearSearchValue~~ | 是否在选中项后清空搜索框，只在 `multiple` 为 `true` 时有效 | boolean | true | 5.9.0 | × |
 | ~~bordered~~ | 是否带边框，请使用 `variant` 替代 | boolean | true | - | × |
 | changeOnSelect | 单选时生效（multiple 下始终都可以选择），点选每级菜单选项值都会发生变化。 | boolean | false |  | × |

--- a/components/select/__tests__/mergedBuiltinPlacements.test.ts
+++ b/components/select/__tests__/mergedBuiltinPlacements.test.ts
@@ -1,0 +1,57 @@
+import type { BuildInPlacements } from '@rc-component/trigger';
+
+import mergedBuiltinPlacements from '../mergedBuiltinPlacements';
+
+describe('mergedBuiltinPlacements', () => {
+  it('enables overflow adjustment by default', () => {
+    const placements = mergedBuiltinPlacements({});
+
+    expect(placements.bottomLeft.overflow).toEqual({
+      adjustX: true,
+      adjustY: true,
+      shiftY: true,
+    });
+  });
+
+  it('disables overflow adjustment', () => {
+    const placements = mergedBuiltinPlacements({ autoAdjustOverflow: false });
+
+    expect(placements.bottomLeft.overflow).toEqual({
+      adjustX: false,
+      adjustY: false,
+    });
+  });
+
+  it('supports custom overflow adjustment', () => {
+    const placements = mergedBuiltinPlacements({
+      autoAdjustOverflow: { adjustX: 0, adjustY: 1 },
+    });
+
+    expect(placements.bottomLeft.overflow).toEqual({
+      adjustX: 0,
+      adjustY: 1,
+      shiftY: true,
+    });
+  });
+
+  it('keeps custom builtin placements', () => {
+    const builtinPlacements: BuildInPlacements = {
+      bottomLeft: {
+        points: ['tl', 'bl'],
+      },
+    };
+
+    expect(
+      mergedBuiltinPlacements({
+        builtinPlacements,
+        autoAdjustOverflow: false,
+      }),
+    ).toBe(builtinPlacements);
+  });
+
+  it('supports scroll popup overflow', () => {
+    const placements = mergedBuiltinPlacements({ popupOverflow: 'scroll' });
+
+    expect(placements.bottomLeft.htmlRegion).toBe('scroll');
+  });
+});

--- a/components/select/__tests__/type.test.tsx
+++ b/components/select/__tests__/type.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+import AutoComplete from '../../auto-complete';
+import Cascader from '../../cascader';
+import TreeSelect from '../../tree-select';
+import Select from '..';
+
+describe('autoAdjustOverflow types', () => {
+  it('supports Select-like components', () => {
+    const components = [
+      <Select key="select" autoAdjustOverflow={false} />,
+      <AutoComplete key="auto-complete" autoAdjustOverflow={{ adjustX: 0, adjustY: 1 }} />,
+      <TreeSelect key="tree-select" autoAdjustOverflow={false} />,
+      <Cascader key="cascader" autoAdjustOverflow={{ adjustX: 1, adjustY: 0 }} />,
+    ];
+
+    expect(components).toHaveLength(4);
+  });
+});

--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -62,6 +62,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
 | --- | --- | --- | --- | --- | --- |
 | allowClear | Customize clear icon | boolean \| { clearIcon?: ReactNode } | false | 5.8.0: Support object type | 6.4.0 |
+| autoAdjustOverflow | Whether to adjust popup placement automatically when popup is off screen | boolean \| AdjustOverflow | true | 6.6.0 | × |
 | ~~autoClearSearchValue~~ | Whether the current search will be cleared on selecting an item. Only applies when `mode` is set to `multiple` or `tags` | boolean | true |  | × |
 | ~~bordered~~ | Whether has border style, please use `variant` instead | boolean | true | - | × |
 | classNames | Customize class for each semantic structure inside the Select component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 5.25.0 |

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -18,6 +18,7 @@ import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticT
 import type { SelectCommonPlacement } from '../_util/motion';
 import { getTransitionName } from '../_util/motion';
 import normalizeIcon from '../_util/normalizeIcon';
+import type { AdjustOverflow } from '../_util/placements';
 import genPurePanel from '../_util/PurePanel';
 import type { InputStatus } from '../_util/statusUtils';
 import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';
@@ -123,6 +124,7 @@ export interface InternalSelectProps<
   styles?: SelectSemanticAllType['stylesAndFn'];
   loadingIcon?: React.ReactNode;
   showSearch?: boolean | (SearchConfig<OptionType> & { searchIcon?: React.ReactNode });
+  autoAdjustOverflow?: boolean | AdjustOverflow;
 }
 
 export interface SelectProps<
@@ -205,6 +207,7 @@ const InternalSelect = <
     classNames,
     clearIcon,
     showSearch,
+    autoAdjustOverflow,
     ...rest
   } = props;
 
@@ -451,7 +454,11 @@ const InternalSelect = <
       style={mergedStyles.root}
       popupMatchSelectWidth={mergedPopupMatchSelectWidth}
       transitionName={getTransitionName(rootPrefixCls, 'slide-up', transitionName)}
-      builtinPlacements={mergedBuiltinPlacements(builtinPlacements, popupOverflow)}
+      builtinPlacements={mergedBuiltinPlacements({
+        builtinPlacements,
+        popupOverflow,
+        autoAdjustOverflow,
+      })}
       listHeight={listHeight}
       listItemHeight={listItemHeight}
       mode={mode}

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -63,6 +63,7 @@ demo:
 | 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
 | --- | --- | --- | --- | --- | --- |
 | allowClear | 自定义清除按钮 | boolean \| { clearIcon?: ReactNode } | false | 5.8.0: 支持对象类型 | 6.4.0 |
+| autoAdjustOverflow | 浮层被遮挡时自动调整位置 | boolean \| AdjustOverflow | true | 6.6.0 | × |
 | ~~autoClearSearchValue~~ | 是否在选中项后清空搜索框，只在 `mode` 为 `multiple` 或 `tags` 时有效 | boolean | true |  | × |
 | ~~bordered~~ | 是否带边框，请使用 `variant` 替代 | boolean | true | - | × |
 | classNames | 用于自定义 Select 组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), string> | - |  | 5.25.0 |

--- a/components/select/mergedBuiltinPlacements.ts
+++ b/components/select/mergedBuiltinPlacements.ts
@@ -1,16 +1,30 @@
 import type { AlignType, BuildInPlacements } from '@rc-component/trigger';
 
+import type { AdjustOverflow } from '../_util/placements';
+import { getMergedOverflow } from '../_util/placements';
 import type { PopupOverflow } from '../config-provider/context';
 
-const getBuiltInPlacements = (popupOverflow?: PopupOverflow): Record<string, AlignType> => {
+interface MergedPlacementsConfig {
+  builtinPlacements?: BuildInPlacements;
+  popupOverflow?: PopupOverflow;
+  autoAdjustOverflow?: boolean | AdjustOverflow;
+}
+
+const getBuiltInPlacements = ({
+  popupOverflow,
+  autoAdjustOverflow,
+}: MergedPlacementsConfig): Record<string, AlignType> => {
   const htmlRegion: AlignType['htmlRegion'] = popupOverflow === 'scroll' ? 'scroll' : 'visible';
 
   const sharedConfig: AlignType = {
-    overflow: {
-      adjustX: true,
-      adjustY: true,
-      shiftY: true,
-    },
+    overflow: getMergedOverflow(
+      {
+        adjustX: true,
+        adjustY: true,
+        shiftY: true,
+      },
+      autoAdjustOverflow,
+    ),
     htmlRegion,
     dynamicInset: true,
   };
@@ -39,11 +53,8 @@ const getBuiltInPlacements = (popupOverflow?: PopupOverflow): Record<string, Ali
   };
 };
 
-function mergedBuiltinPlacements(
-  buildInPlacements?: BuildInPlacements,
-  popupOverflow?: PopupOverflow,
-) {
-  return buildInPlacements || getBuiltInPlacements(popupOverflow);
+function mergedBuiltinPlacements(config: MergedPlacementsConfig) {
+  return config.builtinPlacements || getBuiltInPlacements(config);
 }
 
 export default mergedBuiltinPlacements;

--- a/components/tree-select/index.en-US.md
+++ b/components/tree-select/index.en-US.md
@@ -40,6 +40,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | Property | Description | Type | Default | Version | [Global Config](/components/config-provider#component-config) |
 | --- | --- | --- | --- | --- | --- |
 | allowClear | Customize clear icon | boolean \| { clearIcon?: ReactNode } | false | 5.8.0: Support object type | × |
+| autoAdjustOverflow | Whether to adjust popup placement automatically when popup is off screen | boolean \| AdjustOverflow | true | 6.6.0 | × |
 | ~~autoClearSearchValue~~ | If auto clear search input value when multiple select is selected/deselected | boolean | true |  | × |
 | ~~bordered~~ | Whether has border style, please use `variant` instead | boolean | true | - | × |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 5.25.0 |

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -15,6 +15,7 @@ import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import type { SelectCommonPlacement } from '../_util/motion';
 import { getTransitionName } from '../_util/motion';
+import type { AdjustOverflow } from '../_util/placements';
 import genPurePanel from '../_util/PurePanel';
 import type { InputStatus } from '../_util/statusUtils';
 import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';
@@ -115,6 +116,7 @@ interface BaseTreeSelectProps<ValueType = any, OptionType extends DataNode = Dat
   disabled?: boolean;
   status?: InputStatus;
   variant?: Variant;
+  autoAdjustOverflow?: boolean | AdjustOverflow;
 }
 
 export interface TreeSelectProps<ValueType = any, OptionType extends DataNode = DataNode>
@@ -204,6 +206,7 @@ const InternalTreeSelect: InternalTreeSelectRef = (props, ref) => {
     treeCheckStrictly,
     styles,
     classNames,
+    autoAdjustOverflow,
     ...restProps
   } = props;
 
@@ -418,7 +421,11 @@ const InternalTreeSelect: InternalTreeSelectRef = (props, ref) => {
       disabled={mergedDisabled}
       {...selectProps}
       popupMatchSelectWidth={mergedPopupMatchSelectWidth}
-      builtinPlacements={mergedBuiltinPlacements(builtinPlacements, popupOverflow)}
+      builtinPlacements={mergedBuiltinPlacements({
+        builtinPlacements,
+        popupOverflow,
+        autoAdjustOverflow,
+      })}
       ref={ref}
       prefixCls={prefixCls}
       className={mergedClassName}

--- a/components/tree-select/index.zh-CN.md
+++ b/components/tree-select/index.zh-CN.md
@@ -41,6 +41,7 @@ demo:
 | 参数 | 说明 | 类型 | 默认值 | 版本 | [全局配置](/components/config-provider-cn#component-config) |
 | --- | --- | --- | --- | --- | --- |
 | allowClear | 自定义清除按钮 | boolean \| { clearIcon?: ReactNode } | false | 5.8.0: 支持对象形式 | × |
+| autoAdjustOverflow | 浮层被遮挡时自动调整位置 | boolean \| AdjustOverflow | true | 6.6.0 | × |
 | ~~autoClearSearchValue~~ | 当多选模式下值被选择，自动清空搜索框 | boolean | true |  | × |
 | ~~bordered~~ | 是否带边框，请使用 `variant` 替代 | boolean | true | - | × |
 | classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - |  | 5.25.0 |


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- Rewritten based on the previous implementation and discussion in https://github.com/ant-design/ant-design/pull/52428.


### 💡 Background and Solution

This PR rewrites [#52428](https://github.com/ant-design/ant-design/pull/52428) for the current placement architecture and extends `autoAdjustOverflow` consistently to:

- Select
- AutoComplete
- TreeSelect
- Cascader

The public API is:

```ts
autoAdjustOverflow?: boolean | AdjustOverflow;
```

The default value is `true`, which preserves the existing behavior rather than changing it. Before this PR, Select's default placements already enabled [`adjustX`, `adjustY`, and `shiftY`](https://github.com/ant-design/ant-design/blob/228df6d4411691ae45a7e23e66bee890379d5909/components/select/mergedBuiltinPlacements.ts#L8-L14).

This API also follows existing Ant Design conventions: [Tooltip](https://github.com/ant-design/ant-design/blob/228df6d4411691ae45a7e23e66bee890379d5909/components/tooltip/shared/sharedProps.en-US.md#L6-L9) and [Dropdown](https://github.com/ant-design/ant-design/blob/228df6d4411691ae45a7e23e66bee890379d5909/components/dropdown/index.en-US.md#L46-L52) already document `autoAdjustOverflow` with a default value of `true`.

Behavior:

- `true` or `undefined` preserves the existing automatic adjustment behavior.
- `false` disables horizontal and vertical flipping.
- An `AdjustOverflow` object can override `adjustX` and `adjustY` independently.
- Custom `builtinPlacements` remain the highest-priority configuration.


Usage:

```tsx
<Select autoAdjustOverflow={false} />

<TreeSelect
  autoAdjustOverflow={{
    adjustX: 0,
    adjustY: 1,
  }}
/>
```

#### Self-test TSX

```tsx
import React, { useState } from 'react';
import { Select, Space, Switch, Typography } from 'antd';

const options = [
  { value: 'Hangzhou', label: 'Hangzhou' },
  { value: 'Ningbo', label: 'Ningbo' },
  { value: 'Wenzhou', label: 'Wenzhou' },
];

const App: React.FC = () => {
  const [autoAdjustOverflow, setAutoAdjustOverflow] = useState(true);

  return (
    <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
      <Space>
        <Switch checked={autoAdjustOverflow} onChange={setAutoAdjustOverflow} />
        <Typography.Text>
          autoAdjustOverflow: <Typography.Text code>{String(autoAdjustOverflow)}</Typography.Text>
        </Typography.Text>
      </Space>

      <div
        style={{
          position: 'relative',
          height: 240,
          overflow: 'hidden',
          border: '1px solid #d9d9d9',
          borderRadius: 8,
          background: 'linear-gradient(#fff, #fafafa)',
        }}
      >
        <Typography.Text type="secondary" style={{ position: 'absolute', top: 16, left: 16 }}>
          Popup visible area
        </Typography.Text>
        <div style={{ position: 'absolute', bottom: 72, left: 16 }}>
          <Select
            open
            value="Hangzhou"
            style={{ width: 200 }}
            placement="bottomLeft"
            autoAdjustOverflow={autoAdjustOverflow}
            getPopupContainer={(triggerNode) => triggerNode.parentElement!}
            options={options}
          />
        </div>
      </div>
    </Space>
  );
};

export default App;

```

#### Screenshots / Recording

https://github.com/user-attachments/assets/d309d38c-3df0-4311-b4bf-1592344a49cb




### 📝 Change Log

| Language   | Changelog                                                                                 |
| ---------- | ----------------------------------------------------------------------------------------- |
| 🇺🇸 English | 🆕 Add `autoAdjustOverflow` support to Select, AutoComplete, TreeSelect, and Cascader.    |
| 🇨🇳 Chinese | 🆕 新增 Select、AutoComplete、TreeSelect 和 Cascader 对 `autoAdjustOverflow` 属性的支持。 |
