### PR TITLE
docs(float-button): unify FloatButton translation

### DIFF
--- a/components/float-button/index.zh-CN.md
+++ b/components/float-button/index.zh-CN.md
@@ -23,7 +23,7 @@ demo:
 <code src="./demo/shape.tsx" iframe="360">形状</code>
 <code src="./demo/content.tsx" iframe="360">描述</code>
 <code src="./demo/tooltip.tsx" iframe="360">含有气泡卡片的悬浮按钮</code>
-<code src="./demo/group.tsx" iframe="360">浮动按钮组</code>
+<code src="./demo/group.tsx" iframe="360">悬浮按钮组</code>
 <code src="./demo/group-menu.tsx" iframe="360">菜单模式</code>
 <code src="./demo/controlled.tsx" iframe="360">受控模式</code>
 <code src="./demo/placement.tsx" iframe="380" version="5.21.0">弹出方向</code>


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

FloatButton 在中文文档中都是 “悬浮按钮”，而 demo 中 "FloatButton Group" 的标题却是 “浮动按钮组”，术语不一致。

统一为 “悬浮按钮”。

### 📝 更新日志

| 语言    | 更新描述             |
| ------- | -------------------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志           |