### PR TITLE
fix(Listy): improve virtual scrollbar track hover feedback

### DIFF
--- a/components/listy/style/index.ts
+++ b/components/listy/style/index.ts
@@ -84,6 +84,11 @@ const genListyStyle: GenerateStyle<ListyToken, CSSObject> = (token) => {
 
       [`${componentCls}-scrollbar`]: {
         zIndex: 1,
+        cursor: 'pointer',
+
+        '&:hover': {
+          backgroundColor: token.colorFillQuaternary,
+        },
       },
 
       // ========================= RTL ========================


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Follow up #58679

### 💡 需求背景和解决方案

#58679 为 Select、Table 和 Tree 的虚拟滚动条轨道补充了 hover 背景与指针样式，Listy 同样使用虚拟滚动，但轨道目前缺少对应反馈。

本次为 Listy 虚拟滚动条轨道增加指针样式，并在 hover 时使用 `colorFillQuaternary` 作为轨道背景，使交互反馈与其他虚拟滚动组件保持一致。不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 💄 Improve Listy virtual scrollbar track hover feedback. |
| 🇨🇳 中文 | 💄 优化 Listy 虚拟滚动条轨道的 hover 反馈。 |
