### PR TITLE
refactor(DatePicker): avoid semantic props type assertion

### DIFF
--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -122,13 +122,13 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
     const mergedDisabled = customDisabled ?? disabled;
 
     // =========== Merged Props for Semantic ===========
-    const mergedProps = {
+    const mergedProps: DateRangePickerProps = {
       ...props,
       size: mergedSize,
       disabled: mergedDisabled,
       status: customStatus,
       variant: customVariant,
-    } as DateRangePickerProps;
+    };
 
     const [mergedClassNames, mergedStyles] = useMergedPickerSemantic<DateRangePickerProps>(
       pickerType,


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🤖 TypeScript 定义更新

### 🔗 相关 Issue

相关 PR：#58905  
Review comment：https://github.com/ant-design/ant-design/pull/58905#discussion_r3735244909

### 💡 需求背景和解决方案

PR #58905 中通过类型断言构造 RangePicker 的语义化回调参数。根据 review 建议，将类型定义移动至变量声明处并移除类型断言，使 TypeScript 能直接校验对象结构。

该调整不影响运行时行为和公开 API。

验证通过：

- `npm run tsc`
- DatePicker semantic tests（12/12）
- antd lint
- ESLint

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | 无需更新日志 |
