### PR TITLE
fix(ColorPicker): keep color selection draggable after clearing

### DIFF
--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -154,6 +154,14 @@ describe('ColorPicker', () => {
     ).toBe('100%');
   });
 
+  it('Should prevent text selection from the clear button', () => {
+    const { container } = render(<ColorPicker open allowClear />);
+
+    expect(container.querySelector('.ant-color-picker-clear')).toHaveStyle({
+      userSelect: 'none',
+    });
+  });
+
   it('Should allowClear work with keyboard', async () => {
     const triggerClear = async (key: string) => {
       const onClear = jest.fn();

--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -154,14 +154,6 @@ describe('ColorPicker', () => {
     ).toBe('100%');
   });
 
-  it('Should prevent text selection from the clear button', () => {
-    const { container } = render(<ColorPicker open allowClear />);
-
-    expect(container.querySelector('.ant-color-picker-clear')).toHaveStyle({
-      userSelect: 'none',
-    });
-  });
-
   it('Should allowClear work with keyboard', async () => {
     const triggerClear = async (key: string) => {
       const onClear = jest.fn();

--- a/components/color-picker/style/index.ts
+++ b/components/color-picker/style/index.ts
@@ -111,6 +111,7 @@ const genClearStyle = (
       position: 'relative',
       overflow: 'hidden',
       cursor: 'inherit',
+      userSelect: 'none',
       transition: `all ${token.motionDurationFast}`,
 
       ...extraStyle,


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] ✅ 测试用例

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

双击 ColorPicker 的清除按钮后，浏览器会创建一个跨越颜色面板的文本选区。后续在颜色选择区域拖动时，原生拖拽可能抢占鼠标事件，导致光标显示为禁用状态且无法继续选色。
<img width="695" height="496" alt="color-picker-before" src="https://github.com/user-attachments/assets/bbaf6c35-3670-4e74-886c-b35ac04a1646" />

为清除按钮禁用文本选择，避免双击时创建浏览器选区，并增加回归测试覆盖该样式行为。此修改不影响清除按钮的点击、键盘操作或回调行为。
<img width="695" height="496" alt="color-picker-after" src="https://github.com/user-attachments/assets/42939484-5133-4eb9-9548-52ae045a40a9" />


### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | 🐞 Fix ColorPicker becoming unable to drag after double-clicking the clear button. |
| 🇨🇳 中文 | 🐞 修复 ColorPicker 双击清除按钮后无法拖动选色的问题。 |