### PR TITLE
fix(Descriptions): restore equal column widths

### DIFF
--- a/components/descriptions/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/descriptions/__tests__/__snapshots__/index.test.tsx.snap
@@ -8,6 +8,11 @@ exports[`Descriptions Descriptions support colon 1`] = `
     class="ant-descriptions-view"
   >
     <table>
+      <colgroup>
+        <col
+          style="width: 100%;"
+        />
+      </colgroup>
       <tbody>
         <tr
           class="ant-descriptions-row"
@@ -47,6 +52,11 @@ exports[`Descriptions Descriptions support style 1`] = `
     class="ant-descriptions-view"
   >
     <table>
+      <colgroup>
+        <col
+          style="width: 100%;"
+        />
+      </colgroup>
       <tbody>
         <tr
           class="ant-descriptions-row"
@@ -80,6 +90,11 @@ exports[`Descriptions Descriptions.Item support className 1`] = `
     class="ant-descriptions-view"
   >
     <table>
+      <colgroup>
+        <col
+          style="width: 100%;"
+        />
+      </colgroup>
       <tbody>
         <tr
           class="ant-descriptions-row"
@@ -118,6 +133,17 @@ exports[`Descriptions column is number 1`] = `
     class="ant-descriptions-view"
   >
     <table>
+      <colgroup>
+        <col
+          style="width: 33.333333333333336%;"
+        />
+        <col
+          style="width: 33.333333333333336%;"
+        />
+        <col
+          style="width: 33.333333333333336%;"
+        />
+      </colgroup>
       <tbody>
         <tr
           class="ant-descriptions-row"
@@ -217,6 +243,11 @@ exports[`Descriptions number 0 should render correct 1`] = `
     class="ant-descriptions-view"
   >
     <table>
+      <colgroup>
+        <col
+          style="width: 100%;"
+        />
+      </colgroup>
       <tbody>
         <tr
           class="ant-descriptions-row"
@@ -258,6 +289,11 @@ exports[`Descriptions should items work 1`] = `
       class="ant-descriptions-view"
     >
       <table>
+        <colgroup>
+          <col
+            style="width: 100%;"
+          />
+        </colgroup>
         <tbody>
           <tr
             class="ant-descriptions-row"
@@ -343,6 +379,11 @@ exports[`Descriptions should work with React Fragment 1`] = `
     class="ant-descriptions-view"
   >
     <table>
+      <colgroup>
+        <col
+          style="width: 100%;"
+        />
+      </colgroup>
       <tbody>
         <tr
           class="ant-descriptions-row"
@@ -427,6 +468,11 @@ exports[`Descriptions vertical layout 1`] = `
     class="ant-descriptions-view"
   >
     <table>
+      <colgroup>
+        <col
+          style="width: 100%;"
+        />
+      </colgroup>
       <tbody>
         <tr
           class="ant-descriptions-row"
@@ -586,6 +632,11 @@ exports[`Descriptions when item is rendered conditionally 1`] = `
     class="ant-descriptions-view"
   >
     <table>
+      <colgroup>
+        <col
+          style="width: 100%;"
+        />
+      </colgroup>
       <tbody>
         <tr
           class="ant-descriptions-row"

--- a/components/descriptions/__tests__/image.test.ts
+++ b/components/descriptions/__tests__/image.test.ts
@@ -1,5 +1,25 @@
-import { imageDemoTest } from '../../../tests/shared/imageTest';
+import React from 'react';
+
+import Basic from '../demo/basic';
+import imageTest, { imageDemoTest } from '../../../tests/shared/imageTest';
 
 describe('Descriptions image', () => {
-  imageDemoTest('descriptions');
+  imageTest(
+    React.createElement(Basic),
+    'descriptions-basic',
+    'components/descriptions/demo/basic.tsx',
+    {
+      beforeScreenshot: async (testPage) => {
+        const widths = await testPage.$$eval(
+          '.ant-descriptions-view > table > tbody > tr:first-child > .ant-descriptions-item',
+          (cells) => cells.map((cell) => cell.getBoundingClientRect().width),
+        );
+
+        expect(widths).toHaveLength(3);
+        expect(Math.max(...widths) - Math.min(...widths)).toBeLessThan(1);
+      },
+    },
+  );
+
+  imageDemoTest('descriptions', { skip: ['basic.tsx'] });
 });

--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -245,6 +245,13 @@ const Descriptions: React.FC<DescriptionsProps> & CompoundedComponent = (props) 
         )}
         <div className={`${prefixCls}-view`}>
           <table>
+            {!bordered && (
+              <colgroup>
+                {Array.from({ length: mergedColumn }, (_, index) => (
+                  <col key={index} style={{ width: `${100 / mergedColumn}%` }} />
+                ))}
+              </colgroup>
+            )}
             <tbody>
               {rows.map((row, index) => (
                 <Row


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

close #58887

### 💡 需求背景和解决方案

非边框模式的 Descriptions 使用自动表格布局后，各列会根据内容宽度分配空间，导致默认列不再等宽。

本次为非边框模式输出 `<colgroup>`，根据当前 column 数量为逻辑列设置相同比例宽度。边框模式保持原有布局，同时避免重新引入 max-content 容器中的表格超宽问题。

增加图像测试布局断言，并同步相关 DOM 快照。TypeScript、ESLint、Biome 以及 Chromium 实际布局验证均已通过。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Descriptions restores equal column widths in borderless mode. |
| 🇨🇳 中文 | 修复 Descriptions 无边框模式下默认列宽不均的问题。 |