### PR TITLE
fix(Upload): forward focus events

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -55,6 +55,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
     onDownload,
     onChange,
     onDrop,
+    onFocus,
     previewFile,
     disabled: customDisabled,
     locale: propLocale,
@@ -395,6 +396,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
   } as any;
 
   delete rcUploadProps.className;
+  delete rcUploadProps.onFocus;
   delete rcUploadProps.style;
 
   // Remove id to avoid open by label when trigger is hidden
@@ -491,7 +493,7 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
     );
 
     return (
-      <span className={mergedRootCls} ref={wrapRef} style={mergedRootStyle}>
+      <span className={mergedRootCls} ref={wrapRef} style={mergedRootStyle} onFocus={onFocus}>
         <div
           className={dragCls}
           style={mergedStyles.trigger}
@@ -526,14 +528,14 @@ const InternalUpload: React.ForwardRefRenderFunction<UploadRef, UploadProps> = (
 
   if (listType === 'picture-card' || listType === 'picture-circle') {
     return (
-      <span className={mergedRootCls} ref={wrapRef} style={mergedRootStyle}>
+      <span className={mergedRootCls} ref={wrapRef} style={mergedRootStyle} onFocus={onFocus}>
         {renderUploadList(uploadButton, !!children)}
       </span>
     );
   }
 
   return (
-    <span className={mergedRootCls} ref={wrapRef} style={mergedRootStyle}>
+    <span className={mergedRootCls} ref={wrapRef} style={mergedRootStyle} onFocus={onFocus}>
       {uploadButton}
       {renderUploadList()}
     </span>

--- a/components/upload/__tests__/accessibility.test.tsx
+++ b/components/upload/__tests__/accessibility.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import type { UploadProps } from '..';
 import Upload from '..';
-import { render, screen } from '../../../tests/utils';
+import { fireEvent, render, screen } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
 import zhTW from '../../locale/zh_TW';
 
@@ -16,6 +16,24 @@ const fileList: UploadProps['fileList'] = [
 ];
 
 describe('Upload accessibility', () => {
+  it.each<[string, Pick<UploadProps, 'type' | 'listType'>]>([
+    ['select', {}],
+    ['drag', { type: 'drag' }],
+    ['picture-card', { listType: 'picture-card' }],
+  ])('forwards focus events from the %s layout', (_, uploadProps) => {
+    const onFocus = jest.fn();
+
+    render(
+      <Upload {...uploadProps} onFocus={onFocus}>
+        <button type="button">Upload trigger</button>
+      </Upload>,
+    );
+
+    fireEvent.focus(screen.getByRole('button', { name: 'Upload trigger' }));
+
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
   it('uses the merged locale for default file actions', () => {
     render(
       <Upload

--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -80,6 +80,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | onChange | A callback function, can be executed when uploading state is changing. It will trigger by every uploading phase. see [onChange](#onchange) | function | - |  | × |
 | onDrop | A callback function executed when files are dragged and dropped into the upload area | (event: React.DragEvent) => void | - | 4.16.0 | × |
 | onDownload | Click the method to download the file, pass the method to perform the method logic, and do not pass the default jump to the new TAB | function(file): void | (Jump to new TAB) |  | × |
+| onFocus | Called when focus enters the Upload component | (event: React.FocusEvent&lt;HTMLSpanElement>) => void | - | 6.7.0 | × |
 | onPreview | A callback function, will be executed when the file link or preview icon is clicked | function(file) | - |  | × |
 | onRemove | A callback function, will be executed when removing file button is clicked, remove event will be prevented when the return value is false or a Promise which resolve(false) or reject | function(file): boolean \| Promise | - |  | × |
 

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -81,6 +81,7 @@ demo:
 | onChange | 上传文件改变时的回调，上传每个阶段都会触发该事件。详见 [onChange](#onchange) | function | - |  | × |
 | onDrop | 当文件被拖入上传区域时执行的回调功能 | (event: React.DragEvent) => void | - | 4.16.0 | × |
 | onDownload | 点击下载文件时的回调，如果没有指定，则默认跳转到文件 url 对应的标签页 | function(file): void | (跳转新标签页) |  | × |
+| onFocus | 焦点进入 Upload 组件时的回调 | (event: React.FocusEvent&lt;HTMLSpanElement>) => void | - | 6.7.0 | × |
 | onPreview | 点击文件链接或预览图标时的回调 | function(file) | - |  | × |
 | onRemove | 点击移除文件时的回调，返回值为 false 时不移除。支持返回一个 Promise 对象，Promise 对象 resolve(false) 或 reject 时不移除 | function(file): boolean \| Promise | - |  | × |
 

--- a/components/upload/interface.ts
+++ b/components/upload/interface.ts
@@ -105,8 +105,10 @@ export type UploadSemanticType = {
 
 export type UploadSemanticAllType<T = any> = GenerateSemantic<UploadSemanticType, UploadProps<T>>;
 
-export interface UploadProps<T = any>
-  extends Pick<RcUploadProps, 'capture' | 'hasControlInside' | 'pastable'> {
+export interface UploadProps<T = any> extends Pick<
+  RcUploadProps,
+  'capture' | 'hasControlInside' | 'pastable'
+> {
   type?: UploadType;
   name?: string;
   defaultFileList?: Array<UploadFile<T>>;
@@ -127,6 +129,7 @@ export interface UploadProps<T = any>
   ) => BeforeUploadValueType | Promise<BeforeUploadValueType>;
   onChange?: (info: UploadChangeParam<UploadFile<T>>) => void;
   onDrop?: (event: React.DragEvent<HTMLDivElement>) => void;
+  onFocus?: React.FocusEventHandler<HTMLSpanElement>;
   listType?: UploadListType;
   className?: string;
   classNames?: UploadSemanticAllType<T>['classNamesAndFn'];


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- Closes #16807.

### 💡 Background and Solution

`Upload` accepts arbitrary props at runtime, but its public type does not expose `onFocus` and none of its outer root wrappers receive the event. Focus entering the default trigger or a custom focusable child therefore cannot be observed through the Upload component.

This change:

- adds `onFocus?: React.FocusEventHandler<HTMLSpanElement>` to `UploadProps`;
- forwards it from the semantic root in select, drag, picture-card, and picture-circle render paths;
- removes `onFocus` from the props passed to `rc-upload`, keeping the callback at one component boundary and preventing duplicate calls if the dependency later forwards it;
- documents the API in English and Chinese;
- adds the same regression assertion across the three distinct root render paths.

Validation:

- `npm test -- components/upload/__tests__ --runInBand` — 10 suites, 215 passed, 3 skipped, 77 snapshots passed;
- `npm run test:vitest -- components/upload/__tests__/accessibility.test.tsx --maxWorkers=1` — 6 passed;
- `npm run compileOnly`;
- target Prettier, ESLint, Biome, Remark, and `git diff --check`.

A full local `npm run tsc` reached only existing master errors in Table demos and `tests/shared/imageTest.tsx`; no changed Upload file reported a type error.

Duplicate check: #58814 and #57334 have unrelated file-level overlap in `Upload.tsx` and `upload.test.tsx` for async removal and ConfigProvider state. This PR does not touch their target logic or test sections. I found no open PR for `onFocus` or #16807.

AI assistance disclosure: Codex was used to trace the current event path, draft the focused implementation and tests, and run the validation above. The behavior and command results are directly reproducible from this diff.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Upload so the `onFocus` callback runs when focus enters select, drag, and picture-card layouts. |
| 🇨🇳 Chinese | 🐞 修复 Upload 在焦点进入选择、拖拽和卡片布局时未触发 `onFocus` 回调的问题。 |