### PR TITLE
fix(Tabs): center bare `<svg>` icons at any size

### DIFF
--- a/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4209,6 +4209,38 @@ exports[`renders components/tabs/demo/icon.tsx extend context correctly 1`] = `
           </div>
         </div>
         <div
+          class="ant-tabs-tab"
+          data-node-key="3"
+        >
+          <div
+            aria-controls="rc-tabs-test-panel-3"
+            aria-selected="false"
+            class="ant-tabs-tab-btn"
+            id="rc-tabs-test-tab-3"
+            role="tab"
+            tabindex="-1"
+          >
+            <span
+              class="ant-tabs-tab-icon"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+              >
+                <path
+                  d="M12 20.7l-1.4-1.3C5.4 14.8 2 11.7 2 8a5 5 0 0 1 10-1.7A5 5 0 0 1 22 8c0 3.7-3.4 6.8-8.6 11.4L12 20.7z"
+                />
+              </svg>
+            </span>
+            <span>
+              Tab 3
+            </span>
+          </div>
+        </div>
+        <div
           class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
         />
       </div>

--- a/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
@@ -3553,6 +3553,36 @@ exports[`renders components/tabs/demo/icon.tsx correctly 1`] = `
           </div>
         </div>
         <div
+          class="ant-tabs-tab"
+          data-node-key="3"
+        >
+          <div
+            aria-selected="false"
+            class="ant-tabs-tab-btn"
+            role="tab"
+            tabindex="-1"
+          >
+            <span
+              class="ant-tabs-tab-icon"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+              >
+                <path
+                  d="M12 20.7l-1.4-1.3C5.4 14.8 2 11.7 2 8a5 5 0 0 1 10-1.7A5 5 0 0 1 22 8c0 3.7-3.4 6.8-8.6 11.4L12 20.7z"
+                />
+              </svg>
+            </span>
+            <span>
+              Tab 3
+            </span>
+          </div>
+        </div>
+        <div
           class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
         />
       </div>

--- a/components/tabs/demo/icon.md
+++ b/components/tabs/demo/icon.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-有图标的标签。
+有图标的标签。`icon` 也支持第三方图标库的裸 `<svg>` 元素，会自动与文字居中对齐。
 
 ## en-US
 
-The Tab with Icon.
+The Tab with Icon. `icon` also accepts a bare `<svg>` element from a third-party icon library, which stays vertically centred with the label.

--- a/components/tabs/demo/icon.tsx
+++ b/components/tabs/demo/icon.tsx
@@ -2,18 +2,22 @@ import React from 'react';
 import { AndroidOutlined, AppleOutlined } from '@ant-design/icons';
 import { Tabs } from 'antd';
 
+// Icons from third-party libraries (e.g. lucide, react-icons) render as a bare `<svg>`
+// rather than an `.anticon` wrapper. It stays vertically centred with the label.
+const HeartIcon: React.FC = () => (
+  <svg viewBox="0 0 24 24" width="1em" height="1em" fill="currentColor" aria-hidden="true">
+    <path d="M12 20.7l-1.4-1.3C5.4 14.8 2 11.7 2 8a5 5 0 0 1 10-1.7A5 5 0 0 1 22 8c0 3.7-3.4 6.8-8.6 11.4L12 20.7z" />
+  </svg>
+);
+
 const App: React.FC = () => (
   <Tabs
     defaultActiveKey="2"
-    items={[AppleOutlined, AndroidOutlined].map((Icon, i) => {
-      const id = String(i + 1);
-      return {
-        key: id,
-        label: `Tab ${id}`,
-        children: `Tab ${id}`,
-        icon: <Icon />,
-      };
-    })}
+    items={[
+      { key: '1', label: 'Tab 1', children: 'Tab 1', icon: <AppleOutlined /> },
+      { key: '2', label: 'Tab 2', children: 'Tab 2', icon: <AndroidOutlined /> },
+      { key: '3', label: 'Tab 3', children: 'Tab 3', icon: <HeartIcon /> },
+    ]}
   />
 );
 

--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -768,6 +768,18 @@ const genTabStyle: GenerateStyle<TabsToken, CSSObject> = (token) => {
         [`${tabCls}-icon:not(:last-child)`]: {
           marginInlineEnd: token.marginSM,
         },
+
+        // Icons from third-party libraries render as a bare `<svg>` inside the icon wrapper,
+        // which the `.anticon` reset never reaches. An `<svg>` has no baseline of its own, so it
+        // is aligned by its bottom margin edge (CSS 2.1 §10.8.1) and rides above the label.
+        // `vertical-align: middle` centres its margin box on the x-height line; `margin-block-end`
+        // then lifts it by half its own value onto the cap-height centre (capHeight − xHeight ≈
+        // 0.2em across typical fonts), keeping it centred at any icon size.
+        // Only matches a bare `<svg>`: an `.anticon` keeps its `<svg>` one level deeper.
+        [`${tabCls}-icon > svg`]: {
+          verticalAlign: 'middle',
+          marginBlockEnd: '0.2em',
+        },
       },
 
       '&-remove': {


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] 📽️ Demo improvement
- [x] 💄 Component style improvement

### 🔗 Related Issues

Same class of bug as the just-merged Tag fix #58723, applied to `Tabs`.

### 💡 Background and Solution

**The problem.** A tab `icon` from a third-party library (lucide, react-icons, …) renders as a bare `<svg>` inside `.ant-tabs-tab-icon`, which the `.anticon` reset never reaches. An `<svg>` has no baseline of its own, so it is aligned by its bottom margin edge (CSS 2.1 §10.8.1) and rides above the label.

The nudge that keeps an `.anticon` centred (`vertical-align: -0.125em`) can't fix this: it is a **constant** that resolves against the tab font, while an `.anticon`'s `<svg>` is always `1em`. A third-party `<svg>` may be sized in `px`, so a constant correction under-corrects more and more as the icon grows — the error is **unbounded**:

| icon size | master | after |
| --- | --- | --- |
| 1em (14px) | −2.00px | **−0.11px** |
| 16px | −3.00px | **−0.11px** |
| 24px | −7.00px | **−0.11px** |

(negative = icon centre rides **above** the label's cap-height centre; measured in headless Chromium against the real compiled style.)

**The fix.**

```ts
[`${tabCls}-icon > svg`]: {
  verticalAlign: 'middle',
  marginBlockEnd: '0.2em',
},
```

`vertical-align: middle` centres the icon's margin box on the x-height line (a ratio → size-independent); `margin-block-end` then lifts it by half its own value onto the cap-height centre (`capHeight − xHeight ≈ 0.2em` across typical fonts). Residual is **~0.1px flat** from `1em` to `24px`.

**Scope is exact.** `.ant-tabs-tab-icon > svg` only matches a **bare** `<svg>`: an `.anticon` keeps its `<svg>` one level deeper (`.ant-tabs-tab-icon > .anticon > svg`), so `@ant-design/icons` and the editable-card remove icon are byte-for-byte unchanged (the `.anticon` reference measured identically before and after).

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/mohamedkhaled4053/ant-design/pr-assets-tabs-svg/tab-before.png) | ![after](https://raw.githubusercontent.com/mohamedkhaled4053/ant-design/pr-assets-tabs-svg/tab-after.png) |

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Tabs bare `<svg>` icons from third-party libraries riding above the label; they are now vertically centred at any icon size. |
| 🇨🇳 Chinese | 🐞 修复 Tabs 使用第三方图标库的裸 `<svg>` 图标时高于文字的问题，现在任意尺寸下都与文字居中对齐。 |
