### PR TITLE
docs: improve complex Form label association

### DIFF
--- a/components/form/__tests__/__snapshots__/complex-form-control.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/complex-form-control.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Form complex control demo associates the Username label with its nested control 1`] = `
+<input
+  aria-required="true"
+  class="ant-input ant-input-outlined css-var-root ant-input-css-var"
+  id="username"
+  placeholder="Please input"
+  style="width: 160px;"
+  type="text"
+  value=""
+/>
+`;

--- a/components/form/__tests__/__snapshots__/vitest/complex-form-control.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/vitest/complex-form-control.test.tsx.snap
@@ -1,0 +1,13 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Form complex control demo > associates the Username label with its nested control 1`] = `
+<input
+  aria-required="true"
+  class="ant-input ant-input-outlined css-var-root ant-input-css-var"
+  id="username"
+  placeholder="Please input"
+  style="width: 160px;"
+  type="text"
+  value=""
+/>
+`;

--- a/components/form/__tests__/complex-form-control.test.tsx
+++ b/components/form/__tests__/complex-form-control.test.tsx
@@ -7,6 +7,9 @@ describe('Form complex control demo', () => {
   it('associates the Username label with its nested control', () => {
     render(<ComplexFormControl />);
 
-    expect(screen.getByLabelText('Username')).toHaveAttribute('id', 'username');
+    const usernameInput = screen.getByLabelText('Username');
+
+    expect(usernameInput).toHaveAttribute('id', 'username');
+    expect(usernameInput).toMatchSnapshot();
   });
 });

--- a/components/form/__tests__/complex-form-control.test.tsx
+++ b/components/form/__tests__/complex-form-control.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { render, screen } from '../../../tests/utils';
+import ComplexFormControl from '../demo/complex-form-control';
+
+describe('Form complex control demo', () => {
+  it('associates the Username label with its nested control', () => {
+    render(<ComplexFormControl />);
+
+    expect(screen.getByLabelText('Username')).toHaveAttribute('id', 'username');
+  });
+});

--- a/components/form/demo/complex-form-control.md
+++ b/components/form/demo/complex-form-control.md
@@ -7,7 +7,8 @@
 -   <Input />
 - </Form.Item>
 + <Form.Item label="Field" htmlFor="field">
-+   <Form.Item name="field" noStyle><Input id="field" /></Form.Item> // 直接包裹才会绑定表单
++   <Form.Item name="field" noStyle><Input id="field" /></Form.Item>
++   {/* 直接包裹才会绑定表单 */}
 +   <span>description</span>
 + </Form.Item>
 ```
@@ -33,7 +34,8 @@ This demo shows how to use `Form.Item` with multiple controls. `<Form.Item name=
 -   <Input />
 - </Form.Item>
 + <Form.Item label="Field" htmlFor="field">
-+   <Form.Item name="field" noStyle><Input id="field" /></Form.Item> // that will bind input
++   <Form.Item name="field" noStyle><Input id="field" /></Form.Item>
++   {/* The nested item binds the input. */}
 +   <span>description</span>
 + </Form.Item>
 ```

--- a/components/form/demo/complex-form-control.md
+++ b/components/form/demo/complex-form-control.md
@@ -6,11 +6,13 @@
 - <Form.Item label="Field" name="field">
 -   <Input />
 - </Form.Item>
-+ <Form.Item label="Field">
-+   <Form.Item name="field" noStyle><Input /></Form.Item> // 直接包裹才会绑定表单
++ <Form.Item label="Field" htmlFor="field">
++   <Form.Item name="field" noStyle><Input id="field" /></Form.Item> // 直接包裹才会绑定表单
 +   <span>description</span>
 + </Form.Item>
 ```
+
+当带有 `label` 的外层 `Form.Item` 没有 `name` 时，它无法自动推断内层控件的 ID。如果该标签对应一个控件，请为外层设置 `htmlFor`，并为内层控件设置相同的 `id`，以保留点击标签聚焦和屏幕阅读器关联。
 
 这里展示了三种典型场景：
 
@@ -30,11 +32,13 @@ This demo shows how to use `Form.Item` with multiple controls. `<Form.Item name=
 - <Form.Item label="Field" name="field">
 -   <Input />
 - </Form.Item>
-+ <Form.Item label="Field">
-+   <Form.Item name="field" noStyle><Input /></Form.Item> // that will bind input
++ <Form.Item label="Field" htmlFor="field">
++   <Form.Item name="field" noStyle><Input id="field" /></Form.Item> // that will bind input
 +   <span>description</span>
 + </Form.Item>
 ```
+
+When the outer labeled `Form.Item` has no `name`, it cannot infer the nested control's ID. If the label describes a single control, set `htmlFor` on the outer item and the same `id` on the nested control to preserve label-click focus and screen reader association.
 
 This demo shows three typical usages:
 

--- a/components/form/demo/complex-form-control.tsx
+++ b/components/form/demo/complex-form-control.tsx
@@ -13,14 +13,14 @@ const App: React.FC = () => (
     wrapperCol={{ span: 16 }}
     style={{ maxWidth: 600 }}
   >
-    <Form.Item label="Username">
+    <Form.Item label="Username" htmlFor="username">
       <Space>
         <Form.Item
           name="username"
           noStyle
           rules={[{ required: true, message: 'Username is required' }]}
         >
-          <Input style={{ width: 160 }} placeholder="Please input" />
+          <Input id="username" style={{ width: 160 }} placeholder="Please input" />
         </Form.Item>
         <Tooltip title="Useful information">
           <Typography.Link href="#API">Need Help?</Typography.Link>


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Closes #53431

### 💡 Background and Solution

The official complex form control demo uses a layout-only outer `Form.Item` with a label and a nested named item. Because the outer item has no `name`, it cannot infer the nested control ID, so its label is not associated with the Username input. Clicking the label does not focus the field, and assistive technology cannot obtain the Username label from the native label/control relationship.

This PR:

- gives the outer Username item `htmlFor="username"` and the nested input the matching `id`;
- documents the explicit `htmlFor`/`id` pairing in both English and Chinese when a layout-only item labels one nested control;
- adds a focused regression test that resolves the Username input through its label.

The multi-control Address and BirthDate examples are left unchanged because one label should not be attached to multiple controls.

### ✅ Verification

- Jest: `components/form/__tests__/complex-form-control.test.tsx` (1/1)
- Vitest: `components/form/__tests__/complex-form-control.test.tsx` (1/1)
- `npm run compileOnly`
- Dumi production build completed and emitted the updated English and Chinese Form pages
- ESLint, Biome, Prettier, Remark, and `git diff --check`

`npm run tsc` still reports the pre-existing unrelated `FullToken.antCls` errors in Table demos and a Puppeteer type-version mismatch in `tests/shared/imageTest.tsx`; none of the changed Form files reports a TypeScript error.

AI assistance disclosure: Codex was used to trace the Form label/field ID flow, audit open pull request file overlap, draft the focused changes, and run the verification commands. The behavior and test results above are directly reproducible from this branch.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | ⌨️ Improve Form complex-control documentation so a label can be explicitly associated with its nested control. |
| 🇨🇳 Chinese | ⌨️ 改进 Form 复杂控件文档，支持将标签明确关联到内层控件。 |
