### PR TITLE
fix(table): avoid duplicate onOpenChange(false) when closing filter dropdown (Closes #58988)

### DIFF
--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -290,8 +290,10 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
     });
   };
 
-  const onConfirm = () => {
-    triggerVisible(false);
+  const onConfirm = (shouldClose = true) => {
+    if (shouldClose) {
+      triggerVisible(false);
+    }
     internalTriggerFilter(getFilteredKeysSync());
   };
 
@@ -331,7 +333,7 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
       triggerVisible(newVisible);
 
       if (!newVisible && !column.filterDropdown && filterOnClose) {
-        onConfirm();
+        onConfirm(false);
       }
     }
   };


### PR DESCRIPTION
## Summary

Fixes #58988 — when a Table column uses both built-in filters and `filterDropdownProps.onOpenChange`, closing the filter panel triggers `onOpenChange(false)` twice, causing side effects (state sync, analytics, etc.) to run twice.

### Root cause

In `FilterDropdown.tsx`, the `onVisibleChange` handler calls:

```ts
triggerVisible(newVisible);   // 1st onOpenChange(false)

if (!newVisible && !column.filterDropdown && filterOnClose) {
  onConfirm();                // onConfirm internally calls triggerVisible(false) again
}
```

`onConfirm()` was unconditionally calling `triggerVisible(false)`, so when invoked from `onVisibleChange` after the dropdown already closed, it produced a second `onOpenChange(false)`.

### Fix

Give `onConfirm` a `shouldClose` parameter (default `true` so the "Confirm" button behavior is unchanged). When called from `onVisibleChange` while the panel is already closing, pass `false` to skip the redundant close:

```ts
const onConfirm = (shouldClose = true) => {
  if (shouldClose) {
    triggerVisible(false);
  }
  internalTriggerFilter(getFilteredKeysSync());
};

// onVisibleChange:
if (!newVisible && !column.filterDropdown && filterOnClose) {
  onConfirm(false); // already closing, skip redundant triggerVisible
}
```

### Testing

- [x] `filterOnClose` path: opening then closing the panel now emits exactly `true, false` instead of `true, false, false`
- [x] Confirm button still calls `triggerVisible(false)` (default `shouldClose = true`)
- [x] No behavior change for other call paths (`onReset`, `doFilter`)

Verified against the reproduction from the issue (antd 6.5.3 / React 19.2.8).
