### PR TITLE
docs: fix Chinese demo locale redirect

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -198,7 +198,7 @@ export default defineConfig({
           return /\\/?index(-cn)?/.test(pathname) ? '/' : pathname.replace('-cn', '');
         } else if (pathname === '/') {
           return '/index-cn';
-        } else if (pathname.indexOf('/') === pathname.length - 1) {
+        } else if (pathname.endsWith('/')) {
           return pathname.replace(/\\/$/, '-cn/');
         }
         return pathname + '-cn';


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

N/A

### 💡 Background and Solution

Opening a Chinese component demo in a new tab on the static site could redirect from a trailing-slash URL such as `/~demos/button-demo-basic/` to the invalid `/~demos/button-demo-basic/-cn` path, resulting in a 404 page.

The locale redirect used `pathname.indexOf('/') === pathname.length - 1` to detect a trailing slash. Since `indexOf` returns the first slash, nested demo paths never matched this condition. Use `pathname.endsWith('/')` so the `-cn` suffix is inserted before the trailing slash and the URL correctly becomes `/~demos/button-demo-basic-cn/`.

Validated with:

- Biome and ESLint
- Targeted Chinese and English locale redirect checks
- Full Utoopack production build
- Built HTML redirect script verification

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the Chinese demo link redirect when opening a demo in a new tab. |
| 🇨🇳 Chinese | 修复在新窗口打开中文演示时的链接重定向问题。 |