### PR TITLE
docs: fix typos in code comment and docs

### DIFF
--- a/components/_util/hooks/useMergeSemantic/index.ts
+++ b/components/_util/hooks/useMergeSemantic/index.ts
@@ -30,7 +30,7 @@ export const mergeClassNames = <
             // Loop fill
             acc[key] = mergeClassNames(keySchema, acc[key], curVal);
           } else {
-            // Covert string to object structure
+            // Convert string to object structure
             const { _default: defaultField } = keySchema;
             if (defaultField) {
               acc[key] = acc[key] || {};

--- a/docs/react/faq.en-US.md
+++ b/docs/react/faq.en-US.md
@@ -63,7 +63,7 @@ And which you should avoid doing:
 - Bug as feature. It will break in any other case (e.g. Use div as Tabs children)
 - Use magic code to realize requirement but which can be realized with normal API
 
-## How to use other data-time lib like Moment.js?
+## How to use other date-time lib like Moment.js?
 
 Please refer to [Use custom date library](/docs/react/use-custom-date-library).
 

--- a/docs/spec/detail-page.en-US.md
+++ b/docs/spec/detail-page.en-US.md
@@ -138,7 +138,7 @@ Conclude the closeness of each information module according to the relevance amo
 <img class="preview-img no-padding" src="https://gw.alipayobjects.com/zos/antfincdn/J7ccrSNpjz/89878d45-ca15-4a6a-853e-3281fe02f114.png">
 </ImagePreview>
 
-Select presentation modes of the information according to its types and complexity. Abased on the complexity from low to high, the followings are available components:
+Select presentation modes of the information according to its types and complexity. Based on the complexity from low to high, the followings are available components:
 
 ## Read more
 


### PR DESCRIPTION
A few small typos:

- `components/_util/hooks/useMergeSemantic/index.ts`: comment "Covert string to object structure" -> "Convert" (the code immediately converts the string to an object).
- `docs/react/faq.en-US.md`: heading "How to use other data-time lib like Moment.js?" -> "date-time" (the zh-CN heading is 时间日期; Moment.js is a date-time library).
- `docs/spec/detail-page.en-US.md`: "Abased on the complexity" -> "Based on the complexity".

Documentation only.
