### PR TITLE
fix: apply disabled text color to AutoComplete input

### DIFF
--- a/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1162,6 +1162,203 @@ exports[`renders components/auto-complete/demo/disabled-custom-debug.tsx extend 
 
 exports[`renders components/auto-complete/demo/disabled-custom-debug.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/auto-complete/demo/disabled-in-form-debug.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+  style="width: 240px; gap: 12px;"
+>
+  <form
+    class="ant-form ant-form-horizontal css-var-test-id ant-form-css-var"
+  >
+    <div
+      class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-horizontal"
+      style="margin-bottom: 0px;"
+    >
+      <div
+        class="ant-row ant-form-item-row css-var-test-id"
+      >
+        <div
+          class="ant-col ant-form-item-label css-var-test-id"
+        >
+          <label
+            class=""
+            title="Form disabled"
+          >
+            Form disabled
+          </label>
+        </div>
+        <div
+          class="ant-col ant-form-item-control css-var-test-id"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <div
+                class="ant-select ant-select-outlined ant-select-in-form-item ant-select-auto-complete css-var-test-id ant-select-css-var ant-select-single ant-select-disabled ant-select-show-search"
+              >
+                <div
+                  class="ant-select-content ant-select-content-has-value ant-select-content-has-search-value"
+                  title="Disabled Value"
+                >
+                  Disabled Value
+                  <input
+                    aria-autocomplete="list"
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    autocomplete="new-password"
+                    class="ant-select-input"
+                    disabled=""
+                    id="test-id"
+                    role="combobox"
+                    type="text"
+                    value="Disabled Value"
+                  />
+                </div>
+              </div>
+              <div
+                class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomLeft"
+                style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+              >
+                <div>
+                  <div
+                    id="test-id_list"
+                    role="listbox"
+                    style="height: 0px; width: 0px; overflow: hidden;"
+                  >
+                    <div
+                      aria-selected="true"
+                      id="test-id_list_0"
+                      role="option"
+                    >
+                      Disabled Value
+                    </div>
+                  </div>
+                  <div
+                    class="rc-virtual-list"
+                    style="position: relative;"
+                  >
+                    <div
+                      class="rc-virtual-list-holder"
+                      style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+                    >
+                      <div>
+                        <div
+                          class="rc-virtual-list-holder-inner"
+                          style="display: flex; flex-direction: column;"
+                        >
+                          <div
+                            aria-disabled="false"
+                            class="ant-select-item ant-select-item-option"
+                            title="Disabled Value"
+                          >
+                            <div
+                              class="ant-select-item-option-content"
+                            >
+                              Disabled Value
+                            </div>
+                            <span
+                              aria-hidden="true"
+                              class="ant-select-item-option-state"
+                              style="user-select: none;"
+                              unselectable="on"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+  <div
+    class="ant-select ant-select-outlined ant-select-auto-complete css-var-test-id ant-select-css-var ant-select-single ant-select-disabled ant-select-show-search"
+  >
+    <div
+      class="ant-select-content ant-select-content-has-value ant-select-content-has-search-value"
+      title="Disabled Value"
+    >
+      Disabled Value
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="new-password"
+        class="ant-select-input"
+        disabled=""
+        id="test-id"
+        role="combobox"
+        type="text"
+        value="Disabled Value"
+      />
+    </div>
+  </div>
+  <div
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomLeft"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+  >
+    <div>
+      <div
+        id="test-id_list"
+        role="listbox"
+        style="height: 0px; width: 0px; overflow: hidden;"
+      >
+        <div
+          aria-selected="true"
+          id="test-id_list_0"
+          role="option"
+        >
+          Disabled Value
+        </div>
+      </div>
+      <div
+        class="rc-virtual-list"
+        style="position: relative;"
+      >
+        <div
+          class="rc-virtual-list-holder"
+          style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+        >
+          <div>
+            <div
+              class="rc-virtual-list-holder-inner"
+              style="display: flex; flex-direction: column;"
+            >
+              <div
+                aria-disabled="false"
+                class="ant-select-item ant-select-item-option"
+                title="Disabled Value"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  Disabled Value
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/auto-complete/demo/disabled-in-form-debug.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/auto-complete/demo/filled-custom-debug.tsx extend context correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-wrap-wrap"

--- a/components/auto-complete/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo.test.tsx.snap
@@ -501,6 +501,93 @@ exports[`renders components/auto-complete/demo/disabled-custom-debug.tsx correct
 </div>
 `;
 
+exports[`renders components/auto-complete/demo/disabled-in-form-debug.tsx correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+  style="width:240px;gap:12px"
+>
+  <form
+    class="ant-form ant-form-horizontal css-var-test-id ant-form-css-var"
+  >
+    <div
+      class="ant-form-item css-var-test-id ant-form-css-var ant-form-item-horizontal"
+      style="margin-bottom:0"
+    >
+      <div
+        class="ant-row ant-form-item-row css-var-test-id"
+      >
+        <div
+          class="ant-col ant-form-item-label css-var-test-id"
+        >
+          <label
+            class=""
+            title="Form disabled"
+          >
+            Form disabled
+          </label>
+        </div>
+        <div
+          class="ant-col ant-form-item-control css-var-test-id"
+        >
+          <div
+            class="ant-form-item-control-input"
+          >
+            <div
+              class="ant-form-item-control-input-content"
+            >
+              <div
+                class="ant-select ant-select-outlined ant-select-in-form-item ant-select-auto-complete css-var-test-id ant-select-css-var ant-select-single ant-select-disabled ant-select-show-search"
+              >
+                <div
+                  class="ant-select-content ant-select-content-has-value ant-select-content-has-search-value"
+                  title="Disabled Value"
+                >
+                  Disabled Value
+                  <input
+                    aria-autocomplete="list"
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    autocomplete="new-password"
+                    class="ant-select-input"
+                    disabled=""
+                    id="test-id"
+                    role="combobox"
+                    type="text"
+                    value="Disabled Value"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+  <div
+    class="ant-select ant-select-outlined ant-select-auto-complete css-var-test-id ant-select-css-var ant-select-single ant-select-disabled ant-select-show-search"
+  >
+    <div
+      class="ant-select-content ant-select-content-has-value ant-select-content-has-search-value"
+      title="Disabled Value"
+    >
+      Disabled Value
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="new-password"
+        class="ant-select-input"
+        disabled=""
+        id="test-id"
+        role="combobox"
+        type="text"
+        value="Disabled Value"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/auto-complete/demo/filled-custom-debug.tsx correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-wrap-wrap"

--- a/components/auto-complete/__tests__/index.test.tsx
+++ b/components/auto-complete/__tests__/index.test.tsx
@@ -6,30 +6,11 @@ import { resetWarned } from '../../_util/warning';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { render, screen } from '../../../tests/utils';
-import Form from '../../form';
 import Input from '../../input';
 
 describe('AutoComplete', () => {
   mountTest(AutoComplete);
   rtlTest(AutoComplete);
-
-  it('should apply disabled text color to the inner input when Form is disabled', () => {
-    const { container } = render(
-      <Form disabled>
-        <AutoComplete value="disabled" options={[{ value: 'disabled' }]} />
-      </Form>,
-    );
-    const select = container.querySelector<HTMLElement>('.ant-select-disabled')!;
-    const input = container.querySelector<HTMLInputElement>('input')!;
-    // The inner input paints its text through `--ant-select-color`, and the disabled
-    // selector overrides that variable with the disabled token. Assert the winning `color`
-    // rule on the input itself (so a higher-specificity override on the input is caught),
-    // together with the disabled variable value that feeds it.
-    expect(getComputedStyle(input).color).toBe('var(--ant-select-color)');
-    expect(getComputedStyle(select).getPropertyValue('--ant-select-color')).toBe(
-      'var(--ant-color-text-disabled)',
-    );
-  });
 
   it('AutoComplete with custom Input render perfectly', async () => {
     render(

--- a/components/auto-complete/__tests__/index.test.tsx
+++ b/components/auto-complete/__tests__/index.test.tsx
@@ -6,11 +6,24 @@ import { resetWarned } from '../../_util/warning';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { render, screen } from '../../../tests/utils';
+import Form from '../../form';
 import Input from '../../input';
 
 describe('AutoComplete', () => {
   mountTest(AutoComplete);
   rtlTest(AutoComplete);
+
+  it('should use disabled text color when Form is disabled', () => {
+    const { container } = render(
+      <Form disabled>
+        <AutoComplete value="disabled" options={[{ value: 'disabled' }]} />
+      </Form>,
+    );
+    const select = container.querySelector<HTMLElement>('.ant-select-disabled')!;
+    expect(getComputedStyle(select).getPropertyValue('--ant-select-color')).toBe(
+      'var(--ant-color-text-disabled)',
+    );
+  });
 
   it('AutoComplete with custom Input render perfectly', async () => {
     render(

--- a/components/auto-complete/__tests__/index.test.tsx
+++ b/components/auto-complete/__tests__/index.test.tsx
@@ -13,13 +13,19 @@ describe('AutoComplete', () => {
   mountTest(AutoComplete);
   rtlTest(AutoComplete);
 
-  it('should use disabled text color when Form is disabled', () => {
+  it('should apply disabled text color to the inner input when Form is disabled', () => {
     const { container } = render(
       <Form disabled>
         <AutoComplete value="disabled" options={[{ value: 'disabled' }]} />
       </Form>,
     );
     const select = container.querySelector<HTMLElement>('.ant-select-disabled')!;
+    const input = container.querySelector<HTMLInputElement>('input')!;
+    // The inner input paints its text through `--ant-select-color`, and the disabled
+    // selector overrides that variable with the disabled token. Assert the winning `color`
+    // rule on the input itself (so a higher-specificity override on the input is caught),
+    // together with the disabled variable value that feeds it.
+    expect(getComputedStyle(input).color).toBe('var(--ant-select-color)');
     expect(getComputedStyle(select).getPropertyValue('--ant-select-color')).toBe(
       'var(--ant-color-text-disabled)',
     );

--- a/components/auto-complete/demo/disabled-in-form-debug.md
+++ b/components/auto-complete/demo/disabled-in-form-debug.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+禁用状态下的文字颜色 Debug：AutoComplete 在禁用的 Form 中以及直接禁用时，输入框文字均应使用禁用色。
+
+## en-US
+
+Disabled text color debug: the input text should use the disabled color both when the AutoComplete sits inside a disabled Form and when it is disabled directly.

--- a/components/auto-complete/demo/disabled-in-form-debug.tsx
+++ b/components/auto-complete/demo/disabled-in-form-debug.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { AutoComplete, Flex, Form } from 'antd';
+
+const options = [{ value: 'Disabled Value' }];
+
+const App: React.FC = () => (
+  <Flex vertical gap={12} style={{ width: 240 }}>
+    <Form disabled>
+      <Form.Item label="Form disabled" style={{ marginBottom: 0 }}>
+        <AutoComplete value="Disabled Value" options={options} />
+      </Form.Item>
+    </Form>
+    <AutoComplete disabled value="Disabled Value" options={options} />
+  </Flex>
+);
+
+export default App;

--- a/components/auto-complete/index.en-US.md
+++ b/components/auto-complete/index.en-US.md
@@ -35,6 +35,7 @@ The differences with Select are:
 <code src="./demo/allowClear.tsx">Customize clear button</code>
 <code src="./demo/style-class.tsx" version="6.0.0">Custom semantic dom styling</code>
 <code src="./demo/disabled-custom-debug.tsx" debug>Disabled custom input debug</code>
+<code src="./demo/disabled-in-form-debug.tsx" debug>Disabled text color in Form debug</code>
 <code src="./demo/filled-custom-debug.tsx" debug>Filled custom input debug</code>
 <code src="./demo/form-debug.tsx" debug>Debug in Form</code>
 <code src="./demo/AutoComplete-and-Select.tsx" debug>AutoComplete and Select</code>

--- a/components/auto-complete/index.zh-CN.md
+++ b/components/auto-complete/index.zh-CN.md
@@ -36,6 +36,7 @@ demo:
 <code src="./demo/allowClear.tsx">自定义清除按钮</code>
 <code src="./demo/style-class.tsx" version="6.0.0">自定义语义结构的样式和类</code>
 <code src="./demo/disabled-custom-debug.tsx" debug>禁用自定义输入 Debug</code>
+<code src="./demo/disabled-in-form-debug.tsx" debug>禁用文字颜色在 Form 中 Debug</code>
 <code src="./demo/filled-custom-debug.tsx" debug>填充形态自定义输入 Debug</code>
 <code src="./demo/form-debug.tsx" debug>在 Form 中 Debug</code>
 <code src="./demo/AutoComplete-and-Select.tsx" debug>AutoComplete 和 Select</code>

--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -236,7 +236,7 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
         // ==========================================================
         '&-disabled': {
           background: token.colorBgContainerDisabled,
-          color: token.colorTextDisabled,
+          [varName('color')]: token.colorTextDisabled,
           cursor: 'not-allowed',
 
           input: {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #58837

### 💡 Background and Solution

Inside a disabled Form the AutoComplete input kept its normal text color instead of the greyed-out disabled color that Input and Select show. The disabled Select style set the text color straight on the wrapper, but the inner input reads the `--ant-select-color` variable, which stayed at the normal color, so the value never inherited the disabled tone. The disabled state now resets that variable so the inner input picks up the disabled color as well.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix AutoComplete input keeping normal text color instead of the disabled color when disabled. |
| 🇨🇳 Chinese | 修复 AutoComplete 禁用时输入框文字仍显示正常颜色而非禁用色的问题。 |
