### PR TITLE
fix(Transfer): respect locale.remove in one-way mode

### DIFF
--- a/components/transfer/ListBody.tsx
+++ b/components/transfer/ListBody.tsx
@@ -52,6 +52,7 @@ const TransferListBody: React.ForwardRefRenderFunction<
     onScroll,
     onItemSelect,
     onItemRemove,
+    remove,
   } = props;
   const [current, setCurrent] = React.useState<number>(1);
 
@@ -137,6 +138,7 @@ const TransferListBody: React.ForwardRefRenderFunction<
             showRemove={showRemove}
             onClick={onInternalClick}
             onRemove={onRemove}
+            removeLabel={remove}
             checked={selectedKeys.includes(item.key)}
             disabled={globalDisabled}
           />

--- a/components/transfer/ListItem.tsx
+++ b/components/transfer/ListItem.tsx
@@ -20,6 +20,7 @@ type ListItemProps<RecordType> = {
   onRemove?: (item: RecordType) => void;
   item: RecordType;
   showRemove?: boolean;
+  removeLabel?: string;
 };
 
 const ListItem = <RecordType extends KeyWiseTransferItem>(props: ListItemProps<RecordType>) => {
@@ -35,6 +36,7 @@ const ListItem = <RecordType extends KeyWiseTransferItem>(props: ListItemProps<R
     onClick,
     onRemove,
     showRemove,
+    removeLabel,
   } = props;
   const mergedDisabled = disabled || item?.disabled;
   const classes = clsx(`${prefixCls}-content-item`, classNames.item, {
@@ -72,7 +74,7 @@ const ListItem = <RecordType extends KeyWiseTransferItem>(props: ListItemProps<R
           type="button"
           disabled={mergedDisabled}
           className={`${prefixCls}-content-item-remove`}
-          aria-label={contextLocale?.remove}
+          aria-label={removeLabel ?? contextLocale?.remove}
           onClick={() => onRemove?.(item)}
         >
           <DeleteOutlined />

--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -863,10 +863,18 @@ describe('Transfer', () => {
     });
   });
 
-  it('remove by click icon', () => {
+  it('should use the component locale for one-way item removal', () => {
     const onChange = jest.fn();
-    const { container } = render(<Transfer {...listCommonProps} onChange={onChange} oneWay />);
-    fireEvent.click(container.querySelectorAll('.ant-transfer-list-content-item-remove')[0]);
+    const { getByRole } = render(
+      <Transfer
+        {...listCommonProps}
+        locale={{ remove: 'Remove target item' }}
+        onChange={onChange}
+        oneWay
+      />,
+    );
+
+    fireEvent.click(getByRole('button', { name: 'Remove target item' }));
     expect(onChange).toHaveBeenCalledWith([], 'left', ['b']);
   });
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [x] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None. I searched the open issues and pull requests for this behavior and did not find an existing report or patch.

### 💡 Background and Solution

`Transfer` already merges `ConfigProvider` locale values with the component-level `locale` prop. In one-way mode, however, each item's remove button read `Transfer.remove` from context again inside `ListItem`. As a result, an instance-level override such as `locale={{ remove: 'Remove target item' }}` was ignored by the button's accessible name.

This change forwards the merged `remove` label through the internal list body to the remove button. `ListItem` retains its context fallback so direct `Transfer.List` usage continues to work when no label is provided. The regression test verifies both the custom accessible name and the existing remove action.

Validation:

- Jest Transfer suites: 61 tests and 6 snapshots passed.
- Full `npm run compile` passed on Node 24.
- Targeted ESLint, Prettier, and `git diff --check` passed.
- Full `tsc --noEmit` was also run; it reports the same six Table demo `antCls` errors and one Puppeteer type mismatch on an untouched `master` worktree.

Codex was used to trace the locale data flow, draft the implementation and regression test, and run the validations above.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Transfer now respects `locale.remove` for one-way item actions. |
| 🇨🇳 Chinese | Transfer 单向模式的项目移除按钮现在会正确使用 `locale.remove`。 |
