### PR TITLE
fix(Table): skip disabled rows across pages when selecting all data

### DIFF
--- a/components/table/__tests__/Table.rowSelection.test.tsx
+++ b/components/table/__tests__/Table.rowSelection.test.tsx
@@ -629,6 +629,31 @@ describe('Table.rowSelection', () => {
       expect(onChange).toHaveBeenCalledWith([0, 2], expect.anything(), { type: 'all' });
     });
 
+    // https://github.com/ant-design/ant-design/issues/58842
+    it('SELECTION_ALL should skip disabled rows on other pages', () => {
+      jest.useFakeTimers();
+      const onChange = jest.fn();
+      const { container } = render(
+        createTable({
+          pagination: { pageSize: 2 },
+          rowSelection: {
+            onChange,
+            getCheckboxProps: (record) => ({ disabled: record.key === 3 }),
+            selections: [Table.SELECTION_ALL],
+          },
+        }),
+      );
+
+      fireEvent.mouseEnter(container.querySelector('.ant-dropdown-trigger')!);
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      fireEvent.click(container.querySelector('li.ant-dropdown-menu-item')!);
+      expect(onChange).toHaveBeenCalledWith([0, 1, 2], expect.anything(), { type: 'all' });
+    });
+
     it('SELECTION_INVERT', () => {
       jest.useFakeTimers();
       const onChange = jest.fn();

--- a/components/table/__tests__/Table.rowSelection.test.tsx
+++ b/components/table/__tests__/Table.rowSelection.test.tsx
@@ -652,6 +652,13 @@ describe('Table.rowSelection', () => {
 
       fireEvent.click(container.querySelector('li.ant-dropdown-menu-item')!);
       expect(onChange).toHaveBeenCalledWith([0, 1, 2], expect.anything(), { type: 'all' });
+
+      fireEvent.click(container.querySelector('.ant-pagination-item-2')!);
+      expect(
+        container.querySelector<HTMLInputElement>(
+          'tbody tr[data-row-key="3"] input[type="checkbox"]',
+        )?.checked,
+      ).toBe(false);
     });
 
     it('SELECTION_INVERT', () => {

--- a/components/table/hooks/useSelection.tsx
+++ b/components/table/hooks/useSelection.tsx
@@ -304,8 +304,7 @@ const useSelection = <RecordType extends AnyObject = AnyObject>(
             setSelectedKeys(
               data.reduce<Key[]>((keys, record, index) => {
                 const key = getRowKey(record, index);
-                const checkProps = checkboxPropsMap.get(key);
-                if (!checkProps?.disabled || derivedSelectedKeySet.has(key)) {
+                if (!isCheckboxDisabled(record) || derivedSelectedKeySet.has(key)) {
                   keys.push(key);
                 }
                 return keys;
@@ -376,6 +375,7 @@ const useSelection = <RecordType extends AnyObject = AnyObject>(
     tableLocale.selectInvert,
     tableLocale.selectNone,
     checkboxPropsMap,
+    isCheckboxDisabled,
     derivedSelectedKeySet,
     data,
     pageData,


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [ ] 🆕 新特性提交
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #58842

### 💡 需求背景和解决方案

Table 使用分页和 `Table.SELECTION_ALL` 时，选择逻辑会遍历完整数据源，但此前只根据当前页缓存的 `getCheckboxProps` 判断行是否禁用，导致其他页的禁用行仍被加入 `selectedRowKeys`。

本次改为通过记录动态判断禁用状态，确保跨页全选跳过所有禁用行，同时保留已经选中的禁用项。新增了禁用行位于其他分页时的回归用例。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Table selecting disabled rows on other pages when using `Table.SELECTION_ALL`. |
| 🇨🇳 中文 | 修复 Table 使用 `Table.SELECTION_ALL` 跨页全选时会选中其他页禁用行的问题。 |