### PR TITLE
docs(Alert): label visibility switch for accessibility

### DIFF
--- a/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/alert/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1704,6 +1704,7 @@ Array [
   </p>,
   <button
     aria-checked="true"
+    aria-label="Alert visibility"
     class="ant-switch css-var-test-id ant-switch-checked ant-switch-disabled"
     disabled=""
     role="switch"

--- a/components/alert/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/alert/__tests__/__snapshots__/demo.test.ts.snap
@@ -1684,6 +1684,7 @@ Array [
   </p>,
   <button
     aria-checked="true"
+    aria-label="Alert visibility"
     class="ant-switch css-var-test-id ant-switch-checked ant-switch-disabled"
     disabled=""
     role="switch"

--- a/components/alert/__tests__/a11y.test.ts
+++ b/components/alert/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('alert', { disabledRules: ['button-name'] });
+accessibilityDemoTest('alert');

--- a/components/alert/demo/smooth-closed.tsx
+++ b/components/alert/demo/smooth-closed.tsx
@@ -18,7 +18,12 @@ const App: React.FC = () => {
         />
       )}
       <p>click the close button to see the effect</p>
-      <Switch onChange={setVisible} checked={visible} disabled={visible} />
+      <Switch
+        aria-label="Alert visibility"
+        onChange={setVisible}
+        checked={visible}
+        disabled={visible}
+      />
     </>
   );
 };


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Contributes to #22343.

### 💡 Background and Solution

The Switch in the Alert `smooth-closed` demo rendered as an unnamed button. Enabling axe's `button-name` rule therefore failed on that demo, so the rule was disabled for the entire Alert demo suite.

This change:

- gives the visibility Switch a stable accessible name;
- removes the Alert-wide `button-name` exemption, so all 14 Alert demos now enforce the rule;
- updates the generated demo snapshots.

No public API or visual behavior changes.

Validation:

- `npx jest components/alert --config .jest.js --no-cache -i` (6 suites passed, 68 tests passed, 4 skipped, 42 snapshots passed)
- `npx eslint components/alert/__tests__/a11y.test.ts components/alert/demo/smooth-closed.tsx`
- Prettier and `git diff --check`

AI assistance disclosure: Codex was used to trace the failing demo, scan current open pull-request files for overlap, and draft and validate the patch. The final diff and test results were checked against current `master`.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Label the Alert smooth-close demo's visibility switch and enforce accessible button names across Alert demos. |
| 🇨🇳 Chinese | 为 Alert 平滑关闭示例的可见性开关补充无障碍名称，并在所有 Alert 示例中启用按钮名称检查。 |
