### PR TITLE
docs(Tree): add version to scrollTo demo

### DIFF
--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -27,7 +27,7 @@ Almost anything can be represented in a tree structure. Examples include directo
 <code src="./demo/directory-debug.tsx" debug>Directory Debug</code>
 <code src="./demo/switcher-icon.tsx">Customize collapse/expand icon</code>
 <code src="./demo/virtual-scroll.tsx">Virtual scroll</code>
-<code src="./demo/scroll-to.tsx">Scroll to nested node</code>
+<code src="./demo/scroll-to.tsx" version="6.6.0">Scroll to nested node</code>
 <code src="./demo/drag-debug.tsx" debug>Drag Debug</code>
 <code src="./demo/big-data.tsx" debug>Big data</code>
 <code src="./demo/block-node.tsx">Block Node</code>

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -28,7 +28,7 @@ demo:
 <code src="./demo/directory-debug.tsx" debug>目录 Debug</code>
 <code src="./demo/switcher-icon.tsx">自定义展开/折叠图标</code>
 <code src="./demo/virtual-scroll.tsx">虚拟滚动</code>
-<code src="./demo/scroll-to.tsx">滚动到嵌套节点</code>
+<code src="./demo/scroll-to.tsx" version="6.6.0">滚动到嵌套节点</code>
 <code src="./demo/drag-debug.tsx" debug>Drag Debug</code>
 <code src="./demo/big-data.tsx" debug>大数据</code>
 <code src="./demo/block-node.tsx">占据整行</code>


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement

### 🔗 Related Issues

- Follow-up to #58841 and [review comment](https://github.com/ant-design/ant-design/pull/58841#discussion_r3688922060)

### 💡 Background and Solution

Add the missing `version="6.6.0"` metadata to the Tree scroll-to demo in both the English and Chinese documentation.

### 📝 Change Log

N/A
