### PR TITLE
fix: localize Modal and Notification close button names

### DIFF
--- a/components/_util/__tests__/hooks.test.tsx
+++ b/components/_util/__tests__/hooks.test.tsx
@@ -223,6 +223,30 @@ describe('hooks test', () => {
     expect(container.querySelector('.custom-close-wrapper')).toBeTruthy();
   });
 
+  it('should localize the close control without overriding a custom icon label', () => {
+    const [, closeIcon, , ariaProps] = computeClosable(
+      {
+        closable: true,
+        closeIcon: <span aria-label="Custom icon" />,
+      },
+      null,
+      {},
+      'Localized close',
+    );
+    const { container } = render(<>{closeIcon}</>);
+
+    expect(ariaProps).toEqual({ 'aria-label': 'Localized close' });
+    expect(container.querySelector('span')).toHaveAttribute('aria-label', 'Custom icon');
+
+    const [, , , customAriaProps] = computeClosable(
+      { closable: { 'aria-label': 'Custom close' } },
+      null,
+      {},
+      'Localized close',
+    );
+    expect(customAriaProps).toEqual({ 'aria-label': 'Custom close' });
+  });
+
   const computeClosableParams: { params: any[]; res: [boolean, string] }[] = [
     {
       params: [

--- a/components/_util/hooks/useClosable.tsx
+++ b/components/_util/hooks/useClosable.tsx
@@ -119,7 +119,13 @@ const computeCloseIcon = (
     );
   }
 
-  return [finalCloseIcon, ariaOrDataProps];
+  return [
+    finalCloseIcon,
+    {
+      'aria-label': closeLabel,
+      ...ariaOrDataProps,
+    },
+  ];
 };
 
 export const computeClosable = (

--- a/components/locale/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/index.test.tsx.snap
@@ -7096,7 +7096,7 @@ exports[`Locale Provider should display the text as ar 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="إغلاق"
             class="ant-modal-close"
             type="button"
           >
@@ -12331,7 +12331,7 @@ exports[`Locale Provider should display the text as az 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Bağla"
             class="ant-modal-close"
             type="button"
           >
@@ -17566,7 +17566,7 @@ exports[`Locale Provider should display the text as bg 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Затвори"
             class="ant-modal-close"
             type="button"
           >
@@ -22801,7 +22801,7 @@ exports[`Locale Provider should display the text as bn-bd 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="বন্ধ"
             class="ant-modal-close"
             type="button"
           >
@@ -28036,7 +28036,7 @@ exports[`Locale Provider should display the text as by 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Закрыць"
             class="ant-modal-close"
             type="button"
           >
@@ -33271,7 +33271,7 @@ exports[`Locale Provider should display the text as ca 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Tancar"
             class="ant-modal-close"
             type="button"
           >
@@ -38506,7 +38506,7 @@ exports[`Locale Provider should display the text as cs 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Zavřít"
             class="ant-modal-close"
             type="button"
           >
@@ -43741,7 +43741,7 @@ exports[`Locale Provider should display the text as da 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Luk"
             class="ant-modal-close"
             type="button"
           >
@@ -48976,7 +48976,7 @@ exports[`Locale Provider should display the text as de 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Schließen"
             class="ant-modal-close"
             type="button"
           >
@@ -54211,7 +54211,7 @@ exports[`Locale Provider should display the text as el 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Κλείσιμο"
             class="ant-modal-close"
             type="button"
           >
@@ -69916,7 +69916,7 @@ exports[`Locale Provider should display the text as es 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Cerrar"
             class="ant-modal-close"
             type="button"
           >
@@ -75151,7 +75151,7 @@ exports[`Locale Provider should display the text as es-us 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Cerrar"
             class="ant-modal-close"
             type="button"
           >
@@ -80386,7 +80386,7 @@ exports[`Locale Provider should display the text as et 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Sulge"
             class="ant-modal-close"
             type="button"
           >
@@ -85621,7 +85621,7 @@ exports[`Locale Provider should display the text as eu 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Itxi"
             class="ant-modal-close"
             type="button"
           >
@@ -90856,7 +90856,7 @@ exports[`Locale Provider should display the text as fa 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="بستن"
             class="ant-modal-close"
             type="button"
           >
@@ -96091,7 +96091,7 @@ exports[`Locale Provider should display the text as fi 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Sulje"
             class="ant-modal-close"
             type="button"
           >
@@ -101326,7 +101326,7 @@ exports[`Locale Provider should display the text as fr 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Fermer"
             class="ant-modal-close"
             type="button"
           >
@@ -106561,7 +106561,7 @@ exports[`Locale Provider should display the text as fr 2`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Fermer"
             class="ant-modal-close"
             type="button"
           >
@@ -111796,7 +111796,7 @@ exports[`Locale Provider should display the text as fr 3`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Fermer"
             class="ant-modal-close"
             type="button"
           >
@@ -117031,7 +117031,7 @@ exports[`Locale Provider should display the text as ga 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Dún"
             class="ant-modal-close"
             type="button"
           >
@@ -122266,7 +122266,7 @@ exports[`Locale Provider should display the text as gl 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Cerrar"
             class="ant-modal-close"
             type="button"
           >
@@ -127501,7 +127501,7 @@ exports[`Locale Provider should display the text as he 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="סגור"
             class="ant-modal-close"
             type="button"
           >
@@ -132736,7 +132736,7 @@ exports[`Locale Provider should display the text as hi 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="बंद"
             class="ant-modal-close"
             type="button"
           >
@@ -137971,7 +137971,7 @@ exports[`Locale Provider should display the text as hr 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Zatvori"
             class="ant-modal-close"
             type="button"
           >
@@ -143206,7 +143206,7 @@ exports[`Locale Provider should display the text as hu 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Bezárás"
             class="ant-modal-close"
             type="button"
           >
@@ -148441,7 +148441,7 @@ exports[`Locale Provider should display the text as hy-am 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Դադարեցնել"
             class="ant-modal-close"
             type="button"
           >
@@ -153676,7 +153676,7 @@ exports[`Locale Provider should display the text as id 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Tutup"
             class="ant-modal-close"
             type="button"
           >
@@ -158911,7 +158911,7 @@ exports[`Locale Provider should display the text as is 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Loka"
             class="ant-modal-close"
             type="button"
           >
@@ -164146,7 +164146,7 @@ exports[`Locale Provider should display the text as it 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Chiudi"
             class="ant-modal-close"
             type="button"
           >
@@ -169381,7 +169381,7 @@ exports[`Locale Provider should display the text as ja 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="閉じる"
             class="ant-modal-close"
             type="button"
           >
@@ -174616,7 +174616,7 @@ exports[`Locale Provider should display the text as ka 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="დახურვა"
             class="ant-modal-close"
             type="button"
           >
@@ -179851,7 +179851,7 @@ exports[`Locale Provider should display the text as kk 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Жабу"
             class="ant-modal-close"
             type="button"
           >
@@ -185084,7 +185084,7 @@ exports[`Locale Provider should display the text as km 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="បិទ"
             class="ant-modal-close"
             type="button"
           >
@@ -190319,7 +190319,7 @@ exports[`Locale Provider should display the text as kn 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="ಮುಚ್ಚಿ"
             class="ant-modal-close"
             type="button"
           >
@@ -195554,7 +195554,7 @@ exports[`Locale Provider should display the text as ko 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="닫기"
             class="ant-modal-close"
             type="button"
           >
@@ -200789,7 +200789,7 @@ exports[`Locale Provider should display the text as ku 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Betal ke"
             class="ant-modal-close"
             type="button"
           >
@@ -206024,7 +206024,7 @@ exports[`Locale Provider should display the text as ku-iq 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Betal ke"
             class="ant-modal-close"
             type="button"
           >
@@ -211259,7 +211259,7 @@ exports[`Locale Provider should display the text as lt 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Uždaryti"
             class="ant-modal-close"
             type="button"
           >
@@ -216494,7 +216494,7 @@ exports[`Locale Provider should display the text as lv 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Aizvērt"
             class="ant-modal-close"
             type="button"
           >
@@ -221729,7 +221729,7 @@ exports[`Locale Provider should display the text as mk 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Затвори"
             class="ant-modal-close"
             type="button"
           >
@@ -226964,7 +226964,7 @@ exports[`Locale Provider should display the text as ml 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="മുടക്കുക"
             class="ant-modal-close"
             type="button"
           >
@@ -232199,7 +232199,7 @@ exports[`Locale Provider should display the text as mn-mn 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Хаах"
             class="ant-modal-close"
             type="button"
           >
@@ -237434,7 +237434,7 @@ exports[`Locale Provider should display the text as mr 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="बंद करा"
             class="ant-modal-close"
             type="button"
           >
@@ -242669,7 +242669,7 @@ exports[`Locale Provider should display the text as ms-my 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Tutup"
             class="ant-modal-close"
             type="button"
           >
@@ -247904,7 +247904,7 @@ exports[`Locale Provider should display the text as my 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="ပိတ်ပါ"
             class="ant-modal-close"
             type="button"
           >
@@ -253139,7 +253139,7 @@ exports[`Locale Provider should display the text as nb 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Lukk"
             class="ant-modal-close"
             type="button"
           >
@@ -258374,7 +258374,7 @@ exports[`Locale Provider should display the text as ne-np 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="बन्द"
             class="ant-modal-close"
             type="button"
           >
@@ -263609,7 +263609,7 @@ exports[`Locale Provider should display the text as nl 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Sluiten"
             class="ant-modal-close"
             type="button"
           >
@@ -268844,7 +268844,7 @@ exports[`Locale Provider should display the text as nl-be 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Sluiten"
             class="ant-modal-close"
             type="button"
           >
@@ -274079,7 +274079,7 @@ exports[`Locale Provider should display the text as pl 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Zamknij"
             class="ant-modal-close"
             type="button"
           >
@@ -279314,7 +279314,7 @@ exports[`Locale Provider should display the text as pt 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Fechar"
             class="ant-modal-close"
             type="button"
           >
@@ -284549,7 +284549,7 @@ exports[`Locale Provider should display the text as pt-br 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Fechar"
             class="ant-modal-close"
             type="button"
           >
@@ -289784,7 +289784,7 @@ exports[`Locale Provider should display the text as ro 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Închide"
             class="ant-modal-close"
             type="button"
           >
@@ -295019,7 +295019,7 @@ exports[`Locale Provider should display the text as ru 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Закрыть"
             class="ant-modal-close"
             type="button"
           >
@@ -300254,7 +300254,7 @@ exports[`Locale Provider should display the text as si 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="වසන්න"
             class="ant-modal-close"
             type="button"
           >
@@ -305489,7 +305489,7 @@ exports[`Locale Provider should display the text as sk 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Zavrieť"
             class="ant-modal-close"
             type="button"
           >
@@ -310724,7 +310724,7 @@ exports[`Locale Provider should display the text as sl 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Zapri"
             class="ant-modal-close"
             type="button"
           >
@@ -315959,7 +315959,7 @@ exports[`Locale Provider should display the text as sq 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Mbyll"
             class="ant-modal-close"
             type="button"
           >
@@ -321194,7 +321194,7 @@ exports[`Locale Provider should display the text as sr 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Zatvori"
             class="ant-modal-close"
             type="button"
           >
@@ -326429,7 +326429,7 @@ exports[`Locale Provider should display the text as sv 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Stäng"
             class="ant-modal-close"
             type="button"
           >
@@ -331664,7 +331664,7 @@ exports[`Locale Provider should display the text as ta 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="மூடு"
             class="ant-modal-close"
             type="button"
           >
@@ -336899,7 +336899,7 @@ exports[`Locale Provider should display the text as th 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="ปิด"
             class="ant-modal-close"
             type="button"
           >
@@ -342134,7 +342134,7 @@ exports[`Locale Provider should display the text as tk 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Ýagty"
             class="ant-modal-close"
             type="button"
           >
@@ -347369,7 +347369,7 @@ exports[`Locale Provider should display the text as tr 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Kapat"
             class="ant-modal-close"
             type="button"
           >
@@ -352604,7 +352604,7 @@ exports[`Locale Provider should display the text as uk 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Закрити"
             class="ant-modal-close"
             type="button"
           >
@@ -357839,7 +357839,7 @@ exports[`Locale Provider should display the text as ur 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="بند کریں"
             class="ant-modal-close"
             type="button"
           >
@@ -363074,7 +363074,7 @@ exports[`Locale Provider should display the text as uz-latn 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Yopish"
             class="ant-modal-close"
             type="button"
           >
@@ -368309,7 +368309,7 @@ exports[`Locale Provider should display the text as vi 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Đóng"
             class="ant-modal-close"
             type="button"
           >
@@ -373544,7 +373544,7 @@ exports[`Locale Provider should display the text as zh-cn 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="关闭"
             class="ant-modal-close"
             type="button"
           >
@@ -378779,7 +378779,7 @@ exports[`Locale Provider should display the text as zh-hk 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="關閉"
             class="ant-modal-close"
             type="button"
           >
@@ -384014,7 +384014,7 @@ exports[`Locale Provider should display the text as zh-tw 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="關閉"
             class="ant-modal-close"
             type="button"
           >

--- a/components/locale/__tests__/__snapshots__/vitest/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/vitest/index.test.tsx.snap
@@ -2085,7 +2085,7 @@ exports[`Locale Provider > should display the text as ar 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="إغلاق"
             class="ant-modal-close"
             type="button"
           >
@@ -4034,7 +4034,7 @@ exports[`Locale Provider > should display the text as az 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Bağla"
             class="ant-modal-close"
             type="button"
           >
@@ -5983,7 +5983,7 @@ exports[`Locale Provider > should display the text as bg 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Затвори"
             class="ant-modal-close"
             type="button"
           >
@@ -7932,7 +7932,7 @@ exports[`Locale Provider > should display the text as bn-bd 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="বন্ধ"
             class="ant-modal-close"
             type="button"
           >
@@ -9881,7 +9881,7 @@ exports[`Locale Provider > should display the text as by 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Закрыць"
             class="ant-modal-close"
             type="button"
           >
@@ -11830,7 +11830,7 @@ exports[`Locale Provider > should display the text as ca 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Tancar"
             class="ant-modal-close"
             type="button"
           >
@@ -13779,7 +13779,7 @@ exports[`Locale Provider > should display the text as cs 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Zavřít"
             class="ant-modal-close"
             type="button"
           >
@@ -15728,7 +15728,7 @@ exports[`Locale Provider > should display the text as da 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Luk"
             class="ant-modal-close"
             type="button"
           >
@@ -17677,7 +17677,7 @@ exports[`Locale Provider > should display the text as de 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Schließen"
             class="ant-modal-close"
             type="button"
           >
@@ -19626,7 +19626,7 @@ exports[`Locale Provider > should display the text as el 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Κλείσιμο"
             class="ant-modal-close"
             type="button"
           >
@@ -25473,7 +25473,7 @@ exports[`Locale Provider > should display the text as es 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Cerrar"
             class="ant-modal-close"
             type="button"
           >
@@ -27422,7 +27422,7 @@ exports[`Locale Provider > should display the text as es-us 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Cerrar"
             class="ant-modal-close"
             type="button"
           >
@@ -29371,7 +29371,7 @@ exports[`Locale Provider > should display the text as et 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Sulge"
             class="ant-modal-close"
             type="button"
           >
@@ -31320,7 +31320,7 @@ exports[`Locale Provider > should display the text as eu 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Itxi"
             class="ant-modal-close"
             type="button"
           >
@@ -33269,7 +33269,7 @@ exports[`Locale Provider > should display the text as fa 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="بستن"
             class="ant-modal-close"
             type="button"
           >
@@ -35218,7 +35218,7 @@ exports[`Locale Provider > should display the text as fi 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Sulje"
             class="ant-modal-close"
             type="button"
           >
@@ -37167,7 +37167,7 @@ exports[`Locale Provider > should display the text as fr 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Fermer"
             class="ant-modal-close"
             type="button"
           >
@@ -39116,7 +39116,7 @@ exports[`Locale Provider > should display the text as fr 2`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Fermer"
             class="ant-modal-close"
             type="button"
           >
@@ -41065,7 +41065,7 @@ exports[`Locale Provider > should display the text as fr 3`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Fermer"
             class="ant-modal-close"
             type="button"
           >
@@ -43014,7 +43014,7 @@ exports[`Locale Provider > should display the text as ga 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Dún"
             class="ant-modal-close"
             type="button"
           >
@@ -44963,7 +44963,7 @@ exports[`Locale Provider > should display the text as gl 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Cerrar"
             class="ant-modal-close"
             type="button"
           >
@@ -46912,7 +46912,7 @@ exports[`Locale Provider > should display the text as he 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="סגור"
             class="ant-modal-close"
             type="button"
           >
@@ -48861,7 +48861,7 @@ exports[`Locale Provider > should display the text as hi 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="बंद"
             class="ant-modal-close"
             type="button"
           >
@@ -50810,7 +50810,7 @@ exports[`Locale Provider > should display the text as hr 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Zatvori"
             class="ant-modal-close"
             type="button"
           >
@@ -52759,7 +52759,7 @@ exports[`Locale Provider > should display the text as hu 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Bezárás"
             class="ant-modal-close"
             type="button"
           >
@@ -54708,7 +54708,7 @@ exports[`Locale Provider > should display the text as hy-am 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Դադարեցնել"
             class="ant-modal-close"
             type="button"
           >
@@ -56657,7 +56657,7 @@ exports[`Locale Provider > should display the text as id 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Tutup"
             class="ant-modal-close"
             type="button"
           >
@@ -58606,7 +58606,7 @@ exports[`Locale Provider > should display the text as is 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Loka"
             class="ant-modal-close"
             type="button"
           >
@@ -60555,7 +60555,7 @@ exports[`Locale Provider > should display the text as it 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Chiudi"
             class="ant-modal-close"
             type="button"
           >
@@ -62504,7 +62504,7 @@ exports[`Locale Provider > should display the text as ja 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="閉じる"
             class="ant-modal-close"
             type="button"
           >
@@ -64453,7 +64453,7 @@ exports[`Locale Provider > should display the text as ka 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="დახურვა"
             class="ant-modal-close"
             type="button"
           >
@@ -66402,7 +66402,7 @@ exports[`Locale Provider > should display the text as kk 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Жабу"
             class="ant-modal-close"
             type="button"
           >
@@ -68349,7 +68349,7 @@ exports[`Locale Provider > should display the text as km 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="បិទ"
             class="ant-modal-close"
             type="button"
           >
@@ -70298,7 +70298,7 @@ exports[`Locale Provider > should display the text as kn 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="ಮುಚ್ಚಿ"
             class="ant-modal-close"
             type="button"
           >
@@ -72247,7 +72247,7 @@ exports[`Locale Provider > should display the text as ko 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="닫기"
             class="ant-modal-close"
             type="button"
           >
@@ -74196,7 +74196,7 @@ exports[`Locale Provider > should display the text as ku 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Betal ke"
             class="ant-modal-close"
             type="button"
           >
@@ -76145,7 +76145,7 @@ exports[`Locale Provider > should display the text as ku-iq 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Betal ke"
             class="ant-modal-close"
             type="button"
           >
@@ -78094,7 +78094,7 @@ exports[`Locale Provider > should display the text as lt 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Uždaryti"
             class="ant-modal-close"
             type="button"
           >
@@ -80043,7 +80043,7 @@ exports[`Locale Provider > should display the text as lv 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Aizvērt"
             class="ant-modal-close"
             type="button"
           >
@@ -81992,7 +81992,7 @@ exports[`Locale Provider > should display the text as mk 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Затвори"
             class="ant-modal-close"
             type="button"
           >
@@ -83941,7 +83941,7 @@ exports[`Locale Provider > should display the text as ml 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="മുടക്കുക"
             class="ant-modal-close"
             type="button"
           >
@@ -85890,7 +85890,7 @@ exports[`Locale Provider > should display the text as mn-mn 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Хаах"
             class="ant-modal-close"
             type="button"
           >
@@ -87839,7 +87839,7 @@ exports[`Locale Provider > should display the text as mr 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="बंद करा"
             class="ant-modal-close"
             type="button"
           >
@@ -89788,7 +89788,7 @@ exports[`Locale Provider > should display the text as ms-my 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Tutup"
             class="ant-modal-close"
             type="button"
           >
@@ -91737,7 +91737,7 @@ exports[`Locale Provider > should display the text as my 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="ပိတ်ပါ"
             class="ant-modal-close"
             type="button"
           >
@@ -93686,7 +93686,7 @@ exports[`Locale Provider > should display the text as nb 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Lukk"
             class="ant-modal-close"
             type="button"
           >
@@ -95635,7 +95635,7 @@ exports[`Locale Provider > should display the text as ne-np 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="बन्द"
             class="ant-modal-close"
             type="button"
           >
@@ -97584,7 +97584,7 @@ exports[`Locale Provider > should display the text as nl 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Sluiten"
             class="ant-modal-close"
             type="button"
           >
@@ -99533,7 +99533,7 @@ exports[`Locale Provider > should display the text as nl-be 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Sluiten"
             class="ant-modal-close"
             type="button"
           >
@@ -101482,7 +101482,7 @@ exports[`Locale Provider > should display the text as pl 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Zamknij"
             class="ant-modal-close"
             type="button"
           >
@@ -103431,7 +103431,7 @@ exports[`Locale Provider > should display the text as pt 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Fechar"
             class="ant-modal-close"
             type="button"
           >
@@ -105380,7 +105380,7 @@ exports[`Locale Provider > should display the text as pt-br 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Fechar"
             class="ant-modal-close"
             type="button"
           >
@@ -107329,7 +107329,7 @@ exports[`Locale Provider > should display the text as ro 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Închide"
             class="ant-modal-close"
             type="button"
           >
@@ -109278,7 +109278,7 @@ exports[`Locale Provider > should display the text as ru 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Закрыть"
             class="ant-modal-close"
             type="button"
           >
@@ -111227,7 +111227,7 @@ exports[`Locale Provider > should display the text as si 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="වසන්න"
             class="ant-modal-close"
             type="button"
           >
@@ -113176,7 +113176,7 @@ exports[`Locale Provider > should display the text as sk 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Zavrieť"
             class="ant-modal-close"
             type="button"
           >
@@ -115125,7 +115125,7 @@ exports[`Locale Provider > should display the text as sl 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Zapri"
             class="ant-modal-close"
             type="button"
           >
@@ -117074,7 +117074,7 @@ exports[`Locale Provider > should display the text as sq 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Mbyll"
             class="ant-modal-close"
             type="button"
           >
@@ -119023,7 +119023,7 @@ exports[`Locale Provider > should display the text as sr 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Zatvori"
             class="ant-modal-close"
             type="button"
           >
@@ -120972,7 +120972,7 @@ exports[`Locale Provider > should display the text as sv 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Stäng"
             class="ant-modal-close"
             type="button"
           >
@@ -122921,7 +122921,7 @@ exports[`Locale Provider > should display the text as ta 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="மூடு"
             class="ant-modal-close"
             type="button"
           >
@@ -124870,7 +124870,7 @@ exports[`Locale Provider > should display the text as th 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="ปิด"
             class="ant-modal-close"
             type="button"
           >
@@ -126819,7 +126819,7 @@ exports[`Locale Provider > should display the text as tk 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Ýagty"
             class="ant-modal-close"
             type="button"
           >
@@ -128768,7 +128768,7 @@ exports[`Locale Provider > should display the text as tr 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Kapat"
             class="ant-modal-close"
             type="button"
           >
@@ -130717,7 +130717,7 @@ exports[`Locale Provider > should display the text as uk 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Закрити"
             class="ant-modal-close"
             type="button"
           >
@@ -132666,7 +132666,7 @@ exports[`Locale Provider > should display the text as ur 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="بند کریں"
             class="ant-modal-close"
             type="button"
           >
@@ -134615,7 +134615,7 @@ exports[`Locale Provider > should display the text as uz-latn 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Yopish"
             class="ant-modal-close"
             type="button"
           >
@@ -136564,7 +136564,7 @@ exports[`Locale Provider > should display the text as vi 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="Đóng"
             class="ant-modal-close"
             type="button"
           >
@@ -138513,7 +138513,7 @@ exports[`Locale Provider > should display the text as zh-cn 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="关闭"
             class="ant-modal-close"
             type="button"
           >
@@ -140462,7 +140462,7 @@ exports[`Locale Provider > should display the text as zh-hk 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="關閉"
             class="ant-modal-close"
             type="button"
           >
@@ -142411,7 +142411,7 @@ exports[`Locale Provider > should display the text as zh-tw 1`] = `
           class="ant-modal-container"
         >
           <button
-            aria-label="Close"
+            aria-label="關閉"
             class="ant-modal-close"
             type="button"
           >

--- a/components/modal/__tests__/Modal.test.tsx
+++ b/components/modal/__tests__/Modal.test.tsx
@@ -7,6 +7,7 @@ import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { act, createEvent, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
+import zhTW from '../../locale/zh_TW';
 
 jest.mock('@rc-component/util/lib/Portal');
 
@@ -380,6 +381,15 @@ describe('Modal', () => {
     render(<Modal open closable={{ 'aria-label': 'xxx' }} />);
     const element = document.body.querySelector('.ant-modal-close');
     expect(element).toHaveAttribute('aria-label', 'xxx');
+  });
+
+  it('should localize the close button accessible name', () => {
+    render(
+      <ConfigProvider locale={zhTW}>
+        <Modal open />
+      </ConfigProvider>,
+    );
+    expect(document.body.querySelector('.ant-modal-close')).toHaveAttribute('aria-label', '關閉');
   });
 
   describe('closable onClose and afterClose ', () => {

--- a/components/notification/__tests__/hooks.test.tsx
+++ b/components/notification/__tests__/hooks.test.tsx
@@ -5,6 +5,7 @@ import { render as testLibRender } from '@testing-library/react';
 import notification from '..';
 import { act, fireEvent, pureRender, render } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
+import zhTW from '../../locale/zh_TW';
 
 describe('notification.hooks', () => {
   beforeEach(() => {
@@ -91,6 +92,34 @@ describe('notification.hooks', () => {
     expect(document.querySelectorAll('.my-test-notification-notice')).toHaveLength(1);
     expect(document.querySelectorAll('.anticon-check-circle')).toHaveLength(1);
     expect(document.querySelector('.hook-test-result')!.textContent).toBe('bamboo');
+  });
+
+  it('should use the locale around the context holder for the close button', () => {
+    const Demo = () => {
+      const [api, holder] = notification.useNotification();
+
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              api.open({ title: 'Notification', duration: 0 });
+            }}
+          >
+            Open notification
+          </button>
+          <ConfigProvider locale={zhTW}>{holder}</ConfigProvider>
+        </>
+      );
+    };
+
+    const { getByRole } = render(<Demo />);
+    fireEvent.click(getByRole('button', { name: 'Open notification' }));
+
+    expect(document.querySelector('.ant-notification-notice-close')).toHaveAttribute(
+      'aria-label',
+      '關閉',
+    );
   });
 
   it('should be same hook', () => {

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -22,6 +22,8 @@ import { ConfigContext } from '../config-provider';
 import { useComponentConfig } from '../config-provider/context';
 import type { NotificationConfig as CPNotificationConfig } from '../config-provider/context';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
+import { useLocale } from '../locale';
+import defaultLocale from '../locale/en_US';
 import useStackConfig from './hooks/useStackConfig';
 import type {
   ArgsProps,
@@ -47,6 +49,7 @@ type HolderProps = NotificationConfig & {
 interface HolderRef extends NotificationAPI {
   prefixCls: string;
   notification?: CPNotificationConfig;
+  closeLabel: string;
 }
 
 const Wrapper: FC<PropsWithChildren<{ prefixCls: string }>> = ({ children, prefixCls }) => {
@@ -84,6 +87,7 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
   } = props;
   const { getPrefixCls, getPopupContainer, direction } = useComponentConfig('notification');
   const { notification } = useContext(ConfigContext);
+  const [contextLocale] = useLocale('global', defaultLocale.global);
 
   const prefixCls = staticPrefixCls || getPrefixCls('notification');
 
@@ -137,6 +141,7 @@ const Holder = React.forwardRef<HolderRef, HolderProps>((props, ref) => {
     ...api,
     prefixCls,
     notification,
+    closeLabel: contextLocale.close ?? defaultLocale.global?.close ?? 'Close',
   }));
 
   return holder;
@@ -166,7 +171,7 @@ export function useInternalNotification(
         return;
       }
 
-      const { open: originOpen, prefixCls, notification } = holderRef.current;
+      const { open: originOpen, prefixCls, notification, closeLabel } = holderRef.current;
       const contextClassName = notification?.className || {};
 
       const noticePrefixCls = `${prefixCls}-notice`;
@@ -210,6 +215,7 @@ export function useInternalNotification(
           closable: true,
           closeIcon: realCloseIcon,
         },
+        closeLabel,
       );
 
       const mergedClosable = rawClosable


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [x] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

No existing issue found after searching for Modal/Notification close-button locale and accessible-name reports.

### 💡 Background and Solution

`global.close` was already applied to the nested close icon, but the actual Modal and Notification close buttons still exposed rc-dialog/rc-notification's English `aria-label="Close"`. Because the control's own label takes precedence over descendant content, screen readers announced English even under a non-English `ConfigProvider` locale.

This change:

- forwards the localized close label to the actual close control while preserving explicit `closable['aria-label']` precedence;
- leaves a custom close icon's own accessible label untouched;
- resolves Notification's label from the locale surrounding its rendered `contextHolder`;
- keeps an English `Close` fallback when a partial custom locale omits `global.close`;
- adds focused Modal, Notification, and shared-hook regression tests and updates both locale snapshot suites.

Open PRs #56450 and #55328 touch the two implementation files but do not address localized close-control names. PRs #58866, #58818, and #58604 overlap only with generated locale snapshot files. This branch is based on current `master`, and none of those changes semantically duplicate this fix.

Validation:

- `npm run compile`
- Jest focused suites: 100/100 tests, 6/6 snapshots
- Jest locale suite: 76/76 tests and snapshots
- Vitest focused suites: 50/50 tests
- Vitest locale suite: 76/76 tests and snapshots
- targeted ESLint, Biome lint, and `git diff --check`
- `tsc --noEmit` has no errors in changed files; its remaining Table demo/Puppeteer type errors are reproducible on the untouched base environment

AI assistance disclosure: Codex traced the accessible-name precedence and Notification holder context, drafted the patch and tests, and ran the validation above. The PR does not claim unperformed manual review.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Modal and Notification close buttons now use localized accessible names. |
| 🇨🇳 Chinese | Modal 和 Notification 的关闭按钮现在会使用本地化的无障碍名称。 |
