### PR TITLE
test: enable Rate listitem accessibility checks

### DIFF
--- a/components/rate/__tests__/a11y.test.ts
+++ b/components/rate/__tests__/a11y.test.ts
@@ -1,6 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('rate', {
-  // waiting for rc-rate fix
-  disabledRules: ['listitem'],
-});
+accessibilityDemoTest('rate');


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- Related to #22343
- Upstream fix: https://github.com/react-component/rate/pull/195

### 💡 Background and Solution

`@rc-component/rate` corrected its list semantics in react-component/rate#195, and Ant Design now consumes version 1.0.1. The Rate accessibility suite still disabled the axe `listitem` rule with a stale waiting-for-upstream comment.

This change removes that exemption so every Rate demo enforces valid list item ownership. There is no runtime or API change.

Validation:

`npx jest components/rate/__tests__/a11y.test.ts --config .jest.js --no-cache -i`

Result: 8 tests passed.

AI assistance disclosure: Codex was used to trace the canonical upstream fix, audit all open Ant Design PR changed files for overlap, and run validation. The one-line patch was reviewed and verified against current master.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Strengthen Rate accessibility regression coverage for list semantics. |
| 🇨🇳 Chinese | 加强 Rate 列表语义的无障碍回归测试覆盖。 |