### PR TITLE
fix(DatePicker): hide decorative range separator

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -12783,7 +12783,7 @@ exports[`ConfigProvider components DatePicker RangePicker configProvider 1`] = `
       class="config-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="config-picker-separator"
       >
         <span
@@ -12873,7 +12873,7 @@ exports[`ConfigProvider components DatePicker RangePicker configProvider compone
       class="config-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="config-picker-separator"
       >
         <span
@@ -12963,7 +12963,7 @@ exports[`ConfigProvider components DatePicker RangePicker configProvider compone
       class="config-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="config-picker-separator"
       >
         <span
@@ -13052,7 +13052,7 @@ exports[`ConfigProvider components DatePicker RangePicker configProvider compone
       class="config-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="config-picker-separator"
       >
         <span
@@ -13141,7 +13141,7 @@ exports[`ConfigProvider components DatePicker RangePicker configProvider compone
       class="config-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="config-picker-separator"
       >
         <span
@@ -13230,7 +13230,7 @@ exports[`ConfigProvider components DatePicker RangePicker normal 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -13319,7 +13319,7 @@ exports[`ConfigProvider components DatePicker RangePicker prefixCls 1`] = `
       class="prefix-RangePicker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="prefix-RangePicker-separator"
       >
         <span

--- a/components/date-picker/__tests__/RangePicker.test.tsx
+++ b/components/date-picker/__tests__/RangePicker.test.tsx
@@ -57,8 +57,24 @@ describe('RangePicker', () => {
     }).not.toThrow();
   });
 
-  it('customize separator', () => {
-    const { container } = render(<RangePicker separator="test" />);
+  it('hides the default separator from the accessibility tree', () => {
+    const { container, queryByRole } = render(<RangePicker />);
+    const separator = container.querySelector('.ant-picker-separator');
+
+    expect(separator).toHaveAttribute('aria-hidden', 'true');
+    expect(separator).not.toHaveAttribute('aria-label');
+    expect(queryByRole('img', { name: 'swap-right' })).not.toBeInTheDocument();
+  });
+
+  it('preserves a custom separator accessible name', () => {
+    const { container, getByLabelText } = render(
+      <RangePicker separator={<span aria-label="Custom range separator">test</span>} />,
+    );
+    const separator = container.querySelector('.ant-picker-separator');
+
+    expect(separator).not.toHaveAttribute('aria-hidden');
+    expect(separator).not.toHaveAttribute('aria-label');
+    expect(getByLabelText('Custom range separator')).toBeInTheDocument();
     expect(container.firstChild).toMatchSnapshot();
   });
 

--- a/components/date-picker/__tests__/__snapshots__/RangePicker.test.tsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/RangePicker.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`RangePicker customize separator 1`] = `
+exports[`RangePicker preserves a custom separator accessible name 1`] = `
 <div
   class="ant-picker ant-picker-range ant-picker-outlined css-var-root ant-picker-css-var"
 >
@@ -20,10 +20,13 @@ exports[`RangePicker customize separator 1`] = `
     class="ant-picker-range-separator"
   >
     <span
-      aria-label="to"
       class="ant-picker-separator"
     >
-      test
+      <span
+        aria-label="Custom range separator"
+      >
+        test
+      </span>
     </span>
   </div>
   <div
@@ -90,7 +93,7 @@ Array [
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span

--- a/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -21,7 +21,7 @@ Array [
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -9361,7 +9361,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx extend context corr
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -12228,7 +12228,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -13430,7 +13430,7 @@ exports[`renders components/date-picker/demo/disabled.tsx extend context correct
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -17663,7 +17663,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -18864,7 +18864,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx extend context co
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -21408,7 +21408,7 @@ exports[`renders components/date-picker/demo/external-panel.tsx extend context c
                     class="ant-picker-range-separator"
                   >
                     <span
-                      aria-label="to"
+                      aria-hidden="true"
                       class="ant-picker-separator"
                     >
                       <span
@@ -25381,7 +25381,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -26591,7 +26591,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx extend context cor
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -29871,7 +29871,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -31073,7 +31073,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -33566,7 +33566,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -34768,7 +34768,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx extend context cor
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -38236,7 +38236,7 @@ exports[`renders components/date-picker/demo/format.tsx extend context correctly
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -42930,7 +42930,7 @@ exports[`renders components/date-picker/demo/mode.tsx extend context correctly 1
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -50146,7 +50146,7 @@ Array [
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -51989,7 +51989,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -53208,7 +53208,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx extend context co
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -55392,7 +55392,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -56593,7 +56593,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -58742,7 +58742,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -60089,7 +60089,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -60574,7 +60574,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -60888,7 +60888,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx extend context cor
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -62016,7 +62016,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -63226,7 +63226,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx extend context 
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -64649,7 +64649,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -71993,7 +71993,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -73195,7 +73195,7 @@ exports[`renders components/date-picker/demo/status.tsx extend context correctly
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -76505,7 +76505,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -79200,7 +79200,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -82433,7 +82433,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -83785,7 +83785,7 @@ exports[`renders components/date-picker/demo/suffix.tsx extend context correctly
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -92049,7 +92049,7 @@ exports[`renders components/date-picker/demo/time.tsx extend context correctly 1
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -94218,7 +94218,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -96034,7 +96034,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -97850,7 +97850,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -99666,7 +99666,7 @@ exports[`renders components/date-picker/demo/variant.tsx extend context correctl
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span

--- a/components/date-picker/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`renders components/date-picker/demo/_semantic.tsx correctly 1`] = `
             class="ant-picker-range-separator"
           >
             <span
-              aria-label="to"
+              aria-hidden="true"
               class="ant-picker-separator"
             >
               <span

--- a/components/date-picker/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`renders components/date-picker/demo/allow-empty.tsx correctly 1`] = `
     class="ant-picker-range-separator"
   >
     <span
-      aria-label="to"
+      aria-hidden="true"
       class="ant-picker-separator"
     >
       <span
@@ -668,7 +668,7 @@ exports[`renders components/date-picker/demo/cell-render.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -971,7 +971,7 @@ exports[`renders components/date-picker/demo/disabled.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -1060,7 +1060,7 @@ exports[`renders components/date-picker/demo/disabled.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -1338,7 +1338,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -1426,7 +1426,7 @@ exports[`renders components/date-picker/demo/disabled-date.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -1697,7 +1697,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -1785,7 +1785,7 @@ exports[`renders components/date-picker/demo/extra-footer.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -2013,7 +2013,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -2102,7 +2102,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -2332,7 +2332,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -2421,7 +2421,7 @@ exports[`renders components/date-picker/demo/filled-debug.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -2794,7 +2794,7 @@ exports[`renders components/date-picker/demo/format.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -3122,7 +3122,7 @@ exports[`renders components/date-picker/demo/mode.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5058,7 +5058,7 @@ Array [
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -5196,7 +5196,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5284,7 +5284,7 @@ exports[`renders components/date-picker/demo/preset-ranges.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5380,7 +5380,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5468,7 +5468,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5556,7 +5556,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5644,7 +5644,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5732,7 +5732,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5821,7 +5821,7 @@ exports[`renders components/date-picker/demo/range-picker.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -5973,7 +5973,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx correctly 1`] =
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -6070,7 +6070,7 @@ exports[`renders components/date-picker/demo/select-in-range.tsx correctly 1`] =
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -6319,7 +6319,7 @@ exports[`renders components/date-picker/demo/size.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -6640,7 +6640,7 @@ exports[`renders components/date-picker/demo/status.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -6729,7 +6729,7 @@ exports[`renders components/date-picker/demo/status.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -6997,7 +6997,7 @@ exports[`renders components/date-picker/demo/suffix.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -7174,7 +7174,7 @@ exports[`renders components/date-picker/demo/suffix.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -7404,7 +7404,7 @@ exports[`renders components/date-picker/demo/suffix.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -7497,7 +7497,7 @@ exports[`renders components/date-picker/demo/suffix.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -7894,7 +7894,7 @@ exports[`renders components/date-picker/demo/time.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -8030,7 +8030,7 @@ exports[`renders components/date-picker/demo/variant.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -8158,7 +8158,7 @@ exports[`renders components/date-picker/demo/variant.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -8286,7 +8286,7 @@ exports[`renders components/date-picker/demo/variant.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -8414,7 +8414,7 @@ exports[`renders components/date-picker/demo/variant.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span

--- a/components/date-picker/__tests__/__snapshots__/mount.test.ts.snap
+++ b/components/date-picker/__tests__/__snapshots__/mount.test.ts.snap
@@ -146,7 +146,7 @@ exports[`mount rtl render component should be rendered correctly in RTL directio
     class="ant-picker-range-separator"
   >
     <span
-      aria-label="to"
+      aria-hidden="true"
       class="ant-picker-separator"
     >
       <span

--- a/components/date-picker/__tests__/__snapshots__/vitest/mount.test.ts.snap
+++ b/components/date-picker/__tests__/__snapshots__/vitest/mount.test.ts.snap
@@ -146,7 +146,7 @@ exports[`mount > rtl render > component should be rendered correctly in RTL dire
     class="ant-picker-range-separator"
   >
     <span
-      aria-label="to"
+      aria-hidden="true"
       class="ant-picker-separator"
     >
       <span

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -93,6 +93,7 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
     const rootPrefixCls = getPrefixCls();
 
     const mergedSeparator = separator ?? rangePicker?.separator;
+    const hasCustomSeparator = mergedSeparator !== undefined && mergedSeparator !== null;
 
     const [variant, enableVariantCls] = useVariant('rangePicker', customVariant, bordered);
 
@@ -162,8 +163,11 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
       <ContextIsolator space>
         <RCRangePicker<DateType>
           separator={
-            <span aria-label="to" className={`${prefixCls}-separator`}>
-              {mergedSeparator ?? <SwapRightOutlined />}
+            <span
+              aria-hidden={hasCustomSeparator ? undefined : true}
+              className={`${prefixCls}-separator`}
+            >
+              {hasCustomSeparator ? mergedSeparator : <SwapRightOutlined />}
             </span>
           }
           disabled={mergedDisabled}

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -9,6 +9,7 @@ import { clsx } from 'clsx';
 
 import ContextIsolator from '../../_util/ContextIsolator';
 import { useAllowClear, useZIndex } from '../../_util/hooks';
+import { isNonNullable } from '../../_util/is';
 import { getMergedStatus, getStatusClassNames } from '../../_util/statusUtils';
 import type { AnyObject } from '../../_util/type';
 import { devUseWarning } from '../../_util/warning';
@@ -93,7 +94,7 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
     const rootPrefixCls = getPrefixCls();
 
     const mergedSeparator = separator ?? rangePicker?.separator;
-    const hasCustomSeparator = mergedSeparator !== undefined && mergedSeparator !== null;
+    const hasCustomSeparator = isNonNullable(mergedSeparator);
 
     const [variant, enableVariantCls] = useVariant('rangePicker', customVariant, bordered);
 

--- a/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
@@ -1340,7 +1340,7 @@ Array [
                               class="ant-picker-range-separator"
                             >
                               <span
-                                aria-label="to"
+                                aria-hidden="true"
                                 class="ant-picker-separator"
                               >
                                 <span

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3638,7 +3638,7 @@ Array [
                   class="ant-picker-range-separator"
                 >
                   <span
-                    aria-label="to"
+                    aria-hidden="true"
                     class="ant-picker-separator"
                   >
                     <span
@@ -17627,7 +17627,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                 class="ant-picker-range-separator"
               >
                 <span
-                  aria-label="to"
+                  aria-hidden="true"
                   class="ant-picker-separator"
                 >
                   <span
@@ -18858,7 +18858,7 @@ exports[`renders components/form/demo/time-related-controls.tsx extend context c
                 class="ant-picker-range-separator"
               >
                 <span
-                  aria-label="to"
+                  aria-hidden="true"
                   class="ant-picker-separator"
                 >
                   <span
@@ -28026,7 +28026,7 @@ exports[`renders components/form/demo/validate-static.tsx extend context correct
                 class="ant-picker-range-separator"
               >
                 <span
-                  aria-label="to"
+                  aria-hidden="true"
                   class="ant-picker-separator"
                 >
                   <span
@@ -33666,7 +33666,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                 class="ant-picker-range-separator"
               >
                 <span
-                  aria-label="to"
+                  aria-hidden="true"
                   class="ant-picker-separator"
                 >
                   <span

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2278,7 +2278,7 @@ Array [
                   class="ant-picker-range-separator"
                 >
                   <span
-                    aria-label="to"
+                    aria-hidden="true"
                     class="ant-picker-separator"
                   >
                     <span
@@ -9825,7 +9825,7 @@ exports[`renders components/form/demo/time-related-controls.tsx correctly 1`] = 
                 class="ant-picker-range-separator"
               >
                 <span
-                  aria-label="to"
+                  aria-hidden="true"
                   class="ant-picker-separator"
                 >
                   <span
@@ -9943,7 +9943,7 @@ exports[`renders components/form/demo/time-related-controls.tsx correctly 1`] = 
                 class="ant-picker-range-separator"
               >
                 <span
-                  aria-label="to"
+                  aria-hidden="true"
                   class="ant-picker-separator"
                 >
                   <span
@@ -12762,7 +12762,7 @@ exports[`renders components/form/demo/validate-static.tsx correctly 1`] = `
                 class="ant-picker-range-separator"
               >
                 <span
-                  aria-label="to"
+                  aria-hidden="true"
                   class="ant-picker-separator"
                 >
                   <span
@@ -15112,7 +15112,7 @@ exports[`renders components/form/demo/variant.tsx correctly 1`] = `
                 class="ant-picker-range-separator"
               >
                 <span
-                  aria-label="to"
+                  aria-hidden="true"
                   class="ant-picker-separator"
                 >
                   <span

--- a/components/form/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/index.test.tsx.snap
@@ -608,7 +608,7 @@ exports[`Form form should support disabled 1`] = `
                 class="ant-picker-range-separator"
               >
                 <span
-                  aria-label="to"
+                  aria-hidden="true"
                   class="ant-picker-separator"
                 >
                   <span

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3746,7 +3746,7 @@ Array [
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -7911,7 +7911,7 @@ exports[`renders components/input/demo/group.tsx extend context correctly 1`] = 
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span

--- a/components/input/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.tsx.snap
@@ -909,7 +909,7 @@ Array [
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -2861,7 +2861,7 @@ exports[`renders components/input/demo/group.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span

--- a/components/locale/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/index.test.tsx.snap
@@ -4346,7 +4346,7 @@ exports[`Locale Provider should display the text as ar 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -9581,7 +9581,7 @@ exports[`Locale Provider should display the text as az 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -14816,7 +14816,7 @@ exports[`Locale Provider should display the text as bg 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -20051,7 +20051,7 @@ exports[`Locale Provider should display the text as bn-bd 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -25286,7 +25286,7 @@ exports[`Locale Provider should display the text as by 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -30521,7 +30521,7 @@ exports[`Locale Provider should display the text as ca 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -35756,7 +35756,7 @@ exports[`Locale Provider should display the text as cs 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -40991,7 +40991,7 @@ exports[`Locale Provider should display the text as da 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -46226,7 +46226,7 @@ exports[`Locale Provider should display the text as de 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -51461,7 +51461,7 @@ exports[`Locale Provider should display the text as el 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -56696,7 +56696,7 @@ exports[`Locale Provider should display the text as en 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -61931,7 +61931,7 @@ exports[`Locale Provider should display the text as en-gb 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -67166,7 +67166,7 @@ exports[`Locale Provider should display the text as es 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -72401,7 +72401,7 @@ exports[`Locale Provider should display the text as es-us 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -77636,7 +77636,7 @@ exports[`Locale Provider should display the text as et 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -82871,7 +82871,7 @@ exports[`Locale Provider should display the text as eu 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -88106,7 +88106,7 @@ exports[`Locale Provider should display the text as fa 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -93341,7 +93341,7 @@ exports[`Locale Provider should display the text as fi 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -98576,7 +98576,7 @@ exports[`Locale Provider should display the text as fr 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -103811,7 +103811,7 @@ exports[`Locale Provider should display the text as fr 2`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -109046,7 +109046,7 @@ exports[`Locale Provider should display the text as fr 3`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -114281,7 +114281,7 @@ exports[`Locale Provider should display the text as ga 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -119516,7 +119516,7 @@ exports[`Locale Provider should display the text as gl 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -124751,7 +124751,7 @@ exports[`Locale Provider should display the text as he 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -129986,7 +129986,7 @@ exports[`Locale Provider should display the text as hi 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -135221,7 +135221,7 @@ exports[`Locale Provider should display the text as hr 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -140456,7 +140456,7 @@ exports[`Locale Provider should display the text as hu 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -145691,7 +145691,7 @@ exports[`Locale Provider should display the text as hy-am 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -150926,7 +150926,7 @@ exports[`Locale Provider should display the text as id 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -156161,7 +156161,7 @@ exports[`Locale Provider should display the text as is 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -161396,7 +161396,7 @@ exports[`Locale Provider should display the text as it 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -166631,7 +166631,7 @@ exports[`Locale Provider should display the text as ja 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -171866,7 +171866,7 @@ exports[`Locale Provider should display the text as ka 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -177101,7 +177101,7 @@ exports[`Locale Provider should display the text as kk 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -182336,7 +182336,7 @@ exports[`Locale Provider should display the text as km 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -187569,7 +187569,7 @@ exports[`Locale Provider should display the text as kn 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -192804,7 +192804,7 @@ exports[`Locale Provider should display the text as ko 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -198039,7 +198039,7 @@ exports[`Locale Provider should display the text as ku 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -203274,7 +203274,7 @@ exports[`Locale Provider should display the text as ku-iq 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -208509,7 +208509,7 @@ exports[`Locale Provider should display the text as lt 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -213744,7 +213744,7 @@ exports[`Locale Provider should display the text as lv 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -218979,7 +218979,7 @@ exports[`Locale Provider should display the text as mk 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -224214,7 +224214,7 @@ exports[`Locale Provider should display the text as ml 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -229449,7 +229449,7 @@ exports[`Locale Provider should display the text as mn-mn 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -234684,7 +234684,7 @@ exports[`Locale Provider should display the text as mr 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -239919,7 +239919,7 @@ exports[`Locale Provider should display the text as ms-my 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -245154,7 +245154,7 @@ exports[`Locale Provider should display the text as my 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -250389,7 +250389,7 @@ exports[`Locale Provider should display the text as nb 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -255624,7 +255624,7 @@ exports[`Locale Provider should display the text as ne-np 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -260859,7 +260859,7 @@ exports[`Locale Provider should display the text as nl 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -266094,7 +266094,7 @@ exports[`Locale Provider should display the text as nl-be 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -271329,7 +271329,7 @@ exports[`Locale Provider should display the text as pl 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -276564,7 +276564,7 @@ exports[`Locale Provider should display the text as pt 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -281799,7 +281799,7 @@ exports[`Locale Provider should display the text as pt-br 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -287034,7 +287034,7 @@ exports[`Locale Provider should display the text as ro 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -292269,7 +292269,7 @@ exports[`Locale Provider should display the text as ru 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -297504,7 +297504,7 @@ exports[`Locale Provider should display the text as si 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -302739,7 +302739,7 @@ exports[`Locale Provider should display the text as sk 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -307974,7 +307974,7 @@ exports[`Locale Provider should display the text as sl 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -313209,7 +313209,7 @@ exports[`Locale Provider should display the text as sq 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -318444,7 +318444,7 @@ exports[`Locale Provider should display the text as sr 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -323679,7 +323679,7 @@ exports[`Locale Provider should display the text as sv 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -328914,7 +328914,7 @@ exports[`Locale Provider should display the text as ta 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -334149,7 +334149,7 @@ exports[`Locale Provider should display the text as th 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -339384,7 +339384,7 @@ exports[`Locale Provider should display the text as tk 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -344619,7 +344619,7 @@ exports[`Locale Provider should display the text as tr 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -349854,7 +349854,7 @@ exports[`Locale Provider should display the text as uk 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -355089,7 +355089,7 @@ exports[`Locale Provider should display the text as ur 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -360324,7 +360324,7 @@ exports[`Locale Provider should display the text as uz-latn 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -365559,7 +365559,7 @@ exports[`Locale Provider should display the text as vi 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -370794,7 +370794,7 @@ exports[`Locale Provider should display the text as zh-cn 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -376029,7 +376029,7 @@ exports[`Locale Provider should display the text as zh-hk 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -381264,7 +381264,7 @@ exports[`Locale Provider should display the text as zh-tw 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span

--- a/components/locale/__tests__/__snapshots__/vitest/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/vitest/index.test.tsx.snap
@@ -531,7 +531,7 @@ exports[`Locale Provider > should display the text as ar 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -2480,7 +2480,7 @@ exports[`Locale Provider > should display the text as az 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -4429,7 +4429,7 @@ exports[`Locale Provider > should display the text as bg 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -6378,7 +6378,7 @@ exports[`Locale Provider > should display the text as bn-bd 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -8327,7 +8327,7 @@ exports[`Locale Provider > should display the text as by 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -10276,7 +10276,7 @@ exports[`Locale Provider > should display the text as ca 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -12225,7 +12225,7 @@ exports[`Locale Provider > should display the text as cs 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -14174,7 +14174,7 @@ exports[`Locale Provider > should display the text as da 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -16123,7 +16123,7 @@ exports[`Locale Provider > should display the text as de 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -18072,7 +18072,7 @@ exports[`Locale Provider > should display the text as el 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -20021,7 +20021,7 @@ exports[`Locale Provider > should display the text as en 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -21970,7 +21970,7 @@ exports[`Locale Provider > should display the text as en-gb 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -23919,7 +23919,7 @@ exports[`Locale Provider > should display the text as es 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -25868,7 +25868,7 @@ exports[`Locale Provider > should display the text as es-us 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -27817,7 +27817,7 @@ exports[`Locale Provider > should display the text as et 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -29766,7 +29766,7 @@ exports[`Locale Provider > should display the text as eu 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -31715,7 +31715,7 @@ exports[`Locale Provider > should display the text as fa 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -33664,7 +33664,7 @@ exports[`Locale Provider > should display the text as fi 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -35613,7 +35613,7 @@ exports[`Locale Provider > should display the text as fr 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -37562,7 +37562,7 @@ exports[`Locale Provider > should display the text as fr 2`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -39511,7 +39511,7 @@ exports[`Locale Provider > should display the text as fr 3`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -41460,7 +41460,7 @@ exports[`Locale Provider > should display the text as ga 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -43409,7 +43409,7 @@ exports[`Locale Provider > should display the text as gl 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -45358,7 +45358,7 @@ exports[`Locale Provider > should display the text as he 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -47307,7 +47307,7 @@ exports[`Locale Provider > should display the text as hi 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -49256,7 +49256,7 @@ exports[`Locale Provider > should display the text as hr 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -51205,7 +51205,7 @@ exports[`Locale Provider > should display the text as hu 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -53154,7 +53154,7 @@ exports[`Locale Provider > should display the text as hy-am 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -55103,7 +55103,7 @@ exports[`Locale Provider > should display the text as id 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -57052,7 +57052,7 @@ exports[`Locale Provider > should display the text as is 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -59001,7 +59001,7 @@ exports[`Locale Provider > should display the text as it 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -60950,7 +60950,7 @@ exports[`Locale Provider > should display the text as ja 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -62899,7 +62899,7 @@ exports[`Locale Provider > should display the text as ka 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -64848,7 +64848,7 @@ exports[`Locale Provider > should display the text as kk 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -66797,7 +66797,7 @@ exports[`Locale Provider > should display the text as km 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -68744,7 +68744,7 @@ exports[`Locale Provider > should display the text as kn 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -70693,7 +70693,7 @@ exports[`Locale Provider > should display the text as ko 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -72642,7 +72642,7 @@ exports[`Locale Provider > should display the text as ku 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -74591,7 +74591,7 @@ exports[`Locale Provider > should display the text as ku-iq 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -76540,7 +76540,7 @@ exports[`Locale Provider > should display the text as lt 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -78489,7 +78489,7 @@ exports[`Locale Provider > should display the text as lv 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -80438,7 +80438,7 @@ exports[`Locale Provider > should display the text as mk 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -82387,7 +82387,7 @@ exports[`Locale Provider > should display the text as ml 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -84336,7 +84336,7 @@ exports[`Locale Provider > should display the text as mn-mn 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -86285,7 +86285,7 @@ exports[`Locale Provider > should display the text as mr 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -88234,7 +88234,7 @@ exports[`Locale Provider > should display the text as ms-my 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -90183,7 +90183,7 @@ exports[`Locale Provider > should display the text as my 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -92132,7 +92132,7 @@ exports[`Locale Provider > should display the text as nb 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -94081,7 +94081,7 @@ exports[`Locale Provider > should display the text as ne-np 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -96030,7 +96030,7 @@ exports[`Locale Provider > should display the text as nl 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -97979,7 +97979,7 @@ exports[`Locale Provider > should display the text as nl-be 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -99928,7 +99928,7 @@ exports[`Locale Provider > should display the text as pl 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -101877,7 +101877,7 @@ exports[`Locale Provider > should display the text as pt 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -103826,7 +103826,7 @@ exports[`Locale Provider > should display the text as pt-br 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -105775,7 +105775,7 @@ exports[`Locale Provider > should display the text as ro 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -107724,7 +107724,7 @@ exports[`Locale Provider > should display the text as ru 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -109673,7 +109673,7 @@ exports[`Locale Provider > should display the text as si 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -111622,7 +111622,7 @@ exports[`Locale Provider > should display the text as sk 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -113571,7 +113571,7 @@ exports[`Locale Provider > should display the text as sl 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -115520,7 +115520,7 @@ exports[`Locale Provider > should display the text as sq 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -117469,7 +117469,7 @@ exports[`Locale Provider > should display the text as sr 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -119418,7 +119418,7 @@ exports[`Locale Provider > should display the text as sv 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -121367,7 +121367,7 @@ exports[`Locale Provider > should display the text as ta 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -123316,7 +123316,7 @@ exports[`Locale Provider > should display the text as th 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -125265,7 +125265,7 @@ exports[`Locale Provider > should display the text as tk 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -127214,7 +127214,7 @@ exports[`Locale Provider > should display the text as tr 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -129163,7 +129163,7 @@ exports[`Locale Provider > should display the text as uk 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -131112,7 +131112,7 @@ exports[`Locale Provider > should display the text as ur 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -133061,7 +133061,7 @@ exports[`Locale Provider > should display the text as uz-latn 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -135010,7 +135010,7 @@ exports[`Locale Provider > should display the text as vi 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -136959,7 +136959,7 @@ exports[`Locale Provider > should display the text as zh-cn 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -138908,7 +138908,7 @@ exports[`Locale Provider > should display the text as zh-hk 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -140857,7 +140857,7 @@ exports[`Locale Provider > should display the text as zh-tw 1`] = `
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1863,7 +1863,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
           class="ant-picker-range-separator"
         >
           <span
-            aria-label="to"
+            aria-hidden="true"
             class="ant-picker-separator"
           >
             <span
@@ -3089,7 +3089,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
           class="ant-picker-range-separator"
         >
           <span
-            aria-label="to"
+            aria-hidden="true"
             class="ant-picker-separator"
           >
             <span
@@ -6641,7 +6641,7 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
           class="ant-picker-range-separator"
         >
           <span
-            aria-label="to"
+            aria-hidden="true"
             class="ant-picker-separator"
           >
             <span
@@ -12543,7 +12543,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
           class="ant-picker-range-separator"
         >
           <span
-            aria-label="to"
+            aria-hidden="true"
             class="ant-picker-separator"
           >
             <span

--- a/components/space/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.tsx.snap
@@ -924,7 +924,7 @@ exports[`renders components/space/demo/compact.tsx correctly 1`] = `
           class="ant-picker-range-separator"
         >
           <span
-            aria-label="to"
+            aria-hidden="true"
             class="ant-picker-separator"
           >
             <span
@@ -1037,7 +1037,7 @@ exports[`renders components/space/demo/compact.tsx correctly 1`] = `
           class="ant-picker-range-separator"
         >
           <span
-            aria-label="to"
+            aria-hidden="true"
             class="ant-picker-separator"
           >
             <span
@@ -1481,7 +1481,7 @@ exports[`renders components/space/demo/compact.tsx correctly 1`] = `
           class="ant-picker-range-separator"
         >
           <span
-            aria-label="to"
+            aria-hidden="true"
             class="ant-picker-separator"
           >
             <span
@@ -3442,7 +3442,7 @@ exports[`renders components/space/demo/compact-debug.tsx correctly 1`] = `
           class="ant-picker-range-separator"
         >
           <span
-            aria-label="to"
+            aria-hidden="true"
             class="ant-picker-separator"
           >
             <span

--- a/components/time-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/time-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -14664,7 +14664,7 @@ Array [
       class="ant-picker-range-separator"
     >
       <span
-        aria-label="to"
+        aria-hidden="true"
         class="ant-picker-separator"
       >
         <span
@@ -25765,7 +25765,7 @@ exports[`renders components/time-picker/demo/status.tsx extend context correctly
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -27370,7 +27370,7 @@ exports[`renders components/time-picker/demo/status.tsx extend context correctly
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -35278,7 +35278,7 @@ exports[`renders components/time-picker/demo/suffix.tsx extend context correctly
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -40017,7 +40017,7 @@ exports[`renders components/time-picker/demo/variant.tsx extend context correctl
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -43181,7 +43181,7 @@ exports[`renders components/time-picker/demo/variant.tsx extend context correctl
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -46345,7 +46345,7 @@ exports[`renders components/time-picker/demo/variant.tsx extend context correctl
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -49509,7 +49509,7 @@ exports[`renders components/time-picker/demo/variant.tsx extend context correctl
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span

--- a/components/time-picker/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/time-picker/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`renders components/time-picker/demo/_semantic.tsx correctly 1`] = `
             class="ant-picker-range-separator"
           >
             <span
-              aria-label="to"
+              aria-hidden="true"
               class="ant-picker-separator"
             >
               <span

--- a/components/time-picker/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/time-picker/__tests__/__snapshots__/demo.test.tsx.snap
@@ -553,7 +553,7 @@ exports[`renders components/time-picker/demo/range-picker.tsx correctly 1`] = `
     class="ant-picker-range-separator"
   >
     <span
-      aria-label="to"
+      aria-hidden="true"
       class="ant-picker-separator"
     >
       <span
@@ -1041,7 +1041,7 @@ exports[`renders components/time-picker/demo/status.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -1132,7 +1132,7 @@ exports[`renders components/time-picker/demo/status.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -1459,7 +1459,7 @@ exports[`renders components/time-picker/demo/suffix.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -1646,7 +1646,7 @@ exports[`renders components/time-picker/demo/variant.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -1780,7 +1780,7 @@ exports[`renders components/time-picker/demo/variant.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -1914,7 +1914,7 @@ exports[`renders components/time-picker/demo/variant.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span
@@ -2048,7 +2048,7 @@ exports[`renders components/time-picker/demo/variant.tsx correctly 1`] = `
         class="ant-picker-range-separator"
       >
         <span
-          aria-label="to"
+          aria-hidden="true"
           class="ant-picker-separator"
         >
           <span


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Fixes #58998.

### 💡 Background and Solution

`RangePicker` currently puts the hardcoded accessible name `to` on its separator wrapper. The default `SwapRightOutlined` child also exposes `swap-right`, so non-English screen readers receive English-only names for a decorative element. Because a parent `aria-label` takes precedence over descendant content, the wrapper also overrides an accessible name supplied by a custom `separator`.

This change:

- marks only the default separator as decorative with `aria-hidden="true"`;
- leaves a custom separator exposed without a parent label, preserving the custom node's own semantics;
- adds focused assertions for both paths and refreshes the directly affected Jest and Vitest snapshots;
- does not add or change any public API or locale key.

Validation:

- Jest related tests: 228 suites, 3,206 passed, 95 skipped, 3,596 snapshots passed;
- Vitest related tests: 10 files, 159 tests passed;
- `npm run compileOnly`;
- ESLint and Biome on the changed source and test files;
- `git diff --check`;
- full `tsc --noEmit` produces the same seven pre-existing Table demo/Puppeteer errors on an unchanged `master`, with no error from this patch.

AI assistance disclosure: Codex was used to trace the accessibility behavior, draft the focused implementation and tests, refresh affected snapshots, and run the validation commands. The behavior and results above are directly reproducible from this pull request.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | DatePicker RangePicker no longer exposes its decorative default separator to screen readers and preserves accessible names on custom separators. |
| 🇨🇳 Chinese | DatePicker RangePicker 的装饰性默认分隔符不再被屏幕阅读器朗读，并会保留自定义分隔符的无障碍名称。 |
