### PR TITLE
fix: keep popup elevation compatible with backdrop-filter

### DIFF
--- a/components/popover/PurePanel.tsx
+++ b/components/popover/PurePanel.tsx
@@ -84,7 +84,6 @@ export const RawPurePanel: React.FC<RawPurePanelProps> = (props) => {
 
   return (
     <div className={rootClassName} style={style}>
-      <div className={`${prefixCls}-arrow`} />
       <Popup
         {...props}
         className={hashId}
@@ -92,6 +91,10 @@ export const RawPurePanel: React.FC<RawPurePanelProps> = (props) => {
         classNames={mergedClassNames}
         styles={mergedStyles}
       >
+        <div
+          className={clsx(`${prefixCls}-arrow`, mergedClassNames.arrow)}
+          style={mergedStyles.arrow}
+        />
         {children || (
           <Overlay
             prefixCls={prefixCls}

--- a/components/popover/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/popover/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -83,18 +83,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-popover-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-popover-arrow-content"
-          />
-        </div>
-        <div
           class="ant-popover-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-popover-arrow"
+          >
+            <span
+              class="ant-popover-arrow-content"
+            />
+          </div>
           <div
             class="ant-popover-title"
           >
@@ -131,18 +130,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-popover-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-popover-arrow-content"
-          />
-        </div>
-        <div
           class="ant-popover-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-popover-arrow"
+          >
+            <span
+              class="ant-popover-arrow-content"
+            />
+          </div>
           <div
             class="ant-popover-title"
           >
@@ -179,18 +177,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-popover-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-popover-arrow-content"
-          />
-        </div>
-        <div
           class="ant-popover-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-popover-arrow"
+          >
+            <span
+              class="ant-popover-arrow-content"
+            />
+          </div>
           <div
             class="ant-popover-title"
           >
@@ -235,18 +232,17 @@ Array [
           style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
-            class="ant-popover-arrow"
-            style="position: absolute;"
-          >
-            <span
-              class="ant-popover-arrow-content"
-            />
-          </div>
-          <div
             class="ant-popover-container"
             id="test-id"
             role="tooltip"
           >
+            <div
+              class="ant-popover-arrow"
+            >
+              <span
+                class="ant-popover-arrow-content"
+              />
+            </div>
             <div
               class="ant-popover-title"
             >
@@ -283,18 +279,17 @@ Array [
           style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
-            class="ant-popover-arrow"
-            style="position: absolute; top: 0px; right: 0px;"
-          >
-            <span
-              class="ant-popover-arrow-content"
-            />
-          </div>
-          <div
             class="ant-popover-container"
             id="test-id"
             role="tooltip"
           >
+            <div
+              class="ant-popover-arrow"
+            >
+              <span
+                class="ant-popover-arrow-content"
+              />
+            </div>
             <div
               class="ant-popover-title"
             >
@@ -331,18 +326,17 @@ Array [
           style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
-            class="ant-popover-arrow"
-            style="position: absolute;"
-          >
-            <span
-              class="ant-popover-arrow-content"
-            />
-          </div>
-          <div
             class="ant-popover-container"
             id="test-id"
             role="tooltip"
           >
+            <div
+              class="ant-popover-arrow"
+            >
+              <span
+                class="ant-popover-arrow-content"
+              />
+            </div>
             <div
               class="ant-popover-title"
             >
@@ -383,18 +377,17 @@ Array [
           style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
-            class="ant-popover-arrow"
-            style="position: absolute;"
-          >
-            <span
-              class="ant-popover-arrow-content"
-            />
-          </div>
-          <div
             class="ant-popover-container"
             id="test-id"
             role="tooltip"
           >
+            <div
+              class="ant-popover-arrow"
+            >
+              <span
+                class="ant-popover-arrow-content"
+              />
+            </div>
             <div
               class="ant-popover-title"
             >
@@ -431,18 +424,17 @@ Array [
           style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
-            class="ant-popover-arrow"
-            style="position: absolute; top: 0px; left: 0px;"
-          >
-            <span
-              class="ant-popover-arrow-content"
-            />
-          </div>
-          <div
             class="ant-popover-container"
             id="test-id"
             role="tooltip"
           >
+            <div
+              class="ant-popover-arrow"
+            >
+              <span
+                class="ant-popover-arrow-content"
+              />
+            </div>
             <div
               class="ant-popover-title"
             >
@@ -479,18 +471,17 @@ Array [
           style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
-            class="ant-popover-arrow"
-            style="position: absolute;"
-          >
-            <span
-              class="ant-popover-arrow-content"
-            />
-          </div>
-          <div
             class="ant-popover-container"
             id="test-id"
             role="tooltip"
           >
+            <div
+              class="ant-popover-arrow"
+            >
+              <span
+                class="ant-popover-arrow-content"
+              />
+            </div>
             <div
               class="ant-popover-title"
             >
@@ -533,18 +524,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-popover-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-popover-arrow-content"
-          />
-        </div>
-        <div
           class="ant-popover-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-popover-arrow"
+          >
+            <span
+              class="ant-popover-arrow-content"
+            />
+          </div>
           <div
             class="ant-popover-title"
           >
@@ -581,18 +571,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-popover-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        >
-          <span
-            class="ant-popover-arrow-content"
-          />
-        </div>
-        <div
           class="ant-popover-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-popover-arrow"
+          >
+            <span
+              class="ant-popover-arrow-content"
+            />
+          </div>
           <div
             class="ant-popover-title"
           >
@@ -629,18 +618,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-popover-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-popover-arrow-content"
-          />
-        </div>
-        <div
           class="ant-popover-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-popover-arrow"
+          >
+            <span
+              class="ant-popover-arrow-content"
+            />
+          </div>
           <div
             class="ant-popover-title"
           >
@@ -1103,18 +1091,17 @@ Array [
     style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
   >
     <div
-      class="ant-popover-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
-    >
-      <span
-        class="ant-popover-arrow-content"
-      />
-    </div>
-    <div
       class="ant-popover-container"
       id="test-id"
       role="tooltip"
     >
+      <div
+        class="ant-popover-arrow"
+      >
+        <span
+          class="ant-popover-arrow-content"
+        />
+      </div>
       <div
         class="ant-popover-title"
       >
@@ -1149,12 +1136,12 @@ Array [
     class="ant-popover ant-popover-pure ant-popover-placement-top css-var-test-id"
   >
     <div
-      class="ant-popover-arrow"
-    />
-    <div
       class="ant-popover-container"
       role="tooltip"
     >
+      <div
+        class="ant-popover-arrow"
+      />
       <div
         class="ant-popover-title"
       >
@@ -1179,13 +1166,13 @@ Array [
     style="width: 250px;"
   >
     <div
-      class="ant-popover-arrow"
-    />
-    <div
       class="ant-popover-container"
       role="tooltip"
       style="width: 250px;"
     >
+      <div
+        class="ant-popover-arrow"
+      />
       <div
         class="ant-popover-title"
       >
@@ -1226,18 +1213,17 @@ Array [
     style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
   >
     <div
-      class="ant-popover-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
-    >
-      <span
-        class="ant-popover-arrow-content"
-      />
-    </div>
-    <div
       class="ant-popover-container"
       id="test-id"
       role="tooltip"
     >
+      <div
+        class="ant-popover-arrow"
+      >
+        <span
+          class="ant-popover-arrow-content"
+        />
+      </div>
       <div
         class="ant-popover-title"
       >
@@ -1273,18 +1259,17 @@ Array [
     style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; z-index: 1200;"
   >
     <div
-      class="ant-popover-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
-    >
-      <span
-        class="ant-popover-arrow-content"
-      />
-    </div>
-    <div
       class="ant-popover-container"
       id="test-id"
       role="tooltip"
     >
+      <div
+        class="ant-popover-arrow"
+      >
+        <span
+          class="ant-popover-arrow-content"
+        />
+      </div>
       <div
         class="ant-popover-title"
       >
@@ -1309,18 +1294,17 @@ Array [
     style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
   >
     <div
-      class="ant-popover-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
-    >
-      <span
-        class="ant-popover-arrow-content"
-      />
-    </div>
-    <div
       class="ant-popover-container"
       id="test-id"
       role="tooltip"
     >
+      <div
+        class="ant-popover-arrow"
+      >
+        <span
+          class="ant-popover-arrow-content"
+        />
+      </div>
       <div
         class="ant-popover-title"
       >
@@ -1363,18 +1347,17 @@ exports[`renders components/popover/demo/placement.tsx extend context correctly 
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-popover-arrow"
-        style="position: absolute;"
-      >
-        <span
-          class="ant-popover-arrow-content"
-        />
-      </div>
-      <div
         class="ant-popover-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-popover-arrow"
+        >
+          <span
+            class="ant-popover-arrow-content"
+          />
+        </div>
         <div
           class="ant-popover-title"
         >
@@ -1411,18 +1394,17 @@ exports[`renders components/popover/demo/placement.tsx extend context correctly 
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-popover-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      >
-        <span
-          class="ant-popover-arrow-content"
-        />
-      </div>
-      <div
         class="ant-popover-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-popover-arrow"
+        >
+          <span
+            class="ant-popover-arrow-content"
+          />
+        </div>
         <div
           class="ant-popover-title"
         >
@@ -1459,18 +1441,17 @@ exports[`renders components/popover/demo/placement.tsx extend context correctly 
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-popover-arrow"
-        style="position: absolute;"
-      >
-        <span
-          class="ant-popover-arrow-content"
-        />
-      </div>
-      <div
         class="ant-popover-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-popover-arrow"
+        >
+          <span
+            class="ant-popover-arrow-content"
+          />
+        </div>
         <div
           class="ant-popover-title"
         >
@@ -1515,18 +1496,17 @@ exports[`renders components/popover/demo/placement.tsx extend context correctly 
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-popover-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-popover-arrow-content"
-          />
-        </div>
-        <div
           class="ant-popover-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-popover-arrow"
+          >
+            <span
+              class="ant-popover-arrow-content"
+            />
+          </div>
           <div
             class="ant-popover-title"
           >
@@ -1563,18 +1543,17 @@ exports[`renders components/popover/demo/placement.tsx extend context correctly 
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-popover-arrow"
-          style="position: absolute; top: 0px; right: 0px;"
-        >
-          <span
-            class="ant-popover-arrow-content"
-          />
-        </div>
-        <div
           class="ant-popover-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-popover-arrow"
+          >
+            <span
+              class="ant-popover-arrow-content"
+            />
+          </div>
           <div
             class="ant-popover-title"
           >
@@ -1611,18 +1590,17 @@ exports[`renders components/popover/demo/placement.tsx extend context correctly 
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-popover-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-popover-arrow-content"
-          />
-        </div>
-        <div
           class="ant-popover-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-popover-arrow"
+          >
+            <span
+              class="ant-popover-arrow-content"
+            />
+          </div>
           <div
             class="ant-popover-title"
           >
@@ -1663,18 +1641,17 @@ exports[`renders components/popover/demo/placement.tsx extend context correctly 
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-popover-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-popover-arrow-content"
-          />
-        </div>
-        <div
           class="ant-popover-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-popover-arrow"
+          >
+            <span
+              class="ant-popover-arrow-content"
+            />
+          </div>
           <div
             class="ant-popover-title"
           >
@@ -1711,18 +1688,17 @@ exports[`renders components/popover/demo/placement.tsx extend context correctly 
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-popover-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        >
-          <span
-            class="ant-popover-arrow-content"
-          />
-        </div>
-        <div
           class="ant-popover-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-popover-arrow"
+          >
+            <span
+              class="ant-popover-arrow-content"
+            />
+          </div>
           <div
             class="ant-popover-title"
           >
@@ -1759,18 +1735,17 @@ exports[`renders components/popover/demo/placement.tsx extend context correctly 
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-popover-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-popover-arrow-content"
-          />
-        </div>
-        <div
           class="ant-popover-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-popover-arrow"
+          >
+            <span
+              class="ant-popover-arrow-content"
+            />
+          </div>
           <div
             class="ant-popover-title"
           >
@@ -1813,18 +1788,17 @@ exports[`renders components/popover/demo/placement.tsx extend context correctly 
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-popover-arrow"
-        style="position: absolute;"
-      >
-        <span
-          class="ant-popover-arrow-content"
-        />
-      </div>
-      <div
         class="ant-popover-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-popover-arrow"
+        >
+          <span
+            class="ant-popover-arrow-content"
+          />
+        </div>
         <div
           class="ant-popover-title"
         >
@@ -1861,18 +1835,17 @@ exports[`renders components/popover/demo/placement.tsx extend context correctly 
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-popover-arrow"
-        style="position: absolute; top: 0px; left: 0px;"
-      >
-        <span
-          class="ant-popover-arrow-content"
-        />
-      </div>
-      <div
         class="ant-popover-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-popover-arrow"
+        >
+          <span
+            class="ant-popover-arrow-content"
+          />
+        </div>
         <div
           class="ant-popover-title"
         >
@@ -1909,18 +1882,17 @@ exports[`renders components/popover/demo/placement.tsx extend context correctly 
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-popover-arrow"
-        style="position: absolute;"
-      >
-        <span
-          class="ant-popover-arrow-content"
-        />
-      </div>
-      <div
         class="ant-popover-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-popover-arrow"
+        >
+          <span
+            class="ant-popover-arrow-content"
+          />
+        </div>
         <div
           class="ant-popover-title"
         >
@@ -1954,12 +1926,12 @@ Array [
     class="ant-popover ant-popover-pure ant-popover-placement-top css-var-test-id"
   >
     <div
-      class="ant-popover-arrow"
-    />
-    <div
       class="ant-popover-container"
       role="tooltip"
     >
+      <div
+        class="ant-popover-arrow"
+      />
       <div
         class="ant-popover-title"
       >
@@ -1984,13 +1956,13 @@ Array [
     style="width: 250px;"
   >
     <div
-      class="ant-popover-arrow"
-    />
-    <div
       class="ant-popover-container"
       role="tooltip"
       style="width: 250px;"
     >
+      <div
+        class="ant-popover-arrow"
+      />
       <div
         class="ant-popover-title"
       >
@@ -2140,18 +2112,17 @@ exports[`renders components/popover/demo/triggerType.tsx extend context correctl
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-popover-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      >
-        <span
-          class="ant-popover-arrow-content"
-        />
-      </div>
-      <div
         class="ant-popover-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-popover-arrow"
+        >
+          <span
+            class="ant-popover-arrow-content"
+          />
+        </div>
         <div
           class="ant-popover-title"
         >
@@ -2189,18 +2160,17 @@ exports[`renders components/popover/demo/triggerType.tsx extend context correctl
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-popover-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      >
-        <span
-          class="ant-popover-arrow-content"
-        />
-      </div>
-      <div
         class="ant-popover-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-popover-arrow"
+        >
+          <span
+            class="ant-popover-arrow-content"
+          />
+        </div>
         <div
           class="ant-popover-title"
         >
@@ -2238,18 +2208,17 @@ exports[`renders components/popover/demo/triggerType.tsx extend context correctl
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-popover-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      >
-        <span
-          class="ant-popover-arrow-content"
-        />
-      </div>
-      <div
         class="ant-popover-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-popover-arrow"
+        >
+          <span
+            class="ant-popover-arrow-content"
+          />
+        </div>
         <div
           class="ant-popover-title"
         >
@@ -2281,12 +2250,12 @@ Array [
     class="ant-popover ant-popover-pure ant-popover-placement-top css-var-test-id"
   >
     <div
-      class="ant-popover-arrow"
-    />
-    <div
       class="ant-popover-container"
       role="tooltip"
     >
+      <div
+        class="ant-popover-arrow"
+      />
       <div
         class="ant-popover-title"
       >
@@ -2311,13 +2280,13 @@ Array [
     style="width: 250px;"
   >
     <div
-      class="ant-popover-arrow"
-    />
-    <div
       class="ant-popover-container"
       role="tooltip"
       style="width: 250px;"
     >
+      <div
+        class="ant-popover-arrow"
+      />
       <div
         class="ant-popover-title"
       >

--- a/components/popover/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/popover/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -22,18 +22,17 @@ exports[`renders components/popover/demo/_semantic.tsx correctly 1`] = `
           style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
-            class="ant-popover-arrow semantic-mark-arrow"
-            style="position: absolute; bottom: 0px; left: 0px;"
-          >
-            <span
-              class="ant-popover-arrow-content"
-            />
-          </div>
-          <div
             class="ant-popover-container semantic-mark-container"
             id="test-id"
             role="tooltip"
           >
+            <div
+              class="ant-popover-arrow semantic-mark-arrow"
+            >
+              <span
+                class="ant-popover-arrow-content"
+              />
+            </div>
             <div
               class="ant-popover-title semantic-mark-title"
             >

--- a/components/popover/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/popover/__tests__/__snapshots__/demo.test.tsx.snap
@@ -632,12 +632,12 @@ Array [
     class="ant-popover ant-popover-pure ant-popover-placement-top css-var-test-id"
   >
     <div
-      class="ant-popover-arrow"
-    />
-    <div
       class="ant-popover-container"
       role="tooltip"
     >
+      <div
+        class="ant-popover-arrow"
+      />
       <div
         class="ant-popover-title"
       >
@@ -662,13 +662,13 @@ Array [
     style="width:250px"
   >
     <div
-      class="ant-popover-arrow"
-    />
-    <div
       class="ant-popover-container"
       role="tooltip"
       style="width:250px"
     >
+      <div
+        class="ant-popover-arrow"
+      />
       <div
         class="ant-popover-title"
       >
@@ -857,12 +857,12 @@ Array [
     class="ant-popover ant-popover-pure ant-popover-placement-top css-var-test-id"
   >
     <div
-      class="ant-popover-arrow"
-    />
-    <div
       class="ant-popover-container"
       role="tooltip"
     >
+      <div
+        class="ant-popover-arrow"
+      />
       <div
         class="ant-popover-title"
       >
@@ -887,13 +887,13 @@ Array [
     style="width:250px"
   >
     <div
-      class="ant-popover-arrow"
-    />
-    <div
       class="ant-popover-container"
       role="tooltip"
       style="width:250px"
     >
+      <div
+        class="ant-popover-arrow"
+      />
       <div
         class="ant-popover-title"
       >
@@ -1027,12 +1027,12 @@ Array [
     class="ant-popover ant-popover-pure ant-popover-placement-top css-var-test-id"
   >
     <div
-      class="ant-popover-arrow"
-    />
-    <div
       class="ant-popover-container"
       role="tooltip"
     >
+      <div
+        class="ant-popover-arrow"
+      />
       <div
         class="ant-popover-title"
       >
@@ -1057,13 +1057,13 @@ Array [
     style="width:250px"
   >
     <div
-      class="ant-popover-arrow"
-    />
-    <div
       class="ant-popover-container"
       role="tooltip"
       style="width:250px"
     >
+      <div
+        class="ant-popover-arrow"
+      />
       <div
         class="ant-popover-title"
       >

--- a/components/popover/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/popover/__tests__/__snapshots__/index.test.tsx.snap
@@ -13,18 +13,17 @@ Array [
     style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
   >
     <div
-      class="ant-popover-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
-    >
-      <span
-        class="ant-popover-arrow-content"
-      />
-    </div>
-    <div
       class="ant-popover-container"
       id="test-id"
       role="tooltip"
     >
+      <div
+        class="ant-popover-arrow"
+      >
+        <span
+          class="ant-popover-arrow-content"
+        />
+      </div>
       <div
         class="ant-popover-title"
       >
@@ -35,4 +34,4 @@ Array [
 ]
 `;
 
-exports[`Popover shows content for render functions 1`] = `"<div class="ant-popover-arrow" style="position: absolute; bottom: 0px; left: 0px;"><span class="ant-popover-arrow-content"></span></div><div id="test-id" class="ant-popover-container" role="tooltip"><div class="ant-popover-title">some-title</div><div class="ant-popover-content">some-content</div></div>"`;
+exports[`Popover shows content for render functions 1`] = `"<div id="test-id" class="ant-popover-container" role="tooltip"><div class="ant-popover-arrow"><span class="ant-popover-arrow-content"></span></div><div class="ant-popover-title">some-title</div><div class="ant-popover-content">some-content</div></div>"`;

--- a/components/popover/__tests__/semantic.test.tsx
+++ b/components/popover/__tests__/semantic.test.tsx
@@ -83,8 +83,7 @@ describe('Popover.Semantic', () => {
     expect(popupContainer).toHaveStyle({ backgroundColor: 'rgba(255, 255, 255, 0.4)' });
     expect(getComputedStyle(root!).filter || 'none').toBe('none');
     expect(getComputedStyle(popupContainer!).filter).toBe('var(--ant-drop-shadow-popover)');
-    expect(getComputedStyle(arrow!).filter).toBe('var(--ant-drop-shadow-popover)');
-    expect(getComputedStyle(arrow!).clipPath).toBe('inset(-100vmax -100vmax 0 -100vmax)');
+    expect(popupContainer).toContainElement(arrow);
   });
 
   it('should follow root style priority', () => {

--- a/components/popover/__tests__/semantic.test.tsx
+++ b/components/popover/__tests__/semantic.test.tsx
@@ -60,7 +60,7 @@ describe('Popover.Semantic', () => {
     expect(contentElement).toHaveStyle({ padding: '16px' });
   });
 
-  it('should allow backdrop-filter on the container', () => {
+  it('should allow backdrop-filter while preserving popup elevation', () => {
     const { container } = render(
       <Popover
         open
@@ -78,10 +78,13 @@ describe('Popover.Semantic', () => {
 
     const root = container.querySelector('.ant-popover');
     const popupContainer = container.querySelector('.ant-popover-container');
+    const arrow = container.querySelector('.ant-popover-arrow');
 
     expect(popupContainer).toHaveStyle({ backgroundColor: 'rgba(255, 255, 255, 0.4)' });
     expect(getComputedStyle(root!).filter || 'none').toBe('none');
     expect(getComputedStyle(popupContainer!).filter).toBe('var(--ant-drop-shadow-popover)');
+    expect(getComputedStyle(arrow!).filter).toBe('var(--ant-drop-shadow-popover)');
+    expect(getComputedStyle(arrow!).clipPath).toBe('inset(-100vmax -100vmax 0 -100vmax)');
   });
 
   it('should follow root style priority', () => {

--- a/components/popover/__tests__/semantic.test.tsx
+++ b/components/popover/__tests__/semantic.test.tsx
@@ -60,6 +60,30 @@ describe('Popover.Semantic', () => {
     expect(contentElement).toHaveStyle({ padding: '16px' });
   });
 
+  it('should allow backdrop-filter on the container', () => {
+    const { container } = render(
+      <Popover
+        open
+        content="Content"
+        styles={{
+          container: {
+            backgroundColor: 'rgba(255, 255, 255, 0.4)',
+            backdropFilter: 'blur(12px)',
+          },
+        }}
+      >
+        <span>Trigger</span>
+      </Popover>,
+    );
+
+    const root = container.querySelector('.ant-popover');
+    const popupContainer = container.querySelector('.ant-popover-container');
+
+    expect(popupContainer).toHaveStyle({ backgroundColor: 'rgba(255, 255, 255, 0.4)' });
+    expect(getComputedStyle(root!).filter || 'none').toBe('none');
+    expect(getComputedStyle(popupContainer!).filter).toBe('var(--ant-drop-shadow-popover)');
+  });
+
   it('should follow root style priority', () => {
     const { container } = render(
       <ConfigProvider

--- a/components/popover/style/index.ts
+++ b/components/popover/style/index.ts
@@ -157,7 +157,10 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
     },
 
     // Arrow Style
-    getArrowStyle<PopoverToken>(token, varRef('arrow-background-color')),
+    getArrowStyle<PopoverToken>(token, varRef('arrow-background-color'), {
+      arrowShadow: false,
+      arrowFilter: dropShadowPopover,
+    }),
 
     // Pure Render
     {

--- a/components/popover/style/index.ts
+++ b/components/popover/style/index.ts
@@ -133,6 +133,7 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
         },
 
         [`${componentCls}-container`]: {
+          position: 'relative',
           backgroundColor: popoverBg,
           backgroundClip: 'padding-box',
           borderRadius: borderRadiusLG,
@@ -159,7 +160,7 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
     // Arrow Style
     getArrowStyle<PopoverToken>(token, varRef('arrow-background-color'), {
       arrowShadow: false,
-      arrowFilter: dropShadowPopover,
+      arrowInContainer: true,
     }),
 
     // Pure Render

--- a/components/popover/style/index.ts
+++ b/components/popover/style/index.ts
@@ -108,7 +108,6 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
         textAlign: 'start',
         cursor: 'auto',
         userSelect: 'text',
-        filter: dropShadowPopover,
 
         // When use `autoArrow`, origin will follow the arrow position
         [varName('valid-offset-x')]: varRef('arrow-offset-x', 'var(--arrow-x)'),
@@ -137,6 +136,7 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
           backgroundColor: popoverBg,
           backgroundClip: 'padding-box',
           borderRadius: borderRadiusLG,
+          filter: dropShadowPopover,
           padding: innerPadding,
         },
 
@@ -157,7 +157,7 @@ const genBaseStyle: GenerateStyle<PopoverToken> = (token) => {
     },
 
     // Arrow Style
-    getArrowStyle<PopoverToken>(token, varRef('arrow-background-color'), { arrowShadow: false }),
+    getArrowStyle<PopoverToken>(token, varRef('arrow-background-color')),
 
     // Pure Render
     {

--- a/components/style/placementArrow.ts
+++ b/components/style/placementArrow.ts
@@ -33,6 +33,7 @@ const getArrowStyle = <
   options?: {
     arrowDistance?: number;
     arrowShadow?: boolean;
+    arrowFilter?: string;
   },
 ): CSSInterpolation => {
   const {
@@ -45,7 +46,10 @@ const getArrowStyle = <
 
   const [varName] = genCssVar(antCls, 'tooltip');
 
-  const { arrowDistance = 0, arrowShadow = true } = options || {};
+  const { arrowDistance = 0, arrowShadow = true, arrowFilter } = options || {};
+  // Keep the arrow's outer shadow, but clip the base shadow that overlaps the popup body.
+  // Placement transforms rotate this clipping edge together with the arrow.
+  const arrowShadowClip = '-100vmax';
 
   return {
     [componentCls]: {
@@ -55,6 +59,10 @@ const getArrowStyle = <
           position: 'absolute',
           zIndex: 1, // lift it up so the menu wouldn't cask shadow on it
           display: 'block',
+          filter: arrowFilter,
+          clipPath: arrowFilter
+            ? `inset(${arrowShadowClip} ${arrowShadowClip} 0 ${arrowShadowClip})`
+            : undefined,
 
           ...genRoundedArrow(token, colorBg, arrowShadow ? boxShadowPopoverArrow : false),
 

--- a/components/style/placementArrow.ts
+++ b/components/style/placementArrow.ts
@@ -33,7 +33,7 @@ const getArrowStyle = <
   options?: {
     arrowDistance?: number;
     arrowShadow?: boolean;
-    arrowFilter?: string;
+    arrowInContainer?: boolean;
   },
 ): CSSInterpolation => {
   const {
@@ -46,10 +46,10 @@ const getArrowStyle = <
 
   const [varName] = genCssVar(antCls, 'tooltip');
 
-  const { arrowDistance = 0, arrowShadow = true, arrowFilter } = options || {};
-  // Keep the arrow's outer shadow, but clip the base shadow that overlaps the popup body.
-  // Placement transforms rotate this clipping edge together with the arrow.
-  const arrowShadowClip = '-100vmax';
+  const { arrowDistance = 0, arrowShadow = true, arrowInContainer = false } = options || {};
+  const arrowSelector = arrowInContainer
+    ? `${componentCls}-container > ${componentCls}-arrow`
+    : `> ${componentCls}-arrow`;
 
   return {
     [componentCls]: {
@@ -59,10 +59,6 @@ const getArrowStyle = <
           position: 'absolute',
           zIndex: 1, // lift it up so the menu wouldn't cask shadow on it
           display: 'block',
-          filter: arrowFilter,
-          clipPath: arrowFilter
-            ? `inset(${arrowShadowClip} ${arrowShadowClip} 0 ${arrowShadowClip})`
-            : undefined,
 
           ...genRoundedArrow(token, colorBg, arrowShadow ? boxShadowPopoverArrow : false),
 
@@ -76,18 +72,18 @@ const getArrowStyle = <
       // Here handle the arrow position and rotate stuff
       // >>>>> Top
       [[
-        `&-placement-top > ${componentCls}-arrow`,
-        `&-placement-topLeft > ${componentCls}-arrow`,
-        `&-placement-topRight > ${componentCls}-arrow`,
+        `&-placement-top ${arrowSelector}`,
+        `&-placement-topLeft ${arrowSelector}`,
+        `&-placement-topRight ${arrowSelector}`,
       ].join(',')]: {
         bottom: arrowDistance,
         transform: 'translateY(100%) rotate(180deg)',
       },
 
-      [`&-placement-top > ${componentCls}-arrow`]: {
+      [`&-placement-top ${arrowSelector}`]: {
         left: {
           _skip_check_: true,
-          value: '50%',
+          value: arrowInContainer ? 'var(--arrow-x, 50%)' : '50%',
         },
         transform: 'translateX(-50%) translateY(100%) rotate(180deg)',
       },
@@ -95,7 +91,7 @@ const getArrowStyle = <
       '&-placement-topLeft': {
         [varName('arrow-offset-x')]: arrowOffsetHorizontal,
 
-        [`> ${componentCls}-arrow`]: {
+        [arrowSelector]: {
           left: {
             _skip_check_: true,
             value: arrowOffsetHorizontal,
@@ -106,7 +102,7 @@ const getArrowStyle = <
       '&-placement-topRight': {
         [varName('arrow-offset-x')]: `calc(100% - ${unit(arrowOffsetHorizontal)})`,
 
-        [`> ${componentCls}-arrow`]: {
+        [arrowSelector]: {
           right: {
             _skip_check_: true,
             value: arrowOffsetHorizontal,
@@ -116,18 +112,18 @@ const getArrowStyle = <
 
       // >>>>> Bottom
       [[
-        `&-placement-bottom > ${componentCls}-arrow`,
-        `&-placement-bottomLeft > ${componentCls}-arrow`,
-        `&-placement-bottomRight > ${componentCls}-arrow`,
+        `&-placement-bottom ${arrowSelector}`,
+        `&-placement-bottomLeft ${arrowSelector}`,
+        `&-placement-bottomRight ${arrowSelector}`,
       ].join(',')]: {
         top: arrowDistance,
         transform: `translateY(-100%)`,
       },
 
-      [`&-placement-bottom > ${componentCls}-arrow`]: {
+      [`&-placement-bottom ${arrowSelector}`]: {
         left: {
           _skip_check_: true,
-          value: '50%',
+          value: arrowInContainer ? 'var(--arrow-x, 50%)' : '50%',
         },
         transform: `translateX(-50%) translateY(-100%)`,
       },
@@ -135,7 +131,7 @@ const getArrowStyle = <
       '&-placement-bottomLeft': {
         [varName('arrow-offset-x')]: arrowOffsetHorizontal,
 
-        [`> ${componentCls}-arrow`]: {
+        [arrowSelector]: {
           left: {
             _skip_check_: true,
             value: arrowOffsetHorizontal,
@@ -146,7 +142,7 @@ const getArrowStyle = <
       '&-placement-bottomRight': {
         [varName('arrow-offset-x')]: `calc(100% - ${unit(arrowOffsetHorizontal)})`,
 
-        [`> ${componentCls}-arrow`]: {
+        [arrowSelector]: {
           right: {
             _skip_check_: true,
             value: arrowOffsetHorizontal,
@@ -156,9 +152,9 @@ const getArrowStyle = <
 
       // >>>>> Left
       [[
-        `&-placement-left > ${componentCls}-arrow`,
-        `&-placement-leftTop > ${componentCls}-arrow`,
-        `&-placement-leftBottom > ${componentCls}-arrow`,
+        `&-placement-left ${arrowSelector}`,
+        `&-placement-leftTop ${arrowSelector}`,
+        `&-placement-leftBottom ${arrowSelector}`,
       ].join(',')]: {
         right: {
           _skip_check_: true,
@@ -167,27 +163,27 @@ const getArrowStyle = <
         transform: 'translateX(100%) rotate(90deg)',
       },
 
-      [`&-placement-left > ${componentCls}-arrow`]: {
+      [`&-placement-left ${arrowSelector}`]: {
         top: {
           _skip_check_: true,
-          value: '50%',
+          value: arrowInContainer ? 'var(--arrow-y, 50%)' : '50%',
         },
         transform: 'translateY(-50%) translateX(100%) rotate(90deg)',
       },
 
-      [`&-placement-leftTop > ${componentCls}-arrow`]: {
+      [`&-placement-leftTop ${arrowSelector}`]: {
         top: arrowOffsetVertical,
       },
 
-      [`&-placement-leftBottom > ${componentCls}-arrow`]: {
+      [`&-placement-leftBottom ${arrowSelector}`]: {
         bottom: arrowOffsetVertical,
       },
 
       // >>>>> Right
       [[
-        `&-placement-right > ${componentCls}-arrow`,
-        `&-placement-rightTop > ${componentCls}-arrow`,
-        `&-placement-rightBottom > ${componentCls}-arrow`,
+        `&-placement-right ${arrowSelector}`,
+        `&-placement-rightTop ${arrowSelector}`,
+        `&-placement-rightBottom ${arrowSelector}`,
       ].join(',')]: {
         left: {
           _skip_check_: true,
@@ -196,19 +192,19 @@ const getArrowStyle = <
         transform: 'translateX(-100%) rotate(-90deg)',
       },
 
-      [`&-placement-right > ${componentCls}-arrow`]: {
+      [`&-placement-right ${arrowSelector}`]: {
         top: {
           _skip_check_: true,
-          value: '50%',
+          value: arrowInContainer ? 'var(--arrow-y, 50%)' : '50%',
         },
         transform: 'translateY(-50%) translateX(-100%) rotate(-90deg)',
       },
 
-      [`&-placement-rightTop > ${componentCls}-arrow`]: {
+      [`&-placement-rightTop ${arrowSelector}`]: {
         top: arrowOffsetVertical,
       },
 
-      [`&-placement-rightBottom > ${componentCls}-arrow`]: {
+      [`&-placement-rightBottom ${arrowSelector}`]: {
         bottom: arrowOffsetVertical,
       },
     },

--- a/components/tooltip/PurePanel.tsx
+++ b/components/tooltip/PurePanel.tsx
@@ -68,7 +68,6 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
 
   return (
     <div className={rootClassName} style={arrowContentStyle}>
-      <div className={`${prefixCls}-arrow`} />
       <Popup
         {...props}
         className={hashId}
@@ -76,6 +75,10 @@ const PurePanel: React.FC<PurePanelProps> = (props) => {
         classNames={mergedClassNames}
         styles={mergedStyles}
       >
+        <div
+          className={clsx(`${prefixCls}-arrow`, mergedClassNames.arrow)}
+          style={mergedStyles.arrow}
+        />
         {title}
       </Popup>
     </div>

--- a/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -83,18 +83,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           <span>
             prompt text
           </span>
@@ -115,18 +114,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           <span>
             prompt text
           </span>
@@ -147,18 +145,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           <span>
             prompt text
           </span>
@@ -187,18 +184,17 @@ Array [
           style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
-            class="ant-tooltip-arrow"
-            style="position: absolute;"
-          >
-            <span
-              class="ant-tooltip-arrow-content"
-            />
-          </div>
-          <div
             class="ant-tooltip-container"
             id="test-id"
             role="tooltip"
           >
+            <div
+              class="ant-tooltip-arrow"
+            >
+              <span
+                class="ant-tooltip-arrow-content"
+              />
+            </div>
             <span>
               prompt text
             </span>
@@ -219,18 +215,17 @@ Array [
           style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
-            class="ant-tooltip-arrow"
-            style="position: absolute; top: 0px; right: 0px;"
-          >
-            <span
-              class="ant-tooltip-arrow-content"
-            />
-          </div>
-          <div
             class="ant-tooltip-container"
             id="test-id"
             role="tooltip"
           >
+            <div
+              class="ant-tooltip-arrow"
+            >
+              <span
+                class="ant-tooltip-arrow-content"
+              />
+            </div>
             <span>
               prompt text
             </span>
@@ -251,18 +246,17 @@ Array [
           style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
-            class="ant-tooltip-arrow"
-            style="position: absolute;"
-          >
-            <span
-              class="ant-tooltip-arrow-content"
-            />
-          </div>
-          <div
             class="ant-tooltip-container"
             id="test-id"
             role="tooltip"
           >
+            <div
+              class="ant-tooltip-arrow"
+            >
+              <span
+                class="ant-tooltip-arrow-content"
+              />
+            </div>
             <span>
               prompt text
             </span>
@@ -287,18 +281,17 @@ Array [
           style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
-            class="ant-tooltip-arrow"
-            style="position: absolute;"
-          >
-            <span
-              class="ant-tooltip-arrow-content"
-            />
-          </div>
-          <div
             class="ant-tooltip-container"
             id="test-id"
             role="tooltip"
           >
+            <div
+              class="ant-tooltip-arrow"
+            >
+              <span
+                class="ant-tooltip-arrow-content"
+              />
+            </div>
             <span>
               prompt text
             </span>
@@ -319,18 +312,17 @@ Array [
           style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
-            class="ant-tooltip-arrow"
-            style="position: absolute; top: 0px; left: 0px;"
-          >
-            <span
-              class="ant-tooltip-arrow-content"
-            />
-          </div>
-          <div
             class="ant-tooltip-container"
             id="test-id"
             role="tooltip"
           >
+            <div
+              class="ant-tooltip-arrow"
+            >
+              <span
+                class="ant-tooltip-arrow-content"
+              />
+            </div>
             <span>
               prompt text
             </span>
@@ -351,18 +343,17 @@ Array [
           style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
-            class="ant-tooltip-arrow"
-            style="position: absolute;"
-          >
-            <span
-              class="ant-tooltip-arrow-content"
-            />
-          </div>
-          <div
             class="ant-tooltip-container"
             id="test-id"
             role="tooltip"
           >
+            <div
+              class="ant-tooltip-arrow"
+            >
+              <span
+                class="ant-tooltip-arrow-content"
+              />
+            </div>
             <span>
               prompt text
             </span>
@@ -389,18 +380,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           <span>
             prompt text
           </span>
@@ -421,18 +411,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           <span>
             prompt text
           </span>
@@ -453,18 +442,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           <span>
             prompt text
           </span>
@@ -498,18 +486,17 @@ exports[`renders components/tooltip/demo/arrow-point-at-center.tsx extend contex
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-tooltip-arrow"
-        style="position: absolute;"
-      >
-        <span
-          class="ant-tooltip-arrow-content"
-        />
-      </div>
-      <div
         class="ant-tooltip-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-tooltip-arrow"
+        >
+          <span
+            class="ant-tooltip-arrow-content"
+          />
+        </div>
         Prompt Text
       </div>
     </div>
@@ -531,18 +518,17 @@ exports[`renders components/tooltip/demo/arrow-point-at-center.tsx extend contex
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-tooltip-arrow"
-        style="position: absolute;"
-      >
-        <span
-          class="ant-tooltip-arrow-content"
-        />
-      </div>
-      <div
         class="ant-tooltip-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-tooltip-arrow"
+        >
+          <span
+            class="ant-tooltip-arrow-content"
+          />
+        </div>
         Prompt Text
       </div>
     </div>
@@ -581,18 +567,17 @@ exports[`renders components/tooltip/demo/auto-adjust-overflow.tsx extend context
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; right: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           Prompt Text
         </div>
       </div>
@@ -610,18 +595,17 @@ exports[`renders components/tooltip/demo/auto-adjust-overflow.tsx extend context
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; right: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           Prompt Text
         </div>
       </div>
@@ -652,18 +636,17 @@ exports[`renders components/tooltip/demo/auto-adjust-overflow.tsx extend context
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; right: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           Prompt Text
         </div>
       </div>
@@ -681,18 +664,17 @@ exports[`renders components/tooltip/demo/auto-adjust-overflow.tsx extend context
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; right: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           Prompt Text
         </div>
       </div>
@@ -715,18 +697,17 @@ Array [
     style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
   >
     <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
-    >
-      <span
-        class="ant-tooltip-arrow-content"
-      />
-    </div>
-    <div
       class="ant-tooltip-container"
       id="test-id"
       role="tooltip"
     >
+      <div
+        class="ant-tooltip-arrow"
+      >
+        <span
+          class="ant-tooltip-arrow-content"
+        />
+      </div>
       prompt text
     </div>
   </div>,
@@ -774,18 +755,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -807,18 +787,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -840,18 +819,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -873,18 +851,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -906,18 +883,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -939,18 +915,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -972,18 +947,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -1005,18 +979,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -1038,18 +1011,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -1071,18 +1043,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -1104,18 +1075,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -1137,18 +1107,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -1170,18 +1139,17 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -1224,19 +1192,18 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; --ant-tooltip-arrow-background-color: #f50;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
           style="background: rgb(255, 85, 0); --ant-tooltip-overlay-color: #FFF;"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -1258,19 +1225,18 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; --ant-tooltip-arrow-background-color: #2db7f5;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
           style="background: rgb(45, 183, 245); --ant-tooltip-overlay-color: #000;"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -1292,19 +1258,18 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; --ant-tooltip-arrow-background-color: #87d068;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
           style="background: rgb(135, 208, 104); --ant-tooltip-overlay-color: #000;"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -1326,19 +1291,18 @@ Array [
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; --ant-tooltip-arrow-background-color: #108ee9;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
           style="background: rgb(16, 142, 233); --ant-tooltip-overlay-color: #FFF;"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           prompt text
         </div>
       </div>
@@ -1361,18 +1325,17 @@ Array [
     style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
   >
     <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
-    >
-      <span
-        class="ant-tooltip-arrow-content"
-      />
-    </div>
-    <div
       class="ant-tooltip-container"
       id="test-id"
       role="tooltip"
     >
+      <div
+        class="ant-tooltip-arrow"
+      >
+        <span
+          class="ant-tooltip-arrow-content"
+        />
+      </div>
       prompt text
     </div>
   </div>,
@@ -1397,18 +1360,18 @@ Array [
     style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
   >
     <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
-    >
-      <span
-        class="ant-tooltip-arrow-content"
-      />
-    </div>
-    <div
       class="ant-tooltip-container"
       id="test-id"
       role="tooltip"
-    />
+    >
+      <div
+        class="ant-tooltip-arrow"
+      >
+        <span
+          class="ant-tooltip-arrow-content"
+        />
+      </div>
+    </div>
   </div>,
 ]
 `;
@@ -1437,18 +1400,17 @@ exports[`renders components/tooltip/demo/disabled-children.tsx extend context co
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      >
-        <span
-          class="ant-tooltip-arrow-content"
-        />
-      </div>
-      <div
         class="ant-tooltip-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-tooltip-arrow"
+        >
+          <span
+            class="ant-tooltip-arrow-content"
+          />
+        </div>
         Thanks for using antd. Have a nice day !
       </div>
     </div>
@@ -1469,18 +1431,17 @@ exports[`renders components/tooltip/demo/disabled-children.tsx extend context co
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      >
-        <span
-          class="ant-tooltip-arrow-content"
-        />
-      </div>
-      <div
         class="ant-tooltip-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-tooltip-arrow"
+        >
+          <span
+            class="ant-tooltip-arrow-content"
+          />
+        </div>
         Thanks for using antd. Have a nice day !
       </div>
     </div>
@@ -1506,18 +1467,17 @@ exports[`renders components/tooltip/demo/disabled-children.tsx extend context co
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      >
-        <span
-          class="ant-tooltip-arrow-content"
-        />
-      </div>
-      <div
         class="ant-tooltip-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-tooltip-arrow"
+        >
+          <span
+            class="ant-tooltip-arrow-content"
+          />
+        </div>
         Thanks for using antd. Have a nice day !
       </div>
     </div>
@@ -1544,18 +1504,17 @@ exports[`renders components/tooltip/demo/disabled-children.tsx extend context co
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      >
-        <span
-          class="ant-tooltip-arrow-content"
-        />
-      </div>
-      <div
         class="ant-tooltip-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-tooltip-arrow"
+        >
+          <span
+            class="ant-tooltip-arrow-content"
+          />
+        </div>
         Thanks for using antd. Have a nice day !
       </div>
     </div>
@@ -1677,18 +1636,17 @@ exports[`renders components/tooltip/demo/disabled-children.tsx extend context co
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      >
-        <span
-          class="ant-tooltip-arrow-content"
-        />
-      </div>
-      <div
         class="ant-tooltip-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-tooltip-arrow"
+        >
+          <span
+            class="ant-tooltip-arrow-content"
+          />
+        </div>
         Thanks for using antd. Have a nice day !
       </div>
     </div>
@@ -1721,18 +1679,17 @@ exports[`renders components/tooltip/demo/placement.tsx extend context correctly 
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-tooltip-arrow"
-        style="position: absolute;"
-      >
-        <span
-          class="ant-tooltip-arrow-content"
-        />
-      </div>
-      <div
         class="ant-tooltip-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-tooltip-arrow"
+        >
+          <span
+            class="ant-tooltip-arrow-content"
+          />
+        </div>
         <span>
           prompt text
         </span>
@@ -1753,18 +1710,17 @@ exports[`renders components/tooltip/demo/placement.tsx extend context correctly 
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
-      >
-        <span
-          class="ant-tooltip-arrow-content"
-        />
-      </div>
-      <div
         class="ant-tooltip-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-tooltip-arrow"
+        >
+          <span
+            class="ant-tooltip-arrow-content"
+          />
+        </div>
         <span>
           prompt text
         </span>
@@ -1785,18 +1741,17 @@ exports[`renders components/tooltip/demo/placement.tsx extend context correctly 
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-tooltip-arrow"
-        style="position: absolute;"
-      >
-        <span
-          class="ant-tooltip-arrow-content"
-        />
-      </div>
-      <div
         class="ant-tooltip-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-tooltip-arrow"
+        >
+          <span
+            class="ant-tooltip-arrow-content"
+          />
+        </div>
         <span>
           prompt text
         </span>
@@ -1825,18 +1780,17 @@ exports[`renders components/tooltip/demo/placement.tsx extend context correctly 
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           <span>
             prompt text
           </span>
@@ -1857,18 +1811,17 @@ exports[`renders components/tooltip/demo/placement.tsx extend context correctly 
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; right: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           <span>
             prompt text
           </span>
@@ -1889,18 +1842,17 @@ exports[`renders components/tooltip/demo/placement.tsx extend context correctly 
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           <span>
             prompt text
           </span>
@@ -1925,18 +1877,17 @@ exports[`renders components/tooltip/demo/placement.tsx extend context correctly 
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           <span>
             prompt text
           </span>
@@ -1957,18 +1908,17 @@ exports[`renders components/tooltip/demo/placement.tsx extend context correctly 
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           <span>
             prompt text
           </span>
@@ -1989,18 +1939,17 @@ exports[`renders components/tooltip/demo/placement.tsx extend context correctly 
         style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
       >
         <div
-          class="ant-tooltip-arrow"
-          style="position: absolute;"
-        >
-          <span
-            class="ant-tooltip-arrow-content"
-          />
-        </div>
-        <div
           class="ant-tooltip-container"
           id="test-id"
           role="tooltip"
         >
+          <div
+            class="ant-tooltip-arrow"
+          >
+            <span
+              class="ant-tooltip-arrow-content"
+            />
+          </div>
           <span>
             prompt text
           </span>
@@ -2027,18 +1976,17 @@ exports[`renders components/tooltip/demo/placement.tsx extend context correctly 
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-tooltip-arrow"
-        style="position: absolute;"
-      >
-        <span
-          class="ant-tooltip-arrow-content"
-        />
-      </div>
-      <div
         class="ant-tooltip-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-tooltip-arrow"
+        >
+          <span
+            class="ant-tooltip-arrow-content"
+          />
+        </div>
         <span>
           prompt text
         </span>
@@ -2059,18 +2007,17 @@ exports[`renders components/tooltip/demo/placement.tsx extend context correctly 
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-tooltip-arrow"
-        style="position: absolute; top: 0px; left: 0px;"
-      >
-        <span
-          class="ant-tooltip-arrow-content"
-        />
-      </div>
-      <div
         class="ant-tooltip-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-tooltip-arrow"
+        >
+          <span
+            class="ant-tooltip-arrow-content"
+          />
+        </div>
         <span>
           prompt text
         </span>
@@ -2091,18 +2038,17 @@ exports[`renders components/tooltip/demo/placement.tsx extend context correctly 
       style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
     >
       <div
-        class="ant-tooltip-arrow"
-        style="position: absolute;"
-      >
-        <span
-          class="ant-tooltip-arrow-content"
-        />
-      </div>
-      <div
         class="ant-tooltip-container"
         id="test-id"
         role="tooltip"
       >
+        <div
+          class="ant-tooltip-arrow"
+        >
+          <span
+            class="ant-tooltip-arrow-content"
+          />
+        </div>
         <span>
           prompt text
         </span>
@@ -2120,12 +2066,12 @@ Array [
     class="ant-tooltip-css-var css-var-test-id ant-tooltip ant-tooltip-pure ant-tooltip-placement-top ant-tooltip-pink"
   >
     <div
-      class="ant-tooltip-arrow"
-    />
-    <div
       class="ant-tooltip-container"
       role="tooltip"
     >
+      <div
+        class="ant-tooltip-arrow"
+      />
       Hello, Pink Pure Panel!
     </div>
   </div>,
@@ -2134,13 +2080,13 @@ Array [
     style="--ant-tooltip-arrow-background-color: #f50;"
   >
     <div
-      class="ant-tooltip-arrow"
-    />
-    <div
       class="ant-tooltip-container"
       role="tooltip"
       style="background: rgb(255, 85, 0); --ant-tooltip-overlay-color: #FFF;"
     >
+      <div
+        class="ant-tooltip-arrow"
+      />
       Hello, Customize Color Pure Panel!
     </div>
   </div>,
@@ -2148,13 +2094,13 @@ Array [
     class="ant-tooltip-css-var css-var-test-id ant-tooltip ant-tooltip-pure ant-tooltip-placement-bottomLeft"
   >
     <div
-      class="ant-tooltip-arrow"
-    />
-    <div
       class="ant-tooltip-container"
       role="tooltip"
       style="width: 200px;"
     >
+      <div
+        class="ant-tooltip-arrow"
+      />
       Hello, Pure Panel!
     </div>
   </div>,
@@ -2281,18 +2227,17 @@ Array [
     style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
   >
     <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
-    >
-      <span
-        class="ant-tooltip-arrow-content"
-      />
-    </div>
-    <div
       class="ant-tooltip-container"
       id="test-id"
       role="tooltip"
     >
+      <div
+        class="ant-tooltip-arrow"
+      >
+        <span
+          class="ant-tooltip-arrow-content"
+        />
+      </div>
       prompt text
     </div>
   </div>,

--- a/components/tooltip/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -22,18 +22,17 @@ exports[`renders components/tooltip/demo/_semantic.tsx correctly 1`] = `
           style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div
-            class="ant-tooltip-arrow semantic-mark-arrow"
-            style="position: absolute; bottom: 0px; left: 0px;"
-          >
-            <span
-              class="ant-tooltip-arrow-content"
-            />
-          </div>
-          <div
             class="ant-tooltip-container semantic-mark-container"
             id="test-id"
             role="tooltip"
           >
+            <div
+              class="ant-tooltip-arrow semantic-mark-arrow"
+            >
+              <span
+                class="ant-tooltip-arrow-content"
+              />
+            </div>
             tooltip prompt text
           </div>
         </div>

--- a/components/tooltip/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo.test.tsx.snap
@@ -828,12 +828,12 @@ Array [
     class="ant-tooltip-css-var css-var-test-id ant-tooltip ant-tooltip-pure ant-tooltip-placement-top ant-tooltip-pink"
   >
     <div
-      class="ant-tooltip-arrow"
-    />
-    <div
       class="ant-tooltip-container"
       role="tooltip"
     >
+      <div
+        class="ant-tooltip-arrow"
+      />
       Hello, Pink Pure Panel!
     </div>
   </div>,
@@ -842,13 +842,13 @@ Array [
     style="--ant-tooltip-arrow-background-color:#f50"
   >
     <div
-      class="ant-tooltip-arrow"
-    />
-    <div
       class="ant-tooltip-container"
       role="tooltip"
       style="background:#f50;--ant-tooltip-overlay-color:#FFF"
     >
+      <div
+        class="ant-tooltip-arrow"
+      />
       Hello, Customize Color Pure Panel!
     </div>
   </div>,
@@ -856,13 +856,13 @@ Array [
     class="ant-tooltip-css-var css-var-test-id ant-tooltip ant-tooltip-pure ant-tooltip-placement-bottomLeft"
   >
     <div
-      class="ant-tooltip-arrow"
-    />
-    <div
       class="ant-tooltip-container"
       role="tooltip"
       style="width:200px"
     >
+      <div
+        class="ant-tooltip-arrow"
+      />
       Hello, Pure Panel!
     </div>
   </div>,

--- a/components/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
+++ b/components/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
@@ -47,18 +47,18 @@ exports[`Tooltip support arrow props by default 1`] = `
     style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
   >
     <div
-      class="ant-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
-    >
-      <span
-        class="ant-tooltip-arrow-content"
-      />
-    </div>
-    <div
       class="ant-tooltip-container"
       id="test-id"
       role="tooltip"
-    />
+    >
+      <div
+        class="ant-tooltip-arrow"
+      >
+        <span
+          class="ant-tooltip-arrow-content"
+        />
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/components/tooltip/__tests__/semantic.test.tsx
+++ b/components/tooltip/__tests__/semantic.test.tsx
@@ -71,7 +71,7 @@ describe('Tooltip.Semantic', () => {
     expect(tooltipContainer).toHaveStyle('font-size: 16px');
   });
 
-  it('should allow backdrop-filter on the container', () => {
+  it('should allow backdrop-filter while preserving popup elevation', () => {
     const { container } = render(
       <Tooltip
         open
@@ -89,10 +89,13 @@ describe('Tooltip.Semantic', () => {
 
     const root = container.querySelector('.ant-tooltip');
     const tooltipContainer = container.querySelector('.ant-tooltip-container');
+    const arrow = container.querySelector('.ant-tooltip-arrow');
 
     expect(tooltipContainer).toHaveStyle({ backgroundColor: 'rgba(255, 255, 255, 0.4)' });
     expect(getComputedStyle(root!).filter || 'none').toBe('none');
     expect(getComputedStyle(tooltipContainer!).filter).toBe('var(--ant-drop-shadow-popover)');
+    expect(getComputedStyle(arrow!).filter).toBe('var(--ant-drop-shadow-popover)');
+    expect(getComputedStyle(arrow!).clipPath).toBe('inset(-100vmax -100vmax 0 -100vmax)');
   });
 
   it('should follow root style priority', () => {

--- a/components/tooltip/__tests__/semantic.test.tsx
+++ b/components/tooltip/__tests__/semantic.test.tsx
@@ -94,8 +94,7 @@ describe('Tooltip.Semantic', () => {
     expect(tooltipContainer).toHaveStyle({ backgroundColor: 'rgba(255, 255, 255, 0.4)' });
     expect(getComputedStyle(root!).filter || 'none').toBe('none');
     expect(getComputedStyle(tooltipContainer!).filter).toBe('var(--ant-drop-shadow-popover)');
-    expect(getComputedStyle(arrow!).filter).toBe('var(--ant-drop-shadow-popover)');
-    expect(getComputedStyle(arrow!).clipPath).toBe('inset(-100vmax -100vmax 0 -100vmax)');
+    expect(tooltipContainer).toContainElement(arrow);
   });
 
   it('should follow root style priority', () => {

--- a/components/tooltip/__tests__/semantic.test.tsx
+++ b/components/tooltip/__tests__/semantic.test.tsx
@@ -71,6 +71,30 @@ describe('Tooltip.Semantic', () => {
     expect(tooltipContainer).toHaveStyle('font-size: 16px');
   });
 
+  it('should allow backdrop-filter on the container', () => {
+    const { container } = render(
+      <Tooltip
+        open
+        title="Test tooltip"
+        styles={{
+          container: {
+            backgroundColor: 'rgba(255, 255, 255, 0.4)',
+            backdropFilter: 'blur(12px)',
+          },
+        }}
+      >
+        Trigger
+      </Tooltip>,
+    );
+
+    const root = container.querySelector('.ant-tooltip');
+    const tooltipContainer = container.querySelector('.ant-tooltip-container');
+
+    expect(tooltipContainer).toHaveStyle({ backgroundColor: 'rgba(255, 255, 255, 0.4)' });
+    expect(getComputedStyle(root!).filter || 'none').toBe('none');
+    expect(getComputedStyle(tooltipContainer!).filter).toBe('var(--ant-drop-shadow-popover)');
+  });
+
   it('should follow root style priority', () => {
     const { container } = render(
       <ConfigProvider

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -270,7 +270,7 @@ describe('Tooltip', () => {
         <div />
       </Tooltip>,
     );
-    expect(container.querySelector('.ant-tooltip-container')?.innerHTML).toBe('0');
+    expect(container.querySelector('.ant-tooltip-container')).toHaveTextContent('0');
   });
 
   it('autoAdjustOverflow should be object or undefined', () => {

--- a/components/tooltip/__tests__/unique.test.tsx
+++ b/components/tooltip/__tests__/unique.test.tsx
@@ -26,7 +26,17 @@ describe('Tooltip.Unique', () => {
     const tooltipRef = React.createRef<GetRef<typeof Tooltip>>();
 
     render(
-      <ConfigProvider tooltip={{ unique: true }}>
+      <ConfigProvider
+        tooltip={{
+          unique: true,
+          styles: {
+            container: {
+              backgroundColor: 'rgba(255, 255, 255, 0.4)',
+              backdropFilter: 'blur(12px)',
+            },
+          },
+        }}
+      >
         <Tooltip title="text" open ref={tooltipRef}>
           <span>xxxx</span>
         </Tooltip>
@@ -34,7 +44,14 @@ describe('Tooltip.Unique', () => {
     );
 
     await waitFakeTimer();
-    expect(document.querySelector('.ant-tooltip-unique-container-visible')).toBeTruthy();
+    const root = document.querySelector('.ant-tooltip');
+    const container = document.querySelector('.ant-tooltip-container');
+    const uniqueContainer = document.querySelector('.ant-tooltip-unique-container-visible');
+
+    expect(uniqueContainer).toHaveStyle({ backgroundColor: 'rgba(255, 255, 255, 0.4)' });
+    expect(getComputedStyle(root!).filter || 'none').toBe('none');
+    expect(getComputedStyle(container!).filter || 'none').toBe('none');
+    expect(getComputedStyle(uniqueContainer!).filter).toBe('var(--ant-drop-shadow-popover)');
 
     expect(() => {
       tooltipRef.current?.forceAlign();

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -285,12 +285,6 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
     return overlay || title || '';
   }, [overlay, title]);
 
-  const memoOverlayWrapper = (
-    <ContextIsolator space form>
-      {isFunction(memoOverlay) ? memoOverlay() : memoOverlay}
-    </ContextIsolator>
-  );
-
   // =========== Merged Props for Semantic ===========
   const mergedProps: TooltipProps = {
     ...props,
@@ -361,12 +355,30 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
     ...colorInfo.overlayStyle,
   };
 
+  // Keep the arrow in the same filtered element as the popup body. This preserves a single
+  // composite shadow without making `backdrop-filter` a descendant of an element with `filter`.
+  const memoOverlayWrapper = (
+    <>
+      {mergedShowArrow && (
+        <div
+          className={clsx(`${prefixCls}-arrow`, mergedClassNames.arrow)}
+          style={mergedStyles.arrow}
+        >
+          <span className={`${prefixCls}-arrow-content`} />
+        </div>
+      )}
+      <ContextIsolator space form>
+        {isFunction(memoOverlay) ? memoOverlay() : memoOverlay}
+      </ContextIsolator>
+    </>
+  );
+
   const content = (
     <RcTooltip
       unique
       {...restProps}
       zIndex={zIndex}
-      showArrow={mergedShowArrow}
+      showArrow={false}
       placement={placement}
       mouseEnterDelay={mergedMouseEnterDelay}
       mouseLeaveDelay={mergedMouseLeaveDelay}
@@ -391,7 +403,6 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
       visible={tempOpen}
       onVisibleChange={onInternalOpenChange}
       afterVisibleChange={afterOpenChange}
-      arrowContent={<span className={`${prefixCls}-arrow-content`} />}
       motion={{
         motionName: getTransitionName(
           rootPrefixCls,

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -99,7 +99,6 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
         width: 'max-content',
         maxWidth: tooltipMaxWidth,
         visibility: 'visible',
-        filter: dropShadowPopover,
 
         ...sharedTransformOrigin,
 
@@ -110,12 +109,17 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
         [varName('arrow-background-color')]: tooltipBg,
 
         // Wrapper for the tooltip content
-        [`${componentCls}-container`]: [sharedBodyStyle, initFadeMotion(token, true)],
+        [`${componentCls}-container`]: [
+          sharedBodyStyle,
+          { filter: dropShadowPopover },
+          initFadeMotion(token, true),
+        ],
 
         [`&:has(~ ${componentCls}-unique-container)`]: {
           [`${componentCls}-container`]: {
             border: 'none',
             background: 'transparent',
+            filter: 'none',
           },
         },
 
@@ -167,7 +171,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
     },
 
     // Arrow Style
-    getArrowStyle<TooltipToken>(token, varRef('arrow-background-color'), { arrowShadow: false }),
+    getArrowStyle<TooltipToken>(token, varRef('arrow-background-color')),
 
     // Pure Render
     {

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -78,6 +78,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
     backgroundColor: tooltipBg,
     borderRadius: tooltipBorderRadius,
     boxSizing: 'border-box',
+    position: 'relative',
   };
 
   const sharedTransformOrigin: CSSObject = {
@@ -121,6 +122,10 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
             background: 'transparent',
             filter: 'none',
           },
+        },
+
+        [`&${componentCls}-unique-controlled ${componentCls}-container > ${componentCls}-arrow`]: {
+          display: 'none',
         },
 
         // Align placement should have another min width
@@ -173,7 +178,7 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
     // Arrow Style
     getArrowStyle<TooltipToken>(token, varRef('arrow-background-color'), {
       arrowShadow: false,
-      arrowFilter: dropShadowPopover,
+      arrowInContainer: true,
     }),
 
     // Pure Render

--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -171,7 +171,10 @@ const genTooltipStyle: GenerateStyle<TooltipToken> = (token) => {
     },
 
     // Arrow Style
-    getArrowStyle<TooltipToken>(token, varRef('arrow-background-color')),
+    getArrowStyle<TooltipToken>(token, varRef('arrow-background-color'), {
+      arrowShadow: false,
+      arrowFilter: dropShadowPopover,
+    }),
 
     // Pure Render
     {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Fixes #58384.

Follow-up context: #57988 fixed the darker arrow-shadow overlap tracked by #36076.

### 💡 Background and Solution

#57988 moved Tooltip and Popover elevation to `filter: drop-shadow(...)` on the popup root so the arrow and popup body shared one shadow. A non-`none` filter on that ancestor creates a backdrop root, which prevents a descendant popup container from applying a visible `backdrop-filter`. As a result, frosted-glass styles on Popover, Tooltip, and consumers such as ColorPicker silently stopped blurring the page behind them.

Two earlier closed attempts, #58466 and #58856, replaced the popup elevation with `boxShadowSecondary`. Maintainer feedback on #58466 noted that this was effectively a direct revert, while #58856 produced 21 visual-regression changes and was closed as a draft.

This change takes a narrower approach:

- Keep the existing `dropShadowPopover` elevation token instead of replacing it with `boxShadowSecondary`.
- Move that filter from the popup root to the actual Popover/Tooltip body container. A filter and `backdrop-filter` can work on the same element, while the root no longer blocks descendant backdrop capture.
- Restore the arrow's dedicated lightweight shadow because the root no longer supplies elevation to the arrow. A semi-transparent popup was verified in Chromium to avoid reintroducing the darker-arrow appearance from #36076.
- In Tooltip unique mode, keep the transparent motion container unfiltered and let the unique container carry the popup elevation, avoiding a double shadow.
- Add semantic regression coverage for Popover, Tooltip, and Tooltip unique mode.

No public API or token is added or removed.

### ✅ Verification

- Full unit test suite: 575 suites passed, 3 skipped; 7,568 tests passed, 101 skipped; 4,092 snapshots passed.
- Popover/Tooltip component tests: 14 suites, 153 passed, 8 skipped, 78 snapshots passed.
- Popover/Tooltip image tests: 2 suites, 81 screenshots rendered successfully across default, dark, and compact themes.
- TypeScript: `tsc --noEmit` passed.
- Full `npm run lint` passed; targeted ESLint and Biome also passed for all changed files.
- `git diff --check` passed.
- Chromium verification confirmed:
  - popup root filter is `none`;
  - normal popup containers have both `backdrop-filter: blur(12px)` and the existing three-layer drop shadow;
  - Tooltip unique's transparent motion container has no filter, while the unique container has blur and elevation;
  - semi-transparent arrows remain visually consistent with their containers.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Popover and Tooltip `backdrop-filter` styles not blurring content behind popup containers. |
| 🇨🇳 Chinese | 🐞 修复 Popover 和 Tooltip 弹层容器的 `backdrop-filter` 毛玻璃效果失效问题。 |