### PR TITLE
site: add skeleton for homepage contributor avatars

### DIFF
--- a/.dumi/pages/index/components/PreviewPane/Components.tsx
+++ b/.dumi/pages/index/components/PreviewPane/Components.tsx
@@ -35,6 +35,7 @@ import {
   Rate,
   Segmented,
   Select,
+  Skeleton,
   Space,
   Spin,
   Steps,
@@ -497,16 +498,20 @@ const ComponentsBlock: React.FC<ComponentsBlockProps> = (props) => {
                 <div className={styles.colCenter}>
                   <div className={styles.avatarSection}>
                     <Avatar.Group className={styles.avatarGroup}>
-                      {avatarGroupList.map(({ src, name }) => (
-                        <Avatar
-                          key={src}
-                          size={46}
-                          src={src}
-                          draggable={false}
-                          alt={`Contributor: ${name}`}
-                          aria-label={`Contributor: ${name}`}
-                        />
-                      ))}
+                      {isLoading
+                        ? Array.from({ length: 6 }, (_, index) => (
+                            <Skeleton.Avatar key={`skeleton-${index}`} active size={46} />
+                          ))
+                        : avatarGroupList.map(({ src, name }) => (
+                            <Avatar
+                              key={src}
+                              size={46}
+                              src={src}
+                              draggable={false}
+                              alt={`Contributor: ${name}`}
+                              aria-label={`Contributor: ${name}`}
+                            />
+                          ))}
                       <Avatar size={46} draggable={false} className={styles.avatarExtra}>
                         +5
                       </Avatar>


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

首页组件预览区域的贡献者头像需要通过 GitHub API 异步获取。在请求完成前，头像区域会短暂显示为空白，影响页面的视觉连续性。
<img width="1448" height="527" alt="before" src="https://github.com/user-attachments/assets/3c958df0-69b6-4cd4-9f1f-80f11f969980" />


本次改动在数据加载期间展示 6 个与实际头像尺寸一致的 `Skeleton.Avatar`，数据加载完成后继续渲染原有贡献者头像。该改动仅优化首页加载体验，不涉及组件 API 或行为变更。
<img width="1448" height="527" alt="after" src="https://github.com/user-attachments/assets/41160f6e-abf0-4956-b5a0-6a9b6517fddf" />


### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | 无需更新日志 |