### PR TITLE
fix(Dropdown): auto-focus menu when opened to enable keyboard navigation (Fixes #58980)

### DIFF
--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -357,6 +357,7 @@ const Dropdown: CompoundedComponent = React.forwardRef<HTMLElement, DropdownProp
       mouseEnterDelay={mouseEnterDelay}
       mouseLeaveDelay={mouseLeaveDelay}
       visible={mergedOpen}
+      autoFocus={props.autoFocus !== undefined ? props.autoFocus : mergedOpen}
       builtinPlacements={builtinPlacements}
       arrow={!!arrow}
       overlayClassName={overlayClassNameCustomized}


### PR DESCRIPTION
## Problem

When a Dropdown menu is opened via click or Enter, focus stays on the trigger and the Down Arrow key has no effect. A keyboard user cannot operate the Dropdown at all.

## Root cause

The Dropdown component did not pass the `autoFocus` prop to the underlying `@rc-component/dropdown`. Without `autoFocus`, the `useAccessibility` hook in `@rc-component/dropdown` does not move focus into the menu overlay when the dropdown opens, and the Down Arrow key has nothing to move between.

## Fix

Pass `autoFocus={mergedOpen}` to `RcDropdown` when the dropdown is visible, unless the user has explicitly set `autoFocus` to a different value. This leverages the existing `autoFocus` mechanism in `@rc-component/dropdown`'s `useAccessibility` hook, which focuses the menu overlay when the dropdown opens. Once the menu has focus, the `@rc-component/menu`'s built-in keyboard handler takes over ArrowDown/ArrowUp navigation.

## Affected W3C compliance

- WCAG 2.1.1 Keyboard
- W3C APG Menu Button Pattern

Closes #58980
