### PR TITLE
fix(Collapse): hide decorative expand icon

### DIFF
--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -153,12 +153,16 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
 
   const renderExpandIcon = React.useCallback(
     (panelProps: PanelProps = {}) => {
+      const iconIsInteractive =
+        panelProps.collapsible === 'header' || panelProps.collapsible === 'icon';
       const icon = isFunction(mergedExpandIcon) ? (
         mergedExpandIcon(panelProps)
       ) : (
         <RightOutlined
           rotate={panelProps.isActive ? (direction === 'rtl' ? -90 : 90) : undefined}
-          aria-hidden
+          {...(iconIsInteractive
+            ? { 'aria-label': panelProps.isActive ? 'expanded' : 'collapsed' }
+            : { 'aria-hidden': true })}
         />
       );
       return cloneElement(icon, (oriProps) => ({

--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -158,7 +158,7 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
       ) : (
         <RightOutlined
           rotate={panelProps.isActive ? (direction === 'rtl' ? -90 : 90) : undefined}
-          aria-label={panelProps.isActive ? 'expanded' : 'collapsed'}
+          aria-hidden
         />
       );
       return cloneElement(icon, (oriProps) => ({

--- a/components/collapse/__tests__/__snapshots__/accessibility.test.tsx.snap
+++ b/components/collapse/__tests__/__snapshots__/accessibility.test.tsx.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Collapse accessibility hides the default expand icon and exposes state on the header 1`] = `
+<div
+  class="ant-collapse ant-collapse-icon-placement-start css-var-root"
+>
+  <div
+    class="ant-collapse-item ant-collapse-item-active"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="true"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-hidden="true"
+          aria-label="right"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            style="transform: rotate(90deg);"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        Header
+      </span>
+    </div>
+    <div
+      class="ant-collapse-panel ant-collapse-panel-active"
+    >
+      <div
+        class="ant-collapse-body"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/components/collapse/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/collapse/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -19,7 +19,8 @@ exports[`renders components/collapse/demo/accordion.tsx extend context correctly
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -59,7 +60,8 @@ exports[`renders components/collapse/demo/accordion.tsx extend context correctly
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -99,7 +101,8 @@ exports[`renders components/collapse/demo/accordion.tsx extend context correctly
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -148,7 +151,8 @@ exports[`renders components/collapse/demo/basic.tsx extend context correctly 1`]
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -202,7 +206,8 @@ exports[`renders components/collapse/demo/basic.tsx extend context correctly 1`]
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -242,7 +247,8 @@ exports[`renders components/collapse/demo/basic.tsx extend context correctly 1`]
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -291,7 +297,8 @@ exports[`renders components/collapse/demo/borderless.tsx extend context correctl
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -345,7 +352,8 @@ exports[`renders components/collapse/demo/borderless.tsx extend context correctl
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -385,7 +393,8 @@ exports[`renders components/collapse/demo/borderless.tsx extend context correctl
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -440,7 +449,8 @@ exports[`renders components/collapse/demo/collapsible.tsx extend context correct
             tabindex="0"
           >
             <span
-              aria-label="expanded"
+              aria-hidden="true"
+              aria-label="right"
               class="anticon anticon-right ant-collapse-arrow"
               role="img"
             >
@@ -506,7 +516,8 @@ exports[`renders components/collapse/demo/collapsible.tsx extend context correct
             tabindex="0"
           >
             <span
-              aria-label="expanded"
+              aria-hidden="true"
+              aria-label="right"
               class="anticon anticon-right ant-collapse-arrow"
               role="img"
             >
@@ -568,7 +579,8 @@ exports[`renders components/collapse/demo/collapsible.tsx extend context correct
             class="ant-collapse-expand-icon"
           >
             <span
-              aria-label="collapsed"
+              aria-hidden="true"
+              aria-label="right"
               class="anticon anticon-right ant-collapse-arrow"
               role="img"
             >
@@ -619,7 +631,8 @@ exports[`renders components/collapse/demo/component-token.tsx extend context cor
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -659,7 +672,8 @@ exports[`renders components/collapse/demo/component-token.tsx extend context cor
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -699,7 +713,8 @@ exports[`renders components/collapse/demo/component-token.tsx extend context cor
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -896,7 +911,8 @@ Array [
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="expanded"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -974,7 +990,8 @@ Array [
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1038,7 +1055,8 @@ Array [
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1242,7 +1260,8 @@ exports[`renders components/collapse/demo/ghost.tsx extend context correctly 1`]
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1296,7 +1315,8 @@ exports[`renders components/collapse/demo/ghost.tsx extend context correctly 1`]
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1336,7 +1356,8 @@ exports[`renders components/collapse/demo/ghost.tsx extend context correctly 1`]
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1385,7 +1406,8 @@ exports[`renders components/collapse/demo/icon.tsx extend context correctly 1`] 
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1458,7 +1480,8 @@ exports[`renders components/collapse/demo/icon.tsx extend context correctly 1`] 
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1523,7 +1546,8 @@ exports[`renders components/collapse/demo/mix.tsx extend context correctly 1`] =
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1563,7 +1587,8 @@ exports[`renders components/collapse/demo/mix.tsx extend context correctly 1`] =
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1603,7 +1628,8 @@ exports[`renders components/collapse/demo/mix.tsx extend context correctly 1`] =
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1652,7 +1678,8 @@ exports[`renders components/collapse/demo/noarrow.tsx extend context correctly 1
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1749,7 +1776,8 @@ Array [
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1809,7 +1837,8 @@ Array [
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1869,7 +1898,8 @@ Array [
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1924,7 +1954,8 @@ exports[`renders components/collapse/demo/style-class.tsx extend context correct
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="expanded"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1977,7 +2008,8 @@ exports[`renders components/collapse/demo/style-class.tsx extend context correct
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -2018,7 +2050,8 @@ exports[`renders components/collapse/demo/style-class.tsx extend context correct
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -2064,7 +2097,8 @@ exports[`renders components/collapse/demo/style-class.tsx extend context correct
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -2105,7 +2139,8 @@ exports[`renders components/collapse/demo/style-class.tsx extend context correct
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="expanded"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -2158,7 +2193,8 @@ exports[`renders components/collapse/demo/style-class.tsx extend context correct
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >

--- a/components/collapse/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/collapse/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -449,8 +449,7 @@ exports[`renders components/collapse/demo/collapsible.tsx extend context correct
             tabindex="0"
           >
             <span
-              aria-hidden="true"
-              aria-label="right"
+              aria-label="expanded"
               class="anticon anticon-right ant-collapse-arrow"
               role="img"
             >
@@ -516,8 +515,7 @@ exports[`renders components/collapse/demo/collapsible.tsx extend context correct
             tabindex="0"
           >
             <span
-              aria-hidden="true"
-              aria-label="right"
+              aria-label="expanded"
               class="anticon anticon-right ant-collapse-arrow"
               role="img"
             >

--- a/components/collapse/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/collapse/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -30,7 +30,8 @@ exports[`renders components/collapse/demo/_semantic.tsx correctly 1`] = `
                 class="ant-collapse-expand-icon semantic-mark-icon"
               >
                 <span
-                  aria-label="expanded"
+                  aria-hidden="true"
+                  aria-label="right"
                   class="anticon anticon-right ant-collapse-arrow"
                   role="img"
                 >

--- a/components/collapse/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/collapse/__tests__/__snapshots__/demo.test.ts.snap
@@ -443,8 +443,7 @@ exports[`renders components/collapse/demo/collapsible.tsx correctly 1`] = `
             tabindex="0"
           >
             <span
-              aria-hidden="true"
-              aria-label="right"
+              aria-label="expanded"
               class="anticon anticon-right ant-collapse-arrow"
               role="img"
             >
@@ -510,8 +509,7 @@ exports[`renders components/collapse/demo/collapsible.tsx correctly 1`] = `
             tabindex="0"
           >
             <span
-              aria-hidden="true"
-              aria-label="right"
+              aria-label="expanded"
               class="anticon anticon-right ant-collapse-arrow"
               role="img"
             >

--- a/components/collapse/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/collapse/__tests__/__snapshots__/demo.test.ts.snap
@@ -19,7 +19,8 @@ exports[`renders components/collapse/demo/accordion.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -59,7 +60,8 @@ exports[`renders components/collapse/demo/accordion.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -99,7 +101,8 @@ exports[`renders components/collapse/demo/accordion.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -146,7 +149,8 @@ exports[`renders components/collapse/demo/basic.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -200,7 +204,8 @@ exports[`renders components/collapse/demo/basic.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -240,7 +245,8 @@ exports[`renders components/collapse/demo/basic.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -287,7 +293,8 @@ exports[`renders components/collapse/demo/borderless.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -341,7 +348,8 @@ exports[`renders components/collapse/demo/borderless.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -381,7 +389,8 @@ exports[`renders components/collapse/demo/borderless.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -434,7 +443,8 @@ exports[`renders components/collapse/demo/collapsible.tsx correctly 1`] = `
             tabindex="0"
           >
             <span
-              aria-label="expanded"
+              aria-hidden="true"
+              aria-label="right"
               class="anticon anticon-right ant-collapse-arrow"
               role="img"
             >
@@ -500,7 +510,8 @@ exports[`renders components/collapse/demo/collapsible.tsx correctly 1`] = `
             tabindex="0"
           >
             <span
-              aria-label="expanded"
+              aria-hidden="true"
+              aria-label="right"
               class="anticon anticon-right ant-collapse-arrow"
               role="img"
             >
@@ -562,7 +573,8 @@ exports[`renders components/collapse/demo/collapsible.tsx correctly 1`] = `
             class="ant-collapse-expand-icon"
           >
             <span
-              aria-label="collapsed"
+              aria-hidden="true"
+              aria-label="right"
               class="anticon anticon-right ant-collapse-arrow"
               role="img"
             >
@@ -611,7 +623,8 @@ exports[`renders components/collapse/demo/component-token.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -651,7 +664,8 @@ exports[`renders components/collapse/demo/component-token.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -691,7 +705,8 @@ exports[`renders components/collapse/demo/component-token.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -884,7 +899,8 @@ Array [
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="expanded"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -962,7 +978,8 @@ Array [
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1026,7 +1043,8 @@ Array [
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1148,7 +1166,8 @@ exports[`renders components/collapse/demo/ghost.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1202,7 +1221,8 @@ exports[`renders components/collapse/demo/ghost.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1242,7 +1262,8 @@ exports[`renders components/collapse/demo/ghost.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1289,7 +1310,8 @@ exports[`renders components/collapse/demo/icon.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1362,7 +1384,8 @@ exports[`renders components/collapse/demo/icon.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1425,7 +1448,8 @@ exports[`renders components/collapse/demo/mix.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1465,7 +1489,8 @@ exports[`renders components/collapse/demo/mix.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1505,7 +1530,8 @@ exports[`renders components/collapse/demo/mix.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1552,7 +1578,8 @@ exports[`renders components/collapse/demo/noarrow.tsx correctly 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -1647,7 +1674,8 @@ Array [
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1707,7 +1735,8 @@ Array [
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1767,7 +1796,8 @@ Array [
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1820,7 +1850,8 @@ exports[`renders components/collapse/demo/style-class.tsx correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="expanded"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1873,7 +1904,8 @@ exports[`renders components/collapse/demo/style-class.tsx correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1914,7 +1946,8 @@ exports[`renders components/collapse/demo/style-class.tsx correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -1960,7 +1993,8 @@ exports[`renders components/collapse/demo/style-class.tsx correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -2001,7 +2035,8 @@ exports[`renders components/collapse/demo/style-class.tsx correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="expanded"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >
@@ -2054,7 +2089,8 @@ exports[`renders components/collapse/demo/style-class.tsx correctly 1`] = `
           class="ant-collapse-expand-icon"
         >
           <span
-            aria-label="collapsed"
+            aria-hidden="true"
+            aria-label="right"
             class="anticon anticon-right ant-collapse-arrow"
             role="img"
           >

--- a/components/collapse/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/collapse/__tests__/__snapshots__/index.test.tsx.snap
@@ -18,7 +18,8 @@ exports[`Collapse Collapse.Panel usage 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -58,7 +59,8 @@ exports[`Collapse Collapse.Panel usage 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -105,7 +107,8 @@ exports[`Collapse could override default openMotion 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="expanded"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -192,7 +195,8 @@ exports[`Collapse should render extra node of panel 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -241,7 +245,8 @@ exports[`Collapse should render extra node of panel 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >

--- a/components/collapse/__tests__/__snapshots__/vitest/accessibility.test.tsx.snap
+++ b/components/collapse/__tests__/__snapshots__/vitest/accessibility.test.tsx.snap
@@ -1,0 +1,57 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Collapse accessibility > hides the default expand icon and exposes state on the header 1`] = `
+<div
+  class="ant-collapse ant-collapse-icon-placement-start css-var-root"
+>
+  <div
+    class="ant-collapse-item ant-collapse-item-active"
+  >
+    <div
+      aria-disabled="false"
+      aria-expanded="true"
+      class="ant-collapse-header"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="ant-collapse-expand-icon"
+      >
+        <span
+          aria-hidden="true"
+          aria-label="right"
+          class="anticon anticon-right ant-collapse-arrow"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            style="transform: rotate(90deg);"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="ant-collapse-title"
+      >
+        Header
+      </span>
+    </div>
+    <div
+      class="ant-collapse-panel ant-collapse-panel-active"
+    >
+      <div
+        class="ant-collapse-body"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/components/collapse/__tests__/accessibility.test.tsx
+++ b/components/collapse/__tests__/accessibility.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Collapse from '..';
+
+describe('Collapse accessibility', () => {
+  it('hides the default expand icon and exposes state on the header', () => {
+    const items = [{ key: '1', label: 'Header' }];
+    const { container, rerender } = render(<Collapse activeKey="1" items={items} />);
+    const header = container.querySelector('.ant-collapse-header');
+    const icon = container.querySelector('.ant-collapse-arrow');
+
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+
+    rerender(<Collapse items={items} />);
+
+    expect(header).toHaveAttribute('aria-expanded', 'false');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('preserves the accessible name of a custom expand icon', () => {
+    const { getByRole } = render(
+      <Collapse
+        expandIcon={() => <span role="img" aria-label="Custom status" />}
+        items={[{ key: '1', label: 'Header' }]}
+      />,
+    );
+
+    expect(getByRole('img', { name: 'Custom status' })).toBeInTheDocument();
+  });
+});

--- a/components/collapse/__tests__/accessibility.test.tsx
+++ b/components/collapse/__tests__/accessibility.test.tsx
@@ -12,6 +12,7 @@ describe('Collapse accessibility', () => {
 
     expect(header).toHaveAttribute('aria-expanded', 'true');
     expect(icon).toHaveAttribute('aria-hidden', 'true');
+    expect(container.firstChild).toMatchSnapshot();
 
     rerender(<Collapse items={items} />);
 

--- a/components/collapse/__tests__/accessibility.test.tsx
+++ b/components/collapse/__tests__/accessibility.test.tsx
@@ -30,4 +30,26 @@ describe('Collapse accessibility', () => {
 
     expect(getByRole('img', { name: 'Custom status' })).toBeInTheDocument();
   });
+
+  it.each(['header', 'icon'] as const)(
+    'keeps a state name when the default icon is interactive for collapsible="%s"',
+    (collapsible) => {
+      const items = [{ key: '1', label: 'Header' }];
+      const { container, rerender } = render(
+        <Collapse activeKey="1" collapsible={collapsible} items={items} />,
+      );
+      const iconControl = container.querySelector('.ant-collapse-expand-icon');
+      const icon = container.querySelector('.ant-collapse-arrow');
+
+      expect(iconControl).toHaveAccessibleName('expanded');
+      expect(icon).toHaveAttribute('aria-label', 'expanded');
+      expect(icon).not.toHaveAttribute('aria-hidden');
+
+      rerender(<Collapse collapsible={collapsible} items={items} />);
+
+      expect(iconControl).toHaveAccessibleName('collapsed');
+      expect(icon).toHaveAttribute('aria-label', 'collapsed');
+      expect(icon).not.toHaveAttribute('aria-hidden');
+    },
+  );
 });

--- a/components/collapse/__tests__/index.test.tsx
+++ b/components/collapse/__tests__/index.test.tsx
@@ -213,30 +213,6 @@ describe('Collapse', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('Check expandIcon aria-label value', () => {
-    const { container, rerender } = render(
-      <Collapse activeKey="1">
-        <Collapse.Panel header="header" key="1" />
-      </Collapse>,
-    );
-
-    expect(container.querySelector('.ant-collapse-arrow')).toHaveAttribute(
-      'aria-label',
-      'expanded',
-    );
-
-    rerender(
-      <Collapse>
-        <Collapse.Panel header="header" key="1" />
-      </Collapse>,
-    );
-
-    expect(container.querySelector('.ant-collapse-arrow')).toHaveAttribute(
-      'aria-label',
-      'collapsed',
-    );
-  });
-
   it('should support borderlessContentBg component token', () => {
     const { container } = render(
       <ConfigProvider

--- a/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5110,7 +5110,8 @@ exports[`renders components/color-picker/demo/panel-render.tsx extend context co
                               class="ant-collapse-expand-icon"
                             >
                               <span
-                                aria-label="expanded"
+                                aria-hidden="true"
+                                aria-label="right"
                                 class="anticon anticon-right ant-collapse-arrow"
                                 role="img"
                               >
@@ -5247,7 +5248,8 @@ exports[`renders components/color-picker/demo/panel-render.tsx extend context co
                               class="ant-collapse-expand-icon"
                             >
                               <span
-                                aria-label="expanded"
+                                aria-hidden="true"
+                                aria-label="right"
                                 class="anticon anticon-right ant-collapse-arrow"
                                 role="img"
                               >
@@ -5384,7 +5386,8 @@ exports[`renders components/color-picker/demo/panel-render.tsx extend context co
                               class="ant-collapse-expand-icon"
                             >
                               <span
-                                aria-label="expanded"
+                                aria-hidden="true"
+                                aria-label="right"
                                 class="anticon anticon-right ant-collapse-arrow"
                                 role="img"
                               >
@@ -5521,7 +5524,8 @@ exports[`renders components/color-picker/demo/panel-render.tsx extend context co
                               class="ant-collapse-expand-icon"
                             >
                               <span
-                                aria-label="expanded"
+                                aria-hidden="true"
+                                aria-label="right"
                                 class="anticon anticon-right ant-collapse-arrow"
                                 role="img"
                               >
@@ -6377,7 +6381,8 @@ Array [
                       class="ant-collapse-expand-icon"
                     >
                       <span
-                        aria-label="expanded"
+                        aria-hidden="true"
+                        aria-label="right"
                         class="anticon anticon-right ant-collapse-arrow"
                         role="img"
                       >
@@ -6514,7 +6519,8 @@ Array [
                       class="ant-collapse-expand-icon"
                     >
                       <span
-                        aria-label="expanded"
+                        aria-hidden="true"
+                        aria-label="right"
                         class="anticon anticon-right ant-collapse-arrow"
                         role="img"
                       >
@@ -6651,7 +6657,8 @@ Array [
                       class="ant-collapse-expand-icon"
                     >
                       <span
-                        aria-label="expanded"
+                        aria-hidden="true"
+                        aria-label="right"
                         class="anticon anticon-right ant-collapse-arrow"
                         role="img"
                       >

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -11742,7 +11742,8 @@ exports[`ConfigProvider components Collapse configProvider 1`] = `
         class="config-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right config-collapse-arrow"
           role="img"
         >
@@ -11789,7 +11790,8 @@ exports[`ConfigProvider components Collapse configProvider componentDisabled 1`]
         class="config-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right config-collapse-arrow"
           role="img"
         >
@@ -11836,7 +11838,8 @@ exports[`ConfigProvider components Collapse configProvider componentSize large 1
         class="config-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right config-collapse-arrow"
           role="img"
         >
@@ -11883,7 +11886,8 @@ exports[`ConfigProvider components Collapse configProvider componentSize medium 
         class="config-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right config-collapse-arrow"
           role="img"
         >
@@ -11930,7 +11934,8 @@ exports[`ConfigProvider components Collapse configProvider componentSize small 1
         class="config-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right config-collapse-arrow"
           role="img"
         >
@@ -11977,7 +11982,8 @@ exports[`ConfigProvider components Collapse normal 1`] = `
         class="ant-collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right ant-collapse-arrow"
           role="img"
         >
@@ -12024,7 +12030,8 @@ exports[`ConfigProvider components Collapse prefixCls 1`] = `
         class="prefix-Collapse-expand-icon"
       >
         <span
-          aria-label="collapsed"
+          aria-hidden="true"
+          aria-label="right"
           class="anticon anticon-right prefix-Collapse-arrow"
           role="img"
         >


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

N/A. I searched the current open issues and pull requests and found no duplicate or target-file overlap.

### 💡 Background and Solution

Collapse headers already expose their expanded state through `aria-expanded`, but the decorative default arrow also announced the hardcoded English labels `expanded` and `collapsed`. In the normal whole-header interaction mode this duplicated the state and leaked English into screen readers under every non-English locale.

This change marks the default arrow as decorative only when it is not the interactive trigger. For `collapsible="header"` and `collapsible="icon"`, rc-collapse turns the icon wrapper into an actual button, so the arrow retains its existing state name to keep that control accessible. Custom `expandIcon` nodes remain untouched, so consumers can continue to provide their own semantics. No public API or locale contract changes are introduced.

Validation:

- Related Jest suites, including the official Collapse axe suite: 8 suites passed; 460 tests passed, 1 skipped; 455 snapshots passed.
- Focused Jest and Vitest accessibility tests: 4/4 passed in each runner.
- `npm run compileOnly` passed.
- Target ESLint, Biome, and `git diff --check` passed.

AI assistance disclosure: Codex traced the accessibility tree, implemented the focused change and regression tests, updated the affected snapshots, investigated the initial CI accessibility failure for interactive icon modes, and ran the validation above. The behavior and results are directly verifiable from this pull request.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Collapse no longer exposes redundant English state labels from decorative default expand icons, while interactive icon triggers retain an accessible name. |
| 🇨🇳 Chinese | Collapse 的装饰性默认展开图标不再向屏幕阅读器重复朗读英文状态，同时可交互的图标触发器仍保留可访问名称。 |
