### PR TITLE
feat(InputNumber): support allowClear

### DIFF
--- a/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -892,6 +892,213 @@ exports[`renders components/input-number/demo/addon.tsx extend context correctly
 ]
 `;
 
+exports[`renders components/input-number/demo/allow-clear.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+  >
+    <input
+      aria-valuenow="123"
+      autocomplete="off"
+      class="ant-input-number-input"
+      role="spinbutton"
+      step="1"
+      value="123"
+    />
+    <div
+      class="ant-input-number-suffix"
+    >
+      <button
+        class="ant-input-number-clear-icon"
+        type="button"
+      >
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-input-number-actions"
+    >
+      <span
+        aria-disabled="false"
+        aria-label="Increase Value"
+        class="ant-input-number-action ant-input-number-action-up"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="up"
+          class="anticon anticon-up"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="up"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span
+        aria-disabled="false"
+        aria-label="Decrease Value"
+        class="ant-input-number-action ant-input-number-action-down"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+  >
+    <input
+      aria-valuenow="456"
+      autocomplete="off"
+      class="ant-input-number-input"
+      role="spinbutton"
+      step="1"
+      value="456"
+    />
+    <div
+      class="ant-input-number-suffix"
+    >
+      <button
+        class="ant-input-number-clear-icon"
+        type="button"
+      >
+        <span
+          aria-label="close"
+          class="anticon anticon-close"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-input-number-actions"
+    >
+      <span
+        aria-disabled="false"
+        aria-label="Increase Value"
+        class="ant-input-number-action ant-input-number-action-up"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="up"
+          class="anticon anticon-up"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="up"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span
+        aria-disabled="false"
+        aria-label="Decrease Value"
+        class="ant-input-number-action ant-input-number-action-down"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/input-number/demo/allow-clear.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/input-number/demo/basic.tsx extend context correctly 1`] = `
 <div
   class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"

--- a/components/input-number/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/input-number/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -34,6 +34,31 @@ exports[`renders components/input-number/demo/_semantic.tsx correctly 1`] = `
             class="ant-input-number-suffix semantic-mark-suffix"
             style="margin-inline-end: 28px;"
           >
+            <button
+              class="ant-input-number-clear-icon semantic-mark-clear ant-input-number-clear-icon-has-suffix"
+              type="button"
+            >
+              <span
+                aria-label="close-circle"
+                class="anticon anticon-close-circle"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="close-circle"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                  />
+                </svg>
+              </span>
+            </button>
             RMB
           </div>
           <div
@@ -729,6 +754,99 @@ exports[`renders components/input-number/demo/_semantic.tsx correctly 1`] = `
               style="margin: 0px; font-size: 12px;"
             >
               单个操作按钮元素，设置按钮的样式、悬浮效果和点击交互
+            </div>
+          </div>
+        </li>
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
+                  clear
+                </h5>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              清除按钮元素，设置清除数值的交互样式
             </div>
           </div>
         </li>

--- a/components/input-number/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input-number/__tests__/__snapshots__/demo.test.tsx.snap
@@ -608,6 +608,211 @@ exports[`renders components/input-number/demo/addon.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/input-number/demo/allow-clear.tsx correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-middle ant-flex-vertical"
+>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+  >
+    <input
+      aria-valuenow="123"
+      autocomplete="off"
+      class="ant-input-number-input"
+      role="spinbutton"
+      step="1"
+      value="123"
+    />
+    <div
+      class="ant-input-number-suffix"
+    >
+      <button
+        class="ant-input-number-clear-icon"
+        type="button"
+      >
+        <span
+          aria-label="close-circle"
+          class="anticon anticon-close-circle"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close-circle"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-input-number-actions"
+    >
+      <span
+        aria-disabled="false"
+        aria-label="Increase Value"
+        class="ant-input-number-action ant-input-number-action-up"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="up"
+          class="anticon anticon-up"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="up"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span
+        aria-disabled="false"
+        aria-label="Decrease Value"
+        class="ant-input-number-action ant-input-number-action-down"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+  >
+    <input
+      aria-valuenow="456"
+      autocomplete="off"
+      class="ant-input-number-input"
+      role="spinbutton"
+      step="1"
+      value="456"
+    />
+    <div
+      class="ant-input-number-suffix"
+    >
+      <button
+        class="ant-input-number-clear-icon"
+        type="button"
+      >
+        <span
+          aria-label="close"
+          class="anticon anticon-close"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="close"
+            fill="currentColor"
+            fill-rule="evenodd"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-input-number-actions"
+    >
+      <span
+        aria-disabled="false"
+        aria-label="Increase Value"
+        class="ant-input-number-action ant-input-number-action-up"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="up"
+          class="anticon anticon-up"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="up"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+      <span
+        aria-disabled="false"
+        aria-label="Decrease Value"
+        class="ant-input-number-action ant-input-number-action-down"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="down"
+          class="anticon anticon-down"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="down"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/input-number/demo/basic.tsx correctly 1`] = `
 <div
   class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"

--- a/components/input-number/__tests__/allow-clear.test.tsx
+++ b/components/input-number/__tests__/allow-clear.test.tsx
@@ -40,6 +40,29 @@ describe('InputNumber allowClear', () => {
     expect(onChange).toHaveBeenLastCalledWith(null);
   });
 
+  it('preserves an uncontrolled default value when allowClear is disabled at runtime', () => {
+    const { container, rerender } = render(<InputNumber allowClear defaultValue={123} />);
+    const input = container.querySelector('input')!;
+
+    rerender(<InputNumber allowClear={false} defaultValue={123} />);
+
+    expect(input).toHaveValue('123');
+    expect(container.querySelector('.ant-input-number-clear-icon')).not.toBeInTheDocument();
+  });
+
+  it('preserves an edited uncontrolled value when allowClear is disabled at runtime', () => {
+    const { container, rerender } = render(<InputNumber allowClear defaultValue={123} />);
+    const input = container.querySelector('input')!;
+
+    fireEvent.change(input, { target: { value: '456' } });
+    expect(input).toHaveValue('456');
+
+    rerender(<InputNumber allowClear={false} defaultValue={123} />);
+
+    expect(input).toHaveValue('456');
+    expect(container.querySelector('.ant-input-number-clear-icon')).not.toBeInTheDocument();
+  });
+
   it('keeps a controlled value when the owner does not update it', () => {
     const onChange = jest.fn();
     const { container } = render(<InputNumber allowClear value={7} onChange={onChange} />);

--- a/components/input-number/__tests__/allow-clear.test.tsx
+++ b/components/input-number/__tests__/allow-clear.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+
+import InputNumber from '..';
+import { fireEvent, render } from '../../../tests/utils';
+
+describe('InputNumber allowClear', () => {
+  it('clears an uncontrolled value and emits both callbacks', () => {
+    const onChange = jest.fn();
+    const onClear = jest.fn();
+    const { container } = render(
+      <InputNumber allowClear defaultValue={123} onChange={onChange} onClear={onClear} />,
+      { container: document.body },
+    );
+    const input = container.querySelector('input')!;
+    const clearButton = container.querySelector<HTMLButtonElement>('.ant-input-number-clear-icon')!;
+
+    fireEvent.click(clearButton);
+
+    expect(input).toHaveValue('');
+    expect(onChange).toHaveBeenLastCalledWith(null);
+    expect(onClear).toHaveBeenCalledTimes(1);
+    expect(clearButton).toHaveClass('ant-input-number-clear-icon-hidden');
+    expect(input).toHaveFocus();
+  });
+
+  it('clears a value entered into an uncontrolled input', () => {
+    const onChange = jest.fn();
+    const { container } = render(<InputNumber allowClear onChange={onChange} />);
+    const input = container.querySelector('input')!;
+    const clearButton = container.querySelector<HTMLButtonElement>('.ant-input-number-clear-icon')!;
+
+    expect(clearButton).toHaveClass('ant-input-number-clear-icon-hidden');
+
+    fireEvent.change(input, { target: { value: '42' } });
+    expect(input).toHaveValue('42');
+    expect(clearButton).not.toHaveClass('ant-input-number-clear-icon-hidden');
+
+    fireEvent.click(clearButton);
+    expect(input).toHaveValue('');
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('keeps a controlled value when the owner does not update it', () => {
+    const onChange = jest.fn();
+    const { container } = render(<InputNumber allowClear value={7} onChange={onChange} />);
+    const input = container.querySelector('input')!;
+    const clearButton = container.querySelector<HTMLButtonElement>('.ant-input-number-clear-icon')!;
+
+    fireEvent.click(clearButton);
+
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(input).toHaveValue('7');
+    expect(clearButton).not.toHaveClass('ant-input-number-clear-icon-hidden');
+  });
+
+  it('clears a controlled value when the owner updates it', () => {
+    const App: React.FC = () => {
+      const [value, setValue] = React.useState<number | null>(7);
+      return <InputNumber allowClear value={value} onChange={setValue} />;
+    };
+    const { container } = render(<App />);
+    const input = container.querySelector('input')!;
+    const clearButton = container.querySelector<HTMLButtonElement>('.ant-input-number-clear-icon')!;
+
+    fireEvent.click(clearButton);
+
+    expect(input).toHaveValue('');
+    expect(clearButton).toHaveClass('ant-input-number-clear-icon-hidden');
+  });
+
+  it('allows zero to be cleared', () => {
+    const onChange = jest.fn();
+    const { container } = render(<InputNumber allowClear defaultValue={0} onChange={onChange} />);
+    const clearButton = container.querySelector<HTMLButtonElement>('.ant-input-number-clear-icon')!;
+
+    expect(clearButton).not.toHaveClass('ant-input-number-clear-icon-hidden');
+    fireEvent.click(clearButton);
+
+    expect(container.querySelector('input')).toHaveValue('');
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('clears stringMode values with null', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <InputNumber stringMode allowClear defaultValue="12345678901234567890" onChange={onChange} />,
+    );
+
+    fireEvent.click(container.querySelector('.ant-input-number-clear-icon')!);
+
+    expect(container.querySelector('input')).toHaveValue('');
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it.each([
+    ['disabled', { disabled: true }],
+    ['readOnly', { readOnly: true }],
+    ['allowClear.disabled', { allowClear: { disabled: true } }],
+  ])('hides the clear button when %s', (_name, extraProps) => {
+    const { container } = render(<InputNumber allowClear defaultValue={123} {...extraProps} />);
+
+    expect(container.querySelector('.ant-input-number-clear-icon')).toHaveClass(
+      'ant-input-number-clear-icon-hidden',
+    );
+  });
+
+  it('supports a custom clear icon alongside a suffix', () => {
+    const { container } = render(
+      <InputNumber
+        allowClear={{ clearIcon: <span data-testid="custom-clear">clear</span> }}
+        defaultValue={123}
+        suffix="USD"
+      />,
+    );
+
+    expect(container.querySelector('[data-testid="custom-clear"]')).toBeInTheDocument();
+    expect(container.querySelector('.ant-input-number-suffix')).toHaveTextContent('clearUSD');
+    expect(container.querySelector('.ant-input-number-clear-icon')).toHaveClass(
+      'ant-input-number-clear-icon-has-suffix',
+    );
+  });
+
+  it('does not blur the input on clear button mouse down', () => {
+    const onBlur = jest.fn();
+    const { container } = render(<InputNumber allowClear defaultValue={123} onBlur={onBlur} />, {
+      container: document.body,
+    });
+    const input = container.querySelector('input')!;
+    const clearButton = container.querySelector('.ant-input-number-clear-icon')!;
+
+    input.focus();
+    fireEvent.mouseDown(clearButton);
+    fireEvent.click(clearButton);
+
+    expect(onBlur).not.toHaveBeenCalled();
+    expect(input).toHaveFocus();
+  });
+});

--- a/components/input-number/__tests__/semantic.test.tsx
+++ b/components/input-number/__tests__/semantic.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
 import InputNumber from '..';
-import { render } from '../../../tests/utils';
-import ConfigProvider from '../../config-provider';
 import {
   expectSemanticRootStylePriority,
   semanticRootStylePriority,
 } from '../../../tests/shared/semanticStylePriority';
+import { render } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
 
 describe('semantic', () => {
   it('should support classNames and styles', () => {
@@ -17,6 +17,7 @@ describe('semantic', () => {
       suffix: 'test-suffix',
       actions: 'test-actions',
       action: 'test-action',
+      clear: 'test-clear',
     };
     const testStyles = {
       root: { color: 'rgb(255, 0, 0)' },
@@ -25,12 +26,15 @@ describe('semantic', () => {
       suffix: { color: 'rgb(0, 255, 0)' },
       actions: { color: 'rgb(255, 255, 0)' },
       action: { color: 'rgb(255, 0, 255)' },
+      clear: { backgroundColor: 'rgb(0, 255, 255)' },
     };
     const { container } = render(
       <InputNumber
         prefix="prefix"
         className="my-class-name"
         suffix={<i>antd</i>}
+        allowClear
+        defaultValue={1}
         styles={testStyles}
         classNames={testClassNames}
       />,
@@ -41,18 +45,21 @@ describe('semantic', () => {
     const suffix = container.querySelector('.ant-input-number-suffix')!;
     const actions = container.querySelector('.ant-input-number-actions')!;
     const action = container.querySelector('.ant-input-number-action')!;
+    const clear = container.querySelector('.ant-input-number-clear-icon')!;
     expect(root.className).toContain(testClassNames.root);
     expect(input.className).toContain(testClassNames.input);
     expect(prefix.className).toContain(testClassNames.prefix);
     expect(suffix.className).toContain(testClassNames.suffix);
     expect(actions.className).toContain(testClassNames.actions);
     expect(action.className).toContain(testClassNames.action);
+    expect(clear.className).toContain(testClassNames.clear);
     expect(root).toHaveStyle(testStyles.root);
     expect(prefix).toHaveStyle(testStyles.prefix);
     expect(input).toHaveStyle(testStyles.input);
     expect(suffix).toHaveStyle(testStyles.suffix);
     expect(actions).toHaveStyle(testStyles.actions);
     expect(action).toHaveStyle(testStyles.action);
+    expect(clear).toHaveStyle(testStyles.clear);
   });
   it('should follow root style priority', () => {
     const { container } = render(

--- a/components/input-number/demo/_semantic.tsx
+++ b/components/input-number/demo/_semantic.tsx
@@ -13,6 +13,7 @@ const locales = {
     suffix: '后缀的包裹元素，设置flex布局、边距和过渡动画样式',
     action: '单个操作按钮元素，设置按钮的样式、悬浮效果和点击交互',
     actions: '操作元素，设置绝对定位、宽度、flex布局和数值调节按钮样式',
+    clear: '清除按钮元素，设置清除数值的交互样式',
   },
   en: {
     root: 'Root element, sets inline-block layout, width, border radius and reset styles',
@@ -23,6 +24,7 @@ const locales = {
       'Single action button element, sets button styling, hover effects and click interactions',
     actions:
       'Actions element, sets absolute positioning, width, flex layout and number adjustment button styles',
+    clear: 'Clear button element, sets the interaction style for clearing the value',
   },
 };
 
@@ -33,6 +35,7 @@ const Block: React.FC<InputNumberProps> = (props) => {
         prefix="￥"
         suffix="RMB"
         defaultValue={100}
+        allowClear
         style={{ width: 200 }}
         styles={{ actions: { opacity: 1, width: 24 }, suffix: { marginInlineEnd: 28 } }}
         {...props}
@@ -60,6 +63,7 @@ const App: React.FC = () => {
         { name: 'suffix', desc: locale.suffix },
         { name: 'actions', desc: locale.actions },
         { name: 'action', desc: locale.action },
+        { name: 'clear', desc: locale.clear },
       ]}
     >
       <Block />

--- a/components/input-number/demo/allow-clear.md
+++ b/components/input-number/demo/allow-clear.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+使用 `allowClear` 显示清除按钮，也可以自定义清除图标。
+
+## en-US
+
+Use `allowClear` to show a clear button, with support for a custom clear icon.

--- a/components/input-number/demo/allow-clear.tsx
+++ b/components/input-number/demo/allow-clear.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { CloseOutlined } from '@ant-design/icons';
+import { Flex, InputNumber } from 'antd';
+
+const App: React.FC = () => (
+  <Flex vertical gap="middle">
+    <InputNumber allowClear defaultValue={123} />
+    <InputNumber allowClear={{ clearIcon: <CloseOutlined /> }} defaultValue={456} />
+  </Flex>
+);
+
+export default App;

--- a/components/input-number/index.en-US.md
+++ b/components/input-number/index.en-US.md
@@ -17,6 +17,7 @@ When a numeric value needs to be provided.
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">Basic</code>
+<code src="./demo/allow-clear.tsx" version="6.7.0">Clear button</code>
 <code src="./demo/size.tsx">Sizes</code>
 <code src="./demo/addon.tsx" debug>Pre / Post tab</code>
 <code src="./demo/disabled.tsx">Disabled</code>
@@ -46,6 +47,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | --- | --- | --- | --- | --- | --- |
 | ~~addonAfter~~ | The label text displayed after (on the right side of) the input field, please use Space.Compact instead | ReactNode | - | 4.17.0 | × |
 | ~~addonBefore~~ | The label text displayed before (on the left side of) the input field, please use Space.Compact instead | ReactNode | - | 4.17.0 | × |
+| allowClear | Whether to show a clear button | boolean \| { clearIcon?: ReactNode, disabled?: boolean } | false | 6.7.0 | × |
 | changeOnBlur | Trigger `onChange` when blur. e.g. reset value in range by blur | boolean | true | 5.11.0 | × |
 | changeOnWheel | Allows control with mouse wheel | boolean | - | 5.14.0 | × |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | 6.0.0 | 6.0.0 |
@@ -72,6 +74,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | value | The current value of the component | number | - | - | × |
 | variant | Variants of Input | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 | 5.19.0 |
 | onChange | The callback triggered when the value is changed | function(value: number \| string \| null) | - | - | × |
+| onClear | Callback when the clear button is clicked | () => void | - | 6.7.0 | × |
 | onPressEnter | The callback function that is triggered when Enter key is pressed | function(e) | - | - | × |
 | onStep | The callback function that is triggered when click up or down buttons / Keyboard / Wheel | (value: number, info: { offset: number, type: 'up' \| 'down', emitter: 'handler' \| 'keydown' \| 'wheel' }) => void | - |  | × |
 | ~~bordered~~ | Whether has border style, please use `variant` instead | boolean | true | - | × |

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -9,9 +9,12 @@ import type {
   InputNumberRef as RcInputNumberRef,
   ValueType,
 } from '@rc-component/input-number';
+import { useMergedState } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import ContextIsolator from '../_util/ContextIsolator';
+import { useAllowClear } from '../_util/hooks';
+import type { AllowClear } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { isPlainObject } from '../_util/is';
@@ -38,6 +41,7 @@ export type InputNumberSemanticType = {
     suffix?: string;
     input?: string;
     actions?: string;
+    clear?: string;
   };
   styles?: {
     root?: React.CSSProperties;
@@ -45,6 +49,7 @@ export type InputNumberSemanticType = {
     suffix?: React.CSSProperties;
     input?: React.CSSProperties;
     actions?: React.CSSProperties;
+    clear?: React.CSSProperties;
   };
 };
 
@@ -105,6 +110,10 @@ export interface InputNumberProps<T extends ValueType = ValueType>
    * @default "outlined"
    */
   variant?: Variant;
+  /** Whether to show a clear button. */
+  allowClear?: AllowClear;
+  /** Callback when the clear button is clicked. */
+  onClear?: () => void;
 }
 
 type InternalInputNumberProps = InputNumberProps & {
@@ -136,8 +145,18 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
       classNames,
       styles,
       mode,
+      allowClear,
+      onClear,
+      value,
+      defaultValue,
+      onChange,
       ...others
     } = props;
+
+    const [mergedValue, setMergedValue] = useMergedState<ValueType | null | undefined>(
+      defaultValue,
+      { value },
+    );
 
     const {
       direction,
@@ -175,12 +194,28 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
 
     const [variant, enableVariantCls] = useVariant('inputNumber', customVariant, bordered);
 
-    const suffixNode = (hasFeedback || suffix) && (
-      <>
-        {suffix}
-        {hasFeedback && feedbackIcon}
-      </>
-    );
+    const mergedAllowClear = useAllowClear({ allowClear, componentName: 'InputNumber' });
+    const allowClearConfig = isPlainObject(mergedAllowClear) ? mergedAllowClear : undefined;
+    const needClear =
+      !!mergedAllowClear &&
+      mergedValue !== null &&
+      mergedValue !== undefined &&
+      mergedValue !== '' &&
+      !mergedDisabled &&
+      !readOnly &&
+      !allowClearConfig?.disabled;
+
+    const handleChange: RcInputNumberProps['onChange'] = (nextValue) => {
+      setMergedValue(nextValue);
+      onChange?.(nextValue);
+    };
+
+    const handleClear = () => {
+      setMergedValue(null);
+      onChange?.(null);
+      onClear?.();
+      inputRef.current?.focus();
+    };
 
     // =========== Merged Props for Semantic ==========
     const mergedProps: InputNumberProps = {
@@ -200,6 +235,30 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
     >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles, styleRoot], {
       props: mergedProps,
     });
+
+    const clearIcon = mergedAllowClear && (
+      <button
+        type="button"
+        className={clsx(`${prefixCls}-clear-icon`, mergedClassNames.clear, {
+          [`${prefixCls}-clear-icon-hidden`]: !needClear,
+          [`${prefixCls}-clear-icon-has-suffix`]: !!suffix || hasFeedback,
+        })}
+        style={mergedStyles.clear}
+        onClick={handleClear}
+        onMouseDown={(event) => event.preventDefault()}
+      >
+        {allowClearConfig?.clearIcon}
+      </button>
+    );
+
+    const suffixNode =
+      hasFeedback || suffix || mergedAllowClear ? (
+        <>
+          {clearIcon}
+          {suffix}
+          {hasFeedback && feedbackIcon}
+        </>
+      ) : undefined;
 
     return (
       <RcInputNumber
@@ -233,6 +292,9 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
         suffix={suffixNode}
         classNames={mergedClassNames}
         styles={mergedStyles}
+        value={mergedAllowClear ? mergedValue : value}
+        defaultValue={mergedAllowClear ? undefined : defaultValue}
+        onChange={handleChange}
         {...others}
       />
     );

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -195,6 +195,10 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
     const [variant, enableVariantCls] = useVariant('inputNumber', customVariant, bordered);
 
     const mergedAllowClear = useAllowClear({ allowClear, componentName: 'InputNumber' });
+    // Keep value ownership stable after allowClear has controlled an uncontrolled input.
+    const needMergedValueRef = React.useRef(false);
+    needMergedValueRef.current ||= !!mergedAllowClear;
+
     const allowClearConfig = isPlainObject(mergedAllowClear) ? mergedAllowClear : undefined;
     const needClear =
       !!mergedAllowClear &&
@@ -292,8 +296,8 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
         suffix={suffixNode}
         classNames={mergedClassNames}
         styles={mergedStyles}
-        value={mergedAllowClear ? mergedValue : value}
-        defaultValue={mergedAllowClear ? undefined : defaultValue}
+        value={needMergedValueRef.current ? mergedValue : value}
+        defaultValue={needMergedValueRef.current ? undefined : defaultValue}
         onChange={handleChange}
         {...others}
       />

--- a/components/input-number/index.zh-CN.md
+++ b/components/input-number/index.zh-CN.md
@@ -18,6 +18,7 @@ demo:
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">基本</code>
+<code src="./demo/allow-clear.tsx" version="6.7.0">清除按钮</code>
 <code src="./demo/size.tsx">三种大小</code>
 <code src="./demo/addon.tsx" debug>前置/后置标签</code>
 <code src="./demo/disabled.tsx">不可用</code>
@@ -47,6 +48,7 @@ demo:
 | --- | --- | --- | --- | --- | --- |
 | ~~addonAfter~~ | 带标签的 input，设置后置标签，请使用 Space.Compact 替换 | ReactNode | - | 4.17.0 | × |
 | ~~addonBefore~~ | 带标签的 input，设置前置标签，请使用 Space.Compact 替换 | ReactNode | - | 4.17.0 | × |
+| allowClear | 是否显示清除按钮 | boolean \| { clearIcon?: ReactNode, disabled?: boolean } | false | 6.7.0 | × |
 | changeOnBlur | 是否在失去焦点时，触发 `onChange` 事件（例如值超出范围时，重新限制回范围并触发事件） | boolean | true | 5.11.0 | × |
 | changeOnWheel | 允许鼠标滚轮改变数值 | boolean | - | 5.14.0 | × |
 | classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | 6.0.0 | 6.0.0 |
@@ -73,6 +75,7 @@ demo:
 | value | 当前值 | number | - | - | × |
 | variant | 形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 | 5.19.0 |
 | onChange | 变化回调 | function(value: number \| string \| null) | - | - | × |
+| onClear | 点击清除按钮时的回调 | () => void | - | 6.7.0 | × |
 | onPressEnter | 按下回车的回调 | function(e) | - | - | × |
 | onStep | 点击上下箭头、键盘、滚轮的回调 | (value: number, info: { offset: number, type: 'up' \| 'down', emitter: 'handler' \| 'keydown' \| 'wheel' }) => void | - | 4.7.0 | × |
 | ~~bordered~~ | 是否带边框，请使用 `variant` 替代 | boolean | true | - | × |

--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -1,7 +1,12 @@
 import type { CSSObject } from '@ant-design/cssinjs';
 import { unit } from '@ant-design/cssinjs';
 
-import { genBasicInputStyle, genPlaceholderStyle, initInputToken } from '../../input/style';
+import {
+  genAllowClearStyle,
+  genBasicInputStyle,
+  genPlaceholderStyle,
+  initInputToken,
+} from '../../input/style';
 import {
   genBorderlessStyle,
   genFilledStyle,
@@ -333,6 +338,10 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token) => {
           transition: `margin ${motionDurationMid}`,
         },
 
+        [`${componentCls}-clear-icon`]: {
+          pointerEvents: 'auto',
+        },
+
         [`&:hover:not(${componentCls}-without-controls)`]: {
           [`${componentCls}-suffix`]: {
             marginInlineEnd: token.handleWidth,
@@ -362,6 +371,7 @@ export default genStyleHooks(
     const inputNumberToken = mergeToken<InputNumberToken>(token, initInputToken(token));
     return [
       genInputNumberStyles(inputNumberToken),
+      genAllowClearStyle(inputNumberToken),
       genCompatibleStyles(inputNumberToken),
       // =====================================================
       // ==             Space Compact                       ==

--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -388,7 +388,7 @@ export const genInputStyle: GenerateStyle<InputToken, CSSObject> = (token) => {
   };
 };
 
-const genAllowClearStyle: GenerateStyle<InputToken, CSSObject> = (token) => {
+export const genAllowClearStyle: GenerateStyle<InputToken, CSSObject> = (token) => {
   const { componentCls } = token;
   return {
     // ========================= Input =========================


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Closes #50885

### 💡 Background and Solution

InputNumber currently lacks the clear action available on Input. This adds `allowClear` and `onClear`, including custom icons and the `allowClear.disabled` option, while preserving the existing DOM when the feature is disabled.

The implementation starts using a merged value when clear support is enabled and retains that ownership for the component lifetime. This is necessary for uncontrolled InputNumber instances: calling the external `onChange(null)` alone does not reset the internal rc-input-number value. Controlled instances keep standard React semantics and only clear visually after their owner accepts `onChange(null)`.

Additional behavior:

- `0` remains a valid, clearable value.
- `stringMode` clears with `null`.
- Disabled and read-only inputs hide the clear action.
- Mouse down does not blur the input, and click restores input focus.
- The clear action is a native button and supports semantic `classNames.clear` and `styles.clear`.
- Existing Input clear styles are reused for consistent appearance.

Tests cover uncontrolled default and entered values, controlled accepted and rejected updates, zero, string mode, disabled/read-only/config-disabled states, custom icon with suffix, focus behavior, callbacks, semantic styling, and runtime allowClear toggling for initial and edited uncontrolled values.

Validation:

- `npx jest components/input-number --config .jest.js --no-cache -i`: 11 suites passed, 112 tests passed, 2 skipped, 71 snapshots passed.
- Focused allow-clear coverage: 13 tests passed; InputNumber index coverage is 85.13% statements and 86.11% lines.
- Targeted ESLint, Biome, Remark, and pre-commit checks passed.
- Full `tsc --noEmit` is currently blocked by six existing `FullToken.antCls` errors in Table demos on the feature branch.
- Full CSS-in-JS validation is currently blocked by existing unrelated repository errors; the changed files pass targeted lint checks.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | InputNumber supports `allowClear` and `onClear` for clearing values. |
| 🇨🇳 Chinese | InputNumber 支持通过 `allowClear` 和 `onClear` 清空数值。 |
