### PR TITLE
docs: fix grammar in detail page spec

### DIFF
--- a/docs/spec/detail-page.en-US.md
+++ b/docs/spec/detail-page.en-US.md
@@ -138,7 +138,7 @@ Conclude the closeness of each information module according to the relevance amo
 <img class="preview-img no-padding" src="https://gw.alipayobjects.com/zos/antfincdn/J7ccrSNpjz/89878d45-ca15-4a6a-853e-3281fe02f114.png">
 </ImagePreview>
 
-Select presentation modes of the information according to its types and complexity. Based on the complexity from low to high, the followings are available components:
+Select presentation modes of the information according to its types and complexity. Based on the complexity from low to high, the following components are available:
 
 ## Read more
 


### PR DESCRIPTION
### What is the purpose of this pull request?

Documentation fix. One sentence in the English detail-page spec is ungrammatical:

> Based on the complexity from low to high, **the followings are available components:**

"Followings" is not a noun in English. Changed to:

> Based on the complexity from low to high, **the following components are available:**

### Description

One line, English docs only. The `zh-CN` counterpart is unchanged since the original Chinese reads correctly.

For context, I ran a spellchecker over `components/` and `docs/` first. Everything else it flagged was a false positive and I left all of it alone - `ProTable` and `Didi` are product names, `optionA`/`optionB` are variable names in a sort comparator, `browsersl.ist` is a URL, `afterAll` and `doubleClick` are test APIs, the `divider` demo strings are Latin filler, and the locale files are Catalan, Danish, and German. This was the only genuine issue in the English docs.