### PR TITLE
fix: Layout Sider trigger icon jitter when collapsing/expanding 

### DIFF
--- a/components/layout/style/sider.ts
+++ b/components/layout/style/sider.ts
@@ -33,7 +33,7 @@ const genSiderStyle: GenerateStyle<LayoutToken, CSSObject> = (token) => {
       // fix firefox can't set width smaller than content on flex item
       minWidth: 0,
       background: siderBg,
-      transition: `all ${motionDurationMid}, background 0s`,
+      transition: `width ${motionDurationMid}, background 0s`,
 
       '&-has-trigger': {
         paddingBottom: triggerHeight,
@@ -70,7 +70,7 @@ const genSiderStyle: GenerateStyle<LayoutToken, CSSObject> = (token) => {
         textAlign: 'center',
         background: triggerBg,
         cursor: 'pointer',
-        transition: `all ${motionDurationMid}`,
+        transition: `width ${motionDurationMid}, background 0s`,
       },
 
       [`${componentCls}-zero-width-trigger`]: {


### PR DESCRIPTION
点击 trigger 折叠/展开 Sider 的时候，trigger 里的图标会左右晃一下。
根因是 sider 和 trigger 都设了 transition: all，sider 宽度变化时， fixed 定位的 trigger 没有设置 left/right，浏览器在每帧重新计算它的
静态位置，导致图标反复居中产生抖动。

改成只对 width 做 transition 就行了，其他的不需要过渡。

close #56196
