### PR TITLE
fix(Alert): show close button when closable contains onClose

### DIFF
--- a/components/alert/Alert.tsx
+++ b/components/alert/Alert.tsx
@@ -247,7 +247,7 @@ const Alert = React.forwardRef<AlertRef, AlertProps>((props, ref) => {
 
   // closeable when closeText or closeIcon is assigned
   const isClosable = React.useMemo<boolean>(() => {
-    if (isPlainObject(closable) && closable.closeIcon) {
+    if (isPlainObject(closable)) {
       return true;
     }
     if (closeText) {

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -49,20 +49,20 @@ describe('Alert', () => {
     errSpy.mockRestore();
   });
 
-  it('onClose and closable.onClose', async () => {
+  it('should use closable.onClose without requiring closeIcon', () => {
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const onClose = jest.fn();
     const handleClosableClose = jest.fn();
-    const { container } = render(
+    render(
       <Alert
         title="Warning Text Warning Text Warning TextW arning Text Warning Text Warning TextWarning Text"
         type="warning"
-        closable={{ onClose: handleClosableClose, closeIcon: true }}
+        closable={{ onClose: handleClosableClose }}
         onClose={onClose}
       />,
     );
 
-    fireEvent.click(container.querySelector('.ant-alert-close-icon')!);
+    fireEvent.click(screen.getByRole('button'));
 
     expect(onClose).toHaveBeenCalledTimes(0);
     expect(handleClosableClose).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] ✅ 测试用例

### 🔗 相关 Issue

Fixes #58884

### 💡 需求背景和解决方案

Alert 已推荐使用 `closable.onClose` 替代顶层的 `onClose`。但仅配置 `closable={{ onClose }}` 时，组件不会显示默认关闭按钮，导致用户无法触发关闭操作。

本次调整将对象形式的 `closable` 直接视为开启关闭能力。当对象中没有配置 `closeIcon` 时，Alert 会使用默认关闭图标，同时保持 `closable.onClose` 优先于顶层 `onClose` 的现有行为。

补充了回归测试，验证不配置 `closeIcon` 时关闭按钮仍会显示，并且点击后调用 `closable.onClose`。

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | Fix Alert not rendering the default close button when only `closable.onClose` is configured. |
| 🇨🇳 中文 | 修复 Alert 仅配置 `closable.onClose` 时不显示默认关闭按钮的问题。 |
