### PR TITLE
docs: fix typos and cross-language link in docs

### DIFF
--- a/docs/blog/extract-ssr.en-US.md
+++ b/docs/blog/extract-ssr.en-US.md
@@ -7,7 +7,7 @@ yuque_url: https://www.yuque.com/ant-design/ant-design/gyacdbtixle9bbm4
 juejin_url: https://juejin.cn/post/7322352551088603163
 ---
 
-For traditional js + css websites, SSR only needs to deal with the hydrate problem of the first rendering. With the introduction of CSS-in-JS technology, developers need to pay additional attention to how to export styles to HTML to ensure the correctness of the view. We provide a lot of implementation methods, and we just talk about the ideas here. If you need complete documentation or examples, please refer to [Customize Theme](/docs/react/customize-theme-cn).
+For traditional js + css websites, SSR only needs to deal with the hydrate problem of the first rendering. With the introduction of CSS-in-JS technology, developers need to pay additional attention to how to export styles to HTML to ensure the correctness of the view. We provide a lot of implementation methods, and we just talk about the ideas here. If you need complete documentation or examples, please refer to [Customize Theme](/docs/react/customize-theme).
 
 ### Inline Style
 

--- a/docs/spec/data-list.en-US.md
+++ b/docs/spec/data-list.en-US.md
@@ -123,7 +123,7 @@ Use when you need to jump to the page to view the complete list.
 - From the perspective of natural interaction, **Expand the list on the same page** is more natural, and it should be noted that the height of the expanded content area should not exceed one screen;
 - From the perspective of the amount of information in the details, if the information display exceeds one screen, it is not convenient for the user to use the unfolding method. At this time, it is better to use **Drawer Expand**;
 - Details need to be shared with others separately, or complex immersive tasks, **jump to independent page** is more suitable;
-- There may be content that the user is interested in in each item of detail, so as to facilitate switching navigation, quickly view and process different items, you can use the ** double column display. **
+- There may be content that the user is interested in, in each item of detail, so as to facilitate switching navigation, quickly view and process different items, you can use the ** double column display. **
 
 ### Batch operations
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

修复文档中的两处问题：

1. **`docs/spec/data-list.en-US.md`**：修复重复单词 "interested in in" → "interested in, in"
2. **`docs/blog/extract-ssr.en-US.md`**：修复英文博客中链接指向中文页面的问题，`/docs/react/customize-theme-cn` → `/docs/react/customize-theme`

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | 无需更新日志 |