### PR TITLE
fix(Badge): adjust processing dot initial opacity under dark theme

### DIFF
--- a/components/badge/style/index.ts
+++ b/components/badge/style/index.ts
@@ -117,6 +117,11 @@ const antStatusProcessing = new Keyframes('antStatusProcessing', {
   '100%': { transform: 'scale(2.4)', opacity: 0 },
 });
 
+const antStatusProcessingDark = new Keyframes('antStatusProcessingDark', {
+  '0%': { transform: 'scale(0.8)', opacity: 0.85 },
+  '100%': { transform: 'scale(2.4)', opacity: 0 },
+});
+
 const antZoomBadgeIn = new Keyframes('antZoomBadgeIn', {
   '0%': { transform: 'scale(0) translate(50%, -50%)', opacity: 0 },
   '100%': { transform: 'scale(1) translate(50%, -50%)' },
@@ -287,6 +292,11 @@ const genSharedBadgeStyle: GenerateStyle<BadgeToken, CSSObject> = (token) => {
             animationIterationCount: 'infinite',
             animationTimingFunction: 'ease-in-out',
             content: '""',
+          },
+          '.ant-dark &': {
+            '&::after': {
+              animationName: antStatusProcessingDark,
+            },
           },
         },
         [`${componentCls}-status-default`]: {

--- a/components/badge/style/index.ts
+++ b/components/badge/style/index.ts
@@ -113,7 +113,7 @@ export interface BadgeToken extends FullToken<'Badge'> {
 }
 
 const antStatusProcessing = new Keyframes('antStatusProcessing', {
-  '0%': { transform: 'scale(0.8)', opacity: 0.5 },
+  '0%': { transform: 'scale(0.8)', opacity: 'var(--badge-processing-opacity, 0.5)' },
   '100%': { transform: 'scale(2.4)', opacity: 0 },
 });
 
@@ -272,6 +272,9 @@ const genSharedBadgeStyle: GenerateStyle<BadgeToken, CSSObject> = (token) => {
           backgroundColor: token.colorInfo,
           borderColor: 'currentcolor',
 
+          // 亮色模式默认透明度
+          '--badge-processing-opacity': '0.5',
+
           '&::after': {
             position: 'absolute',
             top: 0,
@@ -287,6 +290,10 @@ const genSharedBadgeStyle: GenerateStyle<BadgeToken, CSSObject> = (token) => {
             animationIterationCount: 'infinite',
             animationTimingFunction: 'ease-in-out',
             content: '""',
+          },
+          // 暗色模式覆盖透明度变量
+          '.ant-dark &': {
+            '--badge-processing-opacity': '0.85',
           },
         },
         [`${componentCls}-status-default`]: {


### PR DESCRIPTION
## 问题
Badge processing 动画圆点在暗黑模式下视觉亮度偏高，观感刺眼。

## 解决方案
新增暗黑模式专属动画 keyframes，暗色主题下启用新动画，将圆点初始透明度调整为 0.85。

## 自测
- lint 静态校验通过