### PR TITLE
fix: keep bare `<svg>` icons aligned under a `display: block` reset

### DIFF
--- a/components/segmented/style/index.ts
+++ b/components/segmented/style/index.ts
@@ -206,11 +206,15 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken, CSSObject> = (token) => {
         // Icons from third-party libraries render as a bare `<svg>` inside the icon wrapper,
         // which the `.anticon` reset never reaches. An `<svg>` has no baseline of its own, so it
         // is aligned by its bottom margin edge (CSS 2.1 §10.8.1) and rides above the label.
-        // `vertical-align: middle` centres its margin box on the x-height line; `margin-block-end`
-        // then lifts it by half its own value onto the cap-height centre (capHeight − xHeight ≈
-        // 0.2em across typical fonts), keeping it centred at any icon size.
+        // `display: inline-block` keeps it an atomic inline box so `vertical-align` still applies
+        // even under a CSS reset that forces `svg { display: block }` (e.g. Tailwind Preflight),
+        // which would otherwise drop the icon onto its own line. `vertical-align: middle` centres its
+        // margin box on the x-height line; `margin-block-end` then lifts it by half its own value onto
+        // the cap-height centre (capHeight − xHeight ≈ 0.2em across typical fonts), keeping it centred
+        // at any icon size.
         // Only matches a bare `<svg>`: an `.anticon` keeps its `<svg>` one level deeper.
         '&-icon > svg': {
+          display: 'inline-block',
           verticalAlign: 'middle',
           marginBlockEnd: '0.2em',
         },

--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -772,11 +772,15 @@ const genTabStyle: GenerateStyle<TabsToken, CSSObject> = (token) => {
         // Icons from third-party libraries render as a bare `<svg>` inside the icon wrapper,
         // which the `.anticon` reset never reaches. An `<svg>` has no baseline of its own, so it
         // is aligned by its bottom margin edge (CSS 2.1 §10.8.1) and rides above the label.
-        // `vertical-align: middle` centres its margin box on the x-height line; `margin-block-end`
-        // then lifts it by half its own value onto the cap-height centre (capHeight − xHeight ≈
-        // 0.2em across typical fonts), keeping it centred at any icon size.
+        // `display: inline-block` keeps it an atomic inline box so `vertical-align` still applies
+        // even under a CSS reset that forces `svg { display: block }` (e.g. Tailwind Preflight),
+        // which would otherwise drop the icon onto its own line. `vertical-align: middle` centres its
+        // margin box on the x-height line; `margin-block-end` then lifts it by half its own value onto
+        // the cap-height centre (capHeight − xHeight ≈ 0.2em across typical fonts), keeping it centred
+        // at any icon size.
         // Only matches a bare `<svg>`: an `.anticon` keeps its `<svg>` one level deeper.
         [`${tabCls}-icon > svg`]: {
+          display: 'inline-block',
           verticalAlign: 'middle',
           marginBlockEnd: '0.2em',
         },

--- a/components/tag/style/index.ts
+++ b/components/tag/style/index.ts
@@ -148,11 +148,14 @@ const genBaseStyle: GenerateStyle<TagToken, CSSInterpolation> = (token) => {
       // margin edge (CSS 2.1 §10.8.1) and rides above the text. Centre it instead: unlike an
       // `.anticon` (whose `<svg>` is always `1em`, so a fixed `-0.125em` nudge suffices), a
       // third-party `<svg>` may be sized in `px`, so the correction must not depend on size.
-      // `vertical-align: middle` centres the margin box on the x-height line; `margin-block-end`
-      // then lifts it by half its own value onto the cap-height centre (capHeight − xHeight ≈
-      // 0.2em across typical fonts), keeping it centred at any icon size.
+      // `display: inline-block` keeps it an atomic inline box so `vertical-align` still applies even
+      // under a CSS reset that forces `svg { display: block }` (e.g. Tailwind Preflight), which would
+      // otherwise drop the icon onto its own line. `vertical-align: middle` centres the margin box on
+      // the x-height line; `margin-block-end` then lifts it by half its own value onto the cap-height
+      // centre (capHeight − xHeight ≈ 0.2em across typical fonts), keeping it centred at any icon size.
       // Only matches a bare `<svg>`: an `.anticon` keeps its `<svg>` one level deeper.
       '> svg': {
+        display: 'inline-block',
         verticalAlign: 'middle',
         marginBlockEnd: '0.2em',
       },


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

Follow-up to the bare-`<svg>` icon-alignment series: Tag (#58723), Tabs (#58847), Segmented (#58862). Those fixes are visibly broken on the ant.design docs site's own icon demos (e.g. `/components/tabs#tabs-demo-icon`, `/components/tag#tag-demo-icon`).

### 💡 Background and Solution

Each of those fixes centres a bare `<svg>` with `vertical-align: middle` — which only applies to **inline-level** boxes. But any CSS reset that sets `svg { display: block }` turns the icon into a **block** box, and a block box:

1. **ignores `vertical-align` entirely** — so the fix silently no-ops, and
2. **breaks onto its own line** — so the icon rides a full line-height above its label.

`svg { display: block }` is exactly what **Tailwind Preflight** ships (`img, svg, video { display: block; vertical-align: middle }`), and it's also present in the ant.design docs site's own reset — which is why the released demos render broken there even though the fix works fine in a reset-free app. Measured offset under such a reset: **−18px to −24px** across Tag / Tabs / Segmented.

**Fix** — add `display: inline-block` to each existing `> svg` rule so the icon stays an atomic inline box:

```css
.ant-tag > svg,
.ant-tabs-tab-icon > svg,
.ant-segmented-item-icon > svg { display: inline-block; vertical-align: middle; margin-block-end: 0.2em }
```

`vertical-align` applies again and the icon no longer wraps. The rule's specificity (`.ant-x > svg`) beats a bare `svg { display: block }`, and `@ant-design/icons` icons are untouched (an `.anticon` keeps its `<svg>` one level deeper, so `> svg` never matches it). No behaviour change without a reset.

The image below renders all three components under a Tailwind-style `svg { display: block }` reset — before (released) the bare-svg icons ride high / wrap; after (this PR) they sit on the label. The `.anticon` icons (Android) are centred in both, showing the contrast.

![bare svg under display:block reset before/after](https://raw.githubusercontent.com/mohamedkhaled4053/ant-design/assets-bare-svg-inline-block/series-reset-before-after.png)

The same `display: inline-block` addition is included in the open Collapse (#58868) and Breadcrumb (#58869) PRs from the start.

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Fix Tag, Tabs and Segmented so a bare `<svg>` icon stays vertically centered even when a CSS reset (e.g. Tailwind Preflight) sets `svg { display: block }`. |
| 🇨🇳 Chinese | 修复 Tag、Tabs、Segmented 在 CSS reset（如 Tailwind Preflight）将 `svg` 设为 `display: block` 时，裸 `<svg>` 图标无法与文字垂直居中对齐的问题。 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
