### PR TITLE
fix(Input): handle OTP mask input types consistently

### DIFF
--- a/components/input/OTP/OTPInput.tsx
+++ b/components/input/OTP/OTPInput.tsx
@@ -18,7 +18,8 @@ export interface OTPInputProps extends Omit<InputProps, 'onChange'> {
 const DEFAULT_MASK_VALUE = '•';
 
 const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
-  const { className, value, onChange, onActiveChange, index, mask, onFocus, ...restProps } = props;
+  const { className, value, onChange, onActiveChange, index, mask, onFocus, type, ...restProps } =
+    props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('otp');
   const maskValue = typeof mask === 'string' ? mask : DEFAULT_MASK_VALUE;
@@ -77,8 +78,8 @@ const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
 
       <Input
         aria-label={`OTP Input ${index + 1}`}
-        type={mask ? 'password' : 'text'}
         {...restProps}
+        type={type ?? (mask ? 'password' : 'text')}
         ref={inputRef}
         value={value}
         onInput={onInternalChange}

--- a/components/input/OTP/OTPInput.tsx
+++ b/components/input/OTP/OTPInput.tsx
@@ -18,8 +18,7 @@ export interface OTPInputProps extends Omit<InputProps, 'onChange'> {
 const DEFAULT_MASK_VALUE = '•';
 
 const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
-  const { className, value, onChange, onActiveChange, index, mask, onFocus, type, ...restProps } =
-    props;
+  const { className, value, onChange, onActiveChange, index, mask, onFocus, ...restProps } = props;
   const { getPrefixCls } = React.useContext(ConfigContext);
   const prefixCls = getPrefixCls('otp');
   const maskValue = typeof mask === 'string' ? mask : DEFAULT_MASK_VALUE;
@@ -78,8 +77,8 @@ const OTPInput = React.forwardRef<InputRef, OTPInputProps>((props, ref) => {
 
       <Input
         aria-label={`OTP Input ${index + 1}`}
+        type={mask ? 'password' : 'text'}
         {...restProps}
-        type={type ?? (mask === true ? 'password' : 'text')}
         ref={inputRef}
         value={value}
         onInput={onInternalChange}

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -10384,7 +10384,7 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         aria-label="OTP Input 1"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-test-id ant-input-css-var"
         size="1"
-        type="text"
+        type="password"
         value=""
       />
     </span>
@@ -10396,7 +10396,7 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         aria-label="OTP Input 2"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-test-id ant-input-css-var"
         size="1"
-        type="text"
+        type="password"
         value=""
       />
     </span>
@@ -10408,7 +10408,7 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         aria-label="OTP Input 3"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-test-id ant-input-css-var"
         size="1"
-        type="text"
+        type="password"
         value=""
       />
     </span>
@@ -10420,7 +10420,7 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         aria-label="OTP Input 4"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-test-id ant-input-css-var"
         size="1"
-        type="text"
+        type="password"
         value=""
       />
     </span>
@@ -10432,7 +10432,7 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         aria-label="OTP Input 5"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-test-id ant-input-css-var"
         size="1"
-        type="text"
+        type="password"
         value=""
       />
     </span>
@@ -10444,7 +10444,7 @@ exports[`renders components/input/demo/otp.tsx extend context correctly 1`] = `
         aria-label="OTP Input 6"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-test-id ant-input-css-var"
         size="1"
-        type="text"
+        type="password"
         value=""
       />
     </span>

--- a/components/input/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.tsx.snap
@@ -3656,7 +3656,7 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         aria-label="OTP Input 1"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-test-id ant-input-css-var"
         size="1"
-        type="text"
+        type="password"
         value=""
       />
     </span>
@@ -3668,7 +3668,7 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         aria-label="OTP Input 2"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-test-id ant-input-css-var"
         size="1"
-        type="text"
+        type="password"
         value=""
       />
     </span>
@@ -3680,7 +3680,7 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         aria-label="OTP Input 3"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-test-id ant-input-css-var"
         size="1"
-        type="text"
+        type="password"
         value=""
       />
     </span>
@@ -3692,7 +3692,7 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         aria-label="OTP Input 4"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-test-id ant-input-css-var"
         size="1"
-        type="text"
+        type="password"
         value=""
       />
     </span>
@@ -3704,7 +3704,7 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         aria-label="OTP Input 5"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-test-id ant-input-css-var"
         size="1"
-        type="text"
+        type="password"
         value=""
       />
     </span>
@@ -3716,7 +3716,7 @@ exports[`renders components/input/demo/otp.tsx correctly 1`] = `
         aria-label="OTP Input 6"
         class="ant-input ant-input-outlined ant-otp-input ant-otp-mask-input css-var-test-id ant-input-css-var"
         size="1"
-        type="text"
+        type="password"
         value=""
       />
     </span>

--- a/components/input/__tests__/otp.test.tsx
+++ b/components/input/__tests__/otp.test.tsx
@@ -173,6 +173,7 @@ describe('Input.OTP', () => {
     // support string
     rerender(<OTP defaultValue="bamboo" mask="*" />);
     expect(getText(container)).toBe('bamboo');
+    expect(container.querySelector('input')).toHaveAttribute('type', 'password');
 
     // support emoji
     rerender(<OTP defaultValue="bamboo" mask="🔒" />);
@@ -196,7 +197,7 @@ describe('Input.OTP', () => {
   });
 
   it('support type', () => {
-    const { container } = render(<OTP type="number" />);
+    const { container } = render(<OTP mask type="number" />);
     expect(container.querySelector('input')).toHaveAttribute('type', 'number');
   });
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- Follow-up #58805
- 处理 [MadCcc 未完成的 Review 评论](https://github.com/ant-design/ant-design/pull/58805#discussion_r3672296366)
- 关联 #58781

### 💡 需求背景和解决方案

PR #58805 合并时，MadCcc 关于 Input.OTP 输入类型处理的 Review 评论尚未完成：字符串 `mask` 也应默认使用 `password`，同时保留显式 `type` 的覆盖能力。

外层 OTP 会始终向 OTPInput 传递 `type` 字段，未配置时其值为 `undefined`。如果仅通过调整 `{...restProps}` 的展开顺序实现覆盖，`type: undefined` 会覆盖由 `mask` 推导出的 `password`，使布尔遮罩回退为 `text`。

因此本次保留对 `type` 的显式提取，并使用 `type ?? (mask ? 'password' : 'text')` 表达优先级：有效的显式 `type` 优先；未配置时，布尔和字符串 `mask` 均默认使用 `password`。同时补充字符串遮罩默认类型和显式类型覆盖的回归断言。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Input.OTP using text input type with string masks while preserving explicit `type` overrides. |
| 🇨🇳 中文 | 🐞 修复 Input.OTP 使用字符串遮罩时仍采用文本输入类型的问题，并保留显式 `type` 覆盖能力。 |
