### PR TITLE
fix(Segmented): center bare `<svg>` icons at any size

### DIFF
--- a/components/segmented/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/segmented/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2337,6 +2337,46 @@ exports[`renders components/segmented/demo/with-icon.tsx extend context correctl
         </span>
       </div>
     </label>
+    <label
+      class="ant-segmented-item"
+    >
+      <input
+        class="ant-segmented-item-input"
+        name="test-id"
+        type="radio"
+      />
+      <div
+        class="ant-segmented-item-label"
+      >
+        <span
+          class="ant-segmented-item-icon"
+        >
+          <svg
+            aria-hidden="true"
+            fill="none"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="1em"
+          >
+            <rect
+              height="18"
+              rx="2"
+              width="18"
+              x="3"
+              y="4"
+            />
+            <path
+              d="M16 2v4M8 2v4M3 10h18"
+            />
+          </svg>
+        </span>
+        <span>
+          Calendar
+        </span>
+      </div>
+    </label>
   </div>
 </div>
 `;

--- a/components/segmented/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/segmented/__tests__/__snapshots__/demo.test.ts.snap
@@ -2191,6 +2191,46 @@ exports[`renders components/segmented/demo/with-icon.tsx correctly 1`] = `
         </span>
       </div>
     </label>
+    <label
+      class="ant-segmented-item"
+    >
+      <input
+        class="ant-segmented-item-input"
+        name="test-id"
+        type="radio"
+      />
+      <div
+        class="ant-segmented-item-label"
+      >
+        <span
+          class="ant-segmented-item-icon"
+        >
+          <svg
+            aria-hidden="true"
+            fill="none"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="1em"
+          >
+            <rect
+              height="18"
+              rx="2"
+              width="18"
+              x="3"
+              y="4"
+            />
+            <path
+              d="M16 2v4M8 2v4M3 10h18"
+            />
+          </svg>
+        </span>
+        <span>
+          Calendar
+        </span>
+      </div>
+    </label>
   </div>
 </div>
 `;

--- a/components/segmented/demo/with-icon.md
+++ b/components/segmented/demo/with-icon.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-给 Segmented Item 设置 Icon。
+给 Segmented Item 设置 Icon。`icon` 也支持第三方图标库的裸 `<svg>` 元素，会自动与文字居中对齐。
 
 ## en-US
 
-Set `icon` for Segmented Item.
+Set `icon` for Segmented Item. `icon` also accepts a bare `<svg>` element from a third-party icon library, which stays vertically centred with the label.

--- a/components/segmented/demo/with-icon.tsx
+++ b/components/segmented/demo/with-icon.tsx
@@ -2,11 +2,29 @@ import React from 'react';
 import { AppstoreOutlined, BarsOutlined } from '@ant-design/icons';
 import { Segmented } from 'antd';
 
+// Icons from third-party libraries (e.g. lucide, react-icons) render as a bare `<svg>`
+// rather than an `.anticon` wrapper. It stays vertically centred with the label.
+const CalendarIcon: React.FC = () => (
+  <svg
+    viewBox="0 0 24 24"
+    width="1em"
+    height="1em"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    aria-hidden="true"
+  >
+    <rect x="3" y="4" width="18" height="18" rx="2" />
+    <path d="M16 2v4M8 2v4M3 10h18" />
+  </svg>
+);
+
 const Demo: React.FC = () => (
   <Segmented
     options={[
       { label: 'List', value: 'List', icon: <BarsOutlined /> },
       { label: 'Kanban', value: 'Kanban', icon: <AppstoreOutlined /> },
+      { label: 'Calendar', value: 'Calendar', icon: <CalendarIcon /> },
     ]}
   />
 );

--- a/components/segmented/style/index.ts
+++ b/components/segmented/style/index.ts
@@ -203,6 +203,18 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken, CSSObject> = (token) => {
           marginInlineStart: token.calc(token.marginSM).div(2).equal(),
         },
 
+        // Icons from third-party libraries render as a bare `<svg>` inside the icon wrapper,
+        // which the `.anticon` reset never reaches. An `<svg>` has no baseline of its own, so it
+        // is aligned by its bottom margin edge (CSS 2.1 §10.8.1) and rides above the label.
+        // `vertical-align: middle` centres its margin box on the x-height line; `margin-block-end`
+        // then lifts it by half its own value onto the cap-height centre (capHeight − xHeight ≈
+        // 0.2em across typical fonts), keeping it centred at any icon size.
+        // Only matches a bare `<svg>`: an `.anticon` keeps its `<svg>` one level deeper.
+        '&-icon > svg': {
+          verticalAlign: 'middle',
+          marginBlockEnd: '0.2em',
+        },
+
         '&-input': {
           position: 'absolute',
           insetBlockStart: 0,


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] 📽️ Demo improvement
- [x] 💄 Component style improvement

### 🔗 Related Issues

Same class of bug as the merged Tag #58723 and Tabs #58847, applied to `Segmented`.

### 💡 Background and Solution

**The problem.** A Segmented item `icon` from a third-party library (lucide, react-icons, …) renders as a bare `<svg>` inside `.ant-segmented-item-icon`, which the `.anticon` reset never reaches. The item label is a block with a tall `line-height` (not flex), so its inline content is baseline-aligned — and an `<svg>` has no baseline of its own, so it is aligned by its bottom margin edge (CSS 2.1 §10.8.1) and rides above the label.

`.anticon`'s `vertical-align: -0.125em` can't fix this: it is a **constant** that only works because an `.anticon`'s `<svg>` is always `1em`. A third-party `<svg>` may be sized in `px`, so a constant correction under-corrects more and more as the icon grows — the error is **unbounded**:

| icon size | master | after |
| --- | --- | --- |
| 1em (14px) | −2.00px | **−0.11px** |
| 16px | −3.00px | **−0.11px** |
| 24px | −7.00px | **−0.11px** |

(negative = icon centre rides **above** the label's cap-height centre; measured in headless Chromium against the real compiled style, in horizontal / vertical / block layouts alike.)

**The fix.**

```ts
// inside the `${componentCls}-item` block, next to the existing `&-icon + *` rule
'&-icon > svg': {
  verticalAlign: 'middle',
  marginBlockEnd: '0.2em',
},
```

`vertical-align: middle` centres the icon's margin box on the x-height line (a ratio → size-independent); `margin-block-end` then lifts it by half its own value onto the cap-height centre (`capHeight − xHeight ≈ 0.2em` across typical fonts). Residual is **~0.1px flat** from `1em` to `24px`.

**No layout regression.** For the common case (1em icons) the item height is **unchanged** (default / small / large all identical before and after). An over-sized icon that used to *inflate* the row (24px → 33px) now sits centred with the row at its natural height (28.7px), consistently across horizontal, vertical and block modes. The sliding `.ant-segmented-thumb` is a separate absolutely-positioned element and is untouched.

**Scope is exact.** `.ant-segmented-item-icon > svg` only matches a **bare** `<svg>`: an `.anticon` keeps its `<svg>` one level deeper (`.ant-segmented-item-icon > .anticon > svg`), so `@ant-design/icons` icons are byte-for-byte unchanged (the `.anticon` reference measured identically before and after).

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/mohamedkhaled4053/ant-design/pr-assets-segmented-svg/seg-before.png) | ![after](https://raw.githubusercontent.com/mohamedkhaled4053/ant-design/pr-assets-segmented-svg/seg-after.png) |

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Segmented bare `<svg>` icons from third-party libraries riding above the label; they are now vertically centred at any icon size. |
| 🇨🇳 Chinese | 🐞 修复 Segmented 使用第三方图标库的裸 `<svg>` 图标时高于文字的问题，现在任意尺寸下都与文字居中对齐。 |
