### PR TITLE
fix: fix Layout Sider shaking during collapse/expand animation

### DIFF
--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -228,7 +228,6 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
   const divStyle: React.CSSProperties = {
     ...style,
     flex: `0 0 ${siderWidth}`,
-    maxWidth: siderWidth, // Fix width transition bug in IE11
     minWidth: siderWidth, // https://github.com/ant-design/ant-design/issues/6349
     width: siderWidth,
   };

--- a/components/layout/style/sider.ts
+++ b/components/layout/style/sider.ts
@@ -33,7 +33,7 @@ const genSiderStyle: GenerateStyle<LayoutToken, CSSObject> = (token) => {
       // fix firefox can't set width smaller than content on flex item
       minWidth: 0,
       background: siderBg,
-      transition: `all ${motionDurationMid}, background 0s`,
+      transition: `flex ${motionDurationMid}, max-width ${motionDurationMid}, min-width ${motionDurationMid}, background 0s`,
 
       '&-has-trigger': {
         paddingBottom: triggerHeight,


### PR DESCRIPTION
The Sider had `transition: all` which caused four width-related properties (flex-basis, width, min-width, max-width) to animate simultaneously. In CSS Flexbox, flex-basis and width serve overlapping roles, and their independent interpolation during animation caused jitter. Changed transition to only animate flex, max-width, and min-width (excluding width). Also removed the IE11-specific maxWidth inline style.

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

 ### 🤔 This is a ...

  - [ ] 🆕 New feature 
  - [x] 🐞 Bug fix
  - [ ] 📝 Site / documentation improvement
  - [ ] 📽️  Demo improvement
  - [x] 💄 Component style improvement
  - [ ] 🤖 TypeScript definition improvement
  - [ ] 📦 Bundle size optimization
  - [ ] ⚡️ Performance optimization
  - [ ] ⭐️ Feature enhancement
  - [ ] 🌐 Internationalization
  - [ ] 🛠 Refactoring
  - [ ] 🎨 Code style optimization
  - [ ] ✅ Test Case
  - [ ] 🔀 Branch merge
  - [ ] ⏩ Workflow
  - [ ] ⌨️  Accessibility improvement
  - [ ] ❓ Other (about what?)

  ### 🔗 Related Issues

  > Reproduction: https://ant.design/components/layout-cn#layout-demo-custom-trigger

  ### 💡 Background and Solution

  Sider 组件折叠/展开时，侧边栏图标出现抖动（先向左、再向右、再向右移动一点点）。

  **根因**：Sider CSS 使用了 `transition: all`，导致四个宽度属性（`flex-basis`、`width`、`min-width`、`max-width`）同时参与动画。在 CSS Flexbox 中 `flex-basis` 与 `width`
  作用重叠，两者独立插值导致每帧的计算宽度不一致，产生抖动。

  **修复**：
  - 将 `transition: all` 改为只 transition `flex`、`max-width`、`min-width`（排除 `width`，避免与 `flex-basis` 冲突）
  - 移除 IE11 专用的 `maxWidth` 行内样式

  ### 📝 Change Log

  | Language   | Changelog |
  | ---------- | --------- |
  | 🇺🇸 English | 🐞 Fix Layout Sider icons shaking during collapse/expand animation. |
  | 🇨🇳 Chinese | 🐞 修复 Layout Sider 折叠/展开动画时图标抖动的问题。 |
