### PR TITLE
site: homepage tweaks — dynamic contributor avatars, email fix & theme keyboard a11y

### DIFF
--- a/.dumi/pages/index/components/PreviewPane/Components.tsx
+++ b/.dumi/pages/index/components/PreviewPane/Components.tsx
@@ -55,6 +55,7 @@ import { createStyles } from 'antd-style';
 import type { CheckboxGroupProps } from 'antd/es/checkbox';
 import type { ItemType } from 'antd/es/menu/interface';
 import { clsx } from 'clsx';
+import useSWR from 'swr';
 
 const { Title, Text } = Typography;
 const { _InternalPanelDoNotUseOrYouWillBeFired: InternalPopconfirm } = Popconfirm;
@@ -265,15 +266,6 @@ const tagList: TagProps[] = [
   { icon: <FacebookOutlined />, color: '#3b5999', content: 'Facebook' },
 ];
 
-const avatarGroupList = [
-  'https://avatars.githubusercontent.com/u/507615?v=4',
-  'https://avatars.githubusercontent.com/u/5378891?v=4',
-  'https://avatars.githubusercontent.com/u/49217418?v=4',
-  'https://avatars.githubusercontent.com/u/117748716?v=4',
-  'https://avatars.githubusercontent.com/u/59312002?v=4',
-  'https://avatars.githubusercontent.com/u/82765353?v=4',
-];
-
 const buttonList: ButtonProps[] = [
   { type: 'primary', children: 'Primary button' },
   { danger: true, children: 'Danger button' },
@@ -298,6 +290,22 @@ const ComponentsBlock: React.FC<ComponentsBlockProps> = (props) => {
   } = props;
 
   const { styles } = useStyle();
+
+  const { data: contributors } = useSWR<{ avatar_url: string; login: string }[]>(
+    'https://api.github.com/repos/ant-design/ant-design/contributors?per_page=100',
+    (url) => fetch(url).then((res) => res.json()),
+    {
+      dedupingInterval: 1000 * 60 * 60 * 12, // 12 hours
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    },
+  );
+
+  const avatarGroupList = useMemo(() => {
+    if (!contributors?.length) return [];
+    const shuffled = [...contributors].sort(() => Math.random() - 0.5);
+    return shuffled.slice(0, 6).map((c) => ({ src: c.avatar_url, name: c.login }));
+  }, [contributors]);
 
   const { theme, ...restConfig } = config || {};
 
@@ -337,7 +345,7 @@ const ComponentsBlock: React.FC<ComponentsBlockProps> = (props) => {
                   <div>
                     <Flex vertical gap="middle">
                       <Flex gap="middle">
-                        <Input placeholder="antd@email.com" />
+                        <Input placeholder="hi@example.com" />
                         <Select
                           placeholder="Select one"
                           className={styles.selectInput}
@@ -448,8 +456,8 @@ const ComponentsBlock: React.FC<ComponentsBlockProps> = (props) => {
                 <div className={styles.colCenter}>
                   <div className={styles.avatarSection}>
                     <Avatar.Group className={styles.avatarGroup}>
-                      {avatarGroupList.map((src) => (
-                        <Avatar key={src} size={46} src={src} />
+                      {avatarGroupList.map(({ src, name }) => (
+                        <Avatar key={src} size={46} src={src} aria-label={`Contributor: ${name}`} />
                       ))}
                       <Avatar size={46} className={styles.avatarExtra}>
                         +5
@@ -523,7 +531,7 @@ const ComponentsBlock: React.FC<ComponentsBlockProps> = (props) => {
                   >
                     <Avatar
                       size={50}
-                      src="https://avatars.githubusercontent.com/u/27722486?v=4"
+                      src="https://github.com/ant-design.png?size=50"
                       className={styles.signupAvatar}
                     />
                     <Title level={4}>Create an account</Title>

--- a/.dumi/pages/index/components/ThemePreview/index.tsx
+++ b/.dumi/pages/index/components/ThemePreview/index.tsx
@@ -229,11 +229,27 @@ const ThemePreviewContent: React.FC<ThemePreviewProps> = (props) => {
 
   const handleThemeClick = (themeKey: string) => setActiveThemeKey(themeKey);
 
-  const handleKeyDown = (event: React.KeyboardEvent, themeKey: string) => {
-    if (event.key === 'Enter' || event.key === ' ') {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    const keys = previewThemes.map((t) => getPreviewThemeKey(t));
+    const currentIndex = keys.indexOf(activeThemeKey);
+    if (currentIndex === -1) return;
+
+    let nextIndex: number;
+    if (event.key === 'ArrowRight') {
       event.preventDefault();
-      handleThemeClick(themeKey);
+      nextIndex = (currentIndex + 1) % keys.length;
+    } else if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      nextIndex = (currentIndex - 1 + keys.length) % keys.length;
+    } else {
+      return;
     }
+
+    const nextKey = keys[nextIndex];
+    setActiveThemeKey(nextKey);
+    containerRef.current?.querySelector<HTMLDivElement>(`[data-theme-key="${nextKey}"]`)?.focus();
   };
 
   const activeTheme =
@@ -293,7 +309,7 @@ const ThemePreviewContent: React.FC<ThemePreviewProps> = (props) => {
               value={activePane}
               onChange={setActivePane}
             />
-            <Flex align="center" gap={12}>
+            <Flex align="center" gap={12} ref={containerRef} onKeyDown={handleKeyDown}>
               {previewThemes.map((theme) => {
                 const { name, icon: Icon } = theme;
                 const themeKey = getPreviewThemeKey(theme);
@@ -305,8 +321,8 @@ const ThemePreviewContent: React.FC<ThemePreviewProps> = (props) => {
                       className={clsx(styles.themeBlock, { [styles.active]: isSelected })}
                       tabIndex={isSelected ? 0 : -1}
                       aria-selected={isSelected}
+                      data-theme-key={themeKey}
                       onClick={() => handleThemeClick(themeKey)}
-                      onKeyDown={(event) => handleKeyDown(event, themeKey)}
                     >
                       {typeof Icon === 'string' ? (
                         <img src={Icon} alt={name} title={name} draggable={false} />


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📽️ 演示代码改进
- [x] ⌨️ 无障碍改进

### 💡 需求背景和解决方案

**1. 贡献者头像动态拉取** — 首页硬编码的 6 位头像改为从 GitHub API 随机拉取，避免展示不公。SWR 缓存 12 小时。

**2. 修正占位邮箱** — antd@email.com 非官方邮箱，易产生误导，改为 hi@example.com。

**3. 主题切换键盘导航** — 支持 左/右 箭头键循环切换主题预览。

### 📝 更新日志

> 无需更新日志