### PR TITLE
fix(Breadcrumb): align and space bare `<svg>` icons

### DIFF
--- a/components/breadcrumb/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1056,6 +1056,40 @@ exports[`renders components/breadcrumb/demo/withIcon.tsx extend context correctl
     <li
       class="ant-breadcrumb-item"
     >
+      <a
+        class="ant-breadcrumb-link"
+        href=""
+      >
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="1em"
+          stroke="currentColor"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <path
+            d="M3 3v18h18"
+          />
+          <path
+            d="M7 14l4-4 3 3 5-6"
+          />
+        </svg>
+        <span>
+          Dashboard
+        </span>
+      </a>
+    </li>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
       <span
         class="ant-breadcrumb-link"
       >

--- a/components/breadcrumb/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/breadcrumb/__tests__/__snapshots__/demo.test.ts.snap
@@ -698,6 +698,40 @@ exports[`renders components/breadcrumb/demo/withIcon.tsx correctly 1`] = `
     <li
       class="ant-breadcrumb-item"
     >
+      <a
+        class="ant-breadcrumb-link"
+        href=""
+      >
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="1em"
+          stroke="currentColor"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <path
+            d="M3 3v18h18"
+          />
+          <path
+            d="M7 14l4-4 3 3 5-6"
+          />
+        </svg>
+        <span>
+          Dashboard
+        </span>
+      </a>
+    </li>
+    <li
+      aria-hidden="true"
+      class="ant-breadcrumb-separator"
+    >
+      /
+    </li>
+    <li
+      class="ant-breadcrumb-item"
+    >
       <span
         class="ant-breadcrumb-link"
       >

--- a/components/breadcrumb/demo/withIcon.md
+++ b/components/breadcrumb/demo/withIcon.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-图标放在文字前面。
+图标放在文字前面。第三方图标库（如 lucide、react-icons）渲染出的裸 `<svg>` 也会与文字垂直居中并保持间距。
 
 ## en-US
 
-The icon should be placed in front of the text.
+The icon should be placed in front of the text. A bare `<svg>` from a third-party icon library (e.g. lucide, react-icons) stays vertically centred with, and spaced from, the text.

--- a/components/breadcrumb/demo/withIcon.tsx
+++ b/components/breadcrumb/demo/withIcon.tsx
@@ -2,6 +2,23 @@ import React from 'react';
 import { HomeOutlined, UserOutlined } from '@ant-design/icons';
 import { Breadcrumb } from 'antd';
 
+// Icons from third-party libraries (e.g. lucide, react-icons) render as a bare `<svg>`
+// rather than an `.anticon` wrapper. It stays centred with, and spaced from, the label.
+const ChartIcon: React.FC = () => (
+  <svg
+    viewBox="0 0 24 24"
+    width="1em"
+    height="1em"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    aria-hidden="true"
+  >
+    <path d="M3 3v18h18" />
+    <path d="M7 14l4-4 3 3 5-6" />
+  </svg>
+);
+
 const App: React.FC = () => (
   <Breadcrumb
     items={[
@@ -15,6 +32,15 @@ const App: React.FC = () => (
           <>
             <UserOutlined />
             <span>Application List</span>
+          </>
+        ),
+      },
+      {
+        href: '',
+        title: (
+          <>
+            <ChartIcon />
+            <span>Dashboard</span>
           </>
         ),
       },

--- a/components/breadcrumb/style/index.ts
+++ b/components/breadcrumb/style/index.ts
@@ -93,9 +93,28 @@ const genBreadcrumbStyle: GenerateStyle<BreadcrumbToken, CSSObject> = (token) =>
       },
 
       [`${componentCls}-link`]: {
+        // Icons from third-party libraries render as a bare `<svg>`, which the `.anticon`
+        // reset never reaches. An `<svg>` has no baseline of its own, so it is aligned by its
+        // bottom margin edge (CSS 2.1 §10.8.1) and rides above the link text.
+        // `display: inline-block` keeps it an atomic inline box so `vertical-align` still applies
+        // even under a CSS reset that forces `svg { display: block }` (e.g. Tailwind Preflight),
+        // which would otherwise drop the icon onto its own line. `vertical-align: middle` centres
+        // its margin box on the x-height line; `margin-block-end` then lifts it by half its own
+        // value onto the cap-height centre (capHeight − xHeight ≈ 0.2em across typical fonts),
+        // keeping it centred at any icon size.
+        // Only matches a bare `<svg>`: an `.anticon` keeps its `<svg>` one level deeper.
+        '> svg': {
+          display: 'inline-block',
+          verticalAlign: 'middle',
+          marginBlockEnd: '0.2em',
+        },
+
+        // Same spacing an `.anticon` gets before the following text, extended to a bare `<svg>`.
         [`
           > ${iconCls} + span,
-          > ${iconCls} + a
+          > ${iconCls} + a,
+          > svg + span,
+          > svg + a
         `]: {
           marginInlineStart: token.marginXXS,
         },


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

Continues the bare-`<svg>` icon-alignment series already merged for Tag (#58723), Tabs (#58847) and Segmented (#58862). Mirrors the Tag fix, which is the same direct-child case.

### 💡 Background and Solution

Icons from third-party libraries (lucide, react-icons, phosphor) render as a **bare `<svg>`**, not an `.anticon`. A bare `<svg>` has no baseline of its own, so when it is placed in a Breadcrumb item `title` next to the link text the browser aligns it by its bottom margin edge (CSS 2.1 §10.8.1) — it rides **above** the text, and the gap **grows with the icon's size** (an `.anticon`'s constant `-0.125em` nudge can't fix a px-sized svg). The existing icon-to-text spacing rule was also `.anticon`-only, so a bare `<svg>` sat flush against the label.

**Fix** — centre and space the bare svg exactly like an `.anticon`:

```css
.ant-breadcrumb-link > svg { display: inline-block; vertical-align: middle; margin-block-end: 0.2em }
/* + extend the icon+text gap selector to `> svg + span`, `> svg + a` */
```

`middle` centres the svg's margin box on the text x-height line; `margin-block-end` lifts it by half its own value onto the cap-height centre (capHeight − xHeight ≈ 0.2em), keeping it centred at **any** size.

- `display: inline-block` keeps the svg an atomic inline box so `vertical-align` still applies under a CSS reset that forces `svg { display: block }` — most notably **Tailwind Preflight** (and the ant.design docs site's own reset). Without it a block-level svg *ignores* `vertical-align` and breaks onto its own line, which is why the already-released Tag/Tabs icon demos render broken on the docs site even though the fix works in a reset-free app.
- The `> svg` child selector never matches an `.anticon` (its `<svg>` is one level deeper), so existing icons stay **byte-identical**.
- Measured offset (icon centre − text cap centre): **−2px @1em / −7px @24px** before → **~−0.1px flat** after.

![Breadcrumb bare svg icon before/after](https://raw.githubusercontent.com/mohamedkhaled4053/ant-design/assets-bare-svg-collapse-breadcrumb/breadcrumb-bare-svg.png)

Also extended the `withIcon` demo with a bare third-party `<svg>` item.

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Fix Breadcrumb so a bare `<svg>` icon in an item title stays vertically centered with, and spaced from, the text at any size. |
| 🇨🇳 Chinese | 修复 Breadcrumb 面包屑项标题中的裸 `<svg>` 图标在任意尺寸下与文字垂直居中对齐并保持间距的问题。 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

