### PR TITLE
feat(Pagination): support variant and shape props

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -18202,7 +18202,7 @@ exports[`ConfigProvider components Modal prefixCls 1`] = `
 exports[`ConfigProvider components Pagination configProvider 1`] = `
 <div>
   <ul
-    class="config-pagination css-var-root"
+    class="config-pagination config-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -18330,7 +18330,7 @@ exports[`ConfigProvider components Pagination configProvider 1`] = `
     </li>
   </ul>
   <ul
-    class="config-pagination config-pagination-small config-pagination-mini css-var-root"
+    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -18463,7 +18463,7 @@ exports[`ConfigProvider components Pagination configProvider 1`] = `
 exports[`ConfigProvider components Pagination configProvider componentDisabled 1`] = `
 <div>
   <ul
-    class="config-pagination css-var-root"
+    class="config-pagination config-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -18592,7 +18592,7 @@ exports[`ConfigProvider components Pagination configProvider componentDisabled 1
     </li>
   </ul>
   <ul
-    class="config-pagination config-pagination-small config-pagination-mini css-var-root"
+    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -18726,7 +18726,7 @@ exports[`ConfigProvider components Pagination configProvider componentDisabled 1
 exports[`ConfigProvider components Pagination configProvider componentSize large 1`] = `
 <div>
   <ul
-    class="config-pagination config-pagination-large css-var-root"
+    class="config-pagination config-pagination-large config-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -18854,7 +18854,7 @@ exports[`ConfigProvider components Pagination configProvider componentSize large
     </li>
   </ul>
   <ul
-    class="config-pagination config-pagination-small config-pagination-mini css-var-root"
+    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -18987,7 +18987,7 @@ exports[`ConfigProvider components Pagination configProvider componentSize large
 exports[`ConfigProvider components Pagination configProvider componentSize medium 1`] = `
 <div>
   <ul
-    class="config-pagination config-pagination-medium css-var-root"
+    class="config-pagination config-pagination-medium config-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19115,7 +19115,7 @@ exports[`ConfigProvider components Pagination configProvider componentSize mediu
     </li>
   </ul>
   <ul
-    class="config-pagination config-pagination-small config-pagination-mini css-var-root"
+    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19248,7 +19248,7 @@ exports[`ConfigProvider components Pagination configProvider componentSize mediu
 exports[`ConfigProvider components Pagination configProvider componentSize small 1`] = `
 <div>
   <ul
-    class="config-pagination config-pagination-small config-pagination-mini css-var-root"
+    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19376,7 +19376,7 @@ exports[`ConfigProvider components Pagination configProvider componentSize small
     </li>
   </ul>
   <ul
-    class="config-pagination config-pagination-small config-pagination-mini css-var-root"
+    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19509,7 +19509,7 @@ exports[`ConfigProvider components Pagination configProvider componentSize small
 exports[`ConfigProvider components Pagination normal 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19637,7 +19637,7 @@ exports[`ConfigProvider components Pagination normal 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini css-var-root"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19770,7 +19770,7 @@ exports[`ConfigProvider components Pagination normal 1`] = `
 exports[`ConfigProvider components Pagination prefixCls 1`] = `
 <div>
   <ul
-    class="prefix-Pagination css-var-root"
+    class="prefix-Pagination prefix-Pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19898,7 +19898,7 @@ exports[`ConfigProvider components Pagination prefixCls 1`] = `
     </li>
   </ul>
   <ul
-    class="prefix-Pagination prefix-Pagination-small prefix-Pagination-mini css-var-root"
+    class="prefix-Pagination prefix-Pagination-small prefix-Pagination-mini prefix-Pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -18202,7 +18202,7 @@ exports[`ConfigProvider components Modal prefixCls 1`] = `
 exports[`ConfigProvider components Pagination configProvider 1`] = `
 <div>
   <ul
-    class="config-pagination config-pagination-variant-text css-var-root"
+    class="config-pagination config-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -18330,7 +18330,7 @@ exports[`ConfigProvider components Pagination configProvider 1`] = `
     </li>
   </ul>
   <ul
-    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-text css-var-root"
+    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -18463,7 +18463,7 @@ exports[`ConfigProvider components Pagination configProvider 1`] = `
 exports[`ConfigProvider components Pagination configProvider componentDisabled 1`] = `
 <div>
   <ul
-    class="config-pagination config-pagination-variant-text css-var-root"
+    class="config-pagination config-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -18592,7 +18592,7 @@ exports[`ConfigProvider components Pagination configProvider componentDisabled 1
     </li>
   </ul>
   <ul
-    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-text css-var-root"
+    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -18726,7 +18726,7 @@ exports[`ConfigProvider components Pagination configProvider componentDisabled 1
 exports[`ConfigProvider components Pagination configProvider componentSize large 1`] = `
 <div>
   <ul
-    class="config-pagination config-pagination-large config-pagination-variant-text css-var-root"
+    class="config-pagination config-pagination-large config-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -18854,7 +18854,7 @@ exports[`ConfigProvider components Pagination configProvider componentSize large
     </li>
   </ul>
   <ul
-    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-text css-var-root"
+    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -18987,7 +18987,7 @@ exports[`ConfigProvider components Pagination configProvider componentSize large
 exports[`ConfigProvider components Pagination configProvider componentSize medium 1`] = `
 <div>
   <ul
-    class="config-pagination config-pagination-medium config-pagination-variant-text css-var-root"
+    class="config-pagination config-pagination-medium config-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19115,7 +19115,7 @@ exports[`ConfigProvider components Pagination configProvider componentSize mediu
     </li>
   </ul>
   <ul
-    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-text css-var-root"
+    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19248,7 +19248,7 @@ exports[`ConfigProvider components Pagination configProvider componentSize mediu
 exports[`ConfigProvider components Pagination configProvider componentSize small 1`] = `
 <div>
   <ul
-    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-text css-var-root"
+    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19376,7 +19376,7 @@ exports[`ConfigProvider components Pagination configProvider componentSize small
     </li>
   </ul>
   <ul
-    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-text css-var-root"
+    class="config-pagination config-pagination-small config-pagination-mini config-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19509,7 +19509,7 @@ exports[`ConfigProvider components Pagination configProvider componentSize small
 exports[`ConfigProvider components Pagination normal 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19637,7 +19637,7 @@ exports[`ConfigProvider components Pagination normal 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19770,7 +19770,7 @@ exports[`ConfigProvider components Pagination normal 1`] = `
 exports[`ConfigProvider components Pagination prefixCls 1`] = `
 <div>
   <ul
-    class="prefix-Pagination prefix-Pagination-variant-text css-var-root"
+    class="prefix-Pagination prefix-Pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19898,7 +19898,7 @@ exports[`ConfigProvider components Pagination prefixCls 1`] = `
     </li>
   </ul>
   <ul
-    class="prefix-Pagination prefix-Pagination-small prefix-Pagination-mini prefix-Pagination-variant-text css-var-root"
+    class="prefix-Pagination prefix-Pagination-small prefix-Pagination-mini prefix-Pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"

--- a/components/config-provider/__tests__/pagination.test.tsx
+++ b/components/config-provider/__tests__/pagination.test.tsx
@@ -26,4 +26,14 @@ describe('ConfigProvider.Pagination', () => {
     // total={80} < 100, so size changer should not be visible
     expect(container.querySelector('.ant-pagination-options-size-changer')).toBeFalsy();
   });
+
+  it('variant and shape', () => {
+    const { container } = render(
+      <ConfigProvider pagination={{ variant: 'filled', shape: 'round' }}>
+        <Pagination total={50} />
+      </ConfigProvider>,
+    );
+    expect(container.querySelector('.ant-pagination')).toHaveClass('ant-pagination-variant-filled');
+    expect(container.querySelector('.ant-pagination')).toHaveClass('ant-pagination-round');
+  });
 });

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -328,7 +328,12 @@ export type FloatButtonGroupConfig = ComponentStyleConfig &
 export type PaginationConfig = ComponentStyleConfig &
   Pick<
     PaginationProps,
-    'showSizeChanger' | 'totalBoundaryShowSizeChanger' | 'classNames' | 'styles'
+    | 'showSizeChanger'
+    | 'totalBoundaryShowSizeChanger'
+    | 'classNames'
+    | 'styles'
+    | 'variant'
+    | 'shape'
   >;
 
 export type ProgressConfig = ComponentStyleConfig & Pick<ProgressProps, 'classNames' | 'styles'>;

--- a/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3353,7 +3353,7 @@ Array [
       class="ant-list-pagination"
     >
       <ul
-        class="ant-pagination ant-pagination-center css-var-test-id"
+        class="ant-pagination ant-pagination-center ant-pagination-variant-text css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -4533,7 +4533,7 @@ exports[`renders components/list/demo/vertical.tsx extend context correctly 1`] 
     class="ant-list-pagination"
   >
     <ul
-      class="ant-pagination ant-pagination-end css-var-test-id"
+      class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-test-id"
     >
       <li
         aria-disabled="true"

--- a/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3353,7 +3353,7 @@ Array [
       class="ant-list-pagination"
     >
       <ul
-        class="ant-pagination ant-pagination-center ant-pagination-variant-text css-var-test-id"
+        class="ant-pagination ant-pagination-center ant-pagination-variant-outlined css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -4533,7 +4533,7 @@ exports[`renders components/list/demo/vertical.tsx extend context correctly 1`] 
     class="ant-list-pagination"
   >
     <ul
-      class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-test-id"
+      class="ant-pagination ant-pagination-end ant-pagination-variant-outlined css-var-test-id"
     >
       <li
         aria-disabled="true"

--- a/components/list/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.ts.snap
@@ -3279,7 +3279,7 @@ Array [
       class="ant-list-pagination"
     >
       <ul
-        class="ant-pagination ant-pagination-center ant-pagination-variant-text css-var-test-id"
+        class="ant-pagination ant-pagination-center ant-pagination-variant-outlined css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -4428,7 +4428,7 @@ exports[`renders components/list/demo/vertical.tsx correctly 1`] = `
     class="ant-list-pagination"
   >
     <ul
-      class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-test-id"
+      class="ant-pagination ant-pagination-end ant-pagination-variant-outlined css-var-test-id"
     >
       <li
         aria-disabled="true"

--- a/components/list/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.ts.snap
@@ -3279,7 +3279,7 @@ Array [
       class="ant-list-pagination"
     >
       <ul
-        class="ant-pagination ant-pagination-center css-var-test-id"
+        class="ant-pagination ant-pagination-center ant-pagination-variant-text css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -4428,7 +4428,7 @@ exports[`renders components/list/demo/vertical.tsx correctly 1`] = `
     class="ant-list-pagination"
   >
     <ul
-      class="ant-pagination ant-pagination-end css-var-test-id"
+      class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-test-id"
     >
       <li
         aria-disabled="true"

--- a/components/list/__tests__/__snapshots__/pagination.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/pagination.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`List.pagination pagination button should be displayed normally, when the paginator total is not defined 1`] = `
 <ul
-  class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-root"
+  class="ant-pagination ant-pagination-end ant-pagination-variant-outlined css-var-root"
 >
   <li
     aria-disabled="true"
@@ -125,7 +125,7 @@ exports[`List.pagination renders pagination correctly 1`] = `
     class="ant-list-pagination"
   >
     <ul
-      class="ant-pagination ant-pagination-end ant-pagination-variant-text my-page css-var-root"
+      class="ant-pagination ant-pagination-end ant-pagination-variant-outlined my-page css-var-root"
     >
       <li
         aria-disabled="true"
@@ -220,7 +220,7 @@ exports[`List.pagination renders pagination correctly 1`] = `
 
 exports[`List.pagination should default work 1`] = `
 <ul
-  class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-root"
+  class="ant-pagination ant-pagination-end ant-pagination-variant-outlined css-var-root"
 >
   <li
     aria-disabled="false"

--- a/components/list/__tests__/__snapshots__/pagination.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/pagination.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`List.pagination pagination button should be displayed normally, when the paginator total is not defined 1`] = `
 <ul
-  class="ant-pagination ant-pagination-end css-var-root"
+  class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-root"
 >
   <li
     aria-disabled="true"
@@ -125,7 +125,7 @@ exports[`List.pagination renders pagination correctly 1`] = `
     class="ant-list-pagination"
   >
     <ul
-      class="ant-pagination ant-pagination-end my-page css-var-root"
+      class="ant-pagination ant-pagination-end ant-pagination-variant-text my-page css-var-root"
     >
       <li
         aria-disabled="true"
@@ -220,7 +220,7 @@ exports[`List.pagination renders pagination correctly 1`] = `
 
 exports[`List.pagination should default work 1`] = `
 <ul
-  class="ant-pagination ant-pagination-end css-var-root"
+  class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-root"
 >
   <li
     aria-disabled="false"

--- a/components/list/__tests__/__snapshots__/vitest/pagination.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/vitest/pagination.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`List.pagination > pagination button should be displayed normally, when the paginator total is not defined 1`] = `
 <ul
-  class="ant-pagination ant-pagination-variant-text ant-pagination-end css-var-root"
+  class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-root"
 >
   <li
     aria-disabled="true"
@@ -125,7 +125,7 @@ exports[`List.pagination > renders pagination correctly 1`] = `
     class="ant-list-pagination"
   >
     <ul
-      class="ant-pagination ant-pagination-variant-text ant-pagination-end my-page css-var-root"
+      class="ant-pagination ant-pagination-end ant-pagination-variant-text my-page css-var-root"
     >
       <li
         aria-disabled="true"
@@ -220,7 +220,7 @@ exports[`List.pagination > renders pagination correctly 1`] = `
 
 exports[`List.pagination > should default work 1`] = `
 <ul
-  class="ant-pagination ant-pagination-variant-text ant-pagination-end css-var-root"
+  class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-root"
 >
   <li
     aria-disabled="false"

--- a/components/list/__tests__/__snapshots__/vitest/pagination.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/vitest/pagination.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`List.pagination > pagination button should be displayed normally, when the paginator total is not defined 1`] = `
 <ul
-  class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-root"
+  class="ant-pagination ant-pagination-end ant-pagination-variant-outlined css-var-root"
 >
   <li
     aria-disabled="true"
@@ -125,7 +125,7 @@ exports[`List.pagination > renders pagination correctly 1`] = `
     class="ant-list-pagination"
   >
     <ul
-      class="ant-pagination ant-pagination-end ant-pagination-variant-text my-page css-var-root"
+      class="ant-pagination ant-pagination-end ant-pagination-variant-outlined my-page css-var-root"
     >
       <li
         aria-disabled="true"
@@ -220,7 +220,7 @@ exports[`List.pagination > renders pagination correctly 1`] = `
 
 exports[`List.pagination > should default work 1`] = `
 <ul
-  class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-root"
+  class="ant-pagination ant-pagination-end ant-pagination-variant-outlined css-var-root"
 >
   <li
     aria-disabled="false"

--- a/components/list/__tests__/__snapshots__/vitest/pagination.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/vitest/pagination.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`List.pagination > pagination button should be displayed normally, when the paginator total is not defined 1`] = `
 <ul
-  class="ant-pagination ant-pagination-end css-var-root"
+  class="ant-pagination ant-pagination-variant-text ant-pagination-end css-var-root"
 >
   <li
     aria-disabled="true"
@@ -125,7 +125,7 @@ exports[`List.pagination > renders pagination correctly 1`] = `
     class="ant-list-pagination"
   >
     <ul
-      class="ant-pagination ant-pagination-end my-page css-var-root"
+      class="ant-pagination ant-pagination-variant-text ant-pagination-end my-page css-var-root"
     >
       <li
         aria-disabled="true"
@@ -220,7 +220,7 @@ exports[`List.pagination > renders pagination correctly 1`] = `
 
 exports[`List.pagination > should default work 1`] = `
 <ul
-  class="ant-pagination ant-pagination-end css-var-root"
+  class="ant-pagination ant-pagination-variant-text ant-pagination-end css-var-root"
 >
   <li
     aria-disabled="false"

--- a/components/locale/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/index.test.tsx.snap
@@ -1938,7 +1938,7 @@ exports[`Locale Provider set dayjs locale when locale changes 3`] = `
 exports[`Locale Provider should display the text as ar 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -7173,7 +7173,7 @@ exports[`Locale Provider should display the text as ar 1`] = `
 exports[`Locale Provider should display the text as az 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -12408,7 +12408,7 @@ exports[`Locale Provider should display the text as az 1`] = `
 exports[`Locale Provider should display the text as bg 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -17643,7 +17643,7 @@ exports[`Locale Provider should display the text as bg 1`] = `
 exports[`Locale Provider should display the text as bn-bd 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -22878,7 +22878,7 @@ exports[`Locale Provider should display the text as bn-bd 1`] = `
 exports[`Locale Provider should display the text as by 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -28113,7 +28113,7 @@ exports[`Locale Provider should display the text as by 1`] = `
 exports[`Locale Provider should display the text as ca 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -33348,7 +33348,7 @@ exports[`Locale Provider should display the text as ca 1`] = `
 exports[`Locale Provider should display the text as cs 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -38583,7 +38583,7 @@ exports[`Locale Provider should display the text as cs 1`] = `
 exports[`Locale Provider should display the text as da 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -43818,7 +43818,7 @@ exports[`Locale Provider should display the text as da 1`] = `
 exports[`Locale Provider should display the text as de 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -49053,7 +49053,7 @@ exports[`Locale Provider should display the text as de 1`] = `
 exports[`Locale Provider should display the text as el 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -54288,7 +54288,7 @@ exports[`Locale Provider should display the text as el 1`] = `
 exports[`Locale Provider should display the text as en 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -59523,7 +59523,7 @@ exports[`Locale Provider should display the text as en 1`] = `
 exports[`Locale Provider should display the text as en-gb 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -64758,7 +64758,7 @@ exports[`Locale Provider should display the text as en-gb 1`] = `
 exports[`Locale Provider should display the text as es 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -69993,7 +69993,7 @@ exports[`Locale Provider should display the text as es 1`] = `
 exports[`Locale Provider should display the text as es-us 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -75228,7 +75228,7 @@ exports[`Locale Provider should display the text as es-us 1`] = `
 exports[`Locale Provider should display the text as et 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -80463,7 +80463,7 @@ exports[`Locale Provider should display the text as et 1`] = `
 exports[`Locale Provider should display the text as eu 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -85698,7 +85698,7 @@ exports[`Locale Provider should display the text as eu 1`] = `
 exports[`Locale Provider should display the text as fa 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -90933,7 +90933,7 @@ exports[`Locale Provider should display the text as fa 1`] = `
 exports[`Locale Provider should display the text as fi 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -96168,7 +96168,7 @@ exports[`Locale Provider should display the text as fi 1`] = `
 exports[`Locale Provider should display the text as fr 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -101403,7 +101403,7 @@ exports[`Locale Provider should display the text as fr 1`] = `
 exports[`Locale Provider should display the text as fr 2`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -106638,7 +106638,7 @@ exports[`Locale Provider should display the text as fr 2`] = `
 exports[`Locale Provider should display the text as fr 3`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -111873,7 +111873,7 @@ exports[`Locale Provider should display the text as fr 3`] = `
 exports[`Locale Provider should display the text as ga 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -117108,7 +117108,7 @@ exports[`Locale Provider should display the text as ga 1`] = `
 exports[`Locale Provider should display the text as gl 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -122343,7 +122343,7 @@ exports[`Locale Provider should display the text as gl 1`] = `
 exports[`Locale Provider should display the text as he 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -127578,7 +127578,7 @@ exports[`Locale Provider should display the text as he 1`] = `
 exports[`Locale Provider should display the text as hi 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -132813,7 +132813,7 @@ exports[`Locale Provider should display the text as hi 1`] = `
 exports[`Locale Provider should display the text as hr 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -138048,7 +138048,7 @@ exports[`Locale Provider should display the text as hr 1`] = `
 exports[`Locale Provider should display the text as hu 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -143283,7 +143283,7 @@ exports[`Locale Provider should display the text as hu 1`] = `
 exports[`Locale Provider should display the text as hy-am 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -148518,7 +148518,7 @@ exports[`Locale Provider should display the text as hy-am 1`] = `
 exports[`Locale Provider should display the text as id 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -153753,7 +153753,7 @@ exports[`Locale Provider should display the text as id 1`] = `
 exports[`Locale Provider should display the text as is 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -158988,7 +158988,7 @@ exports[`Locale Provider should display the text as is 1`] = `
 exports[`Locale Provider should display the text as it 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -164223,7 +164223,7 @@ exports[`Locale Provider should display the text as it 1`] = `
 exports[`Locale Provider should display the text as ja 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -169458,7 +169458,7 @@ exports[`Locale Provider should display the text as ja 1`] = `
 exports[`Locale Provider should display the text as ka 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -174693,7 +174693,7 @@ exports[`Locale Provider should display the text as ka 1`] = `
 exports[`Locale Provider should display the text as kk 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -179928,7 +179928,7 @@ exports[`Locale Provider should display the text as kk 1`] = `
 exports[`Locale Provider should display the text as km 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -185161,7 +185161,7 @@ exports[`Locale Provider should display the text as km 1`] = `
 exports[`Locale Provider should display the text as kn 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -190396,7 +190396,7 @@ exports[`Locale Provider should display the text as kn 1`] = `
 exports[`Locale Provider should display the text as ko 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -195631,7 +195631,7 @@ exports[`Locale Provider should display the text as ko 1`] = `
 exports[`Locale Provider should display the text as ku 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -200866,7 +200866,7 @@ exports[`Locale Provider should display the text as ku 1`] = `
 exports[`Locale Provider should display the text as ku-iq 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -206101,7 +206101,7 @@ exports[`Locale Provider should display the text as ku-iq 1`] = `
 exports[`Locale Provider should display the text as lt 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -211336,7 +211336,7 @@ exports[`Locale Provider should display the text as lt 1`] = `
 exports[`Locale Provider should display the text as lv 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -216571,7 +216571,7 @@ exports[`Locale Provider should display the text as lv 1`] = `
 exports[`Locale Provider should display the text as mk 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -221806,7 +221806,7 @@ exports[`Locale Provider should display the text as mk 1`] = `
 exports[`Locale Provider should display the text as ml 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -227041,7 +227041,7 @@ exports[`Locale Provider should display the text as ml 1`] = `
 exports[`Locale Provider should display the text as mn-mn 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -232276,7 +232276,7 @@ exports[`Locale Provider should display the text as mn-mn 1`] = `
 exports[`Locale Provider should display the text as mr 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -237511,7 +237511,7 @@ exports[`Locale Provider should display the text as mr 1`] = `
 exports[`Locale Provider should display the text as ms-my 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -242746,7 +242746,7 @@ exports[`Locale Provider should display the text as ms-my 1`] = `
 exports[`Locale Provider should display the text as my 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -247981,7 +247981,7 @@ exports[`Locale Provider should display the text as my 1`] = `
 exports[`Locale Provider should display the text as nb 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -253216,7 +253216,7 @@ exports[`Locale Provider should display the text as nb 1`] = `
 exports[`Locale Provider should display the text as ne-np 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -258451,7 +258451,7 @@ exports[`Locale Provider should display the text as ne-np 1`] = `
 exports[`Locale Provider should display the text as nl 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -263686,7 +263686,7 @@ exports[`Locale Provider should display the text as nl 1`] = `
 exports[`Locale Provider should display the text as nl-be 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -268921,7 +268921,7 @@ exports[`Locale Provider should display the text as nl-be 1`] = `
 exports[`Locale Provider should display the text as pl 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -274156,7 +274156,7 @@ exports[`Locale Provider should display the text as pl 1`] = `
 exports[`Locale Provider should display the text as pt 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -279391,7 +279391,7 @@ exports[`Locale Provider should display the text as pt 1`] = `
 exports[`Locale Provider should display the text as pt-br 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -284626,7 +284626,7 @@ exports[`Locale Provider should display the text as pt-br 1`] = `
 exports[`Locale Provider should display the text as ro 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -289861,7 +289861,7 @@ exports[`Locale Provider should display the text as ro 1`] = `
 exports[`Locale Provider should display the text as ru 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -295096,7 +295096,7 @@ exports[`Locale Provider should display the text as ru 1`] = `
 exports[`Locale Provider should display the text as si 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -300331,7 +300331,7 @@ exports[`Locale Provider should display the text as si 1`] = `
 exports[`Locale Provider should display the text as sk 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -305566,7 +305566,7 @@ exports[`Locale Provider should display the text as sk 1`] = `
 exports[`Locale Provider should display the text as sl 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -310801,7 +310801,7 @@ exports[`Locale Provider should display the text as sl 1`] = `
 exports[`Locale Provider should display the text as sq 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -316036,7 +316036,7 @@ exports[`Locale Provider should display the text as sq 1`] = `
 exports[`Locale Provider should display the text as sr 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -321271,7 +321271,7 @@ exports[`Locale Provider should display the text as sr 1`] = `
 exports[`Locale Provider should display the text as sv 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -326506,7 +326506,7 @@ exports[`Locale Provider should display the text as sv 1`] = `
 exports[`Locale Provider should display the text as ta 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -331741,7 +331741,7 @@ exports[`Locale Provider should display the text as ta 1`] = `
 exports[`Locale Provider should display the text as th 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -336976,7 +336976,7 @@ exports[`Locale Provider should display the text as th 1`] = `
 exports[`Locale Provider should display the text as tk 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -342211,7 +342211,7 @@ exports[`Locale Provider should display the text as tk 1`] = `
 exports[`Locale Provider should display the text as tr 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -347446,7 +347446,7 @@ exports[`Locale Provider should display the text as tr 1`] = `
 exports[`Locale Provider should display the text as uk 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -352681,7 +352681,7 @@ exports[`Locale Provider should display the text as uk 1`] = `
 exports[`Locale Provider should display the text as ur 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -357916,7 +357916,7 @@ exports[`Locale Provider should display the text as ur 1`] = `
 exports[`Locale Provider should display the text as uz-latn 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -363151,7 +363151,7 @@ exports[`Locale Provider should display the text as uz-latn 1`] = `
 exports[`Locale Provider should display the text as vi 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -368386,7 +368386,7 @@ exports[`Locale Provider should display the text as vi 1`] = `
 exports[`Locale Provider should display the text as zh-cn 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -373621,7 +373621,7 @@ exports[`Locale Provider should display the text as zh-cn 1`] = `
 exports[`Locale Provider should display the text as zh-hk 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -378856,7 +378856,7 @@ exports[`Locale Provider should display the text as zh-hk 1`] = `
 exports[`Locale Provider should display the text as zh-tw 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"

--- a/components/locale/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/index.test.tsx.snap
@@ -1938,7 +1938,7 @@ exports[`Locale Provider set dayjs locale when locale changes 3`] = `
 exports[`Locale Provider should display the text as ar 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -7173,7 +7173,7 @@ exports[`Locale Provider should display the text as ar 1`] = `
 exports[`Locale Provider should display the text as az 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -12408,7 +12408,7 @@ exports[`Locale Provider should display the text as az 1`] = `
 exports[`Locale Provider should display the text as bg 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -17643,7 +17643,7 @@ exports[`Locale Provider should display the text as bg 1`] = `
 exports[`Locale Provider should display the text as bn-bd 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -22878,7 +22878,7 @@ exports[`Locale Provider should display the text as bn-bd 1`] = `
 exports[`Locale Provider should display the text as by 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -28113,7 +28113,7 @@ exports[`Locale Provider should display the text as by 1`] = `
 exports[`Locale Provider should display the text as ca 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -33348,7 +33348,7 @@ exports[`Locale Provider should display the text as ca 1`] = `
 exports[`Locale Provider should display the text as cs 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -38583,7 +38583,7 @@ exports[`Locale Provider should display the text as cs 1`] = `
 exports[`Locale Provider should display the text as da 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -43818,7 +43818,7 @@ exports[`Locale Provider should display the text as da 1`] = `
 exports[`Locale Provider should display the text as de 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -49053,7 +49053,7 @@ exports[`Locale Provider should display the text as de 1`] = `
 exports[`Locale Provider should display the text as el 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -54288,7 +54288,7 @@ exports[`Locale Provider should display the text as el 1`] = `
 exports[`Locale Provider should display the text as en 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -59523,7 +59523,7 @@ exports[`Locale Provider should display the text as en 1`] = `
 exports[`Locale Provider should display the text as en-gb 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -64758,7 +64758,7 @@ exports[`Locale Provider should display the text as en-gb 1`] = `
 exports[`Locale Provider should display the text as es 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -69993,7 +69993,7 @@ exports[`Locale Provider should display the text as es 1`] = `
 exports[`Locale Provider should display the text as es-us 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -75228,7 +75228,7 @@ exports[`Locale Provider should display the text as es-us 1`] = `
 exports[`Locale Provider should display the text as et 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -80463,7 +80463,7 @@ exports[`Locale Provider should display the text as et 1`] = `
 exports[`Locale Provider should display the text as eu 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -85698,7 +85698,7 @@ exports[`Locale Provider should display the text as eu 1`] = `
 exports[`Locale Provider should display the text as fa 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -90933,7 +90933,7 @@ exports[`Locale Provider should display the text as fa 1`] = `
 exports[`Locale Provider should display the text as fi 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -96168,7 +96168,7 @@ exports[`Locale Provider should display the text as fi 1`] = `
 exports[`Locale Provider should display the text as fr 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -101403,7 +101403,7 @@ exports[`Locale Provider should display the text as fr 1`] = `
 exports[`Locale Provider should display the text as fr 2`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -106638,7 +106638,7 @@ exports[`Locale Provider should display the text as fr 2`] = `
 exports[`Locale Provider should display the text as fr 3`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -111873,7 +111873,7 @@ exports[`Locale Provider should display the text as fr 3`] = `
 exports[`Locale Provider should display the text as ga 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -117108,7 +117108,7 @@ exports[`Locale Provider should display the text as ga 1`] = `
 exports[`Locale Provider should display the text as gl 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -122343,7 +122343,7 @@ exports[`Locale Provider should display the text as gl 1`] = `
 exports[`Locale Provider should display the text as he 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -127578,7 +127578,7 @@ exports[`Locale Provider should display the text as he 1`] = `
 exports[`Locale Provider should display the text as hi 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -132813,7 +132813,7 @@ exports[`Locale Provider should display the text as hi 1`] = `
 exports[`Locale Provider should display the text as hr 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -138048,7 +138048,7 @@ exports[`Locale Provider should display the text as hr 1`] = `
 exports[`Locale Provider should display the text as hu 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -143283,7 +143283,7 @@ exports[`Locale Provider should display the text as hu 1`] = `
 exports[`Locale Provider should display the text as hy-am 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -148518,7 +148518,7 @@ exports[`Locale Provider should display the text as hy-am 1`] = `
 exports[`Locale Provider should display the text as id 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -153753,7 +153753,7 @@ exports[`Locale Provider should display the text as id 1`] = `
 exports[`Locale Provider should display the text as is 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -158988,7 +158988,7 @@ exports[`Locale Provider should display the text as is 1`] = `
 exports[`Locale Provider should display the text as it 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -164223,7 +164223,7 @@ exports[`Locale Provider should display the text as it 1`] = `
 exports[`Locale Provider should display the text as ja 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -169458,7 +169458,7 @@ exports[`Locale Provider should display the text as ja 1`] = `
 exports[`Locale Provider should display the text as ka 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -174693,7 +174693,7 @@ exports[`Locale Provider should display the text as ka 1`] = `
 exports[`Locale Provider should display the text as kk 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -179928,7 +179928,7 @@ exports[`Locale Provider should display the text as kk 1`] = `
 exports[`Locale Provider should display the text as km 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -185161,7 +185161,7 @@ exports[`Locale Provider should display the text as km 1`] = `
 exports[`Locale Provider should display the text as kn 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -190396,7 +190396,7 @@ exports[`Locale Provider should display the text as kn 1`] = `
 exports[`Locale Provider should display the text as ko 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -195631,7 +195631,7 @@ exports[`Locale Provider should display the text as ko 1`] = `
 exports[`Locale Provider should display the text as ku 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -200866,7 +200866,7 @@ exports[`Locale Provider should display the text as ku 1`] = `
 exports[`Locale Provider should display the text as ku-iq 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -206101,7 +206101,7 @@ exports[`Locale Provider should display the text as ku-iq 1`] = `
 exports[`Locale Provider should display the text as lt 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -211336,7 +211336,7 @@ exports[`Locale Provider should display the text as lt 1`] = `
 exports[`Locale Provider should display the text as lv 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -216571,7 +216571,7 @@ exports[`Locale Provider should display the text as lv 1`] = `
 exports[`Locale Provider should display the text as mk 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -221806,7 +221806,7 @@ exports[`Locale Provider should display the text as mk 1`] = `
 exports[`Locale Provider should display the text as ml 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -227041,7 +227041,7 @@ exports[`Locale Provider should display the text as ml 1`] = `
 exports[`Locale Provider should display the text as mn-mn 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -232276,7 +232276,7 @@ exports[`Locale Provider should display the text as mn-mn 1`] = `
 exports[`Locale Provider should display the text as mr 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -237511,7 +237511,7 @@ exports[`Locale Provider should display the text as mr 1`] = `
 exports[`Locale Provider should display the text as ms-my 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -242746,7 +242746,7 @@ exports[`Locale Provider should display the text as ms-my 1`] = `
 exports[`Locale Provider should display the text as my 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -247981,7 +247981,7 @@ exports[`Locale Provider should display the text as my 1`] = `
 exports[`Locale Provider should display the text as nb 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -253216,7 +253216,7 @@ exports[`Locale Provider should display the text as nb 1`] = `
 exports[`Locale Provider should display the text as ne-np 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -258451,7 +258451,7 @@ exports[`Locale Provider should display the text as ne-np 1`] = `
 exports[`Locale Provider should display the text as nl 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -263686,7 +263686,7 @@ exports[`Locale Provider should display the text as nl 1`] = `
 exports[`Locale Provider should display the text as nl-be 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -268921,7 +268921,7 @@ exports[`Locale Provider should display the text as nl-be 1`] = `
 exports[`Locale Provider should display the text as pl 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -274156,7 +274156,7 @@ exports[`Locale Provider should display the text as pl 1`] = `
 exports[`Locale Provider should display the text as pt 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -279391,7 +279391,7 @@ exports[`Locale Provider should display the text as pt 1`] = `
 exports[`Locale Provider should display the text as pt-br 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -284626,7 +284626,7 @@ exports[`Locale Provider should display the text as pt-br 1`] = `
 exports[`Locale Provider should display the text as ro 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -289861,7 +289861,7 @@ exports[`Locale Provider should display the text as ro 1`] = `
 exports[`Locale Provider should display the text as ru 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -295096,7 +295096,7 @@ exports[`Locale Provider should display the text as ru 1`] = `
 exports[`Locale Provider should display the text as si 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -300331,7 +300331,7 @@ exports[`Locale Provider should display the text as si 1`] = `
 exports[`Locale Provider should display the text as sk 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -305566,7 +305566,7 @@ exports[`Locale Provider should display the text as sk 1`] = `
 exports[`Locale Provider should display the text as sl 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -310801,7 +310801,7 @@ exports[`Locale Provider should display the text as sl 1`] = `
 exports[`Locale Provider should display the text as sq 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -316036,7 +316036,7 @@ exports[`Locale Provider should display the text as sq 1`] = `
 exports[`Locale Provider should display the text as sr 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -321271,7 +321271,7 @@ exports[`Locale Provider should display the text as sr 1`] = `
 exports[`Locale Provider should display the text as sv 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -326506,7 +326506,7 @@ exports[`Locale Provider should display the text as sv 1`] = `
 exports[`Locale Provider should display the text as ta 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -331741,7 +331741,7 @@ exports[`Locale Provider should display the text as ta 1`] = `
 exports[`Locale Provider should display the text as th 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -336976,7 +336976,7 @@ exports[`Locale Provider should display the text as th 1`] = `
 exports[`Locale Provider should display the text as tk 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -342211,7 +342211,7 @@ exports[`Locale Provider should display the text as tk 1`] = `
 exports[`Locale Provider should display the text as tr 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -347446,7 +347446,7 @@ exports[`Locale Provider should display the text as tr 1`] = `
 exports[`Locale Provider should display the text as uk 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -352681,7 +352681,7 @@ exports[`Locale Provider should display the text as uk 1`] = `
 exports[`Locale Provider should display the text as ur 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -357916,7 +357916,7 @@ exports[`Locale Provider should display the text as ur 1`] = `
 exports[`Locale Provider should display the text as uz-latn 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -363151,7 +363151,7 @@ exports[`Locale Provider should display the text as uz-latn 1`] = `
 exports[`Locale Provider should display the text as vi 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -368386,7 +368386,7 @@ exports[`Locale Provider should display the text as vi 1`] = `
 exports[`Locale Provider should display the text as zh-cn 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -373621,7 +373621,7 @@ exports[`Locale Provider should display the text as zh-cn 1`] = `
 exports[`Locale Provider should display the text as zh-hk 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -378856,7 +378856,7 @@ exports[`Locale Provider should display the text as zh-hk 1`] = `
 exports[`Locale Provider should display the text as zh-tw 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"

--- a/components/locale/__tests__/__snapshots__/vitest/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/vitest/index.test.tsx.snap
@@ -213,7 +213,7 @@ exports[`Locale Provider > set dayjs locale when locale changes 3`] = `
 exports[`Locale Provider > should display the text as ar 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -2162,7 +2162,7 @@ exports[`Locale Provider > should display the text as ar 1`] = `
 exports[`Locale Provider > should display the text as az 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -4111,7 +4111,7 @@ exports[`Locale Provider > should display the text as az 1`] = `
 exports[`Locale Provider > should display the text as bg 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -6060,7 +6060,7 @@ exports[`Locale Provider > should display the text as bg 1`] = `
 exports[`Locale Provider > should display the text as bn-bd 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -8009,7 +8009,7 @@ exports[`Locale Provider > should display the text as bn-bd 1`] = `
 exports[`Locale Provider > should display the text as by 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -9958,7 +9958,7 @@ exports[`Locale Provider > should display the text as by 1`] = `
 exports[`Locale Provider > should display the text as ca 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -11907,7 +11907,7 @@ exports[`Locale Provider > should display the text as ca 1`] = `
 exports[`Locale Provider > should display the text as cs 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -13856,7 +13856,7 @@ exports[`Locale Provider > should display the text as cs 1`] = `
 exports[`Locale Provider > should display the text as da 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -15805,7 +15805,7 @@ exports[`Locale Provider > should display the text as da 1`] = `
 exports[`Locale Provider > should display the text as de 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -17754,7 +17754,7 @@ exports[`Locale Provider > should display the text as de 1`] = `
 exports[`Locale Provider > should display the text as el 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19703,7 +19703,7 @@ exports[`Locale Provider > should display the text as el 1`] = `
 exports[`Locale Provider > should display the text as en 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -21652,7 +21652,7 @@ exports[`Locale Provider > should display the text as en 1`] = `
 exports[`Locale Provider > should display the text as en-gb 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -23601,7 +23601,7 @@ exports[`Locale Provider > should display the text as en-gb 1`] = `
 exports[`Locale Provider > should display the text as es 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -25550,7 +25550,7 @@ exports[`Locale Provider > should display the text as es 1`] = `
 exports[`Locale Provider > should display the text as es-us 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -27499,7 +27499,7 @@ exports[`Locale Provider > should display the text as es-us 1`] = `
 exports[`Locale Provider > should display the text as et 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -29448,7 +29448,7 @@ exports[`Locale Provider > should display the text as et 1`] = `
 exports[`Locale Provider > should display the text as eu 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -31397,7 +31397,7 @@ exports[`Locale Provider > should display the text as eu 1`] = `
 exports[`Locale Provider > should display the text as fa 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -33346,7 +33346,7 @@ exports[`Locale Provider > should display the text as fa 1`] = `
 exports[`Locale Provider > should display the text as fi 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -35295,7 +35295,7 @@ exports[`Locale Provider > should display the text as fi 1`] = `
 exports[`Locale Provider > should display the text as fr 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -37244,7 +37244,7 @@ exports[`Locale Provider > should display the text as fr 1`] = `
 exports[`Locale Provider > should display the text as fr 2`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -39193,7 +39193,7 @@ exports[`Locale Provider > should display the text as fr 2`] = `
 exports[`Locale Provider > should display the text as fr 3`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -41142,7 +41142,7 @@ exports[`Locale Provider > should display the text as fr 3`] = `
 exports[`Locale Provider > should display the text as ga 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -43091,7 +43091,7 @@ exports[`Locale Provider > should display the text as ga 1`] = `
 exports[`Locale Provider > should display the text as gl 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -45040,7 +45040,7 @@ exports[`Locale Provider > should display the text as gl 1`] = `
 exports[`Locale Provider > should display the text as he 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -46989,7 +46989,7 @@ exports[`Locale Provider > should display the text as he 1`] = `
 exports[`Locale Provider > should display the text as hi 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -48938,7 +48938,7 @@ exports[`Locale Provider > should display the text as hi 1`] = `
 exports[`Locale Provider > should display the text as hr 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -50887,7 +50887,7 @@ exports[`Locale Provider > should display the text as hr 1`] = `
 exports[`Locale Provider > should display the text as hu 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -52836,7 +52836,7 @@ exports[`Locale Provider > should display the text as hu 1`] = `
 exports[`Locale Provider > should display the text as hy-am 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -54785,7 +54785,7 @@ exports[`Locale Provider > should display the text as hy-am 1`] = `
 exports[`Locale Provider > should display the text as id 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -56734,7 +56734,7 @@ exports[`Locale Provider > should display the text as id 1`] = `
 exports[`Locale Provider > should display the text as is 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -58683,7 +58683,7 @@ exports[`Locale Provider > should display the text as is 1`] = `
 exports[`Locale Provider > should display the text as it 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -60632,7 +60632,7 @@ exports[`Locale Provider > should display the text as it 1`] = `
 exports[`Locale Provider > should display the text as ja 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -62581,7 +62581,7 @@ exports[`Locale Provider > should display the text as ja 1`] = `
 exports[`Locale Provider > should display the text as ka 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -64530,7 +64530,7 @@ exports[`Locale Provider > should display the text as ka 1`] = `
 exports[`Locale Provider > should display the text as kk 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -66479,7 +66479,7 @@ exports[`Locale Provider > should display the text as kk 1`] = `
 exports[`Locale Provider > should display the text as km 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -68426,7 +68426,7 @@ exports[`Locale Provider > should display the text as km 1`] = `
 exports[`Locale Provider > should display the text as kn 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -70375,7 +70375,7 @@ exports[`Locale Provider > should display the text as kn 1`] = `
 exports[`Locale Provider > should display the text as ko 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -72324,7 +72324,7 @@ exports[`Locale Provider > should display the text as ko 1`] = `
 exports[`Locale Provider > should display the text as ku 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -74273,7 +74273,7 @@ exports[`Locale Provider > should display the text as ku 1`] = `
 exports[`Locale Provider > should display the text as ku-iq 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -76222,7 +76222,7 @@ exports[`Locale Provider > should display the text as ku-iq 1`] = `
 exports[`Locale Provider > should display the text as lt 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -78171,7 +78171,7 @@ exports[`Locale Provider > should display the text as lt 1`] = `
 exports[`Locale Provider > should display the text as lv 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -80120,7 +80120,7 @@ exports[`Locale Provider > should display the text as lv 1`] = `
 exports[`Locale Provider > should display the text as mk 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -82069,7 +82069,7 @@ exports[`Locale Provider > should display the text as mk 1`] = `
 exports[`Locale Provider > should display the text as ml 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -84018,7 +84018,7 @@ exports[`Locale Provider > should display the text as ml 1`] = `
 exports[`Locale Provider > should display the text as mn-mn 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -85967,7 +85967,7 @@ exports[`Locale Provider > should display the text as mn-mn 1`] = `
 exports[`Locale Provider > should display the text as mr 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -87916,7 +87916,7 @@ exports[`Locale Provider > should display the text as mr 1`] = `
 exports[`Locale Provider > should display the text as ms-my 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -89865,7 +89865,7 @@ exports[`Locale Provider > should display the text as ms-my 1`] = `
 exports[`Locale Provider > should display the text as my 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -91814,7 +91814,7 @@ exports[`Locale Provider > should display the text as my 1`] = `
 exports[`Locale Provider > should display the text as nb 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -93763,7 +93763,7 @@ exports[`Locale Provider > should display the text as nb 1`] = `
 exports[`Locale Provider > should display the text as ne-np 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -95712,7 +95712,7 @@ exports[`Locale Provider > should display the text as ne-np 1`] = `
 exports[`Locale Provider > should display the text as nl 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -97661,7 +97661,7 @@ exports[`Locale Provider > should display the text as nl 1`] = `
 exports[`Locale Provider > should display the text as nl-be 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -99610,7 +99610,7 @@ exports[`Locale Provider > should display the text as nl-be 1`] = `
 exports[`Locale Provider > should display the text as pl 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -101559,7 +101559,7 @@ exports[`Locale Provider > should display the text as pl 1`] = `
 exports[`Locale Provider > should display the text as pt 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -103508,7 +103508,7 @@ exports[`Locale Provider > should display the text as pt 1`] = `
 exports[`Locale Provider > should display the text as pt-br 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -105457,7 +105457,7 @@ exports[`Locale Provider > should display the text as pt-br 1`] = `
 exports[`Locale Provider > should display the text as ro 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -107406,7 +107406,7 @@ exports[`Locale Provider > should display the text as ro 1`] = `
 exports[`Locale Provider > should display the text as ru 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -109355,7 +109355,7 @@ exports[`Locale Provider > should display the text as ru 1`] = `
 exports[`Locale Provider > should display the text as si 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -111304,7 +111304,7 @@ exports[`Locale Provider > should display the text as si 1`] = `
 exports[`Locale Provider > should display the text as sk 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -113253,7 +113253,7 @@ exports[`Locale Provider > should display the text as sk 1`] = `
 exports[`Locale Provider > should display the text as sl 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -115202,7 +115202,7 @@ exports[`Locale Provider > should display the text as sl 1`] = `
 exports[`Locale Provider > should display the text as sq 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -117151,7 +117151,7 @@ exports[`Locale Provider > should display the text as sq 1`] = `
 exports[`Locale Provider > should display the text as sr 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -119100,7 +119100,7 @@ exports[`Locale Provider > should display the text as sr 1`] = `
 exports[`Locale Provider > should display the text as sv 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -121049,7 +121049,7 @@ exports[`Locale Provider > should display the text as sv 1`] = `
 exports[`Locale Provider > should display the text as ta 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -122998,7 +122998,7 @@ exports[`Locale Provider > should display the text as ta 1`] = `
 exports[`Locale Provider > should display the text as th 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -124947,7 +124947,7 @@ exports[`Locale Provider > should display the text as th 1`] = `
 exports[`Locale Provider > should display the text as tk 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -126896,7 +126896,7 @@ exports[`Locale Provider > should display the text as tk 1`] = `
 exports[`Locale Provider > should display the text as tr 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -128845,7 +128845,7 @@ exports[`Locale Provider > should display the text as tr 1`] = `
 exports[`Locale Provider > should display the text as uk 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -130794,7 +130794,7 @@ exports[`Locale Provider > should display the text as uk 1`] = `
 exports[`Locale Provider > should display the text as ur 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -132743,7 +132743,7 @@ exports[`Locale Provider > should display the text as ur 1`] = `
 exports[`Locale Provider > should display the text as uz-latn 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -134692,7 +134692,7 @@ exports[`Locale Provider > should display the text as uz-latn 1`] = `
 exports[`Locale Provider > should display the text as vi 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -136641,7 +136641,7 @@ exports[`Locale Provider > should display the text as vi 1`] = `
 exports[`Locale Provider > should display the text as zh-cn 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -138590,7 +138590,7 @@ exports[`Locale Provider > should display the text as zh-cn 1`] = `
 exports[`Locale Provider > should display the text as zh-hk 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"
@@ -140539,7 +140539,7 @@ exports[`Locale Provider > should display the text as zh-hk 1`] = `
 exports[`Locale Provider > should display the text as zh-tw 1`] = `
 <div>
   <ul
-    class="ant-pagination css-var-root"
+    class="ant-pagination ant-pagination-variant-text css-var-root"
   >
     <li
       aria-disabled="true"

--- a/components/locale/__tests__/__snapshots__/vitest/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/vitest/index.test.tsx.snap
@@ -213,7 +213,7 @@ exports[`Locale Provider > set dayjs locale when locale changes 3`] = `
 exports[`Locale Provider > should display the text as ar 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -2162,7 +2162,7 @@ exports[`Locale Provider > should display the text as ar 1`] = `
 exports[`Locale Provider > should display the text as az 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -4111,7 +4111,7 @@ exports[`Locale Provider > should display the text as az 1`] = `
 exports[`Locale Provider > should display the text as bg 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -6060,7 +6060,7 @@ exports[`Locale Provider > should display the text as bg 1`] = `
 exports[`Locale Provider > should display the text as bn-bd 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -8009,7 +8009,7 @@ exports[`Locale Provider > should display the text as bn-bd 1`] = `
 exports[`Locale Provider > should display the text as by 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -9958,7 +9958,7 @@ exports[`Locale Provider > should display the text as by 1`] = `
 exports[`Locale Provider > should display the text as ca 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -11907,7 +11907,7 @@ exports[`Locale Provider > should display the text as ca 1`] = `
 exports[`Locale Provider > should display the text as cs 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -13856,7 +13856,7 @@ exports[`Locale Provider > should display the text as cs 1`] = `
 exports[`Locale Provider > should display the text as da 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -15805,7 +15805,7 @@ exports[`Locale Provider > should display the text as da 1`] = `
 exports[`Locale Provider > should display the text as de 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -17754,7 +17754,7 @@ exports[`Locale Provider > should display the text as de 1`] = `
 exports[`Locale Provider > should display the text as el 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -19703,7 +19703,7 @@ exports[`Locale Provider > should display the text as el 1`] = `
 exports[`Locale Provider > should display the text as en 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -21652,7 +21652,7 @@ exports[`Locale Provider > should display the text as en 1`] = `
 exports[`Locale Provider > should display the text as en-gb 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -23601,7 +23601,7 @@ exports[`Locale Provider > should display the text as en-gb 1`] = `
 exports[`Locale Provider > should display the text as es 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -25550,7 +25550,7 @@ exports[`Locale Provider > should display the text as es 1`] = `
 exports[`Locale Provider > should display the text as es-us 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -27499,7 +27499,7 @@ exports[`Locale Provider > should display the text as es-us 1`] = `
 exports[`Locale Provider > should display the text as et 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -29448,7 +29448,7 @@ exports[`Locale Provider > should display the text as et 1`] = `
 exports[`Locale Provider > should display the text as eu 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -31397,7 +31397,7 @@ exports[`Locale Provider > should display the text as eu 1`] = `
 exports[`Locale Provider > should display the text as fa 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -33346,7 +33346,7 @@ exports[`Locale Provider > should display the text as fa 1`] = `
 exports[`Locale Provider > should display the text as fi 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -35295,7 +35295,7 @@ exports[`Locale Provider > should display the text as fi 1`] = `
 exports[`Locale Provider > should display the text as fr 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -37244,7 +37244,7 @@ exports[`Locale Provider > should display the text as fr 1`] = `
 exports[`Locale Provider > should display the text as fr 2`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -39193,7 +39193,7 @@ exports[`Locale Provider > should display the text as fr 2`] = `
 exports[`Locale Provider > should display the text as fr 3`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -41142,7 +41142,7 @@ exports[`Locale Provider > should display the text as fr 3`] = `
 exports[`Locale Provider > should display the text as ga 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -43091,7 +43091,7 @@ exports[`Locale Provider > should display the text as ga 1`] = `
 exports[`Locale Provider > should display the text as gl 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -45040,7 +45040,7 @@ exports[`Locale Provider > should display the text as gl 1`] = `
 exports[`Locale Provider > should display the text as he 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -46989,7 +46989,7 @@ exports[`Locale Provider > should display the text as he 1`] = `
 exports[`Locale Provider > should display the text as hi 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -48938,7 +48938,7 @@ exports[`Locale Provider > should display the text as hi 1`] = `
 exports[`Locale Provider > should display the text as hr 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -50887,7 +50887,7 @@ exports[`Locale Provider > should display the text as hr 1`] = `
 exports[`Locale Provider > should display the text as hu 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -52836,7 +52836,7 @@ exports[`Locale Provider > should display the text as hu 1`] = `
 exports[`Locale Provider > should display the text as hy-am 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -54785,7 +54785,7 @@ exports[`Locale Provider > should display the text as hy-am 1`] = `
 exports[`Locale Provider > should display the text as id 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -56734,7 +56734,7 @@ exports[`Locale Provider > should display the text as id 1`] = `
 exports[`Locale Provider > should display the text as is 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -58683,7 +58683,7 @@ exports[`Locale Provider > should display the text as is 1`] = `
 exports[`Locale Provider > should display the text as it 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -60632,7 +60632,7 @@ exports[`Locale Provider > should display the text as it 1`] = `
 exports[`Locale Provider > should display the text as ja 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -62581,7 +62581,7 @@ exports[`Locale Provider > should display the text as ja 1`] = `
 exports[`Locale Provider > should display the text as ka 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -64530,7 +64530,7 @@ exports[`Locale Provider > should display the text as ka 1`] = `
 exports[`Locale Provider > should display the text as kk 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -66479,7 +66479,7 @@ exports[`Locale Provider > should display the text as kk 1`] = `
 exports[`Locale Provider > should display the text as km 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -68426,7 +68426,7 @@ exports[`Locale Provider > should display the text as km 1`] = `
 exports[`Locale Provider > should display the text as kn 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -70375,7 +70375,7 @@ exports[`Locale Provider > should display the text as kn 1`] = `
 exports[`Locale Provider > should display the text as ko 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -72324,7 +72324,7 @@ exports[`Locale Provider > should display the text as ko 1`] = `
 exports[`Locale Provider > should display the text as ku 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -74273,7 +74273,7 @@ exports[`Locale Provider > should display the text as ku 1`] = `
 exports[`Locale Provider > should display the text as ku-iq 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -76222,7 +76222,7 @@ exports[`Locale Provider > should display the text as ku-iq 1`] = `
 exports[`Locale Provider > should display the text as lt 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -78171,7 +78171,7 @@ exports[`Locale Provider > should display the text as lt 1`] = `
 exports[`Locale Provider > should display the text as lv 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -80120,7 +80120,7 @@ exports[`Locale Provider > should display the text as lv 1`] = `
 exports[`Locale Provider > should display the text as mk 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -82069,7 +82069,7 @@ exports[`Locale Provider > should display the text as mk 1`] = `
 exports[`Locale Provider > should display the text as ml 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -84018,7 +84018,7 @@ exports[`Locale Provider > should display the text as ml 1`] = `
 exports[`Locale Provider > should display the text as mn-mn 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -85967,7 +85967,7 @@ exports[`Locale Provider > should display the text as mn-mn 1`] = `
 exports[`Locale Provider > should display the text as mr 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -87916,7 +87916,7 @@ exports[`Locale Provider > should display the text as mr 1`] = `
 exports[`Locale Provider > should display the text as ms-my 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -89865,7 +89865,7 @@ exports[`Locale Provider > should display the text as ms-my 1`] = `
 exports[`Locale Provider > should display the text as my 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -91814,7 +91814,7 @@ exports[`Locale Provider > should display the text as my 1`] = `
 exports[`Locale Provider > should display the text as nb 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -93763,7 +93763,7 @@ exports[`Locale Provider > should display the text as nb 1`] = `
 exports[`Locale Provider > should display the text as ne-np 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -95712,7 +95712,7 @@ exports[`Locale Provider > should display the text as ne-np 1`] = `
 exports[`Locale Provider > should display the text as nl 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -97661,7 +97661,7 @@ exports[`Locale Provider > should display the text as nl 1`] = `
 exports[`Locale Provider > should display the text as nl-be 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -99610,7 +99610,7 @@ exports[`Locale Provider > should display the text as nl-be 1`] = `
 exports[`Locale Provider > should display the text as pl 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -101559,7 +101559,7 @@ exports[`Locale Provider > should display the text as pl 1`] = `
 exports[`Locale Provider > should display the text as pt 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -103508,7 +103508,7 @@ exports[`Locale Provider > should display the text as pt 1`] = `
 exports[`Locale Provider > should display the text as pt-br 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -105457,7 +105457,7 @@ exports[`Locale Provider > should display the text as pt-br 1`] = `
 exports[`Locale Provider > should display the text as ro 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -107406,7 +107406,7 @@ exports[`Locale Provider > should display the text as ro 1`] = `
 exports[`Locale Provider > should display the text as ru 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -109355,7 +109355,7 @@ exports[`Locale Provider > should display the text as ru 1`] = `
 exports[`Locale Provider > should display the text as si 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -111304,7 +111304,7 @@ exports[`Locale Provider > should display the text as si 1`] = `
 exports[`Locale Provider > should display the text as sk 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -113253,7 +113253,7 @@ exports[`Locale Provider > should display the text as sk 1`] = `
 exports[`Locale Provider > should display the text as sl 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -115202,7 +115202,7 @@ exports[`Locale Provider > should display the text as sl 1`] = `
 exports[`Locale Provider > should display the text as sq 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -117151,7 +117151,7 @@ exports[`Locale Provider > should display the text as sq 1`] = `
 exports[`Locale Provider > should display the text as sr 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -119100,7 +119100,7 @@ exports[`Locale Provider > should display the text as sr 1`] = `
 exports[`Locale Provider > should display the text as sv 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -121049,7 +121049,7 @@ exports[`Locale Provider > should display the text as sv 1`] = `
 exports[`Locale Provider > should display the text as ta 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -122998,7 +122998,7 @@ exports[`Locale Provider > should display the text as ta 1`] = `
 exports[`Locale Provider > should display the text as th 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -124947,7 +124947,7 @@ exports[`Locale Provider > should display the text as th 1`] = `
 exports[`Locale Provider > should display the text as tk 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -126896,7 +126896,7 @@ exports[`Locale Provider > should display the text as tk 1`] = `
 exports[`Locale Provider > should display the text as tr 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -128845,7 +128845,7 @@ exports[`Locale Provider > should display the text as tr 1`] = `
 exports[`Locale Provider > should display the text as uk 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -130794,7 +130794,7 @@ exports[`Locale Provider > should display the text as uk 1`] = `
 exports[`Locale Provider > should display the text as ur 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -132743,7 +132743,7 @@ exports[`Locale Provider > should display the text as ur 1`] = `
 exports[`Locale Provider > should display the text as uz-latn 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -134692,7 +134692,7 @@ exports[`Locale Provider > should display the text as uz-latn 1`] = `
 exports[`Locale Provider > should display the text as vi 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -136641,7 +136641,7 @@ exports[`Locale Provider > should display the text as vi 1`] = `
 exports[`Locale Provider > should display the text as zh-cn 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -138590,7 +138590,7 @@ exports[`Locale Provider > should display the text as zh-cn 1`] = `
 exports[`Locale Provider > should display the text as zh-hk 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"
@@ -140539,7 +140539,7 @@ exports[`Locale Provider > should display the text as zh-hk 1`] = `
 exports[`Locale Provider > should display the text as zh-tw 1`] = `
 <div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-root"
+    class="ant-pagination ant-pagination-variant-outlined css-var-root"
   >
     <li
       aria-disabled="true"

--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -120,8 +120,15 @@ const Pagination: React.FC<PaginationProps> = (props) => {
   const [inputVariant, enableInputVariantCls] = useVariant('input');
 
   // ============================ Variant =============================
+  const hasPaginationVariant = variant !== undefined || contextVariant !== undefined;
   const mergedVariant = variant ?? contextVariant ?? 'outlined';
   const mergedShape = shape ?? contextShape ?? 'default';
+
+  // Nested Input (quick jumper / simple): pagination variant > ConfigProvider input variant
+  const nestedInputVariant = hasPaginationVariant ? mergedVariant : inputVariant;
+  const enableNestedInputCls = hasPaginationVariant
+    ? nestedInputVariant !== 'outlined'
+    : enableInputVariantCls && inputVariant !== 'outlined';
 
   // =========== Merged Props for Semantic ==========
   const mergedProps: PaginationProps = {
@@ -195,6 +202,7 @@ const Pagination: React.FC<PaginationProps> = (props) => {
         getPopupContainer={(triggerNode) => triggerNode.parentNode}
         aria-label={ariaLabel}
         options={options}
+        {...(hasPaginationVariant ? { variant: mergedVariant } : {})}
         {...mergedShowSizeChangerSelectProps}
         value={selectedValue}
         onChange={(nextSize, option) => {
@@ -273,7 +281,7 @@ const Pagination: React.FC<PaginationProps> = (props) => {
     {
       [`${prefixCls}-${align}`]: !!align,
       [`${prefixCls}-${mergedSize}`]: mergedSize,
-      [`${prefixCls}-${inputVariant}`]: enableInputVariantCls && inputVariant !== 'outlined',
+      [`${prefixCls}-${nestedInputVariant}`]: enableNestedInputCls,
       /** @deprecated Should be removed in v7 */
       [`${prefixCls}-mini`]: isSmall,
       [`${prefixCls}-rtl`]: direction === 'rtl',

--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -41,6 +41,10 @@ export type PaginationSemanticType = {
 
 export type PaginationSemanticAllType = GenerateSemantic<PaginationSemanticType, PaginationProps>;
 
+export type PaginationVariant = 'outlined' | 'solid' | 'filled' | 'text';
+
+export type PaginationShape = 'default' | 'round';
+
 export interface PaginationProps
   extends Omit<RcPaginationProps, 'showSizeChanger' | 'pageSizeOptions' | 'classNames' | 'styles'> {
   showQuickJumper?: boolean | { goButton?: React.ReactNode };
@@ -54,6 +58,8 @@ export interface PaginationProps
   selectComponentClass?: any;
   /** `string` type will be removed in next major version. */
   pageSizeOptions?: (string | number)[];
+  variant?: PaginationVariant;
+  shape?: PaginationShape;
   classNames?: PaginationSemanticAllType['classNamesAndFn'];
   styles?: PaginationSemanticAllType['stylesAndFn'];
 }
@@ -82,6 +88,8 @@ const Pagination: React.FC<PaginationProps> = (props) => {
     pageSizeOptions,
     styles,
     classNames,
+    variant,
+    shape,
     ...restProps
   } = props;
   const { xs } = useBreakpoint(responsive);
@@ -96,6 +104,8 @@ const Pagination: React.FC<PaginationProps> = (props) => {
     classNames: contextClassNames,
     styles: contextStyles,
     totalBoundaryShowSizeChanger: contextTotalBoundaryShowSizeChanger,
+    variant: contextVariant,
+    shape: contextShape,
   } = useComponentConfig('pagination');
   const prefixCls = getPrefixCls('pagination', customizePrefixCls);
 
@@ -108,10 +118,16 @@ const Pagination: React.FC<PaginationProps> = (props) => {
   const isSmall = mergedSize === 'small' || !!(xs && !mergedSize && responsive);
   const [inputVariant, enableInputVariantCls] = useVariant('input');
 
+  // ============================ Variant =============================
+  const mergedVariant = variant ?? contextVariant ?? 'text';
+  const mergedShape = shape ?? contextShape ?? 'default';
+
   // =========== Merged Props for Semantic ==========
   const mergedProps: PaginationProps = {
     ...props,
     size: mergedSize,
+    variant: mergedVariant,
+    shape: mergedShape,
   };
 
   // ========================= Style ==========================
@@ -261,6 +277,8 @@ const Pagination: React.FC<PaginationProps> = (props) => {
       [`${prefixCls}-mini`]: isSmall,
       [`${prefixCls}-rtl`]: direction === 'rtl',
       [`${prefixCls}-bordered`]: token.wireframe,
+      [`${prefixCls}-variant-${mergedVariant}`]: mergedVariant,
+      [`${prefixCls}-${mergedShape}`]: mergedShape !== 'default',
     },
     contextClassName,
     className,

--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -15,6 +15,7 @@ import { clsx } from 'clsx';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { devUseWarning } from '../_util/warning';
+import type { Variant } from '../config-provider';
 import { useComponentConfig } from '../config-provider/context';
 import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';
@@ -41,7 +42,7 @@ export type PaginationSemanticType = {
 
 export type PaginationSemanticAllType = GenerateSemantic<PaginationSemanticType, PaginationProps>;
 
-export type PaginationVariant = 'outlined' | 'solid' | 'filled' | 'text';
+export type PaginationVariant = Variant;
 
 export type PaginationShape = 'default' | 'round';
 
@@ -119,7 +120,7 @@ const Pagination: React.FC<PaginationProps> = (props) => {
   const [inputVariant, enableInputVariantCls] = useVariant('input');
 
   // ============================ Variant =============================
-  const mergedVariant = variant ?? contextVariant ?? 'text';
+  const mergedVariant = variant ?? contextVariant ?? 'outlined';
   const mergedShape = shape ?? contextShape ?? 'default';
 
   // =========== Merged Props for Semantic ==========

--- a/components/pagination/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/pagination/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`renders components/pagination/demo/align.tsx extend context correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-start css-var-test-id"
+    class="ant-pagination ant-pagination-start ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -127,7 +127,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-center css-var-test-id"
+    class="ant-pagination ant-pagination-center ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -251,7 +251,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-end css-var-test-id"
+    class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -380,7 +380,7 @@ exports[`renders components/pagination/demo/align.tsx extend context correctly 2
 
 exports[`renders components/pagination/demo/all.tsx extend context correctly 1`] = `
 <ul
-  class="ant-pagination css-var-test-id"
+  class="ant-pagination ant-pagination-variant-text css-var-test-id"
 >
   <li
     class="ant-pagination-total-text"
@@ -746,7 +746,7 @@ exports[`renders components/pagination/demo/all.tsx extend context correctly 2`]
 
 exports[`renders components/pagination/demo/basic.tsx extend context correctly 1`] = `
 <ul
-  class="ant-pagination css-var-test-id"
+  class="ant-pagination ant-pagination-variant-text css-var-test-id"
 >
   <li
     aria-disabled="true"
@@ -875,7 +875,7 @@ exports[`renders components/pagination/demo/basic.tsx extend context correctly 2
 exports[`renders components/pagination/demo/changer.tsx extend context correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination css-var-test-id"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -1221,7 +1221,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -1574,7 +1574,7 @@ exports[`renders components/pagination/demo/changer.tsx extend context correctly
 exports[`renders components/pagination/demo/component-token.tsx extend context correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination css-var-test-id"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -1892,7 +1892,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -2244,7 +2244,7 @@ exports[`renders components/pagination/demo/component-token.tsx extend context c
 
 exports[`renders components/pagination/demo/controlled.tsx extend context correctly 1`] = `
 <ul
-  class="ant-pagination css-var-test-id"
+  class="ant-pagination ant-pagination-variant-text css-var-test-id"
 >
   <li
     aria-disabled="false"
@@ -2372,7 +2372,7 @@ exports[`renders components/pagination/demo/controlled.tsx extend context correc
 
 exports[`renders components/pagination/demo/itemRender.tsx extend context correctly 1`] = `
 <ul
-  class="ant-pagination css-var-test-id"
+  class="ant-pagination ant-pagination-variant-text css-var-test-id"
 >
   <li
     aria-disabled="true"
@@ -2680,7 +2680,7 @@ exports[`renders components/pagination/demo/itemRender.tsx extend context correc
 exports[`renders components/pagination/demo/jump.tsx extend context correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination css-var-test-id"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -3037,7 +3037,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -3420,7 +3420,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     />
   </div>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -3543,7 +3543,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -3832,7 +3832,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -3960,7 +3960,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
   >
     <li
       class="ant-pagination-total-text"
@@ -4272,7 +4272,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     />
   </div>
   <ul
-    class="ant-pagination ant-pagination-large css-var-test-id"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -4395,7 +4395,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-large css-var-test-id"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -4684,7 +4684,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-large css-var-test-id"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -4812,7 +4812,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-large css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
   >
     <li
       class="ant-pagination-total-text"
@@ -5114,7 +5114,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 2`
 
 exports[`renders components/pagination/demo/more.tsx extend context correctly 1`] = `
 <ul
-  class="ant-pagination css-var-test-id"
+  class="ant-pagination ant-pagination-variant-text css-var-test-id"
 >
   <li
     aria-disabled="false"
@@ -5510,7 +5510,7 @@ exports[`renders components/pagination/demo/more.tsx extend context correctly 2`
 exports[`renders components/pagination/demo/simple.tsx extend context correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination css-var-test-id ant-pagination-simple"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple"
   >
     <li
       aria-disabled="false"
@@ -5596,7 +5596,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination css-var-test-id ant-pagination-simple"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple"
   >
     <li
       aria-disabled="false"
@@ -5677,7 +5677,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination css-var-test-id ant-pagination-simple ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -5772,7 +5772,7 @@ exports[`renders components/pagination/demo/style-class.tsx extend context corre
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
 >
   <ul
-    class="ant-pagination acss-8de2dl css-var-test-id"
+    class="ant-pagination ant-pagination-variant-text acss-8de2dl css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -6125,7 +6125,7 @@ exports[`renders components/pagination/demo/style-class.tsx extend context corre
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini acss-8de2dl css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text acss-8de2dl css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -6485,7 +6485,7 @@ exports[`renders components/pagination/demo/style-class.tsx extend context corre
 exports[`renders components/pagination/demo/total.tsx extend context correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination css-var-test-id"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -6769,7 +6769,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination css-var-test-id"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -7056,6 +7056,349 @@ Array [
 
 exports[`renders components/pagination/demo/total.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/pagination/demo/variant.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-center ant-flex-gap-small"
+  >
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      variant:
+    </span>
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+      role="radiogroup"
+    >
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="text"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          text
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="outlined"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          outlined
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="filled"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          filled
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="solid"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          solid
+        </span>
+      </label>
+    </div>
+  </div>
+  <div
+    class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-center ant-flex-gap-small"
+  >
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      shape:
+    </span>
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+      role="radiogroup"
+    >
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="default"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          default
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="round"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          round
+        </span>
+      </label>
+    </div>
+  </div>
+  <ul
+    class="ant-pagination ant-pagination-variant-text css-var-test-id"
+  >
+    <li
+      aria-disabled="true"
+      class="ant-pagination-prev ant-pagination-disabled"
+      title="Previous Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+      tabindex="0"
+      title="1"
+    >
+      <a
+        rel="nofollow"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-2"
+      tabindex="0"
+      title="2"
+    >
+      <a
+        rel="nofollow"
+      >
+        2
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-3"
+      tabindex="0"
+      title="3"
+    >
+      <a
+        rel="nofollow"
+      >
+        3
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-4"
+      tabindex="0"
+      title="4"
+    >
+      <a
+        rel="nofollow"
+      >
+        4
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-5 ant-pagination-item-before-jump-next"
+      tabindex="0"
+      title="5"
+    >
+      <a
+        rel="nofollow"
+      >
+        5
+      </a>
+    </li>
+    <li
+      class="ant-pagination-jump-next ant-pagination-jump-next-custom-icon"
+      tabindex="0"
+      title="Next 5 Pages"
+    >
+      <a
+        class="ant-pagination-item-link"
+      >
+        <div
+          class="ant-pagination-item-container"
+        >
+          <span
+            aria-label="double-right"
+            class="anticon anticon-double-right ant-pagination-item-link-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="double-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-pagination-item-ellipsis"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-99999"
+      tabindex="0"
+      title="99999"
+    >
+      <a
+        rel="nofollow"
+      >
+        99999
+      </a>
+    </li>
+    <li
+      aria-disabled="false"
+      class="ant-pagination-next"
+      tabindex="0"
+      title="Next Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`renders components/pagination/demo/variant.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/pagination/demo/variant-debug.tsx extend context correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
@@ -7071,7 +7414,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </code>
     </span>
     <ul
-      class="ant-pagination css-var-test-id"
+      class="ant-pagination ant-pagination-variant-text css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -7209,7 +7552,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </li>
     </ul>
     <ul
-      class="ant-pagination css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -7305,7 +7648,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </code>
     </span>
     <ul
-      class="ant-pagination ant-pagination-filled css-var-test-id"
+      class="ant-pagination ant-pagination-filled ant-pagination-variant-text css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -7443,7 +7786,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </li>
     </ul>
     <ul
-      class="ant-pagination ant-pagination-filled css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-filled ant-pagination-variant-text css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -7539,7 +7882,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </code>
     </span>
     <ul
-      class="ant-pagination ant-pagination-borderless css-var-test-id"
+      class="ant-pagination ant-pagination-borderless ant-pagination-variant-text css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -7677,7 +8020,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </li>
     </ul>
     <ul
-      class="ant-pagination ant-pagination-borderless css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-borderless ant-pagination-variant-text css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -7773,7 +8116,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </code>
     </span>
     <ul
-      class="ant-pagination ant-pagination-underlined css-var-test-id"
+      class="ant-pagination ant-pagination-underlined ant-pagination-variant-text css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -7911,7 +8254,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </li>
     </ul>
     <ul
-      class="ant-pagination ant-pagination-underlined css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-underlined ant-pagination-variant-text css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -8004,7 +8347,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
 exports[`renders components/pagination/demo/wireframe.tsx extend context correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-bordered css-var-test-id"
+    class="ant-pagination ant-pagination-bordered ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -8350,7 +8693,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-bordered css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-bordered ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -8697,7 +9040,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -9043,7 +9386,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"

--- a/components/pagination/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/pagination/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`renders components/pagination/demo/align.tsx extend context correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-start ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-start ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -127,7 +127,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-center ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-center ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -251,7 +251,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-end ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -380,7 +380,7 @@ exports[`renders components/pagination/demo/align.tsx extend context correctly 2
 
 exports[`renders components/pagination/demo/all.tsx extend context correctly 1`] = `
 <ul
-  class="ant-pagination ant-pagination-variant-text css-var-test-id"
+  class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
 >
   <li
     class="ant-pagination-total-text"
@@ -746,7 +746,7 @@ exports[`renders components/pagination/demo/all.tsx extend context correctly 2`]
 
 exports[`renders components/pagination/demo/basic.tsx extend context correctly 1`] = `
 <ul
-  class="ant-pagination ant-pagination-variant-text css-var-test-id"
+  class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
 >
   <li
     aria-disabled="true"
@@ -875,7 +875,7 @@ exports[`renders components/pagination/demo/basic.tsx extend context correctly 2
 exports[`renders components/pagination/demo/changer.tsx extend context correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -1221,7 +1221,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -1574,7 +1574,7 @@ exports[`renders components/pagination/demo/changer.tsx extend context correctly
 exports[`renders components/pagination/demo/component-token.tsx extend context correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -1892,7 +1892,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -2244,7 +2244,7 @@ exports[`renders components/pagination/demo/component-token.tsx extend context c
 
 exports[`renders components/pagination/demo/controlled.tsx extend context correctly 1`] = `
 <ul
-  class="ant-pagination ant-pagination-variant-text css-var-test-id"
+  class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
 >
   <li
     aria-disabled="false"
@@ -2372,7 +2372,7 @@ exports[`renders components/pagination/demo/controlled.tsx extend context correc
 
 exports[`renders components/pagination/demo/itemRender.tsx extend context correctly 1`] = `
 <ul
-  class="ant-pagination ant-pagination-variant-text css-var-test-id"
+  class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
 >
   <li
     aria-disabled="true"
@@ -2680,7 +2680,7 @@ exports[`renders components/pagination/demo/itemRender.tsx extend context correc
 exports[`renders components/pagination/demo/jump.tsx extend context correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -3037,7 +3037,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -3420,7 +3420,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     />
   </div>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -3543,7 +3543,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -3832,7 +3832,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -3960,7 +3960,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
   >
     <li
       class="ant-pagination-total-text"
@@ -4272,7 +4272,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     />
   </div>
   <ul
-    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -4395,7 +4395,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -4684,7 +4684,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -4812,7 +4812,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 1`
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
   >
     <li
       class="ant-pagination-total-text"
@@ -5114,7 +5114,7 @@ exports[`renders components/pagination/demo/mini.tsx extend context correctly 2`
 
 exports[`renders components/pagination/demo/more.tsx extend context correctly 1`] = `
 <ul
-  class="ant-pagination ant-pagination-variant-text css-var-test-id"
+  class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
 >
   <li
     aria-disabled="false"
@@ -5510,7 +5510,7 @@ exports[`renders components/pagination/demo/more.tsx extend context correctly 2`
 exports[`renders components/pagination/demo/simple.tsx extend context correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-simple"
   >
     <li
       aria-disabled="false"
@@ -5596,7 +5596,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-simple"
   >
     <li
       aria-disabled="false"
@@ -5677,7 +5677,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-simple ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -5772,7 +5772,7 @@ exports[`renders components/pagination/demo/style-class.tsx extend context corre
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
 >
   <ul
-    class="ant-pagination ant-pagination-variant-text acss-8de2dl css-var-test-id"
+    class="ant-pagination ant-pagination-variant-outlined acss-8de2dl css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -6125,7 +6125,7 @@ exports[`renders components/pagination/demo/style-class.tsx extend context corre
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text acss-8de2dl css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined acss-8de2dl css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -6485,7 +6485,7 @@ exports[`renders components/pagination/demo/style-class.tsx extend context corre
 exports[`renders components/pagination/demo/total.tsx extend context correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -6769,7 +6769,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -7083,25 +7083,6 @@ exports[`renders components/pagination/demo/variant.tsx extend context correctly
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
-            value="text"
-          />
-        </span>
-        <span
-          class="ant-radio-button-label"
-        >
-          text
-        </span>
-      </label>
-      <label
-        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
-      >
-        <span
-          class="ant-radio-button"
-        >
-          <input
-            class="ant-radio-button-input"
-            name="test-id"
-            type="radio"
             value="outlined"
           />
         </span>
@@ -7140,13 +7121,32 @@ exports[`renders components/pagination/demo/variant.tsx extend context correctly
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
-            value="solid"
+            value="borderless"
           />
         </span>
         <span
           class="ant-radio-button-label"
         >
-          solid
+          borderless
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="underlined"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          underlined
         </span>
       </label>
     </div>
@@ -7205,7 +7205,7 @@ exports[`renders components/pagination/demo/variant.tsx extend context correctly
     </div>
   </div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -7414,7 +7414,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </code>
     </span>
     <ul
-      class="ant-pagination ant-pagination-variant-text css-var-test-id"
+      class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -7552,7 +7552,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </li>
     </ul>
     <ul
-      class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -7648,7 +7648,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </code>
     </span>
     <ul
-      class="ant-pagination ant-pagination-filled ant-pagination-variant-text css-var-test-id"
+      class="ant-pagination ant-pagination-filled ant-pagination-variant-outlined css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -7786,7 +7786,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </li>
     </ul>
     <ul
-      class="ant-pagination ant-pagination-filled ant-pagination-variant-text css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-filled ant-pagination-variant-outlined css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -7882,7 +7882,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </code>
     </span>
     <ul
-      class="ant-pagination ant-pagination-borderless ant-pagination-variant-text css-var-test-id"
+      class="ant-pagination ant-pagination-borderless ant-pagination-variant-outlined css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -8020,7 +8020,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </li>
     </ul>
     <ul
-      class="ant-pagination ant-pagination-borderless ant-pagination-variant-text css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-borderless ant-pagination-variant-outlined css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -8116,7 +8116,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </code>
     </span>
     <ul
-      class="ant-pagination ant-pagination-underlined ant-pagination-variant-text css-var-test-id"
+      class="ant-pagination ant-pagination-underlined ant-pagination-variant-outlined css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -8254,7 +8254,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
       </li>
     </ul>
     <ul
-      class="ant-pagination ant-pagination-underlined ant-pagination-variant-text css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-underlined ant-pagination-variant-outlined css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -8347,7 +8347,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx extend context cor
 exports[`renders components/pagination/demo/wireframe.tsx extend context correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-bordered ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-bordered ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -8693,7 +8693,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-bordered ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-bordered ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -9040,7 +9040,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -9386,7 +9386,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"

--- a/components/pagination/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/pagination/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -7204,6 +7204,161 @@ exports[`renders components/pagination/demo/variant.tsx extend context correctly
       </label>
     </div>
   </div>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      Basic
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <ul
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
+  >
+    <li
+      aria-disabled="true"
+      class="ant-pagination-prev ant-pagination-disabled"
+      title="Previous Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+      tabindex="0"
+      title="1"
+    >
+      <a
+        rel="nofollow"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-2"
+      tabindex="0"
+      title="2"
+    >
+      <a
+        rel="nofollow"
+      >
+        2
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-3"
+      tabindex="0"
+      title="3"
+    >
+      <a
+        rel="nofollow"
+      >
+        3
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-4"
+      tabindex="0"
+      title="4"
+    >
+      <a
+        rel="nofollow"
+      >
+        4
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-5"
+      tabindex="0"
+      title="5"
+    >
+      <a
+        rel="nofollow"
+      >
+        5
+      </a>
+    </li>
+    <li
+      aria-disabled="false"
+      class="ant-pagination-next"
+      tabindex="0"
+      title="Next Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+  </ul>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      showSizeChanger
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
   <ul
     class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
   >
@@ -7351,14 +7506,14 @@ exports[`renders components/pagination/demo/variant.tsx extend context correctly
       </a>
     </li>
     <li
-      class="ant-pagination-item ant-pagination-item-99999"
+      class="ant-pagination-item ant-pagination-item-50"
       tabindex="0"
-      title="99999"
+      title="50"
     >
       <a
         rel="nofollow"
       >
-        99999
+        50
       </a>
     </li>
     <li
@@ -7392,6 +7547,1284 @@ exports[`renders components/pagination/demo/variant.tsx extend context correctly
           </svg>
         </span>
       </button>
+    </li>
+    <li
+      class="ant-pagination-options"
+    >
+      <div
+        class="ant-select ant-select-outlined ant-pagination-options-size-changer-select ant-pagination-options-size-changer css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow ant-select-show-search"
+      >
+        <div
+          class="ant-select-content ant-select-content-has-value"
+          title="10 / page"
+        >
+          10 / page
+          <input
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-label="Page Size"
+            autocomplete="new-password"
+            class="ant-select-input"
+            id="test-id"
+            role="combobox"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          class="ant-select-suffix"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+      <div
+        class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomLeft"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+      >
+        <div>
+          <div
+            class="ant-select-dropdown-list"
+            style="position: relative;"
+          >
+            <div
+              class="ant-select-dropdown-list-holder"
+              style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+            >
+              <div>
+                <div
+                  class="ant-select-dropdown-list-holder-inner"
+                  id="test-id_list"
+                  role="listbox"
+                  style="display: flex; flex-direction: column;"
+                >
+                  <div
+                    aria-disabled="false"
+                    aria-selected="true"
+                    class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                    id="test-id_list_0"
+                    role="option"
+                    title="10 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      10 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-selected="false"
+                    class="ant-select-item ant-select-item-option"
+                    id="test-id_list_1"
+                    role="option"
+                    title="20 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      20 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-selected="false"
+                    class="ant-select-item ant-select-item-option"
+                    id="test-id_list_2"
+                    role="option"
+                    title="50 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      50 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-selected="false"
+                    class="ant-select-item ant-select-item-option"
+                    id="test-id_list_3"
+                    role="option"
+                    title="100 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      100 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+  </ul>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      showQuickJumper
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <ul
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
+  >
+    <li
+      aria-disabled="true"
+      class="ant-pagination-prev ant-pagination-disabled"
+      title="Previous Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+      tabindex="0"
+      title="1"
+    >
+      <a
+        rel="nofollow"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-2"
+      tabindex="0"
+      title="2"
+    >
+      <a
+        rel="nofollow"
+      >
+        2
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-3"
+      tabindex="0"
+      title="3"
+    >
+      <a
+        rel="nofollow"
+      >
+        3
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-4"
+      tabindex="0"
+      title="4"
+    >
+      <a
+        rel="nofollow"
+      >
+        4
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-5 ant-pagination-item-before-jump-next"
+      tabindex="0"
+      title="5"
+    >
+      <a
+        rel="nofollow"
+      >
+        5
+      </a>
+    </li>
+    <li
+      class="ant-pagination-jump-next ant-pagination-jump-next-custom-icon"
+      tabindex="0"
+      title="Next 5 Pages"
+    >
+      <a
+        class="ant-pagination-item-link"
+      >
+        <div
+          class="ant-pagination-item-container"
+        >
+          <span
+            aria-label="double-right"
+            class="anticon anticon-double-right ant-pagination-item-link-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="double-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-pagination-item-ellipsis"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-50"
+      tabindex="0"
+      title="50"
+    >
+      <a
+        rel="nofollow"
+      >
+        50
+      </a>
+    </li>
+    <li
+      aria-disabled="false"
+      class="ant-pagination-next"
+      tabindex="0"
+      title="Next Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-options"
+    >
+      <div
+        class="ant-select ant-select-outlined ant-pagination-options-size-changer-select ant-pagination-options-size-changer css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow ant-select-show-search"
+      >
+        <div
+          class="ant-select-content ant-select-content-has-value"
+          title="10 / page"
+        >
+          10 / page
+          <input
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-label="Page Size"
+            autocomplete="new-password"
+            class="ant-select-input"
+            id="test-id"
+            role="combobox"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          class="ant-select-suffix"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+      <div
+        class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomLeft"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+      >
+        <div>
+          <div
+            class="ant-select-dropdown-list"
+            style="position: relative;"
+          >
+            <div
+              class="ant-select-dropdown-list-holder"
+              style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+            >
+              <div>
+                <div
+                  class="ant-select-dropdown-list-holder-inner"
+                  id="test-id_list"
+                  role="listbox"
+                  style="display: flex; flex-direction: column;"
+                >
+                  <div
+                    aria-disabled="false"
+                    aria-selected="true"
+                    class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                    id="test-id_list_0"
+                    role="option"
+                    title="10 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      10 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-selected="false"
+                    class="ant-select-item ant-select-item-option"
+                    id="test-id_list_1"
+                    role="option"
+                    title="20 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      20 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-selected="false"
+                    class="ant-select-item ant-select-item-option"
+                    id="test-id_list_2"
+                    role="option"
+                    title="50 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      50 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-selected="false"
+                    class="ant-select-item ant-select-item-option"
+                    id="test-id_list_3"
+                    role="option"
+                    title="100 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      100 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-pagination-options-quick-jumper"
+      >
+        Go to
+        <input
+          aria-label="Page"
+          type="text"
+          value=""
+        />
+        Page
+      </div>
+    </li>
+  </ul>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      showSizeChanger + showQuickJumper
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <ul
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
+  >
+    <li
+      class="ant-pagination-total-text"
+    >
+      Total 500 items
+    </li>
+    <li
+      aria-disabled="true"
+      class="ant-pagination-prev ant-pagination-disabled"
+      title="Previous Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+      tabindex="0"
+      title="1"
+    >
+      <a
+        rel="nofollow"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-2"
+      tabindex="0"
+      title="2"
+    >
+      <a
+        rel="nofollow"
+      >
+        2
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-3"
+      tabindex="0"
+      title="3"
+    >
+      <a
+        rel="nofollow"
+      >
+        3
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-4"
+      tabindex="0"
+      title="4"
+    >
+      <a
+        rel="nofollow"
+      >
+        4
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-5 ant-pagination-item-before-jump-next"
+      tabindex="0"
+      title="5"
+    >
+      <a
+        rel="nofollow"
+      >
+        5
+      </a>
+    </li>
+    <li
+      class="ant-pagination-jump-next ant-pagination-jump-next-custom-icon"
+      tabindex="0"
+      title="Next 5 Pages"
+    >
+      <a
+        class="ant-pagination-item-link"
+      >
+        <div
+          class="ant-pagination-item-container"
+        >
+          <span
+            aria-label="double-right"
+            class="anticon anticon-double-right ant-pagination-item-link-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="double-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-pagination-item-ellipsis"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-50"
+      tabindex="0"
+      title="50"
+    >
+      <a
+        rel="nofollow"
+      >
+        50
+      </a>
+    </li>
+    <li
+      aria-disabled="false"
+      class="ant-pagination-next"
+      tabindex="0"
+      title="Next Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-options"
+    >
+      <div
+        class="ant-select ant-select-outlined ant-pagination-options-size-changer-select ant-pagination-options-size-changer css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow ant-select-show-search"
+      >
+        <div
+          class="ant-select-content ant-select-content-has-value"
+          title="10 / page"
+        >
+          10 / page
+          <input
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-label="Page Size"
+            autocomplete="new-password"
+            class="ant-select-input"
+            id="test-id"
+            role="combobox"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          class="ant-select-suffix"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+      <div
+        class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomLeft"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+      >
+        <div>
+          <div
+            class="ant-select-dropdown-list"
+            style="position: relative;"
+          >
+            <div
+              class="ant-select-dropdown-list-holder"
+              style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+            >
+              <div>
+                <div
+                  class="ant-select-dropdown-list-holder-inner"
+                  id="test-id_list"
+                  role="listbox"
+                  style="display: flex; flex-direction: column;"
+                >
+                  <div
+                    aria-disabled="false"
+                    aria-selected="true"
+                    class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                    id="test-id_list_0"
+                    role="option"
+                    title="10 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      10 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-selected="false"
+                    class="ant-select-item ant-select-item-option"
+                    id="test-id_list_1"
+                    role="option"
+                    title="20 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      20 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-selected="false"
+                    class="ant-select-item ant-select-item-option"
+                    id="test-id_list_2"
+                    role="option"
+                    title="50 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      50 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-selected="false"
+                    class="ant-select-item ant-select-item-option"
+                    id="test-id_list_3"
+                    role="option"
+                    title="100 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      100 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-pagination-options-quick-jumper"
+      >
+        Go to
+        <input
+          aria-label="Page"
+          type="text"
+          value=""
+        />
+        Page
+      </div>
+    </li>
+  </ul>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      disabled
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <ul
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
+  >
+    <li
+      aria-disabled="true"
+      class="ant-pagination-prev ant-pagination-disabled"
+      title="Previous Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+      tabindex="0"
+      title="1"
+    >
+      <a
+        rel="nofollow"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-2"
+      tabindex="0"
+      title="2"
+    >
+      <a
+        rel="nofollow"
+      >
+        2
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-3"
+      tabindex="0"
+      title="3"
+    >
+      <a
+        rel="nofollow"
+      >
+        3
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-4"
+      tabindex="0"
+      title="4"
+    >
+      <a
+        rel="nofollow"
+      >
+        4
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-5 ant-pagination-item-before-jump-next"
+      tabindex="0"
+      title="5"
+    >
+      <a
+        rel="nofollow"
+      >
+        5
+      </a>
+    </li>
+    <li
+      class="ant-pagination-jump-next ant-pagination-jump-next-custom-icon"
+      tabindex="0"
+      title="Next 5 Pages"
+    >
+      <a
+        class="ant-pagination-item-link"
+      >
+        <div
+          class="ant-pagination-item-container"
+        >
+          <span
+            aria-label="double-right"
+            class="anticon anticon-double-right ant-pagination-item-link-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="double-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-pagination-item-ellipsis"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-50"
+      tabindex="0"
+      title="50"
+    >
+      <a
+        rel="nofollow"
+      >
+        50
+      </a>
+    </li>
+    <li
+      aria-disabled="false"
+      class="ant-pagination-next"
+      tabindex="0"
+      title="Next Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-options"
+    >
+      <div
+        class="ant-select ant-select-outlined ant-pagination-options-size-changer-select ant-pagination-options-size-changer css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
+      >
+        <div
+          class="ant-select-content ant-select-content-has-value"
+          title="10 / page"
+        >
+          10 / page
+          <input
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-label="Page Size"
+            autocomplete="new-password"
+            class="ant-select-input"
+            disabled=""
+            id="test-id"
+            role="combobox"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          class="ant-select-suffix"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+      <div
+        class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomLeft"
+        style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+      >
+        <div>
+          <div
+            class="ant-select-dropdown-list"
+            style="position: relative;"
+          >
+            <div
+              class="ant-select-dropdown-list-holder"
+              style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+            >
+              <div>
+                <div
+                  class="ant-select-dropdown-list-holder-inner"
+                  id="test-id_list"
+                  role="listbox"
+                  style="display: flex; flex-direction: column;"
+                >
+                  <div
+                    aria-disabled="false"
+                    aria-selected="true"
+                    class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                    id="test-id_list_0"
+                    role="option"
+                    title="10 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      10 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-selected="false"
+                    class="ant-select-item ant-select-item-option"
+                    id="test-id_list_1"
+                    role="option"
+                    title="20 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      20 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-selected="false"
+                    class="ant-select-item ant-select-item-option"
+                    id="test-id_list_2"
+                    role="option"
+                    title="50 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      50 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-selected="false"
+                    class="ant-select-item ant-select-item-option"
+                    id="test-id_list_3"
+                    role="option"
+                    title="100 / page"
+                  >
+                    <div
+                      class="ant-select-item-option-content"
+                    >
+                      100 / page
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-item-option-state"
+                      style="user-select: none;"
+                      unselectable="on"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-pagination-options-quick-jumper"
+      >
+        Go to
+        <input
+          aria-label="Page"
+          disabled=""
+          type="text"
+          value=""
+        />
+        Page
+      </div>
     </li>
   </ul>
 </div>

--- a/components/pagination/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/pagination/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`renders components/pagination/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-16 acss-my3sst css-var-test-id"
     >
       <ul
-        class="ant-pagination semantic-mark-root css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text semantic-mark-root css-var-test-id"
       >
         <li
           aria-disabled="true"

--- a/components/pagination/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/pagination/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`renders components/pagination/demo/_semantic.tsx correctly 1`] = `
       class="ant-col ant-col-16 acss-my3sst css-var-test-id"
     >
       <ul
-        class="ant-pagination ant-pagination-variant-text semantic-mark-root css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined semantic-mark-root css-var-test-id"
       >
         <li
           aria-disabled="true"

--- a/components/pagination/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/pagination/__tests__/__snapshots__/demo.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`renders components/pagination/demo/align.tsx correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-start ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-start ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -127,7 +127,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-center ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-center ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -251,7 +251,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-end ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -378,7 +378,7 @@ Array [
 
 exports[`renders components/pagination/demo/all.tsx correctly 1`] = `
 <ul
-  class="ant-pagination ant-pagination-variant-text css-var-test-id"
+  class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
 >
   <li
     class="ant-pagination-total-text"
@@ -636,7 +636,7 @@ exports[`renders components/pagination/demo/all.tsx correctly 1`] = `
 
 exports[`renders components/pagination/demo/basic.tsx correctly 1`] = `
 <ul
-  class="ant-pagination ant-pagination-variant-text css-var-test-id"
+  class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
 >
   <li
     aria-disabled="true"
@@ -763,7 +763,7 @@ exports[`renders components/pagination/demo/basic.tsx correctly 1`] = `
 exports[`renders components/pagination/demo/changer.tsx correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -1003,7 +1003,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -1248,7 +1248,7 @@ Array [
 exports[`renders components/pagination/demo/component-token.tsx correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -1460,7 +1460,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -1704,7 +1704,7 @@ Array [
 
 exports[`renders components/pagination/demo/controlled.tsx correctly 1`] = `
 <ul
-  class="ant-pagination ant-pagination-variant-text css-var-test-id"
+  class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
 >
   <li
     aria-disabled="false"
@@ -1830,7 +1830,7 @@ exports[`renders components/pagination/demo/controlled.tsx correctly 1`] = `
 
 exports[`renders components/pagination/demo/itemRender.tsx correctly 1`] = `
 <ul
-  class="ant-pagination ant-pagination-variant-text css-var-test-id"
+  class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
 >
   <li
     aria-disabled="true"
@@ -2030,7 +2030,7 @@ exports[`renders components/pagination/demo/itemRender.tsx correctly 1`] = `
 exports[`renders components/pagination/demo/jump.tsx correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -2281,7 +2281,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -2556,7 +2556,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     />
   </div>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -2679,7 +2679,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -2862,7 +2862,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -2990,7 +2990,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
   >
     <li
       class="ant-pagination-total-text"
@@ -3196,7 +3196,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     />
   </div>
   <ul
-    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -3319,7 +3319,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -3502,7 +3502,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -3630,7 +3630,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
   >
     <li
       class="ant-pagination-total-text"
@@ -3824,7 +3824,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
 
 exports[`renders components/pagination/demo/more.tsx correctly 1`] = `
 <ul
-  class="ant-pagination ant-pagination-variant-text css-var-test-id"
+  class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
 >
   <li
     aria-disabled="false"
@@ -4112,7 +4112,7 @@ exports[`renders components/pagination/demo/more.tsx correctly 1`] = `
 exports[`renders components/pagination/demo/simple.tsx correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-simple"
   >
     <li
       aria-disabled="false"
@@ -4198,7 +4198,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-simple"
   >
     <li
       aria-disabled="false"
@@ -4279,7 +4279,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-simple ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -4372,7 +4372,7 @@ exports[`renders components/pagination/demo/style-class.tsx correctly 1`] = `
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
 >
   <ul
-    class="ant-pagination ant-pagination-variant-text acss-8de2dl css-var-test-id"
+    class="ant-pagination ant-pagination-variant-outlined acss-8de2dl css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -4619,7 +4619,7 @@ exports[`renders components/pagination/demo/style-class.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text acss-8de2dl css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined acss-8de2dl css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -4871,7 +4871,7 @@ exports[`renders components/pagination/demo/style-class.tsx correctly 1`] = `
 exports[`renders components/pagination/demo/total.tsx correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -5049,7 +5049,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -5255,25 +5255,6 @@ exports[`renders components/pagination/demo/variant.tsx correctly 1`] = `
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
-            value="text"
-          />
-        </span>
-        <span
-          class="ant-radio-button-label"
-        >
-          text
-        </span>
-      </label>
-      <label
-        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
-      >
-        <span
-          class="ant-radio-button"
-        >
-          <input
-            class="ant-radio-button-input"
-            name="test-id"
-            type="radio"
             value="outlined"
           />
         </span>
@@ -5312,13 +5293,32 @@ exports[`renders components/pagination/demo/variant.tsx correctly 1`] = `
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
-            value="solid"
+            value="borderless"
           />
         </span>
         <span
           class="ant-radio-button-label"
         >
-          solid
+          borderless
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="underlined"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          underlined
         </span>
       </label>
     </div>
@@ -5377,7 +5377,7 @@ exports[`renders components/pagination/demo/variant.tsx correctly 1`] = `
     </div>
   </div>
   <ul
-    class="ant-pagination ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -5584,7 +5584,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </code>
     </span>
     <ul
-      class="ant-pagination ant-pagination-variant-text css-var-test-id"
+      class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -5722,7 +5722,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </li>
     </ul>
     <ul
-      class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -5818,7 +5818,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </code>
     </span>
     <ul
-      class="ant-pagination ant-pagination-filled ant-pagination-variant-text css-var-test-id"
+      class="ant-pagination ant-pagination-filled ant-pagination-variant-outlined css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -5956,7 +5956,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </li>
     </ul>
     <ul
-      class="ant-pagination ant-pagination-filled ant-pagination-variant-text css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-filled ant-pagination-variant-outlined css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -6052,7 +6052,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </code>
     </span>
     <ul
-      class="ant-pagination ant-pagination-borderless ant-pagination-variant-text css-var-test-id"
+      class="ant-pagination ant-pagination-borderless ant-pagination-variant-outlined css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -6190,7 +6190,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </li>
     </ul>
     <ul
-      class="ant-pagination ant-pagination-borderless ant-pagination-variant-text css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-borderless ant-pagination-variant-outlined css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -6286,7 +6286,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </code>
     </span>
     <ul
-      class="ant-pagination ant-pagination-underlined ant-pagination-variant-text css-var-test-id"
+      class="ant-pagination ant-pagination-underlined ant-pagination-variant-outlined css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -6424,7 +6424,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </li>
     </ul>
     <ul
-      class="ant-pagination ant-pagination-underlined ant-pagination-variant-text css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-underlined ant-pagination-variant-outlined css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -6515,7 +6515,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
 exports[`renders components/pagination/demo/wireframe.tsx correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-bordered ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-bordered ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -6755,7 +6755,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-bordered ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-bordered ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -6996,7 +6996,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered ant-pagination-variant-text css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered ant-pagination-variant-outlined css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -7236,7 +7236,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"

--- a/components/pagination/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/pagination/__tests__/__snapshots__/demo.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`renders components/pagination/demo/align.tsx correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-start css-var-test-id"
+    class="ant-pagination ant-pagination-start ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -127,7 +127,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-center css-var-test-id"
+    class="ant-pagination ant-pagination-center ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -251,7 +251,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-end css-var-test-id"
+    class="ant-pagination ant-pagination-end ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -378,7 +378,7 @@ Array [
 
 exports[`renders components/pagination/demo/all.tsx correctly 1`] = `
 <ul
-  class="ant-pagination css-var-test-id"
+  class="ant-pagination ant-pagination-variant-text css-var-test-id"
 >
   <li
     class="ant-pagination-total-text"
@@ -636,7 +636,7 @@ exports[`renders components/pagination/demo/all.tsx correctly 1`] = `
 
 exports[`renders components/pagination/demo/basic.tsx correctly 1`] = `
 <ul
-  class="ant-pagination css-var-test-id"
+  class="ant-pagination ant-pagination-variant-text css-var-test-id"
 >
   <li
     aria-disabled="true"
@@ -763,7 +763,7 @@ exports[`renders components/pagination/demo/basic.tsx correctly 1`] = `
 exports[`renders components/pagination/demo/changer.tsx correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination css-var-test-id"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -1003,7 +1003,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -1248,7 +1248,7 @@ Array [
 exports[`renders components/pagination/demo/component-token.tsx correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination css-var-test-id"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -1460,7 +1460,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -1704,7 +1704,7 @@ Array [
 
 exports[`renders components/pagination/demo/controlled.tsx correctly 1`] = `
 <ul
-  class="ant-pagination css-var-test-id"
+  class="ant-pagination ant-pagination-variant-text css-var-test-id"
 >
   <li
     aria-disabled="false"
@@ -1830,7 +1830,7 @@ exports[`renders components/pagination/demo/controlled.tsx correctly 1`] = `
 
 exports[`renders components/pagination/demo/itemRender.tsx correctly 1`] = `
 <ul
-  class="ant-pagination css-var-test-id"
+  class="ant-pagination ant-pagination-variant-text css-var-test-id"
 >
   <li
     aria-disabled="true"
@@ -2030,7 +2030,7 @@ exports[`renders components/pagination/demo/itemRender.tsx correctly 1`] = `
 exports[`renders components/pagination/demo/jump.tsx correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination css-var-test-id"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -2281,7 +2281,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -2556,7 +2556,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     />
   </div>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -2679,7 +2679,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -2862,7 +2862,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -2990,7 +2990,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
   >
     <li
       class="ant-pagination-total-text"
@@ -3196,7 +3196,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     />
   </div>
   <ul
-    class="ant-pagination ant-pagination-large css-var-test-id"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -3319,7 +3319,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-large css-var-test-id"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -3502,7 +3502,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-large css-var-test-id"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -3630,7 +3630,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-large css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
   >
     <li
       class="ant-pagination-total-text"
@@ -3824,7 +3824,7 @@ exports[`renders components/pagination/demo/mini.tsx correctly 1`] = `
 
 exports[`renders components/pagination/demo/more.tsx correctly 1`] = `
 <ul
-  class="ant-pagination css-var-test-id"
+  class="ant-pagination ant-pagination-variant-text css-var-test-id"
 >
   <li
     aria-disabled="false"
@@ -4112,7 +4112,7 @@ exports[`renders components/pagination/demo/more.tsx correctly 1`] = `
 exports[`renders components/pagination/demo/simple.tsx correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination css-var-test-id ant-pagination-simple"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple"
   >
     <li
       aria-disabled="false"
@@ -4198,7 +4198,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination css-var-test-id ant-pagination-simple"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple"
   >
     <li
       aria-disabled="false"
@@ -4279,7 +4279,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination css-var-test-id ant-pagination-simple ant-pagination-disabled"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -4372,7 +4372,7 @@ exports[`renders components/pagination/demo/style-class.tsx correctly 1`] = `
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
 >
   <ul
-    class="ant-pagination acss-8de2dl css-var-test-id"
+    class="ant-pagination ant-pagination-variant-text acss-8de2dl css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -4619,7 +4619,7 @@ exports[`renders components/pagination/demo/style-class.tsx correctly 1`] = `
     </li>
   </ul>
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini acss-8de2dl css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text acss-8de2dl css-var-test-id"
   >
     <li
       aria-disabled="true"
@@ -4871,7 +4871,7 @@ exports[`renders components/pagination/demo/style-class.tsx correctly 1`] = `
 exports[`renders components/pagination/demo/total.tsx correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination css-var-test-id"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -5049,7 +5049,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination css-var-test-id"
+    class="ant-pagination ant-pagination-variant-text css-var-test-id"
   >
     <li
       class="ant-pagination-total-text"
@@ -5228,6 +5228,347 @@ Array [
 ]
 `;
 
+exports[`renders components/pagination/demo/variant.tsx correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-center ant-flex-gap-small"
+  >
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      variant:
+    </span>
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+      role="radiogroup"
+    >
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="text"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          text
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="outlined"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          outlined
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="filled"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          filled
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="solid"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          solid
+        </span>
+      </label>
+    </div>
+  </div>
+  <div
+    class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-center ant-flex-gap-small"
+  >
+    <span
+      class="ant-typography css-var-test-id"
+    >
+      shape:
+    </span>
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+      role="radiogroup"
+    >
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="default"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          default
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="round"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          round
+        </span>
+      </label>
+    </div>
+  </div>
+  <ul
+    class="ant-pagination ant-pagination-variant-text css-var-test-id"
+  >
+    <li
+      aria-disabled="true"
+      class="ant-pagination-prev ant-pagination-disabled"
+      title="Previous Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+      tabindex="0"
+      title="1"
+    >
+      <a
+        rel="nofollow"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-2"
+      tabindex="0"
+      title="2"
+    >
+      <a
+        rel="nofollow"
+      >
+        2
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-3"
+      tabindex="0"
+      title="3"
+    >
+      <a
+        rel="nofollow"
+      >
+        3
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-4"
+      tabindex="0"
+      title="4"
+    >
+      <a
+        rel="nofollow"
+      >
+        4
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-5 ant-pagination-item-before-jump-next"
+      tabindex="0"
+      title="5"
+    >
+      <a
+        rel="nofollow"
+      >
+        5
+      </a>
+    </li>
+    <li
+      class="ant-pagination-jump-next ant-pagination-jump-next-custom-icon"
+      tabindex="0"
+      title="Next 5 Pages"
+    >
+      <a
+        class="ant-pagination-item-link"
+      >
+        <div
+          class="ant-pagination-item-container"
+        >
+          <span
+            aria-label="double-right"
+            class="anticon anticon-double-right ant-pagination-item-link-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="double-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-pagination-item-ellipsis"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-99999"
+      tabindex="0"
+      title="99999"
+    >
+      <a
+        rel="nofollow"
+      >
+        99999
+      </a>
+    </li>
+    <li
+      aria-disabled="false"
+      class="ant-pagination-next"
+      tabindex="0"
+      title="Next Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
 <div
   class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
@@ -5243,7 +5584,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </code>
     </span>
     <ul
-      class="ant-pagination css-var-test-id"
+      class="ant-pagination ant-pagination-variant-text css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -5381,7 +5722,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </li>
     </ul>
     <ul
-      class="ant-pagination css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-variant-text css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -5477,7 +5818,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </code>
     </span>
     <ul
-      class="ant-pagination ant-pagination-filled css-var-test-id"
+      class="ant-pagination ant-pagination-filled ant-pagination-variant-text css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -5615,7 +5956,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </li>
     </ul>
     <ul
-      class="ant-pagination ant-pagination-filled css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-filled ant-pagination-variant-text css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -5711,7 +6052,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </code>
     </span>
     <ul
-      class="ant-pagination ant-pagination-borderless css-var-test-id"
+      class="ant-pagination ant-pagination-borderless ant-pagination-variant-text css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -5849,7 +6190,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </li>
     </ul>
     <ul
-      class="ant-pagination ant-pagination-borderless css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-borderless ant-pagination-variant-text css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -5945,7 +6286,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </code>
     </span>
     <ul
-      class="ant-pagination ant-pagination-underlined css-var-test-id"
+      class="ant-pagination ant-pagination-underlined ant-pagination-variant-text css-var-test-id"
     >
       <li
         aria-disabled="false"
@@ -6083,7 +6424,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
       </li>
     </ul>
     <ul
-      class="ant-pagination ant-pagination-underlined css-var-test-id ant-pagination-simple"
+      class="ant-pagination ant-pagination-underlined ant-pagination-variant-text css-var-test-id ant-pagination-simple"
     >
       <li
         aria-disabled="false"
@@ -6174,7 +6515,7 @@ exports[`renders components/pagination/demo/variant-debug.tsx correctly 1`] = `
 exports[`renders components/pagination/demo/wireframe.tsx correctly 1`] = `
 Array [
   <ul
-    class="ant-pagination ant-pagination-bordered css-var-test-id"
+    class="ant-pagination ant-pagination-bordered ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -6414,7 +6755,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-bordered css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-bordered ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"
@@ -6655,7 +6996,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered css-var-test-id"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered ant-pagination-variant-text css-var-test-id"
   >
     <li
       aria-disabled="false"
@@ -6895,7 +7236,7 @@ Array [
   </ul>,
   <br />,
   <ul
-    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered css-var-test-id ant-pagination-disabled"
+    class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-bordered ant-pagination-variant-text css-var-test-id ant-pagination-disabled"
   >
     <li
       aria-disabled="false"

--- a/components/pagination/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/pagination/__tests__/__snapshots__/demo.test.ts.snap
@@ -5376,6 +5376,161 @@ exports[`renders components/pagination/demo/variant.tsx correctly 1`] = `
       </label>
     </div>
   </div>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      Basic
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <ul
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
+  >
+    <li
+      aria-disabled="true"
+      class="ant-pagination-prev ant-pagination-disabled"
+      title="Previous Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+      tabindex="0"
+      title="1"
+    >
+      <a
+        rel="nofollow"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-2"
+      tabindex="0"
+      title="2"
+    >
+      <a
+        rel="nofollow"
+      >
+        2
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-3"
+      tabindex="0"
+      title="3"
+    >
+      <a
+        rel="nofollow"
+      >
+        3
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-4"
+      tabindex="0"
+      title="4"
+    >
+      <a
+        rel="nofollow"
+      >
+        4
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-5"
+      tabindex="0"
+      title="5"
+    >
+      <a
+        rel="nofollow"
+      >
+        5
+      </a>
+    </li>
+    <li
+      aria-disabled="false"
+      class="ant-pagination-next"
+      tabindex="0"
+      title="Next Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+  </ul>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      showSizeChanger
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
   <ul
     class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
   >
@@ -5523,14 +5678,14 @@ exports[`renders components/pagination/demo/variant.tsx correctly 1`] = `
       </a>
     </li>
     <li
-      class="ant-pagination-item ant-pagination-item-99999"
+      class="ant-pagination-item ant-pagination-item-50"
       tabindex="0"
-      title="99999"
+      title="50"
     >
       <a
         rel="nofollow"
       >
-        99999
+        50
       </a>
     </li>
     <li
@@ -5564,6 +5719,860 @@ exports[`renders components/pagination/demo/variant.tsx correctly 1`] = `
           </svg>
         </span>
       </button>
+    </li>
+    <li
+      class="ant-pagination-options"
+    >
+      <div
+        class="ant-select ant-select-outlined ant-pagination-options-size-changer-select ant-pagination-options-size-changer css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow ant-select-show-search"
+      >
+        <div
+          class="ant-select-content ant-select-content-has-value"
+          title="10 / page"
+        >
+          10 / page
+          <input
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-label="Page Size"
+            autocomplete="new-password"
+            class="ant-select-input"
+            id="test-id"
+            role="combobox"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          class="ant-select-suffix"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+    </li>
+  </ul>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      showQuickJumper
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <ul
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
+  >
+    <li
+      aria-disabled="true"
+      class="ant-pagination-prev ant-pagination-disabled"
+      title="Previous Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+      tabindex="0"
+      title="1"
+    >
+      <a
+        rel="nofollow"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-2"
+      tabindex="0"
+      title="2"
+    >
+      <a
+        rel="nofollow"
+      >
+        2
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-3"
+      tabindex="0"
+      title="3"
+    >
+      <a
+        rel="nofollow"
+      >
+        3
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-4"
+      tabindex="0"
+      title="4"
+    >
+      <a
+        rel="nofollow"
+      >
+        4
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-5 ant-pagination-item-before-jump-next"
+      tabindex="0"
+      title="5"
+    >
+      <a
+        rel="nofollow"
+      >
+        5
+      </a>
+    </li>
+    <li
+      class="ant-pagination-jump-next ant-pagination-jump-next-custom-icon"
+      tabindex="0"
+      title="Next 5 Pages"
+    >
+      <a
+        class="ant-pagination-item-link"
+      >
+        <div
+          class="ant-pagination-item-container"
+        >
+          <span
+            aria-label="double-right"
+            class="anticon anticon-double-right ant-pagination-item-link-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="double-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-pagination-item-ellipsis"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-50"
+      tabindex="0"
+      title="50"
+    >
+      <a
+        rel="nofollow"
+      >
+        50
+      </a>
+    </li>
+    <li
+      aria-disabled="false"
+      class="ant-pagination-next"
+      tabindex="0"
+      title="Next Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-options"
+    >
+      <div
+        class="ant-select ant-select-outlined ant-pagination-options-size-changer-select ant-pagination-options-size-changer css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow ant-select-show-search"
+      >
+        <div
+          class="ant-select-content ant-select-content-has-value"
+          title="10 / page"
+        >
+          10 / page
+          <input
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-label="Page Size"
+            autocomplete="new-password"
+            class="ant-select-input"
+            id="test-id"
+            role="combobox"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          class="ant-select-suffix"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+      <div
+        class="ant-pagination-options-quick-jumper"
+      >
+        Go to
+        <input
+          aria-label="Page"
+          type="text"
+          value=""
+        />
+        Page
+      </div>
+    </li>
+  </ul>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      showSizeChanger + showQuickJumper
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <ul
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id"
+  >
+    <li
+      class="ant-pagination-total-text"
+    >
+      Total 500 items
+    </li>
+    <li
+      aria-disabled="true"
+      class="ant-pagination-prev ant-pagination-disabled"
+      title="Previous Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+      tabindex="0"
+      title="1"
+    >
+      <a
+        rel="nofollow"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-2"
+      tabindex="0"
+      title="2"
+    >
+      <a
+        rel="nofollow"
+      >
+        2
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-3"
+      tabindex="0"
+      title="3"
+    >
+      <a
+        rel="nofollow"
+      >
+        3
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-4"
+      tabindex="0"
+      title="4"
+    >
+      <a
+        rel="nofollow"
+      >
+        4
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-5 ant-pagination-item-before-jump-next"
+      tabindex="0"
+      title="5"
+    >
+      <a
+        rel="nofollow"
+      >
+        5
+      </a>
+    </li>
+    <li
+      class="ant-pagination-jump-next ant-pagination-jump-next-custom-icon"
+      tabindex="0"
+      title="Next 5 Pages"
+    >
+      <a
+        class="ant-pagination-item-link"
+      >
+        <div
+          class="ant-pagination-item-container"
+        >
+          <span
+            aria-label="double-right"
+            class="anticon anticon-double-right ant-pagination-item-link-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="double-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-pagination-item-ellipsis"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-50"
+      tabindex="0"
+      title="50"
+    >
+      <a
+        rel="nofollow"
+      >
+        50
+      </a>
+    </li>
+    <li
+      aria-disabled="false"
+      class="ant-pagination-next"
+      tabindex="0"
+      title="Next Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-options"
+    >
+      <div
+        class="ant-select ant-select-outlined ant-pagination-options-size-changer-select ant-pagination-options-size-changer css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow ant-select-show-search"
+      >
+        <div
+          class="ant-select-content ant-select-content-has-value"
+          title="10 / page"
+        >
+          10 / page
+          <input
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-label="Page Size"
+            autocomplete="new-password"
+            class="ant-select-input"
+            id="test-id"
+            role="combobox"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          class="ant-select-suffix"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+      <div
+        class="ant-pagination-options-quick-jumper"
+      >
+        Go to
+        <input
+          aria-label="Page"
+          type="text"
+          value=""
+        />
+        Page
+      </div>
+    </li>
+  </ul>
+  <div
+    class="ant-divider css-var-test-id ant-divider-horizontal ant-divider-with-text ant-divider-with-text-start"
+    role="separator"
+  >
+    <div
+      class="ant-divider-rail ant-divider-rail-start"
+    />
+    <span
+      class="ant-divider-inner-text"
+    >
+      disabled
+    </span>
+    <div
+      class="ant-divider-rail ant-divider-rail-end"
+    />
+  </div>
+  <ul
+    class="ant-pagination ant-pagination-variant-outlined css-var-test-id ant-pagination-disabled"
+  >
+    <li
+      aria-disabled="true"
+      class="ant-pagination-prev ant-pagination-disabled"
+      title="Previous Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+      tabindex="0"
+      title="1"
+    >
+      <a
+        rel="nofollow"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-2"
+      tabindex="0"
+      title="2"
+    >
+      <a
+        rel="nofollow"
+      >
+        2
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-3"
+      tabindex="0"
+      title="3"
+    >
+      <a
+        rel="nofollow"
+      >
+        3
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-4"
+      tabindex="0"
+      title="4"
+    >
+      <a
+        rel="nofollow"
+      >
+        4
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-5 ant-pagination-item-before-jump-next"
+      tabindex="0"
+      title="5"
+    >
+      <a
+        rel="nofollow"
+      >
+        5
+      </a>
+    </li>
+    <li
+      class="ant-pagination-jump-next ant-pagination-jump-next-custom-icon"
+      tabindex="0"
+      title="Next 5 Pages"
+    >
+      <a
+        class="ant-pagination-item-link"
+      >
+        <div
+          class="ant-pagination-item-container"
+        >
+          <span
+            aria-label="double-right"
+            class="anticon anticon-double-right ant-pagination-item-link-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="double-right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M533.2 492.3L277.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H188c-6.7 0-10.4 7.7-6.3 12.9L447.1 512 181.7 851.1A7.98 7.98 0 00188 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5zm304 0L581.9 166.1c-3-3.9-7.7-6.1-12.6-6.1H492c-6.7 0-10.4 7.7-6.3 12.9L751.1 512 485.7 851.1A7.98 7.98 0 00492 864h77.3c4.9 0 9.6-2.3 12.6-6.1l255.3-326.1c9.1-11.7 9.1-27.9 0-39.5z"
+              />
+            </svg>
+          </span>
+          <span
+            class="ant-pagination-item-ellipsis"
+          >
+            <span
+              aria-label="ellipsis"
+              class="anticon anticon-ellipsis"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="ellipsis"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-50"
+      tabindex="0"
+      title="50"
+    >
+      <a
+        rel="nofollow"
+      >
+        50
+      </a>
+    </li>
+    <li
+      aria-disabled="false"
+      class="ant-pagination-next"
+      tabindex="0"
+      title="Next Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-options"
+    >
+      <div
+        class="ant-select ant-select-outlined ant-pagination-options-size-changer-select ant-pagination-options-size-changer css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow ant-select-disabled ant-select-show-search"
+      >
+        <div
+          class="ant-select-content ant-select-content-has-value"
+          title="10 / page"
+        >
+          10 / page
+          <input
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-label="Page Size"
+            autocomplete="new-password"
+            class="ant-select-input"
+            disabled=""
+            id="test-id"
+            role="combobox"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          class="ant-select-suffix"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+      <div
+        class="ant-pagination-options-quick-jumper"
+      >
+        Go to
+        <input
+          aria-label="Page"
+          disabled=""
+          type="text"
+          value=""
+        />
+        Page
+      </div>
     </li>
   </ul>
 </div>

--- a/components/pagination/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/pagination/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Pagination ConfigProvider should be rendered correctly in RTL 1`] = `
 <ul
-  class="ant-pagination ant-pagination-rtl css-var-root"
+  class="ant-pagination ant-pagination-rtl ant-pagination-variant-text css-var-root"
 >
   <li
     aria-disabled="true"
@@ -128,7 +128,7 @@ exports[`Pagination ConfigProvider should be rendered correctly in RTL 1`] = `
 
 exports[`Pagination ConfigProvider should be rendered correctly when componentSize is large 1`] = `
 <ul
-  class="ant-pagination ant-pagination-large css-var-root"
+  class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-root"
 >
   <li
     aria-disabled="true"
@@ -303,7 +303,7 @@ exports[`Pagination ConfigProvider should be rendered correctly when componentSi
 
 exports[`Pagination rtl render component should be rendered correctly in RTL direction 1`] = `
 <ul
-  class="ant-pagination ant-pagination-rtl css-var-root"
+  class="ant-pagination ant-pagination-rtl ant-pagination-variant-text css-var-root"
 >
   <li
     aria-disabled="true"

--- a/components/pagination/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/pagination/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Pagination ConfigProvider should be rendered correctly in RTL 1`] = `
 <ul
-  class="ant-pagination ant-pagination-rtl ant-pagination-variant-text css-var-root"
+  class="ant-pagination ant-pagination-rtl ant-pagination-variant-outlined css-var-root"
 >
   <li
     aria-disabled="true"
@@ -128,7 +128,7 @@ exports[`Pagination ConfigProvider should be rendered correctly in RTL 1`] = `
 
 exports[`Pagination ConfigProvider should be rendered correctly when componentSize is large 1`] = `
 <ul
-  class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-root"
+  class="ant-pagination ant-pagination-large ant-pagination-variant-outlined css-var-root"
 >
   <li
     aria-disabled="true"
@@ -303,7 +303,7 @@ exports[`Pagination ConfigProvider should be rendered correctly when componentSi
 
 exports[`Pagination rtl render component should be rendered correctly in RTL direction 1`] = `
 <ul
-  class="ant-pagination ant-pagination-rtl ant-pagination-variant-text css-var-root"
+  class="ant-pagination ant-pagination-rtl ant-pagination-variant-outlined css-var-root"
 >
   <li
     aria-disabled="true"

--- a/components/pagination/__tests__/__snapshots__/vitest/index.test.tsx.snap
+++ b/components/pagination/__tests__/__snapshots__/vitest/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Pagination > ConfigProvider > should be rendered correctly in RTL 1`] = `
 <ul
-  class="ant-pagination ant-pagination-rtl ant-pagination-variant-text css-var-root"
+  class="ant-pagination ant-pagination-rtl ant-pagination-variant-outlined css-var-root"
 >
   <li
     aria-disabled="true"
@@ -128,7 +128,7 @@ exports[`Pagination > ConfigProvider > should be rendered correctly in RTL 1`] =
 
 exports[`Pagination > ConfigProvider > should be rendered correctly when componentSize is large 1`] = `
 <ul
-  class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-root"
+  class="ant-pagination ant-pagination-large ant-pagination-variant-outlined css-var-root"
 >
   <li
     aria-disabled="true"
@@ -303,7 +303,7 @@ exports[`Pagination > ConfigProvider > should be rendered correctly when compone
 
 exports[`Pagination > rtl render > component should be rendered correctly in RTL direction 1`] = `
 <ul
-  class="ant-pagination ant-pagination-rtl ant-pagination-variant-text css-var-root"
+  class="ant-pagination ant-pagination-rtl ant-pagination-variant-outlined css-var-root"
 >
   <li
     aria-disabled="true"

--- a/components/pagination/__tests__/__snapshots__/vitest/index.test.tsx.snap
+++ b/components/pagination/__tests__/__snapshots__/vitest/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Pagination > ConfigProvider > should be rendered correctly in RTL 1`] = `
 <ul
-  class="ant-pagination ant-pagination-rtl css-var-root"
+  class="ant-pagination ant-pagination-rtl ant-pagination-variant-text css-var-root"
 >
   <li
     aria-disabled="true"
@@ -128,7 +128,7 @@ exports[`Pagination > ConfigProvider > should be rendered correctly in RTL 1`] =
 
 exports[`Pagination > ConfigProvider > should be rendered correctly when componentSize is large 1`] = `
 <ul
-  class="ant-pagination ant-pagination-large css-var-root"
+  class="ant-pagination ant-pagination-large ant-pagination-variant-text css-var-root"
 >
   <li
     aria-disabled="true"
@@ -303,7 +303,7 @@ exports[`Pagination > ConfigProvider > should be rendered correctly when compone
 
 exports[`Pagination > rtl render > component should be rendered correctly in RTL direction 1`] = `
 <ul
-  class="ant-pagination ant-pagination-rtl css-var-root"
+  class="ant-pagination ant-pagination-rtl ant-pagination-variant-text css-var-root"
 >
   <li
     aria-disabled="true"

--- a/components/pagination/__tests__/index.test.tsx
+++ b/components/pagination/__tests__/index.test.tsx
@@ -123,13 +123,15 @@ describe('Pagination', () => {
   });
 
   describe('variant and shape', () => {
-    it('should use text variant by default', () => {
+    it('should use outlined variant by default', () => {
       const { container } = render(<Pagination defaultCurrent={1} total={50} />);
-      expect(container.querySelector('.ant-pagination')).toHaveClass('ant-pagination-variant-text');
+      expect(container.querySelector('.ant-pagination')).toHaveClass(
+        'ant-pagination-variant-outlined',
+      );
       expect(container.querySelector('.ant-pagination-round')).toBeFalsy();
     });
 
-    it.each(['outlined', 'solid', 'filled', 'text'] as const)(
+    it.each(['outlined', 'borderless', 'filled', 'underlined'] as const)(
       'should support variant=%s',
       (variant) => {
         const { container } = render(
@@ -148,24 +150,24 @@ describe('Pagination', () => {
 
     it('should follow ConfigProvider pagination variant and shape', () => {
       const { container } = render(
-        <ConfigProvider pagination={{ variant: 'solid', shape: 'round' }}>
+        <ConfigProvider pagination={{ variant: 'filled', shape: 'round' }}>
           <Pagination defaultCurrent={1} total={50} />
         </ConfigProvider>,
       );
       expect(container.querySelector('.ant-pagination')).toHaveClass(
-        'ant-pagination-variant-solid',
+        'ant-pagination-variant-filled',
       );
       expect(container.querySelector('.ant-pagination')).toHaveClass('ant-pagination-round');
     });
 
     it('should prioritize component props over ConfigProvider', () => {
       const { container } = render(
-        <ConfigProvider pagination={{ variant: 'solid', shape: 'round' }}>
-          <Pagination defaultCurrent={1} total={50} variant="outlined" shape="default" />
+        <ConfigProvider pagination={{ variant: 'filled', shape: 'round' }}>
+          <Pagination defaultCurrent={1} total={50} variant="borderless" shape="default" />
         </ConfigProvider>,
       );
       expect(container.querySelector('.ant-pagination')).toHaveClass(
-        'ant-pagination-variant-outlined',
+        'ant-pagination-variant-borderless',
       );
       expect(container.querySelector('.ant-pagination-round')).toBeFalsy();
     });

--- a/components/pagination/__tests__/index.test.tsx
+++ b/components/pagination/__tests__/index.test.tsx
@@ -171,6 +171,41 @@ describe('Pagination', () => {
       );
       expect(container.querySelector('.ant-pagination-round')).toBeFalsy();
     });
+
+    it('should sync variant to quick jumper input and size changer select', () => {
+      const { container } = render(
+        <Pagination
+          defaultCurrent={1}
+          total={500}
+          variant="filled"
+          showQuickJumper
+          showSizeChanger
+        />,
+      );
+
+      expect(container.querySelector('.ant-pagination')).toHaveClass('ant-pagination-filled');
+      expect(container.querySelector('.ant-pagination')).toHaveClass(
+        'ant-pagination-variant-filled',
+      );
+      expect(container.querySelector('.ant-select')).toHaveClass('ant-select-filled');
+    });
+
+    it('should allow showSizeChanger.variant to override pagination variant', () => {
+      const { container } = render(
+        <Pagination
+          defaultCurrent={1}
+          total={500}
+          variant="filled"
+          showSizeChanger={{ variant: 'borderless' }}
+        />,
+      );
+
+      expect(container.querySelector('.ant-pagination')).toHaveClass(
+        'ant-pagination-variant-filled',
+      );
+      expect(container.querySelector('.ant-select')).toHaveClass('ant-select-borderless');
+      expect(container.querySelector('.ant-select-filled')).toBeFalsy();
+    });
   });
 
   it('showSizeChanger support showSearch=false', () => {

--- a/components/pagination/__tests__/index.test.tsx
+++ b/components/pagination/__tests__/index.test.tsx
@@ -122,6 +122,55 @@ describe('Pagination', () => {
     });
   });
 
+  describe('variant and shape', () => {
+    it('should use text variant by default', () => {
+      const { container } = render(<Pagination defaultCurrent={1} total={50} />);
+      expect(container.querySelector('.ant-pagination')).toHaveClass('ant-pagination-variant-text');
+      expect(container.querySelector('.ant-pagination-round')).toBeFalsy();
+    });
+
+    it.each(['outlined', 'solid', 'filled', 'text'] as const)(
+      'should support variant=%s',
+      (variant) => {
+        const { container } = render(
+          <Pagination defaultCurrent={1} total={50} variant={variant} />,
+        );
+        expect(container.querySelector('.ant-pagination')).toHaveClass(
+          `ant-pagination-variant-${variant}`,
+        );
+      },
+    );
+
+    it('should support shape=round', () => {
+      const { container } = render(<Pagination defaultCurrent={1} total={50} shape="round" />);
+      expect(container.querySelector('.ant-pagination')).toHaveClass('ant-pagination-round');
+    });
+
+    it('should follow ConfigProvider pagination variant and shape', () => {
+      const { container } = render(
+        <ConfigProvider pagination={{ variant: 'solid', shape: 'round' }}>
+          <Pagination defaultCurrent={1} total={50} />
+        </ConfigProvider>,
+      );
+      expect(container.querySelector('.ant-pagination')).toHaveClass(
+        'ant-pagination-variant-solid',
+      );
+      expect(container.querySelector('.ant-pagination')).toHaveClass('ant-pagination-round');
+    });
+
+    it('should prioritize component props over ConfigProvider', () => {
+      const { container } = render(
+        <ConfigProvider pagination={{ variant: 'solid', shape: 'round' }}>
+          <Pagination defaultCurrent={1} total={50} variant="outlined" shape="default" />
+        </ConfigProvider>,
+      );
+      expect(container.querySelector('.ant-pagination')).toHaveClass(
+        'ant-pagination-variant-outlined',
+      );
+      expect(container.querySelector('.ant-pagination-round')).toBeFalsy();
+    });
+  });
+
   it('showSizeChanger support showSearch=false', () => {
     const { container } = render(
       <Pagination

--- a/components/pagination/demo/variant.md
+++ b/components/pagination/demo/variant.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-通过单选切换 `variant` 与 `shape`，预览页码按钮的不同形态组合。
+通过单选切换 `variant` 与 `shape`，并预览基础分页、`showSizeChanger`、`showQuickJumper` 等场景。
 
 ## en-US
 
-Use radio groups to switch `variant` and `shape`, and preview different page item styles.
+Switch `variant` and `shape` with radio groups, and preview basic pagination, `showSizeChanger`, `showQuickJumper`, and more.

--- a/components/pagination/demo/variant.md
+++ b/components/pagination/demo/variant.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+通过单选切换 `variant` 与 `shape`，预览页码按钮的不同形态组合。
+
+## en-US
+
+Use radio groups to switch `variant` and `shape`, and preview different page item styles.

--- a/components/pagination/demo/variant.tsx
+++ b/components/pagination/demo/variant.tsx
@@ -1,13 +1,20 @@
 import React, { useState } from 'react';
-import { Flex, Pagination, Radio, Typography } from 'antd';
+import { Divider, Flex, Pagination, Radio, Typography } from 'antd';
 import type { PaginationProps } from 'antd';
 
-const variants: NonNullable<PaginationProps['variant']>[] = ['text', 'outlined', 'filled', 'solid'];
+const variants: NonNullable<PaginationProps['variant']>[] = [
+  'outlined',
+  'filled',
+  'borderless',
+  'underlined',
+];
 const shapes: NonNullable<PaginationProps['shape']>[] = ['default', 'round'];
 
 const App: React.FC = () => {
-  const [variant, setVariant] = useState<PaginationProps['variant']>('text');
+  const [variant, setVariant] = useState<PaginationProps['variant']>('outlined');
   const [shape, setShape] = useState<PaginationProps['shape']>('default');
+
+  const sharedProps: Pick<PaginationProps, 'variant' | 'shape'> = { variant, shape };
 
   return (
     <Flex vertical gap="middle">
@@ -29,13 +36,34 @@ const App: React.FC = () => {
           options={shapes.map((item) => ({ label: item, value: item }))}
         />
       </Flex>
+
+      <Divider titlePlacement="start">Basic</Divider>
+      <Pagination {...sharedProps} defaultCurrent={1} total={50} />
+
+      <Divider titlePlacement="start">showSizeChanger</Divider>
+      <Pagination {...sharedProps} defaultCurrent={1} total={500} showSizeChanger />
+
+      <Divider titlePlacement="start">showQuickJumper</Divider>
+      <Pagination {...sharedProps} defaultCurrent={1} total={500} showQuickJumper />
+
+      <Divider titlePlacement="start">showSizeChanger + showQuickJumper</Divider>
       <Pagination
+        {...sharedProps}
         defaultCurrent={1}
-        total={99999}
-        pageSize={1}
-        variant={variant}
-        shape={shape}
-        showSizeChanger={false}
+        total={500}
+        showSizeChanger
+        showQuickJumper
+        showTotal={(total) => `Total ${total} items`}
+      />
+
+      <Divider titlePlacement="start">disabled</Divider>
+      <Pagination
+        {...sharedProps}
+        disabled
+        defaultCurrent={1}
+        total={500}
+        showSizeChanger
+        showQuickJumper
       />
     </Flex>
   );

--- a/components/pagination/demo/variant.tsx
+++ b/components/pagination/demo/variant.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { Flex, Pagination, Radio, Typography } from 'antd';
+import type { PaginationProps } from 'antd';
+
+const variants: NonNullable<PaginationProps['variant']>[] = ['text', 'outlined', 'filled', 'solid'];
+const shapes: NonNullable<PaginationProps['shape']>[] = ['default', 'round'];
+
+const App: React.FC = () => {
+  const [variant, setVariant] = useState<PaginationProps['variant']>('text');
+  const [shape, setShape] = useState<PaginationProps['shape']>('default');
+
+  return (
+    <Flex vertical gap="middle">
+      <Flex gap="small" align="center" wrap>
+        <Typography.Text>variant:</Typography.Text>
+        <Radio.Group
+          optionType="button"
+          value={variant}
+          onChange={(e) => setVariant(e.target.value)}
+          options={variants.map((item) => ({ label: item, value: item }))}
+        />
+      </Flex>
+      <Flex gap="small" align="center" wrap>
+        <Typography.Text>shape:</Typography.Text>
+        <Radio.Group
+          optionType="button"
+          value={shape}
+          onChange={(e) => setShape(e.target.value)}
+          options={shapes.map((item) => ({ label: item, value: item }))}
+        />
+      </Flex>
+      <Pagination
+        defaultCurrent={1}
+        total={99999}
+        pageSize={1}
+        variant={variant}
+        shape={shape}
+        showSizeChanger={false}
+      />
+    </Flex>
+  );
+};
+
+export default App;

--- a/components/pagination/index.en-US.md
+++ b/components/pagination/index.en-US.md
@@ -64,7 +64,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
 | total | Total number of data items | number | 0 |  | × |
 | totalBoundaryShowSizeChanger | When `total` larger than it, `showSizeChanger` will be true | number | 50 |  | 6.2.0 |
-| variant | Style variant of page items | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 6.6.0 | 6.6.0 |
+| variant | Style variant of page items. Also applies to size changer and quick jumper unless overridden | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 6.6.0 | 6.6.0 |
 | onChange | Called when the page number or `pageSize` is changed, and it takes the resulting page number and pageSize as its arguments | function(page, pageSize) | - |  | × |
 | onShowSizeChange | Called when `pageSize` is changed | function(current, size) | - |  | × |
 

--- a/components/pagination/index.en-US.md
+++ b/components/pagination/index.en-US.md
@@ -16,6 +16,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*WM86SrBC8TsAAA
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">Basic</code>
+<code src="./demo/variant.tsx" version="6.6.0">Variant and Shape</code>
 <code src="./demo/align.tsx" version="5.19.0">Align</code>
 <code src="./demo/more.tsx">More</code>
 <code src="./demo/changer.tsx">Changer</code>
@@ -52,6 +53,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | pageSize | Number of data items per page | number | - |  | × |
 | pageSizeOptions | Specify the sizeChanger options | number\[] | \[`10`, `20`, `50`, `100`] |  | × |
 | responsive | If `size` is not specified, `Pagination` would resize according to the width of the window | boolean | - |  | × |
+| shape | Shape of page items | `default` \| `round` | `default` | 6.6.0 | 6.6.0 |
 | showLessItems | Show less page items | boolean | false |  | × |
 | showQuickJumper | Determine whether you can jump to pages directly | boolean \| { goButton: ReactNode } | false |  | × |
 | showSizeChanger | Determine whether to show `pageSize` select | boolean \| [SelectProps](/components/select#api) | - | SelectProps: 5.21.0 | 4.21.0, SelectProps: 5.21.0 |
@@ -62,6 +64,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
 | total | Total number of data items | number | 0 |  | × |
 | totalBoundaryShowSizeChanger | When `total` larger than it, `showSizeChanger` will be true | number | 50 |  | 6.2.0 |
+| variant | Style variant of page items | `outlined` \| `solid` \| `filled` \| `text` | `text` | 6.6.0 | 6.6.0 |
 | onChange | Called when the page number or `pageSize` is changed, and it takes the resulting page number and pageSize as its arguments | function(page, pageSize) | - |  | × |
 | onShowSizeChange | Called when `pageSize` is changed | function(current, size) | - |  | × |
 

--- a/components/pagination/index.en-US.md
+++ b/components/pagination/index.en-US.md
@@ -64,7 +64,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
 | total | Total number of data items | number | 0 |  | × |
 | totalBoundaryShowSizeChanger | When `total` larger than it, `showSizeChanger` will be true | number | 50 |  | 6.2.0 |
-| variant | Style variant of page items | `outlined` \| `solid` \| `filled` \| `text` | `text` | 6.6.0 | 6.6.0 |
+| variant | Style variant of page items | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 6.6.0 | 6.6.0 |
 | onChange | Called when the page number or `pageSize` is changed, and it takes the resulting page number and pageSize as its arguments | function(page, pageSize) | - |  | × |
 | onShowSizeChange | Called when `pageSize` is changed | function(current, size) | - |  | × |
 

--- a/components/pagination/index.tsx
+++ b/components/pagination/index.tsx
@@ -1,5 +1,10 @@
 import Pagination from './Pagination';
 
-export type { PaginationConfig, PaginationProps } from './Pagination';
+export type {
+  PaginationConfig,
+  PaginationProps,
+  PaginationShape,
+  PaginationVariant,
+} from './Pagination';
 
 export default Pagination;

--- a/components/pagination/index.zh-CN.md
+++ b/components/pagination/index.zh-CN.md
@@ -65,7 +65,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*WM86SrBC8TsAAA
 | styles | 自定义组件内部各语义化结构的内联样式。支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
 | total | 数据总数 | number | 0 |  | × |
 | totalBoundaryShowSizeChanger | 当 `total` 大于该值时，`showSizeChanger` 默认为 true | number | 50 |  | 6.2.0 |
-| variant | 页码按钮形态变体 | `outlined` \| `solid` \| `filled` \| `text` | `text` | 6.6.0 | 6.6.0 |
+| variant | 页码按钮形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 6.6.0 | 6.6.0 |
 | onChange | 页码或 `pageSize` 改变的回调，参数是改变后的页码及每页条数 | function(page, pageSize) | - |  | × |
 | onShowSizeChange | pageSize 变化的回调 | function(current, size) | - |  | × |
 

--- a/components/pagination/index.zh-CN.md
+++ b/components/pagination/index.zh-CN.md
@@ -17,6 +17,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*WM86SrBC8TsAAA
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">基本</code>
+<code src="./demo/variant.tsx" version="6.6.0">形态与形状</code>
 <code src="./demo/align.tsx" version="5.19.0">方向</code>
 <code src="./demo/more.tsx">更多</code>
 <code src="./demo/changer.tsx">改变</code>
@@ -53,6 +54,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*WM86SrBC8TsAAA
 | pageSize | 每页条数 | number | - |  | × |
 | pageSizeOptions | 指定每页可以显示多少条 | number\[] | \[`10`, `20`, `50`, `100`] |  | × |
 | responsive | 当 size 未指定时，根据屏幕宽度自动调整尺寸 | boolean | - |  | × |
+| shape | 页码按钮形状 | `default` \| `round` | `default` | 6.6.0 | 6.6.0 |
 | showLessItems | 是否显示较少页面内容 | boolean | false |  | × |
 | showQuickJumper | 是否可以快速跳转至某页 | boolean \| { goButton: ReactNode } | false |  | × |
 | showSizeChanger | 是否展示 `pageSize` 切换器 | boolean \| [SelectProps](/components/select-cn#api) | - | SelectProps: 5.21.0 | 4.21.0，SelectProps: 5.21.0 |
@@ -63,6 +65,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*WM86SrBC8TsAAA
 | styles | 自定义组件内部各语义化结构的内联样式。支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
 | total | 数据总数 | number | 0 |  | × |
 | totalBoundaryShowSizeChanger | 当 `total` 大于该值时，`showSizeChanger` 默认为 true | number | 50 |  | 6.2.0 |
+| variant | 页码按钮形态变体 | `outlined` \| `solid` \| `filled` \| `text` | `text` | 6.6.0 | 6.6.0 |
 | onChange | 页码或 `pageSize` 改变的回调，参数是改变后的页码及每页条数 | function(page, pageSize) | - |  | × |
 | onShowSizeChange | pageSize 变化的回调 | function(current, size) | - |  | × |
 

--- a/components/pagination/index.zh-CN.md
+++ b/components/pagination/index.zh-CN.md
@@ -65,7 +65,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*WM86SrBC8TsAAA
 | styles | 自定义组件内部各语义化结构的内联样式。支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), CSSProperties> | - |  | 6.0.0 |
 | total | 数据总数 | number | 0 |  | × |
 | totalBoundaryShowSizeChanger | 当 `total` 大于该值时，`showSizeChanger` 默认为 true | number | 50 |  | 6.2.0 |
-| variant | 页码按钮形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 6.6.0 | 6.6.0 |
+| variant | 页码按钮形态变体；同时作用于页数选择器和快速跳转输入框（可被覆盖） | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 6.6.0 | 6.6.0 |
 | onChange | 页码或 `pageSize` 改变的回调，参数是改变后的页码及每页条数 | function(page, pageSize) | - |  | × |
 | onShowSizeChange | pageSize 变化的回调 | function(current, size) | - |  | × |
 

--- a/components/pagination/style/index.ts
+++ b/components/pagination/style/index.ts
@@ -651,93 +651,47 @@ const genPaginationVariantStyle: GenerateStyle<PaginationToken, CSSObject> = (to
 
   return {
     // ======================== Outlined ========================
-    [`&${componentCls}-variant-outlined`]: {
-      [`${componentCls}-prev, ${componentCls}-next`]: {
-        '&:hover button': {
-          borderColor: token.colorPrimaryHover,
-          backgroundColor: token.itemBg,
-        },
+    // Default styles already match Input-like `outlined` (previous default appearance).
 
-        [`${componentCls}-item-link`]: {
-          backgroundColor: token.itemLinkBg,
-          borderColor: token.colorBorder,
-        },
+    // ======================= Borderless =======================
+    [`&${componentCls}-variant-borderless`]: {
+      [`${componentCls}-item`]: {
+        borderColor: 'transparent',
+        backgroundColor: 'transparent',
 
-        [`&:hover ${componentCls}-item-link`]: {
-          borderColor: token.colorPrimary,
-          backgroundColor: token.itemBg,
-          color: token.colorPrimary,
-        },
+        [`&:not(${componentCls}-item-active)`]: {
+          '&:hover': {
+            backgroundColor: token.colorBgTextHover,
+          },
 
-        [`&${componentCls}-disabled`]: {
-          [`${componentCls}-item-link`]: {
-            borderColor: token.colorBorder,
-            color: token.colorTextDisabled,
+          '&:active': {
+            backgroundColor: token.colorBgTextActive,
           },
         },
-      },
 
-      [`${componentCls}-item`]: {
-        backgroundColor: token.itemBg,
-        border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
-
-        [`&:hover:not(${componentCls}-item-active)`]: {
-          borderColor: token.colorPrimary,
-          backgroundColor: token.itemBg,
+        '&-active': {
+          backgroundColor: 'transparent',
+          borderColor: 'transparent',
 
           a: {
             color: token.colorPrimary,
           },
-        },
-
-        '&-active': {
-          borderColor: token.colorPrimary,
-        },
-      },
-    },
-
-    // ========================= Solid ==========================
-    [`&${componentCls}-variant-solid`]: {
-      [`${componentCls}-item`]: {
-        borderColor: 'transparent',
-
-        [`&:not(${componentCls}-item-active)`]: {
-          '&:hover': {
-            backgroundColor: token.colorPrimaryBg,
-          },
-
-          '&:active': {
-            backgroundColor: token.colorPrimaryBgHover,
-          },
-        },
-
-        '&-active': {
-          backgroundColor: token.colorPrimary,
-          borderColor: 'transparent',
-
-          a: {
-            color: token.colorTextLightSolid,
-          },
 
           '&:hover': {
-            backgroundColor: token.colorPrimaryHover,
+            backgroundColor: token.colorBgTextHover,
             borderColor: 'transparent',
           },
 
           '&:hover a': {
-            color: token.colorTextLightSolid,
+            color: token.colorPrimaryHover,
           },
         },
       },
 
       [`${componentCls}-prev, ${componentCls}-next`]: {
-        [`&:hover ${componentCls}-item-link`]: {
-          backgroundColor: token.colorPrimaryBg,
-          color: token.colorPrimary,
-        },
-
-        [`&:active ${componentCls}-item-link`]: {
-          backgroundColor: token.colorPrimaryBgHover,
+        [`${componentCls}-item-link`]: {
+          backgroundColor: 'transparent',
+          borderColor: 'transparent',
         },
       },
     },
@@ -795,8 +749,71 @@ const genPaginationVariantStyle: GenerateStyle<PaginationToken, CSSObject> = (to
       },
     },
 
-    // ========================== Text ==========================
-    // Default styles already match `text` variant; class kept for API consistency.
+    // ======================= Underlined =======================
+    [`&${componentCls}-variant-underlined`]: {
+      [`${componentCls}-item`]: {
+        borderWidth: `${unit(token.lineWidth)} 0`,
+        borderStyle: `${token.lineType} none`,
+        borderColor: `transparent transparent ${token.colorBorder} transparent`,
+        borderRadius: 0,
+        backgroundColor: 'transparent',
+
+        [`&:not(${componentCls}-item-active)`]: {
+          '&:hover': {
+            backgroundColor: 'transparent',
+            borderColor: `transparent transparent ${token.colorPrimary} transparent`,
+
+            a: {
+              color: token.colorPrimary,
+            },
+          },
+
+          '&:active': {
+            backgroundColor: 'transparent',
+          },
+        },
+
+        '&-active': {
+          backgroundColor: 'transparent',
+          borderColor: `transparent transparent ${token.colorPrimary} transparent`,
+
+          a: {
+            color: token.colorPrimary,
+          },
+
+          '&:hover': {
+            backgroundColor: 'transparent',
+            borderColor: `transparent transparent ${token.colorPrimaryHover} transparent`,
+          },
+
+          '&:hover a': {
+            color: token.colorPrimaryHover,
+          },
+        },
+      },
+
+      [`${componentCls}-prev, ${componentCls}-next`]: {
+        borderRadius: 0,
+
+        [`${componentCls}-item-link`]: {
+          borderWidth: `${unit(token.lineWidth)} 0`,
+          borderStyle: `${token.lineType} none`,
+          borderColor: `transparent transparent ${token.colorBorder} transparent`,
+          borderRadius: 0,
+          backgroundColor: 'transparent',
+        },
+
+        [`&:hover ${componentCls}-item-link`]: {
+          backgroundColor: 'transparent',
+          borderColor: `transparent transparent ${token.colorPrimary} transparent`,
+          color: token.colorPrimary,
+        },
+      },
+
+      [`${componentCls}-jump-prev, ${componentCls}-jump-next`]: {
+        borderRadius: 0,
+      },
+    },
   };
 };
 

--- a/components/pagination/style/index.ts
+++ b/components/pagination/style/index.ts
@@ -83,7 +83,9 @@ export interface ComponentToken {
  * @descEN Token for Pagination component
  */
 export interface PaginationToken
-  extends FullToken<'Pagination'>, SharedComponentToken, SharedInputToken {
+  extends FullToken<'Pagination'>,
+    SharedComponentToken,
+    SharedInputToken {
   /**
    * @desc 输入框轮廓偏移量
    * @descEN Outline offset of input
@@ -642,6 +644,186 @@ const genPaginationItemStyle: GenerateStyle<PaginationToken, CSSObject> = (token
   };
 };
 
+const genPaginationVariantStyle: GenerateStyle<PaginationToken, CSSObject> = (token) => {
+  const { componentCls } = token;
+
+  const itemAndLink = `${componentCls}-item, ${componentCls}-item-link`;
+
+  return {
+    // ======================== Outlined ========================
+    [`&${componentCls}-variant-outlined`]: {
+      [`${componentCls}-prev, ${componentCls}-next`]: {
+        '&:hover button': {
+          borderColor: token.colorPrimaryHover,
+          backgroundColor: token.itemBg,
+        },
+
+        [`${componentCls}-item-link`]: {
+          backgroundColor: token.itemLinkBg,
+          borderColor: token.colorBorder,
+        },
+
+        [`&:hover ${componentCls}-item-link`]: {
+          borderColor: token.colorPrimary,
+          backgroundColor: token.itemBg,
+          color: token.colorPrimary,
+        },
+
+        [`&${componentCls}-disabled`]: {
+          [`${componentCls}-item-link`]: {
+            borderColor: token.colorBorder,
+            color: token.colorTextDisabled,
+          },
+        },
+      },
+
+      [`${componentCls}-item`]: {
+        backgroundColor: token.itemBg,
+        border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorder}`,
+
+        [`&:hover:not(${componentCls}-item-active)`]: {
+          borderColor: token.colorPrimary,
+          backgroundColor: token.itemBg,
+
+          a: {
+            color: token.colorPrimary,
+          },
+        },
+
+        '&-active': {
+          borderColor: token.colorPrimary,
+        },
+      },
+    },
+
+    // ========================= Solid ==========================
+    [`&${componentCls}-variant-solid`]: {
+      [`${componentCls}-item`]: {
+        borderColor: 'transparent',
+
+        [`&:not(${componentCls}-item-active)`]: {
+          '&:hover': {
+            backgroundColor: token.colorPrimaryBg,
+          },
+
+          '&:active': {
+            backgroundColor: token.colorPrimaryBgHover,
+          },
+        },
+
+        '&-active': {
+          backgroundColor: token.colorPrimary,
+          borderColor: 'transparent',
+
+          a: {
+            color: token.colorTextLightSolid,
+          },
+
+          '&:hover': {
+            backgroundColor: token.colorPrimaryHover,
+            borderColor: 'transparent',
+          },
+
+          '&:hover a': {
+            color: token.colorTextLightSolid,
+          },
+        },
+      },
+
+      [`${componentCls}-prev, ${componentCls}-next`]: {
+        [`&:hover ${componentCls}-item-link`]: {
+          backgroundColor: token.colorPrimaryBg,
+          color: token.colorPrimary,
+        },
+
+        [`&:active ${componentCls}-item-link`]: {
+          backgroundColor: token.colorPrimaryBgHover,
+        },
+      },
+    },
+
+    // ========================= Filled =========================
+    [`&${componentCls}-variant-filled`]: {
+      [itemAndLink]: {
+        backgroundColor: token.colorFillTertiary,
+        borderColor: 'transparent',
+      },
+
+      [`${componentCls}-item`]: {
+        [`&:not(${componentCls}-item-active)`]: {
+          '&:hover': {
+            backgroundColor: token.colorFillSecondary,
+          },
+
+          '&:active': {
+            backgroundColor: token.colorFill,
+          },
+        },
+
+        '&-active': {
+          backgroundColor: token.colorPrimaryBg,
+          borderColor: 'transparent',
+
+          a: {
+            color: token.colorPrimary,
+          },
+
+          '&:hover': {
+            backgroundColor: token.colorPrimaryBgHover,
+            borderColor: 'transparent',
+          },
+
+          '&:hover a': {
+            color: token.colorPrimaryHover,
+          },
+        },
+      },
+
+      [`${componentCls}-prev, ${componentCls}-next`]: {
+        [`${componentCls}-item-link`]: {
+          backgroundColor: token.colorFillTertiary,
+          borderColor: 'transparent',
+        },
+
+        [`&:hover ${componentCls}-item-link`]: {
+          backgroundColor: token.colorFillSecondary,
+        },
+
+        [`&:active ${componentCls}-item-link`]: {
+          backgroundColor: token.colorFill,
+        },
+      },
+    },
+
+    // ========================== Text ==========================
+    // Default styles already match `text` variant; class kept for API consistency.
+  };
+};
+
+const genPaginationShapeStyle: GenerateStyle<PaginationToken, CSSObject> = (token) => {
+  const { componentCls } = token;
+
+  const itemSelectors = [
+    `${componentCls}-item`,
+    `${componentCls}-prev`,
+    `${componentCls}-next`,
+    `${componentCls}-jump-prev`,
+    `${componentCls}-jump-next`,
+  ].join(', ');
+
+  return {
+    [`&${componentCls}-round`]: {
+      [itemSelectors]: {
+        borderRadius: 9999,
+      },
+
+      [`${componentCls}-item-link`]: {
+        borderRadius: 9999,
+      },
+    },
+  };
+};
+
 const genPaginationStyle: GenerateStyle<PaginationToken, CSSObject> = (token) => {
   const { componentCls, antCls } = token;
 
@@ -710,6 +892,10 @@ const genPaginationStyle: GenerateStyle<PaginationToken, CSSObject> = (token) =>
 
       // input variant style
       ...genPaginationInputVariantStyle(token),
+
+      // page item variant / shape
+      ...genPaginationVariantStyle(token),
+      ...genPaginationShapeStyle(token),
 
       // size style
       ...genPaginationSmallStyle(token),

--- a/components/table/__tests__/__snapshots__/Table.expand.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.expand.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`Table.expand click to expand 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/Table.expand.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.expand.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`Table.expand click to expand 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/Table.pagination.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.pagination.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`Table.pagination Accepts pagination as true 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"
@@ -233,7 +233,7 @@ exports[`Table.pagination renders pagination correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end my-page css-var-root"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end my-page css-var-root"
       >
         <li
           aria-disabled="true"
@@ -412,7 +412,7 @@ exports[`Table.pagination renders pagination topLeft and bottomRight 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/Table.pagination.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.pagination.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`Table.pagination Accepts pagination as true 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"
@@ -233,7 +233,7 @@ exports[`Table.pagination renders pagination correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end my-page css-var-root"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end my-page css-var-root"
       >
         <li
           aria-disabled="true"
@@ -412,7 +412,7 @@ exports[`Table.pagination renders pagination topLeft and bottomRight 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/Table.rowSelection.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.rowSelection.test.tsx.snap
@@ -314,7 +314,7 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"
@@ -656,7 +656,7 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"
@@ -919,7 +919,7 @@ exports[`Table.rowSelection use column as selection column when key is \`selecti
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/Table.rowSelection.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.rowSelection.test.tsx.snap
@@ -314,7 +314,7 @@ exports[`Table.rowSelection should support getPopupContainer 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"
@@ -656,7 +656,7 @@ exports[`Table.rowSelection should support getPopupContainer from ConfigProvider
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"
@@ -919,7 +919,7 @@ exports[`Table.rowSelection use column as selection column when key is \`selecti
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/Table.sorter.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.sorter.test.tsx.snap
@@ -211,7 +211,7 @@ exports[`Table.sorter should support defaultOrder in Column 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/Table.sorter.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.sorter.test.tsx.snap
@@ -211,7 +211,7 @@ exports[`Table.sorter should support defaultOrder in Column 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -250,7 +250,7 @@ exports[`renders components/table/demo/basic.tsx extend context correctly 1`] = 
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -472,7 +472,7 @@ exports[`renders components/table/demo/bordered.tsx extend context correctly 1`]
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -794,7 +794,7 @@ exports[`renders components/table/demo/colspan-rowspan.tsx extend context correc
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -3425,7 +3425,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -3845,7 +3845,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -4548,7 +4548,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -7970,7 +7970,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -8368,7 +8368,7 @@ exports[`renders components/table/demo/edit-cell.tsx extend context correctly 1`
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -8818,7 +8818,7 @@ exports[`renders components/table/demo/edit-row.tsx extend context correctly 1`]
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -9379,7 +9379,7 @@ exports[`renders components/table/demo/ellipsis.tsx extend context correctly 1`]
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -9950,7 +9950,7 @@ exports[`renders components/table/demo/ellipsis-custom-tooltip.tsx extend contex
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -10254,7 +10254,7 @@ exports[`renders components/table/demo/expand.tsx extend context correctly 1`] =
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -10595,7 +10595,7 @@ exports[`renders components/table/demo/expand-sticky.tsx extend context correctl
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -11576,7 +11576,7 @@ exports[`renders components/table/demo/filter-in-tree.tsx extend context correct
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -12355,7 +12355,7 @@ exports[`renders components/table/demo/filter-search.tsx extend context correctl
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -13556,7 +13556,7 @@ exports[`renders components/table/demo/fixed-header.tsx extend context correctly
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -14895,7 +14895,7 @@ exports[`renders components/table/demo/grouping-columns.tsx extend context corre
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -15998,7 +15998,7 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -16435,7 +16435,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -16799,7 +16799,7 @@ exports[`renders components/table/demo/jsx.tsx extend context correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -17806,7 +17806,7 @@ exports[`renders components/table/demo/measure-row-render.tsx extend context cor
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -18291,7 +18291,7 @@ exports[`renders components/table/demo/multiple-sorter.tsx extend context correc
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -18636,7 +18636,7 @@ exports[`renders components/table/demo/narrow.tsx extend context correctly 1`] =
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="false"
@@ -19394,7 +19394,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -20297,7 +20297,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -21193,7 +21193,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -22089,7 +22089,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -22703,7 +22703,7 @@ exports[`renders components/table/demo/order-column.tsx extend context correctly
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -22970,7 +22970,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
         class="ant-spin-container"
       >
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-start css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-start css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -23286,7 +23286,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -24133,7 +24133,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -24276,7 +24276,7 @@ exports[`renders components/table/demo/responsive.tsx extend context correctly 1
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -24655,7 +24655,7 @@ exports[`renders components/table/demo/row-selection.tsx extend context correctl
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -25211,7 +25211,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx extend co
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -25993,7 +25993,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx extend context c
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -26389,7 +26389,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx extend con
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -29120,7 +29120,7 @@ exports[`renders components/table/demo/selections-debug.tsx extend context corre
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -29339,7 +29339,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -29552,7 +29552,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -29833,7 +29833,7 @@ exports[`renders components/table/demo/style-class.tsx extend context correctly 
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id ant-pagination-simple"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id ant-pagination-simple"
           style="padding: 10px;"
         >
           <li
@@ -30074,7 +30074,7 @@ exports[`renders components/table/demo/style-class.tsx extend context correctly 
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id ant-pagination-simple"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id ant-pagination-simple"
           style="padding: 10px;"
         >
           <li
@@ -30389,7 +30389,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -31094,7 +31094,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -31574,7 +31574,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4877,7 +4877,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-right"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-right"
         >
           <li
             aria-disabled="true"
@@ -5113,7 +5113,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-right"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-right"
         >
           <li
             aria-disabled="true"
@@ -5456,7 +5456,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-right"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-right"
         >
           <li
             aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -250,7 +250,7 @@ exports[`renders components/table/demo/basic.tsx extend context correctly 1`] = 
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -472,7 +472,7 @@ exports[`renders components/table/demo/bordered.tsx extend context correctly 1`]
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -794,7 +794,7 @@ exports[`renders components/table/demo/colspan-rowspan.tsx extend context correc
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -3425,7 +3425,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -3845,7 +3845,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -4548,7 +4548,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -4877,7 +4877,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-right"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-right"
         >
           <li
             aria-disabled="true"
@@ -5113,7 +5113,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-right"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-right"
         >
           <li
             aria-disabled="true"
@@ -5456,7 +5456,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-right"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-right"
         >
           <li
             aria-disabled="true"
@@ -7970,7 +7970,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -8368,7 +8368,7 @@ exports[`renders components/table/demo/edit-cell.tsx extend context correctly 1`
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -8818,7 +8818,7 @@ exports[`renders components/table/demo/edit-row.tsx extend context correctly 1`]
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -9379,7 +9379,7 @@ exports[`renders components/table/demo/ellipsis.tsx extend context correctly 1`]
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -9950,7 +9950,7 @@ exports[`renders components/table/demo/ellipsis-custom-tooltip.tsx extend contex
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -10254,7 +10254,7 @@ exports[`renders components/table/demo/expand.tsx extend context correctly 1`] =
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -10595,7 +10595,7 @@ exports[`renders components/table/demo/expand-sticky.tsx extend context correctl
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -11576,7 +11576,7 @@ exports[`renders components/table/demo/filter-in-tree.tsx extend context correct
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -12355,7 +12355,7 @@ exports[`renders components/table/demo/filter-search.tsx extend context correctl
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -13556,7 +13556,7 @@ exports[`renders components/table/demo/fixed-header.tsx extend context correctly
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -14895,7 +14895,7 @@ exports[`renders components/table/demo/grouping-columns.tsx extend context corre
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -15998,7 +15998,7 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -16435,7 +16435,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -16799,7 +16799,7 @@ exports[`renders components/table/demo/jsx.tsx extend context correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -17806,7 +17806,7 @@ exports[`renders components/table/demo/measure-row-render.tsx extend context cor
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -18291,7 +18291,7 @@ exports[`renders components/table/demo/multiple-sorter.tsx extend context correc
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -18636,7 +18636,7 @@ exports[`renders components/table/demo/narrow.tsx extend context correctly 1`] =
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="false"
@@ -19394,7 +19394,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -20297,7 +20297,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -21193,7 +21193,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -22089,7 +22089,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -22703,7 +22703,7 @@ exports[`renders components/table/demo/order-column.tsx extend context correctly
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -22970,7 +22970,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
         class="ant-spin-container"
       >
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-start css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-start css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -23286,7 +23286,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -24133,7 +24133,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -24276,7 +24276,7 @@ exports[`renders components/table/demo/responsive.tsx extend context correctly 1
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -24655,7 +24655,7 @@ exports[`renders components/table/demo/row-selection.tsx extend context correctl
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -25211,7 +25211,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx extend co
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -25993,7 +25993,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx extend context c
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -26389,7 +26389,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx extend con
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -29120,7 +29120,7 @@ exports[`renders components/table/demo/selections-debug.tsx extend context corre
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -29339,7 +29339,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -29552,7 +29552,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -29833,7 +29833,7 @@ exports[`renders components/table/demo/style-class.tsx extend context correctly 
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id ant-pagination-simple"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id ant-pagination-simple"
           style="padding: 10px;"
         >
           <li
@@ -30074,7 +30074,7 @@ exports[`renders components/table/demo/style-class.tsx extend context correctly 
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id ant-pagination-simple"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id ant-pagination-simple"
           style="padding: 10px;"
         >
           <li
@@ -30389,7 +30389,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -31094,7 +31094,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -31574,7 +31574,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`renders components/table/demo/_semantic.tsx correctly 1`] = `
               </div>
             </div>
             <ul
-              class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end semantic-mark-pagination-root css-var-test-id"
+              class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end semantic-mark-pagination-root css-var-test-id"
             >
               <li
                 aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`renders components/table/demo/_semantic.tsx correctly 1`] = `
               </div>
             </div>
             <ul
-              class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end semantic-mark-pagination-root css-var-test-id"
+              class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end semantic-mark-pagination-root css-var-test-id"
             >
               <li
                 aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.ts.snap
@@ -256,7 +256,7 @@ exports[`renders components/table/demo/basic.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -476,7 +476,7 @@ exports[`renders components/table/demo/bordered.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -796,7 +796,7 @@ exports[`renders components/table/demo/colspan-rowspan.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -3249,7 +3249,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -3535,7 +3535,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -3921,7 +3921,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -4248,7 +4248,7 @@ exports[`renders components/table/demo/drag-column-sorting.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -4466,7 +4466,7 @@ exports[`renders components/table/demo/drag-sorting.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -4792,7 +4792,7 @@ exports[`renders components/table/demo/drag-sorting-handler.tsx correctly 1`] = 
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -7114,7 +7114,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -7340,7 +7340,7 @@ exports[`renders components/table/demo/edit-cell.tsx correctly 1`] = `
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -7788,7 +7788,7 @@ exports[`renders components/table/demo/edit-row.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -8241,7 +8241,7 @@ exports[`renders components/table/demo/ellipsis.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -8546,7 +8546,7 @@ exports[`renders components/table/demo/ellipsis-custom-tooltip.tsx correctly 1`]
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -8848,7 +8848,7 @@ exports[`renders components/table/demo/expand.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -9187,7 +9187,7 @@ exports[`renders components/table/demo/expand-sticky.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -9540,7 +9540,7 @@ exports[`renders components/table/demo/filter-in-tree.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -9893,7 +9893,7 @@ exports[`renders components/table/demo/filter-search.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -12511,7 +12511,7 @@ exports[`renders components/table/demo/fixed-columns-header.tsx correctly 1`] = 
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -14616,7 +14616,7 @@ exports[`renders components/table/demo/fixed-header.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -15673,7 +15673,7 @@ exports[`renders components/table/demo/grouping-columns.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -16217,7 +16217,7 @@ exports[`renders components/table/demo/head.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -16652,7 +16652,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -17020,7 +17020,7 @@ exports[`renders components/table/demo/jsx.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -17440,7 +17440,7 @@ exports[`renders components/table/demo/multiple-sorter.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -17783,7 +17783,7 @@ exports[`renders components/table/demo/narrow.tsx correctly 1`] = `
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="false"
@@ -18433,7 +18433,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -19100,7 +19100,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -19762,7 +19762,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -20424,7 +20424,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -21013,7 +21013,7 @@ exports[`renders components/table/demo/order-column.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -21278,7 +21278,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
         class="ant-spin-container"
       >
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-start css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-start css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -21600,7 +21600,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -22118,7 +22118,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -22259,7 +22259,7 @@ exports[`renders components/table/demo/responsive.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -22636,7 +22636,7 @@ exports[`renders components/table/demo/row-selection.tsx correctly 1`] = `
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -23190,7 +23190,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx correctly
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -23799,7 +23799,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx correctly 1`] = 
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -24203,7 +24203,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx correctly 
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -26712,7 +26712,7 @@ exports[`renders components/table/demo/selections-debug.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -26929,7 +26929,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -27142,7 +27142,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -28256,7 +28256,7 @@ exports[`renders components/table/demo/sticky.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -29358,7 +29358,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -30061,7 +30061,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -30539,7 +30539,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.ts.snap
@@ -256,7 +256,7 @@ exports[`renders components/table/demo/basic.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -476,7 +476,7 @@ exports[`renders components/table/demo/bordered.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -796,7 +796,7 @@ exports[`renders components/table/demo/colspan-rowspan.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -3249,7 +3249,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -3535,7 +3535,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -3921,7 +3921,7 @@ exports[`renders components/table/demo/custom-filter-panel.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -4248,7 +4248,7 @@ exports[`renders components/table/demo/drag-column-sorting.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -4466,7 +4466,7 @@ exports[`renders components/table/demo/drag-sorting.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -4792,7 +4792,7 @@ exports[`renders components/table/demo/drag-sorting-handler.tsx correctly 1`] = 
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -7114,7 +7114,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -7340,7 +7340,7 @@ exports[`renders components/table/demo/edit-cell.tsx correctly 1`] = `
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -7788,7 +7788,7 @@ exports[`renders components/table/demo/edit-row.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -8241,7 +8241,7 @@ exports[`renders components/table/demo/ellipsis.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -8546,7 +8546,7 @@ exports[`renders components/table/demo/ellipsis-custom-tooltip.tsx correctly 1`]
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -8848,7 +8848,7 @@ exports[`renders components/table/demo/expand.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -9187,7 +9187,7 @@ exports[`renders components/table/demo/expand-sticky.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -9540,7 +9540,7 @@ exports[`renders components/table/demo/filter-in-tree.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -9893,7 +9893,7 @@ exports[`renders components/table/demo/filter-search.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -12511,7 +12511,7 @@ exports[`renders components/table/demo/fixed-columns-header.tsx correctly 1`] = 
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -14616,7 +14616,7 @@ exports[`renders components/table/demo/fixed-header.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -15673,7 +15673,7 @@ exports[`renders components/table/demo/grouping-columns.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -16217,7 +16217,7 @@ exports[`renders components/table/demo/head.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -16652,7 +16652,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -17020,7 +17020,7 @@ exports[`renders components/table/demo/jsx.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -17440,7 +17440,7 @@ exports[`renders components/table/demo/multiple-sorter.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -17783,7 +17783,7 @@ exports[`renders components/table/demo/narrow.tsx correctly 1`] = `
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="false"
@@ -18433,7 +18433,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -19100,7 +19100,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -19762,7 +19762,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -20424,7 +20424,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -21013,7 +21013,7 @@ exports[`renders components/table/demo/order-column.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -21278,7 +21278,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
         class="ant-spin-container"
       >
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-start css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-start css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -21600,7 +21600,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -22118,7 +22118,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -22259,7 +22259,7 @@ exports[`renders components/table/demo/responsive.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -22636,7 +22636,7 @@ exports[`renders components/table/demo/row-selection.tsx correctly 1`] = `
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -23190,7 +23190,7 @@ exports[`renders components/table/demo/row-selection-and-operation.tsx correctly
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -23799,7 +23799,7 @@ exports[`renders components/table/demo/row-selection-custom.tsx correctly 1`] = 
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -24203,7 +24203,7 @@ exports[`renders components/table/demo/row-selection-custom-debug.tsx correctly 
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -26712,7 +26712,7 @@ exports[`renders components/table/demo/selections-debug.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -26929,7 +26929,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -27142,7 +27142,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -28256,7 +28256,7 @@ exports[`renders components/table/demo/sticky.tsx correctly 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
       >
         <li
           aria-disabled="true"
@@ -29358,7 +29358,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -30061,7 +30061,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"
@@ -30539,7 +30539,7 @@ Array [
           </div>
         </div>
         <ul
-          class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+          class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
         >
           <li
             aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/vitest/Table.expand.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/vitest/Table.expand.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`Table.expand > click to expand 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"

--- a/components/table/__tests__/__snapshots__/vitest/Table.expand.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/vitest/Table.expand.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`Table.expand > click to expand 1`] = `
         </div>
       </div>
       <ul
-        class="ant-pagination ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-root"
+        class="ant-pagination ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-root"
       >
         <li
           aria-disabled="true"

--- a/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4911,7 +4911,7 @@ Array [
                   </div>
                 </div>
                 <ul
-                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
                 >
                   <li
                     aria-disabled="true"
@@ -5514,7 +5514,7 @@ Array [
                   </div>
                 </div>
                 <ul
-                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
                 >
                   <li
                     aria-disabled="true"
@@ -7457,7 +7457,7 @@ Array [
           </li>
         </ul>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-transfer-list-pagination css-var-test-id ant-pagination-simple"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-transfer-list-pagination css-var-test-id ant-pagination-simple"
         >
           <li
             aria-disabled="true"
@@ -7975,7 +7975,7 @@ Array [
           </li>
         </ul>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-transfer-list-pagination css-var-test-id ant-pagination-simple"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-transfer-list-pagination css-var-test-id ant-pagination-simple"
         >
           <li
             aria-disabled="true"
@@ -13116,7 +13116,7 @@ exports[`renders components/transfer/demo/table-transfer.tsx extend context corr
                   </div>
                 </div>
                 <ul
-                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
                 >
                   <li
                     aria-disabled="true"

--- a/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4911,7 +4911,7 @@ Array [
                   </div>
                 </div>
                 <ul
-                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
                 >
                   <li
                     aria-disabled="true"
@@ -5514,7 +5514,7 @@ Array [
                   </div>
                 </div>
                 <ul
-                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
                 >
                   <li
                     aria-disabled="true"
@@ -7457,7 +7457,7 @@ Array [
           </li>
         </ul>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-transfer-list-pagination css-var-test-id ant-pagination-simple"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-transfer-list-pagination css-var-test-id ant-pagination-simple"
         >
           <li
             aria-disabled="true"
@@ -7975,7 +7975,7 @@ Array [
           </li>
         </ul>
         <ul
-          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-transfer-list-pagination css-var-test-id ant-pagination-simple"
+          class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-transfer-list-pagination css-var-test-id ant-pagination-simple"
         >
           <li
             aria-disabled="true"
@@ -13116,7 +13116,7 @@ exports[`renders components/transfer/demo/table-transfer.tsx extend context corr
                   </div>
                 </div>
                 <ul
-                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
                 >
                   <li
                     aria-disabled="true"

--- a/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
@@ -3588,7 +3588,7 @@ Array [
                   </div>
                 </div>
                 <ul
-                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
                 >
                   <li
                     aria-disabled="true"
@@ -4116,7 +4116,7 @@ Array [
                   </div>
                 </div>
                 <ul
-                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
                 >
                   <li
                     aria-disabled="true"
@@ -8933,7 +8933,7 @@ exports[`renders components/transfer/demo/table-transfer.tsx correctly 1`] = `
                   </div>
                 </div>
                 <ul
-                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
+                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-outlined ant-table-pagination ant-table-pagination-end css-var-test-id"
                 >
                   <li
                     aria-disabled="true"

--- a/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
@@ -3588,7 +3588,7 @@ Array [
                   </div>
                 </div>
                 <ul
-                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
                 >
                   <li
                     aria-disabled="true"
@@ -4116,7 +4116,7 @@ Array [
                   </div>
                 </div>
                 <ul
-                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
                 >
                   <li
                     aria-disabled="true"
@@ -8933,7 +8933,7 @@ exports[`renders components/transfer/demo/table-transfer.tsx correctly 1`] = `
                   </div>
                 </div>
                 <ul
-                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-table-pagination ant-table-pagination-end css-var-test-id"
+                  class="ant-pagination ant-pagination-small ant-pagination-mini ant-pagination-variant-text ant-table-pagination ant-table-pagination-end css-var-test-id"
                 >
                   <li
                     aria-disabled="true"


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
feat: [55338](https://github.com/ant-design/ant-design/issues/55338)

### 💡 Background and Solution
Pagination 页码按钮此前只有默认样式（及 wireframe 边框），无法像 Button / Tag 一样切换视觉形态。
variant: text（默认）| outlined | filled | solid
shape: default（默认）| round
支持通过 ConfigProvider 的 pagination.variant / pagination.shape 全局配置；组件 props 优先

### 📝 Change Log
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add Pagination variant and shape props, with ConfigProvider support |
| 🇨🇳 Chinese | 新增 Pagination variant 与 shape 属性，并支持 ConfigProvider 全局配置 |
