### PR TITLE
fix(DatePicker): pass props to RangePicker semantic callbacks

### DIFF
--- a/components/date-picker/__tests__/semantic.test.tsx
+++ b/components/date-picker/__tests__/semantic.test.tsx
@@ -174,4 +174,21 @@ describe('DatePicker.Semantic', () => {
     const largeRootElement = container.querySelector('.ant-picker');
     expect(largeRootElement).toHaveStyle('font-size: 18px');
   });
+
+  it('should pass props to RangePicker semantic callbacks', () => {
+    const classNamesFn = (info: { props: Record<string, unknown> }) => ({
+      root: info.props.disabled ? 'disabled-root' : 'enabled-root',
+    });
+    const stylesFn = (info: { props: Record<string, unknown> }) => ({
+      root: { fontSize: info.props.size === 'large' ? '18px' : '14px' },
+    });
+
+    const { container } = render(
+      <DatePicker.RangePicker disabled size="large" classNames={classNamesFn} styles={stylesFn} />,
+    );
+    const rootElement = container.querySelector('.ant-picker');
+
+    expect(rootElement).toHaveClass('disabled-root');
+    expect(rootElement).toHaveStyle('font-size: 18px');
+  });
 });

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -86,14 +86,6 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
       });
     }
 
-    const [mergedClassNames, mergedStyles] = useMergedPickerSemantic(
-      pickerType,
-      classNames,
-      styles,
-      popupClassName || dropdownClassName,
-      popupStyle,
-    );
-
     const innerRef = React.useRef<PickerRef>(null);
     const { getPrefixCls, direction, getPopupContainer, rangePicker } = useContext(ConfigContext);
     const prefixCls = getPrefixCls('picker', customizePrefixCls);
@@ -128,6 +120,24 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
     // ===================== Disabled =====================
     const disabled = React.useContext(DisabledContext);
     const mergedDisabled = customDisabled ?? disabled;
+
+    // =========== Merged Props for Semantic ===========
+    const mergedProps = {
+      ...props,
+      size: mergedSize,
+      disabled: mergedDisabled,
+      status: customStatus,
+      variant: customVariant,
+    } as DateRangePickerProps;
+
+    const [mergedClassNames, mergedStyles] = useMergedPickerSemantic<DateRangePickerProps>(
+      pickerType,
+      classNames,
+      styles,
+      popupClassName || dropdownClassName,
+      popupStyle,
+      mergedProps,
+    );
 
     // ===================== FormItemInput =====================
     const formItemContext = useContext(FormItemInputContext);

--- a/components/date-picker/hooks/useMergedPickerSemantic.ts
+++ b/components/date-picker/hooks/useMergedPickerSemantic.ts
@@ -43,7 +43,7 @@ const useMergedPickerSemantic = <P extends AnyObject = AnyObject>(
     };
 
     // Return
-    return [filledClassNames, filledStyles];
+    return [filledClassNames, filledStyles] as const;
   }, [mergedClassNames, mergedStyles, popupClassName, popupStyle]);
 };
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #58903

### 💡 需求背景和解决方案

DatePicker.RangePicker 的函数式 `classNames` 和 `styles` 回调无法获取组件 props，访问属性时会导致组件渲染失败。

本 PR 与单值 DatePicker 保持一致，将合并后的 props 传入语义回调，并补充覆盖 `classNames` 和 `styles` 的回归用例。不涉及公开 API 变更。

验证：`npm run tsc`、目标文件 ESLint、Biome 和 `antd lint` 已通过；未运行 Jest。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix DatePicker.RangePicker functional `classNames` and `styles` callbacks not receiving component props |
| 🇨🇳 中文 | 修复 DatePicker.RangePicker 函数式 `classNames` 和 `styles` 回调无法获取组件属性的问题 |
