### PR TITLE
fix: replace transition:all with specific properties to prevent Sider trigger icon from shaking

### DIFF
--- a/components/layout/style/sider.ts
+++ b/components/layout/style/sider.ts
@@ -33,7 +33,9 @@ const genSiderStyle: GenerateStyle<LayoutToken, CSSObject> = (token) => {
       // fix firefox can't set width smaller than content on flex item
       minWidth: 0,
       background: siderBg,
-      transition: `all ${motionDurationMid}, background 0s`,
+      // Use specific properties instead of `all` to avoid shaking the trigger icon
+      // when the sider width changes. See https://github.com/ant-design/ant-design/issues/56196
+      transition: `width ${motionDurationMid}, min-width ${motionDurationMid}, max-width ${motionDurationMid}, flex 0s, background 0s`,
 
       '&-has-trigger': {
         paddingBottom: triggerHeight,
@@ -70,7 +72,9 @@ const genSiderStyle: GenerateStyle<LayoutToken, CSSObject> = (token) => {
         textAlign: 'center',
         background: triggerBg,
         cursor: 'pointer',
-        transition: `all ${motionDurationMid}`,
+        // Only transition width and color, not position, to keep the trigger icon
+        // in sync with the sider width animation. See: https://github.com/ant-design/ant-design/issues/56196
+        transition: `width ${motionDurationMid}, color ${motionDurationMid}, background ${motionDurationMid}`,
       },
 
       [`${componentCls}-zero-width-trigger`]: {


### PR DESCRIPTION
## Summary
When the Sider collapses/expands, the trigger icon shakes because both the Sider and trigger use `transition: all` with mismatched animation timing. The Sider's width and the trigger's position animate at different rates, causing the centered icon to jitter.

## Fix
Replace `transition: all` with explicit property transitions:
- **Sider** (`ant-layout-sider`): only `width`, `min-width`, `max-width`, `flex`, `background`
- **Trigger** (`ant-layout-sider-trigger`): only `width`, `color`, `background`

This ensures the trigger icon stays in sync with the Sider's width animation and eliminates the visual shake.

Closes #56196