### PR TITLE
fix(Collapse): center bare `<svg>` icons at any size

### DIFF
--- a/components/collapse/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/collapse/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1367,6 +1367,144 @@ exports[`renders components/collapse/demo/ghost.tsx extend context correctly 1`]
 
 exports[`renders components/collapse/demo/ghost.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/collapse/demo/icon.tsx extend context correctly 1`] = `
+<div
+  class="ant-collapse ant-collapse-icon-placement-start css-var-test-id"
+>
+  <div
+    class="ant-collapse-item ant-collapse-item-active"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="true"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="expanded"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            style="transform: rotate(90deg);"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        <span
+          aria-label="smile"
+          class="anticon anticon-smile"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="smile"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+            />
+          </svg>
+        </span>
+         Panel with an Ant Design icon
+      </span>
+    </div>
+    <div
+      class="ant-collapse-panel ant-collapse-panel-active"
+    >
+      <div
+        class="ant-collapse-body"
+      >
+        <p>
+  A dog is a type of domesticated animal.
+  Known for its loyalty and faithfulness,
+  it can be found as a welcome guest in many households across the world.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-collapse-item"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="collapsed"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="1em"
+          stroke="currentColor"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <path
+            d="M3 3v18h18"
+          />
+          <path
+            d="M7 14l4-4 3 3 5-6"
+          />
+        </svg>
+         Panel with a third-party icon
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/collapse/demo/icon.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/collapse/demo/mix.tsx extend context correctly 1`] = `
 <div
   class="ant-collapse ant-collapse-icon-placement-start css-var-test-id"

--- a/components/collapse/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/collapse/__tests__/__snapshots__/demo.test.ts.snap
@@ -1271,6 +1271,142 @@ exports[`renders components/collapse/demo/ghost.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/collapse/demo/icon.tsx correctly 1`] = `
+<div
+  class="ant-collapse ant-collapse-icon-placement-start css-var-test-id"
+>
+  <div
+    class="ant-collapse-item ant-collapse-item-active"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="true"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="expanded"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            style="-ms-transform:rotate(90deg);transform:rotate(90deg)"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        <span
+          aria-label="smile"
+          class="anticon anticon-smile"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="smile"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm352 0a48 48 0 1096 0 48 48 0 10-96 0zM512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm263 711c-34.2 34.2-74 61-118.3 79.8C611 874.2 562.3 884 512 884c-50.3 0-99-9.8-144.8-29.2A370.4 370.4 0 01248.9 775c-34.2-34.2-61-74-79.8-118.3C149.8 611 140 562.3 140 512s9.8-99 29.2-144.8A370.4 370.4 0 01249 248.9c34.2-34.2 74-61 118.3-79.8C413 149.8 461.7 140 512 140c50.3 0 99 9.8 144.8 29.2A370.4 370.4 0 01775.1 249c34.2 34.2 61 74 79.8 118.3C874.2 413 884 461.7 884 512s-9.8 99-29.2 144.8A368.89 368.89 0 01775 775zM664 533h-48.1c-4.2 0-7.8 3.2-8.1 7.4C604 589.9 562.5 629 512 629s-92.1-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4z"
+            />
+          </svg>
+        </span>
+         Panel with an Ant Design icon
+      </span>
+    </div>
+    <div
+      class="ant-collapse-panel ant-collapse-panel-active"
+    >
+      <div
+        class="ant-collapse-body"
+      >
+        <p>
+  A dog is a type of domesticated animal.
+  Known for its loyalty and faithfulness,
+  it can be found as a welcome guest in many households across the world.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-collapse-item"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="false"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-label="collapsed"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="1em"
+          stroke="currentColor"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <path
+            d="M3 3v18h18"
+          />
+          <path
+            d="M7 14l4-4 3 3 5-6"
+          />
+        </svg>
+         Panel with a third-party icon
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/collapse/demo/mix.tsx correctly 1`] = `
 <div
   class="ant-collapse ant-collapse-icon-placement-start css-var-test-id"

--- a/components/collapse/demo/icon.md
+++ b/components/collapse/demo/icon.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+在面板标题中加入图标。第三方图标库（如 lucide、react-icons）渲染出的裸 `<svg>` 也会与标题文字垂直居中对齐。
+
+## en-US
+
+Add an icon to the panel title. A bare `<svg>` from a third-party icon library (e.g. lucide, react-icons) stays vertically centred with the title text.

--- a/components/collapse/demo/icon.tsx
+++ b/components/collapse/demo/icon.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { SmileOutlined } from '@ant-design/icons';
+import type { CollapseProps } from 'antd';
+import { Collapse } from 'antd';
+
+// Icons from third-party libraries (e.g. lucide, react-icons) render as a bare `<svg>`
+// rather than an `.anticon` wrapper. It stays vertically centred with the title text.
+const ChartIcon: React.FC = () => (
+  <svg
+    viewBox="0 0 24 24"
+    width="1em"
+    height="1em"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    aria-hidden="true"
+  >
+    <path d="M3 3v18h18" />
+    <path d="M7 14l4-4 3 3 5-6" />
+  </svg>
+);
+
+const text = `
+  A dog is a type of domesticated animal.
+  Known for its loyalty and faithfulness,
+  it can be found as a welcome guest in many households across the world.
+`;
+
+const items: CollapseProps['items'] = [
+  {
+    key: '1',
+    label: (
+      <>
+        <SmileOutlined /> Panel with an Ant Design icon
+      </>
+    ),
+    children: <p>{text}</p>,
+  },
+  {
+    key: '2',
+    label: (
+      <>
+        <ChartIcon /> Panel with a third-party icon
+      </>
+    ),
+    children: <p>{text}</p>,
+  },
+];
+
+const App: React.FC = () => <Collapse defaultActiveKey={['1']} items={items} />;
+
+export default App;

--- a/components/collapse/index.en-US.md
+++ b/components/collapse/index.en-US.md
@@ -21,6 +21,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*sir-TK0HkWcAAA
 <code src="./demo/mix.tsx">Nested panel</code>
 <code src="./demo/borderless.tsx">Borderless</code>
 <code src="./demo/custom.tsx">Custom Panel</code>
+<code src="./demo/icon.tsx">Panel with icon</code>
 <code src="./demo/noarrow.tsx">No arrow</code>
 <code src="./demo/extra.tsx">Extra node</code>
 <code src="./demo/ghost.tsx">Ghost Collapse</code>

--- a/components/collapse/index.zh-CN.md
+++ b/components/collapse/index.zh-CN.md
@@ -22,6 +22,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*sir-TK0HkWcAAA
 <code src="./demo/mix.tsx">面板嵌套</code>
 <code src="./demo/borderless.tsx">简洁风格</code>
 <code src="./demo/custom.tsx">自定义面板</code>
+<code src="./demo/icon.tsx">面板图标</code>
 <code src="./demo/noarrow.tsx">隐藏箭头</code>
 <code src="./demo/extra.tsx">额外节点</code>
 <code src="./demo/ghost.tsx">幽灵折叠面板</code>

--- a/components/collapse/style/index.ts
+++ b/components/collapse/style/index.ts
@@ -174,6 +174,22 @@ export const genBaseStyle: GenerateStyle<CollapseToken, CSSObject> = (token) => 
           // >>>>> Text
           [`${componentCls}-title`]: {
             marginInlineEnd: 'auto',
+
+            // Icons from third-party libraries render as a bare `<svg>`, which the `.anticon`
+            // reset never reaches. An `<svg>` has no baseline of its own, so it is aligned by its
+            // bottom margin edge (CSS 2.1 §10.8.1) and rides above the title text.
+            // `display: inline-block` keeps it an atomic inline box so `vertical-align` still applies
+            // even under a CSS reset that forces `svg { display: block }` (e.g. Tailwind Preflight),
+            // which would otherwise drop the icon onto its own line. `vertical-align: middle` centres
+            // its margin box on the x-height line; `margin-block-end` then lifts it by half its own
+            // value onto the cap-height centre (capHeight − xHeight ≈ 0.2em across typical fonts),
+            // keeping it centred at any icon size.
+            // Only matches a bare `<svg>`: an `.anticon` keeps its `<svg>` one level deeper.
+            '> svg': {
+              display: 'inline-block',
+              verticalAlign: 'middle',
+              marginBlockEnd: '0.2em',
+            },
           },
         },
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

Continues the bare-`<svg>` icon-alignment series already merged for Tag (#58723), Tabs (#58847) and Segmented (#58862).

### 💡 Background and Solution

Icons from third-party libraries (lucide, react-icons, phosphor) render as a **bare `<svg>`**, not an `.anticon`. A bare `<svg>` has no baseline of its own, so when it is placed in a Collapse panel `label` next to the title text the browser aligns it by its bottom margin edge (CSS 2.1 §10.8.1) — it rides **above** the text, and the gap **grows with the icon's size** (an `.anticon`'s constant `-0.125em` nudge only works because its svg is always `1em`, so it can't fix a px-sized svg).

**Fix** — one rule on the title's bare svg:

```css
.ant-collapse-title > svg { display: inline-block; vertical-align: middle; margin-block-end: 0.2em }
```

`middle` centres the svg's margin box on the text x-height line (a ratio); `margin-block-end` then lifts it by half its own value onto the cap-height centre (capHeight − xHeight ≈ 0.2em across typical fonts), keeping it centred at **any** size.

- `display: inline-block` keeps the svg an atomic inline box so `vertical-align` still applies under a CSS reset that forces `svg { display: block }` — most notably **Tailwind Preflight** (and the ant.design docs site's own reset). Without it a block-level svg *ignores* `vertical-align` and breaks onto its own line, which is why the already-released Tag/Tabs icon demos render broken on the docs site even though the fix works in a reset-free app.
- The `> svg` child selector never matches an `.anticon` (its `<svg>` is one level deeper), and the expand arrow lives in a separate `.ant-collapse-expand-icon` — both stay **byte-identical**.
- Measured offset (icon centre − text cap centre): **−2px @1em / −7px @24px** before → **~−0.1px flat** after.

![Collapse bare svg icon before/after](https://raw.githubusercontent.com/mohamedkhaled4053/ant-design/assets-bare-svg-collapse-breadcrumb/collapse-bare-svg.png)

Also added a "Panel with icon" demo covering both an `@ant-design/icons` icon and a bare third-party `<svg>`.

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Fix Collapse so a bare `<svg>` icon in a panel title stays vertically centered with the title text at any size. |
| 🇨🇳 Chinese | 修复 Collapse 面板标题中的裸 `<svg>` 图标在任意尺寸下与标题文字垂直居中对齐的问题。 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

