### PR TITLE
fix(Popover): preserve backdrop-filter support

### DIFF
--- a/components/popover/__tests__/index.test.tsx
+++ b/components/popover/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 import { warning } from '@rc-component/util';
 
 import Popover from '..';
@@ -6,7 +7,7 @@ import { TriggerMockContext } from '../../../tests/shared/demoTestContext';
 import mountTest from '../../../tests/shared/mountTest';
 import { fireEvent, render } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
-import type { TooltipRef } from '../../tooltip';
+import Tooltip, { type TooltipRef } from '../../tooltip';
 
 const { resetWarned } = warning;
 
@@ -25,6 +26,27 @@ describe('Popover', () => {
     expect(container.querySelector('.bamboo')).toBeFalsy();
     fireEvent.click(container.querySelector('span')!);
     expect(container.querySelector('.bamboo')).toBeTruthy();
+  });
+
+  it('should not use a filtered ancestor for popup shadows', () => {
+    const cache = createCache();
+
+    render(
+      <StyleProvider cache={cache}>
+        <Popover open content="popover">
+          <span>trigger</span>
+        </Popover>
+        <Tooltip open title="tooltip">
+          <span>trigger</span>
+        </Tooltip>
+      </StyleProvider>,
+    );
+
+    const styleText = extractStyle(cache, { plain: true });
+
+    expect(styleText).not.toContain('filter:drop-shadow');
+    expect(styleText).toMatch(/\.ant-popover-container[^}]*box-shadow:/);
+    expect(styleText).toMatch(/\.ant-tooltip-container[^}]*box-shadow:/);
   });
 
   it('should support defaultOpen', () => {

--- a/components/popover/style/index.ts
+++ b/components/popover/style/index.ts
@@ -76,7 +76,7 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
     titleMinWidth,
     fontWeightStrong,
     innerPadding,
-    dropShadowPopover,
+    boxShadowSecondary,
     colorTextHeading,
     borderRadiusLG,
     zIndexPopup,
@@ -108,7 +108,6 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
         textAlign: 'start',
         cursor: 'auto',
         userSelect: 'text',
-        filter: dropShadowPopover,
 
         // When use `autoArrow`, origin will follow the arrow position
         [varName('valid-offset-x')]: varRef('arrow-offset-x', 'var(--arrow-x)'),
@@ -137,6 +136,7 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
           backgroundColor: popoverBg,
           backgroundClip: 'padding-box',
           borderRadius: borderRadiusLG,
+          boxShadow: boxShadowSecondary,
           padding: innerPadding,
         },
 
@@ -157,7 +157,7 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
     },
 
     // Arrow Style
-    getArrowStyle<PopoverToken>(token, varRef('arrow-background-color'), { arrowShadow: false }),
+    getArrowStyle<PopoverToken>(token, varRef('arrow-background-color')),
 
     // Pure Render
     {

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -48,7 +48,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
     tooltipBorderRadius,
     zIndexPopup,
     controlHeight,
-    dropShadowPopover,
+    boxShadowSecondary,
     paddingSM,
     paddingXS,
     arrowOffsetHorizontal,
@@ -77,6 +77,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
     wordWrap: 'break-word',
     backgroundColor: tooltipBg,
     borderRadius: tooltipBorderRadius,
+    boxShadow: boxShadowSecondary,
     boxSizing: 'border-box',
   };
 
@@ -99,7 +100,6 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
         width: 'max-content',
         maxWidth: tooltipMaxWidth,
         visibility: 'visible',
-        filter: dropShadowPopover,
 
         ...sharedTransformOrigin,
 
@@ -116,6 +116,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
           [`${componentCls}-container`]: {
             border: 'none',
             background: 'transparent',
+            boxShadow: 'none',
           },
         },
 
@@ -167,7 +168,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
     },
 
     // Arrow Style
-    getArrowStyle<TooltipToken>(token, varRef('arrow-background-color'), { arrowShadow: false }),
+    getArrowStyle<TooltipToken>(token, varRef('arrow-background-color')),
 
     // Pure Render
     {
@@ -185,7 +186,6 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
         ...sharedTransformOrigin,
         position: 'absolute',
         zIndex: calc(zIndexPopup).sub(1).equal(),
-        filter: dropShadowPopover,
 
         '&-hidden': {
           display: 'none',


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Popover and Tooltip frosted-glass styles not applying when using CSS `backdrop-filter`. |
| 🇨🇳 Chinese | 🐞 修复 Popover 和 Tooltip 使用 CSS `backdrop-filter` 时毛玻璃效果失效的问题。 |