### PR TITLE
test(BorderBeam): avoid testing internal hook directly

### DIFF
--- a/components/border-beam/__tests__/index.test.tsx
+++ b/components/border-beam/__tests__/index.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
-import { renderHook } from '@testing-library/react';
 
 import BorderBeam from '..';
 import mountTest from '../../../tests/shared/mountTest';
@@ -8,8 +7,6 @@ import rtlTest from '../../../tests/shared/rtlTest';
 import { render, waitFor } from '../../../tests/utils';
 import ConfigProvider, { defaultPrefixCls } from '../../config-provider';
 import { genCssVar } from '../../theme/util/genStyleUtils';
-import useBorderSize from '../hooks/useBorderSize';
-import type { BorderWidth } from '../util';
 
 describe('BorderBeam', () => {
   mountTest(() => <BorderBeam>content</BorderBeam>);
@@ -147,15 +144,27 @@ describe('BorderBeam', () => {
     );
   });
 
-  it('should reset the inferred border width when the host becomes unavailable', () => {
-    const element = document.createElement('div');
-    element.style.border = '4px solid #fff';
-    const { result, rerender } = renderHook<BorderWidth, HTMLElement>(useBorderSize, {
-      initialProps: element,
+  it('should remove the effect when the host becomes unavailable', async () => {
+    const { container, rerender } = render(
+      <BorderBeam>
+        <div style={{ border: '4px solid #fff' }}>
+          <span>content</span>
+        </div>
+      </BorderBeam>,
+    );
+
+    await waitFor(() => {
+      expect(getBeamElement(container).style.getPropertyValue(varName('inset-offset'))).toBe(
+        '-4px -4px -4px -4px',
+      );
     });
-    expect(result.current).toEqual([4, 4, 4, 4]);
-    rerender(undefined);
-    expect(result.current).toEqual([0, 0, 0, 0]);
+
+    rerender(<BorderBeam>content</BorderBeam>);
+
+    await waitFor(() => {
+      expect(container).toHaveTextContent('content');
+      expect(container.querySelector('.ant-border-beam')).toBeFalsy();
+    });
   });
 
   it('should support customizing the beam loop duration', async () => {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- https://github.com/ant-design/ant-design/pull/58923#discussion_r3754954211

### 💡 需求背景和解决方案

PR #58923 的 review 指出不应直接测试内部 hook。

本 PR 移除对 `useBorderSize` 的直接引用和 `renderHook` 用例，改为通过 BorderBeam 的公开渲染与 rerender 路径覆盖宿主不可用场景。

验证结果：

- BorderBeam 组件测试 17/17 通过
- 覆盖率与修改前完全一致
- `useBorderSize.ts` 的 statements、branches、functions 和 lines 均保持 100%

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A      |
| 🇨🇳 中文 | 无需更新 |
