### PR TITLE
fix: use localized names for Upload actions

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -41407,6 +41407,7 @@ exports[`ConfigProvider components Upload configProvider 1`] = `
           class="config-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="config-btn css-var-root config-btn-text config-btn-color-default config-btn-variant-text config-btn-sm config-btn-icon-only config-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -41575,6 +41576,7 @@ exports[`ConfigProvider components Upload configProvider componentSize large 1`]
           class="config-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="config-btn css-var-root config-btn-text config-btn-color-default config-btn-variant-text config-btn-sm config-btn-icon-only config-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -41674,6 +41676,7 @@ exports[`ConfigProvider components Upload configProvider componentSize medium 1`
           class="config-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="config-btn css-var-root config-btn-text config-btn-color-default config-btn-variant-text config-btn-sm config-btn-icon-only config-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -41773,6 +41776,7 @@ exports[`ConfigProvider components Upload configProvider componentSize small 1`]
           class="config-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="config-btn css-var-root config-btn-text config-btn-color-default config-btn-variant-text config-btn-sm config-btn-icon-only config-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -41872,6 +41876,7 @@ exports[`ConfigProvider components Upload normal 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -41971,6 +41976,7 @@ exports[`ConfigProvider components Upload prefixCls 1`] = `
           class="prefix-Upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only prefix-Upload-list-item-action"
             title="Remove file"
             type="button"

--- a/components/upload/UploadList/ListItem.tsx
+++ b/components/upload/UploadList/ListItem.tsx
@@ -227,6 +227,7 @@ const ListItem = React.forwardRef<HTMLDivElement, ListItemProps>(
           rel="noopener noreferrer"
           onClick={(e) => onPreview(file, e)}
           title={locale.previewFile}
+          aria-label={locale.previewFile || undefined}
         >
           {isFunction(customPreviewIcon)
             ? customPreviewIcon(file)

--- a/components/upload/UploadList/index.tsx
+++ b/components/upload/UploadList/index.tsx
@@ -129,6 +129,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<UploadListRef, UploadLi
       type: 'text',
       size: 'small',
       title,
+      'aria-label': title || undefined,
       onClick: (e: React.MouseEvent<HTMLElement>) => {
         callback();
         if (React.isValidElement<{ onClick?: React.MouseEventHandler<HTMLElement> }>(customIcon)) {

--- a/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/upload/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -260,6 +260,7 @@ exports[`renders components/upload/demo/component-token.tsx extend context corre
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -334,6 +335,7 @@ exports[`renders components/upload/demo/component-token.tsx extend context corre
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -409,6 +411,7 @@ exports[`renders components/upload/demo/component-token.tsx extend context corre
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -652,6 +655,7 @@ exports[`renders components/upload/demo/debug-disabled.tsx extend context correc
               class="ant-upload-list-item-actions"
             >
               <a
+                aria-label="Preview file"
                 href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -711,6 +715,7 @@ exports[`renders components/upload/demo/debug-disabled.tsx extend context correc
               class="ant-upload-list-item-actions"
             >
               <a
+                aria-label="Preview file"
                 href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -914,6 +919,7 @@ exports[`renders components/upload/demo/debug-disabled.tsx extend context correc
               class="ant-upload-list-item-actions"
             >
               <a
+                aria-label="Preview file"
                 href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -973,6 +979,7 @@ exports[`renders components/upload/demo/debug-disabled.tsx extend context correc
               class="ant-upload-list-item-actions"
             >
               <a
+                aria-label="Preview file"
                 href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -1299,6 +1306,7 @@ exports[`renders components/upload/demo/defaultFileList.tsx extend context corre
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -1373,6 +1381,7 @@ exports[`renders components/upload/demo/defaultFileList.tsx extend context corre
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -1448,6 +1457,7 @@ exports[`renders components/upload/demo/defaultFileList.tsx extend context corre
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -2211,6 +2221,7 @@ exports[`renders components/upload/demo/file-type.tsx extend context correctly 1
           class="ant-upload-list-item-actions"
         >
           <a
+            aria-label="Preview file"
             href="http://cdn07.foxitsoftware.cn/pub/foxit/cpdf/FoxitCompanyProfile.pdf"
             rel="noopener noreferrer"
             target="_blank"
@@ -2237,6 +2248,7 @@ exports[`renders components/upload/demo/file-type.tsx extend context correctly 1
             </span>
           </a>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -2323,6 +2335,7 @@ exports[`renders components/upload/demo/file-type.tsx extend context correctly 1
           class="ant-upload-list-item-actions"
         >
           <a
+            aria-label="Preview file"
             href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.doc"
             rel="noopener noreferrer"
             target="_blank"
@@ -2349,6 +2362,7 @@ exports[`renders components/upload/demo/file-type.tsx extend context correctly 1
             </span>
           </a>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -2440,6 +2454,7 @@ exports[`renders components/upload/demo/file-type.tsx extend context correctly 1
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -2551,6 +2566,7 @@ exports[`renders components/upload/demo/file-type.tsx extend context correctly 1
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -2654,6 +2670,7 @@ exports[`renders components/upload/demo/file-type.tsx extend context correctly 1
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -2853,6 +2870,7 @@ exports[`renders components/upload/demo/fileList.tsx extend context correctly 1`
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3109,6 +3127,7 @@ exports[`renders components/upload/demo/picture-card.tsx extend context correctl
           class="ant-upload-list-item-actions"
         >
           <a
+            aria-label="Preview file"
             href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
             rel="noopener noreferrer"
             target="_blank"
@@ -3135,6 +3154,7 @@ exports[`renders components/upload/demo/picture-card.tsx extend context correctl
             </span>
           </a>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3198,6 +3218,7 @@ exports[`renders components/upload/demo/picture-card.tsx extend context correctl
           class="ant-upload-list-item-actions"
         >
           <a
+            aria-label="Preview file"
             href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
             rel="noopener noreferrer"
             target="_blank"
@@ -3224,6 +3245,7 @@ exports[`renders components/upload/demo/picture-card.tsx extend context correctl
             </span>
           </a>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3287,6 +3309,7 @@ exports[`renders components/upload/demo/picture-card.tsx extend context correctl
           class="ant-upload-list-item-actions"
         >
           <a
+            aria-label="Preview file"
             href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
             rel="noopener noreferrer"
             target="_blank"
@@ -3313,6 +3336,7 @@ exports[`renders components/upload/demo/picture-card.tsx extend context correctl
             </span>
           </a>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3376,6 +3400,7 @@ exports[`renders components/upload/demo/picture-card.tsx extend context correctl
           class="ant-upload-list-item-actions"
         >
           <a
+            aria-label="Preview file"
             href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
             rel="noopener noreferrer"
             target="_blank"
@@ -3402,6 +3427,7 @@ exports[`renders components/upload/demo/picture-card.tsx extend context correctl
             </span>
           </a>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3498,6 +3524,7 @@ exports[`renders components/upload/demo/picture-card.tsx extend context correctl
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3640,6 +3667,7 @@ exports[`renders components/upload/demo/picture-circle.tsx extend context correc
           class="ant-upload-list-item-actions"
         >
           <a
+            aria-label="Preview file"
             href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
             rel="noopener noreferrer"
             target="_blank"
@@ -3666,6 +3694,7 @@ exports[`renders components/upload/demo/picture-circle.tsx extend context correc
             </span>
           </a>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3762,6 +3791,7 @@ exports[`renders components/upload/demo/picture-circle.tsx extend context correc
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3959,6 +3989,7 @@ exports[`renders components/upload/demo/picture-style.tsx extend context correct
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -4022,6 +4053,7 @@ exports[`renders components/upload/demo/picture-style.tsx extend context correct
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -4096,6 +4128,7 @@ exports[`renders components/upload/demo/picture-style.tsx extend context correct
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -4310,6 +4343,7 @@ exports[`renders components/upload/demo/style-class.tsx extend context correctly
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -4385,6 +4419,7 @@ exports[`renders components/upload/demo/style-class.tsx extend context correctly
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -4461,6 +4496,7 @@ exports[`renders components/upload/demo/style-class.tsx extend context correctly
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -4612,6 +4648,7 @@ exports[`renders components/upload/demo/style-class.tsx extend context correctly
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -4687,6 +4724,7 @@ exports[`renders components/upload/demo/style-class.tsx extend context correctly
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -4763,6 +4801,7 @@ exports[`renders components/upload/demo/style-class.tsx extend context correctly
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -4982,6 +5021,7 @@ exports[`renders components/upload/demo/upload-custom-action-icon.tsx extend con
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Download file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-upload-list-item-action"
             title="Download file"
             type="button"
@@ -4991,6 +5031,7 @@ exports[`renders components/upload/demo/upload-custom-action-icon.tsx extend con
             </span>
           </button>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -5074,6 +5115,7 @@ exports[`renders components/upload/demo/upload-custom-action-icon.tsx extend con
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Download file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-upload-list-item-action"
             title="Download file"
             type="button"
@@ -5083,6 +5125,7 @@ exports[`renders components/upload/demo/upload-custom-action-icon.tsx extend con
             </span>
           </button>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -5167,6 +5210,7 @@ exports[`renders components/upload/demo/upload-custom-action-icon.tsx extend con
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"

--- a/components/upload/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/upload/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -103,6 +103,7 @@ exports[`renders components/upload/demo/_semantic.tsx correctly 1`] = `
                 class="ant-upload-list-item-actions"
               >
                 <button
+                  aria-label="Remove file"
                   class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
                   title="Remove file"
                   type="button"
@@ -177,6 +178,7 @@ exports[`renders components/upload/demo/_semantic.tsx correctly 1`] = `
                 class="ant-upload-list-item-actions"
               >
                 <button
+                  aria-label="Remove file"
                   class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
                   title="Remove file"
                   type="button"
@@ -251,6 +253,7 @@ exports[`renders components/upload/demo/_semantic.tsx correctly 1`] = `
                 class="ant-upload-list-item-actions"
               >
                 <button
+                  aria-label="Remove file"
                   class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
                   title="Remove file"
                   type="button"

--- a/components/upload/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/upload/__tests__/__snapshots__/demo.test.ts.snap
@@ -256,6 +256,7 @@ exports[`renders components/upload/demo/component-token.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -330,6 +331,7 @@ exports[`renders components/upload/demo/component-token.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -404,6 +406,7 @@ exports[`renders components/upload/demo/component-token.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -623,6 +626,7 @@ exports[`renders components/upload/demo/debug-disabled.tsx correctly 1`] = `
               class="ant-upload-list-item-actions"
             >
               <a
+                aria-label="Preview file"
                 href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -682,6 +686,7 @@ exports[`renders components/upload/demo/debug-disabled.tsx correctly 1`] = `
               class="ant-upload-list-item-actions"
             >
               <a
+                aria-label="Preview file"
                 href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -864,6 +869,7 @@ exports[`renders components/upload/demo/debug-disabled.tsx correctly 1`] = `
               class="ant-upload-list-item-actions"
             >
               <a
+                aria-label="Preview file"
                 href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -923,6 +929,7 @@ exports[`renders components/upload/demo/debug-disabled.tsx correctly 1`] = `
               class="ant-upload-list-item-actions"
             >
               <a
+                aria-label="Preview file"
                 href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -1226,6 +1233,7 @@ exports[`renders components/upload/demo/defaultFileList.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -1300,6 +1308,7 @@ exports[`renders components/upload/demo/defaultFileList.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -1374,6 +1383,7 @@ exports[`renders components/upload/demo/defaultFileList.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -1633,6 +1643,7 @@ exports[`renders components/upload/demo/drag-sorting.tsx correctly 1`] = `
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -1716,6 +1727,7 @@ exports[`renders components/upload/demo/drag-sorting.tsx correctly 1`] = `
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -1799,6 +1811,7 @@ exports[`renders components/upload/demo/drag-sorting.tsx correctly 1`] = `
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -1882,6 +1895,7 @@ exports[`renders components/upload/demo/drag-sorting.tsx correctly 1`] = `
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -1964,6 +1978,7 @@ exports[`renders components/upload/demo/drag-sorting.tsx correctly 1`] = `
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -2070,6 +2085,7 @@ exports[`renders components/upload/demo/file-type.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <a
+            aria-label="Preview file"
             href="http://cdn07.foxitsoftware.cn/pub/foxit/cpdf/FoxitCompanyProfile.pdf"
             rel="noopener noreferrer"
             target="_blank"
@@ -2096,6 +2112,7 @@ exports[`renders components/upload/demo/file-type.tsx correctly 1`] = `
             </span>
           </a>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -2182,6 +2199,7 @@ exports[`renders components/upload/demo/file-type.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <a
+            aria-label="Preview file"
             href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.doc"
             rel="noopener noreferrer"
             target="_blank"
@@ -2208,6 +2226,7 @@ exports[`renders components/upload/demo/file-type.tsx correctly 1`] = `
             </span>
           </a>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -2298,6 +2317,7 @@ exports[`renders components/upload/demo/file-type.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -2388,6 +2408,7 @@ exports[`renders components/upload/demo/file-type.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -2470,6 +2491,7 @@ exports[`renders components/upload/demo/file-type.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -2647,6 +2669,7 @@ exports[`renders components/upload/demo/fileList.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -2897,6 +2920,7 @@ exports[`renders components/upload/demo/picture-card.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <a
+            aria-label="Preview file"
             href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
             rel="noopener noreferrer"
             target="_blank"
@@ -2923,6 +2947,7 @@ exports[`renders components/upload/demo/picture-card.tsx correctly 1`] = `
             </span>
           </a>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -2986,6 +3011,7 @@ exports[`renders components/upload/demo/picture-card.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <a
+            aria-label="Preview file"
             href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
             rel="noopener noreferrer"
             target="_blank"
@@ -3012,6 +3038,7 @@ exports[`renders components/upload/demo/picture-card.tsx correctly 1`] = `
             </span>
           </a>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3075,6 +3102,7 @@ exports[`renders components/upload/demo/picture-card.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <a
+            aria-label="Preview file"
             href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
             rel="noopener noreferrer"
             target="_blank"
@@ -3101,6 +3129,7 @@ exports[`renders components/upload/demo/picture-card.tsx correctly 1`] = `
             </span>
           </a>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3164,6 +3193,7 @@ exports[`renders components/upload/demo/picture-card.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <a
+            aria-label="Preview file"
             href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
             rel="noopener noreferrer"
             target="_blank"
@@ -3190,6 +3220,7 @@ exports[`renders components/upload/demo/picture-card.tsx correctly 1`] = `
             </span>
           </a>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3285,6 +3316,7 @@ exports[`renders components/upload/demo/picture-card.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3405,6 +3437,7 @@ exports[`renders components/upload/demo/picture-circle.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <a
+            aria-label="Preview file"
             href="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
             rel="noopener noreferrer"
             target="_blank"
@@ -3431,6 +3464,7 @@ exports[`renders components/upload/demo/picture-circle.tsx correctly 1`] = `
             </span>
           </a>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3526,6 +3560,7 @@ exports[`renders components/upload/demo/picture-circle.tsx correctly 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3701,6 +3736,7 @@ exports[`renders components/upload/demo/picture-style.tsx correctly 1`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3764,6 +3800,7 @@ exports[`renders components/upload/demo/picture-style.tsx correctly 1`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -3837,6 +3874,7 @@ exports[`renders components/upload/demo/picture-style.tsx correctly 1`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -4027,6 +4065,7 @@ exports[`renders components/upload/demo/style-class.tsx correctly 1`] = `
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -4102,6 +4141,7 @@ exports[`renders components/upload/demo/style-class.tsx correctly 1`] = `
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -4177,6 +4217,7 @@ exports[`renders components/upload/demo/style-class.tsx correctly 1`] = `
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -4308,6 +4349,7 @@ exports[`renders components/upload/demo/style-class.tsx correctly 1`] = `
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -4383,6 +4425,7 @@ exports[`renders components/upload/demo/style-class.tsx correctly 1`] = `
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -4458,6 +4501,7 @@ exports[`renders components/upload/demo/style-class.tsx correctly 1`] = `
             class="ant-upload-list-item-actions"
           >
             <button
+              aria-label="Remove file"
               class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
               title="Remove file"
               type="button"
@@ -4657,6 +4701,7 @@ exports[`renders components/upload/demo/upload-custom-action-icon.tsx correctly 
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Download file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-upload-list-item-action"
             title="Download file"
             type="button"
@@ -4666,6 +4711,7 @@ exports[`renders components/upload/demo/upload-custom-action-icon.tsx correctly 
             </span>
           </button>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -4753,6 +4799,7 @@ exports[`renders components/upload/demo/upload-custom-action-icon.tsx correctly 
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Download file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-upload-list-item-action"
             title="Download file"
             type="button"
@@ -4762,6 +4809,7 @@ exports[`renders components/upload/demo/upload-custom-action-icon.tsx correctly 
             </span>
           </button>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -4849,6 +4897,7 @@ exports[`renders components/upload/demo/upload-custom-action-icon.tsx correctly 
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"

--- a/components/upload/__tests__/__snapshots__/uploadlist.test.tsx.snap
+++ b/components/upload/__tests__/__snapshots__/uploadlist.test.tsx.snap
@@ -68,6 +68,7 @@ exports[`Upload List handle error 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -231,6 +232,7 @@ exports[`Upload List should be uploading when upload a file 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -338,6 +340,7 @@ exports[`Upload List should non-image format file preview 1`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -401,6 +404,7 @@ exports[`Upload List should non-image format file preview 1`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -478,6 +482,7 @@ exports[`Upload List should non-image format file preview 1`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -555,6 +560,7 @@ exports[`Upload List should non-image format file preview 1`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -618,6 +624,7 @@ exports[`Upload List should non-image format file preview 1`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -681,6 +688,7 @@ exports[`Upload List should non-image format file preview 1`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -744,6 +752,7 @@ exports[`Upload List should non-image format file preview 1`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -807,6 +816,7 @@ exports[`Upload List should non-image format file preview 1`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -870,6 +880,7 @@ exports[`Upload List should non-image format file preview 1`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -933,6 +944,7 @@ exports[`Upload List should non-image format file preview 1`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -1037,6 +1049,7 @@ exports[`Upload List should support removeIcon and downloadIcon 1`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -1083,6 +1096,7 @@ exports[`Upload List should support removeIcon and downloadIcon 1`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Download file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Download file"
             type="button"
@@ -1096,6 +1110,7 @@ exports[`Upload List should support removeIcon and downloadIcon 1`] = `
             </span>
           </button>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -1183,6 +1198,7 @@ exports[`Upload List should support removeIcon and downloadIcon 2`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -1229,6 +1245,7 @@ exports[`Upload List should support removeIcon and downloadIcon 2`] = `
           class="ant-upload-list-item-actions picture"
         >
           <button
+            aria-label="Download file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Download file"
             type="button"
@@ -1242,6 +1259,7 @@ exports[`Upload List should support removeIcon and downloadIcon 2`] = `
             </span>
           </button>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -1434,6 +1452,7 @@ exports[`Upload List should support showXxxIcon functions 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"
@@ -1534,6 +1553,7 @@ exports[`Upload List should support showXxxIcon functions 1`] = `
           class="ant-upload-list-item-actions"
         >
           <button
+            aria-label="Download file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Download file"
             type="button"
@@ -1547,6 +1567,7 @@ exports[`Upload List should support showXxxIcon functions 1`] = `
             </span>
           </button>
           <button
+            aria-label="Remove file"
             class="ant-btn css-var-root ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only ant-upload-list-item-action"
             title="Remove file"
             type="button"

--- a/components/upload/__tests__/accessibility.test.tsx
+++ b/components/upload/__tests__/accessibility.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import type { UploadProps } from '..';
+import Upload from '..';
+import { render, screen } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
+import zhTW from '../../locale/zh_TW';
+
+const fileList: UploadProps['fileList'] = [
+  {
+    uid: 'report',
+    name: 'report.pdf',
+    status: 'done',
+    url: '/report.pdf',
+  },
+];
+
+describe('Upload accessibility', () => {
+  it('uses the merged locale for default file actions', () => {
+    render(
+      <Upload
+        fileList={fileList}
+        listType="picture-card"
+        locale={{ removeFile: 'Localized remove' }}
+        showUploadList={{ showDownloadIcon: true }}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'Preview file' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Download file' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Localized remove' })).toBeInTheDocument();
+  });
+
+  it('keeps localized action names when custom icons have their own names', () => {
+    render(
+      <ConfigProvider locale={zhTW}>
+        <Upload
+          fileList={fileList}
+          listType="picture-card"
+          showUploadList={{
+            showDownloadIcon: true,
+            removeIcon: () => <span role="img" aria-label="Remove icon" />,
+            previewIcon: () => <span role="img" aria-label="Preview icon" />,
+            downloadIcon: () => <span role="img" aria-label="Download icon" />,
+          }}
+        />
+      </ConfigProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: '移除檔案' })).toHaveAttribute('title', '移除檔案');
+    expect(screen.getByRole('link', { name: '預覽檔案' })).toHaveAttribute('title', '預覽檔案');
+    expect(screen.getByRole('button', { name: '下載檔案' })).toHaveAttribute('title', '下載檔案');
+  });
+
+  it('keeps the icon fallback when an action locale is empty', () => {
+    render(
+      <Upload
+        fileList={fileList}
+        listType="picture-card"
+        locale={{ removeFile: '', previewFile: '' }}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'delete' })).not.toHaveAttribute('aria-label');
+    expect(screen.getByRole('link', { name: 'eye' })).not.toHaveAttribute('aria-label');
+  });
+});


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [x] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

N/A — this is a focused internal accessibility correction. I checked the open issue and pull request queues before submitting; no existing report or patch covers these action names. PR #57474 touches a separate error-message block in `ListItem.tsx` and has no behavioral or line-level overlap.

### 💡 Background and Solution

Upload already has localized strings for its remove, preview, and download actions, but those strings were only exposed through `title`. The interactive controls had no explicit accessible name, so screen readers used the descendant icon names instead (`delete`, `eye`, and `download`). Custom icons could similarly replace the action meaning with their own icon label.

This patch applies the existing locale strings to the actual interactive controls:

- Remove and download Buttons receive the corresponding localized `aria-label` through the shared action renderer.
- The picture-card / picture-circle preview action link receives `locale.previewFile`.
- Existing `title`, click, disabled, link, and custom-icon behavior is unchanged.
- An explicitly empty locale string omits `aria-label`, preserving the previous descendant-icon fallback.

The new cross-runner tests cover default locale merging, Traditional Chinese (Taiwan) labels with custom icons, and empty-label fallback for both the shared Button path and the separate preview-link path.

Validation:

- Test-first regression reproduced the old `eye` / `download` / `delete` and custom-icon accessible names before the source change.
- Full Upload Jest suite — 10 suites passed; 212 passed, 3 skipped; 77 snapshots passed.
- New accessibility test in Vitest — 3/3 passed.
- ConfigProvider component suite — 378/378 tests and snapshots passed.
- TypeScript, targeted ESLint, Biome, and `git diff --check` — passed.
- `ut compile` — passed.
- All 123 mechanically updated snapshot lines are the expected localized `aria-label` attributes.

AI assistance disclosure: Codex traced the accessible-name computation and locale merge paths, drafted the test-first patch, audited the open contribution queues, and ran the validation above.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Upload remove, preview, and download actions now expose localized accessible names. |
| 🇨🇳 Chinese | Upload 的移除、預覽與下載操作現在會向輔助技術提供在地化名稱。 |
