### PR TITLE
fix(Transfer): correct deselect all after filtering

### DIFF
--- a/components/transfer/Section.tsx
+++ b/components/transfer/Section.tsx
@@ -374,7 +374,7 @@ const TransferSection = <RecordType extends KeyWiseTransferItem>(
         label: checkStatus === 'all' ? deselectAll : selectAll,
         onClick() {
           const keys = getEnabledItemKeys(filteredItems);
-          onItemSelectAll?.(keys, keys.length !== checkedKeys.length);
+          onItemSelectAll?.(keys, checkStatus !== 'all');
         },
       },
       pagination

--- a/components/transfer/__tests__/dropdown.test.tsx
+++ b/components/transfer/__tests__/dropdown.test.tsx
@@ -46,6 +46,38 @@ describe('Transfer.Dropdown', () => {
     jest.useRealTimers();
   });
 
+  it('deselect all filtered items', () => {
+    jest.useFakeTimers();
+
+    const onSelectChange = jest.fn();
+    const { container } = render(
+      <Transfer
+        dataSource={[
+          { key: 'a', title: 'Apple' },
+          { key: 'b', title: 'Banana' },
+        ]}
+        selectedKeys={['a', 'b']}
+        targetKeys={[]}
+        showSearch
+        render={(item) => item.title}
+        onSelectChange={onSelectChange}
+      />,
+    );
+
+    fireEvent.change(container.querySelector('.ant-transfer-list-search input')!, {
+      target: { value: 'Apple' },
+    });
+    fireEvent.mouseEnter(container.querySelector('.ant-dropdown-trigger')!);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    clickItem(container, 0);
+    expect(onSelectChange).toHaveBeenCalledWith(['b'], []);
+
+    jest.useRealTimers();
+  });
+
   it('select current page', () => {
     jest.useFakeTimers();
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

fix #58840

### 💡 需求背景和解决方案

Transfer 在搜索过滤后，通过选择下拉菜单执行 “Deselect all data” 时，会错误比较过滤项数量与全部已选项数量，导致隐藏项仍被选中时取消操作失效。

本次修改统一使用过滤结果的 `checkStatus` 判断选择状态，并增加回归测试，确保只取消当前过滤项，同时保留隐藏项的选择状态。不涉及公开 API 变更。

已通过 React 18/19 定向测试、React 19 全量 Jest 和 Vitest。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Transfer failing to deselect filtered items from the selection dropdown. |
| 🇨🇳 中文 | 🐞 修复 Transfer 通过选择下拉菜单无法取消搜索过滤项的问题。 |