### PR TITLE
fix(form): prevent height fluctuation during rapid validation changes

### DIFF
--- a/components/form/FormItem/ItemHolder.tsx
+++ b/components/form/FormItem/ItemHolder.tsx
@@ -62,7 +62,7 @@ export default function ItemHolder(props: ItemHolderProps) {
   const debounceErrors = useDebounce(errors);
   const debounceWarnings = useDebounce(warnings);
   const hasHelp = isNonNullable(help);
-  const hasError = !!(hasHelp || errors.length || warnings.length);
+  const hasError = !!(hasHelp || debounceErrors.length || debounceWarnings.length);
   const isOnScreen = !!itemRef.current && isVisible(itemRef.current);
   const [marginBottom, setMarginBottom] = React.useState<number | null>(null);
 
@@ -76,7 +76,7 @@ export default function ItemHolder(props: ItemHolderProps) {
   }, [hasError, isOnScreen]);
 
   const onErrorVisibleChanged = (nextVisible: boolean) => {
-    if (!nextVisible) {
+    if (!nextVisible && !hasError) {
       setMarginBottom(null);
     }
   };


### PR DESCRIPTION
## Summary

Fix Form height fluctuation during rapid validation changes.

## Root cause

The `ItemHolder` component uses the raw `errors`/`warnings` arrays to determine `hasError`, while the error display in `FormItemInput` uses debounced values (`debounceErrors`/`debounceWarnings`) via `useDebounce`. This mismatch creates a timing window where:

1. `useDebounce` applies errors immediately (0ms) but delays error removal by 10ms
2. When errors disappear rapidly, `hasError` (raw) becomes `false` immediately while `debounceErrors` still shows errors for 10ms
3. The `marginBottom` stabilization logic in `useLayoutEffect` recalculates on every `hasError` change, leading to a `marginBottom` value that fluctuates between `null` and the computed value

## Fix

Two changes in `ItemHolder.tsx`:

1. **Use debounced errors for `hasError`** — aligns the error state with the actual display state, so `marginBottom` stabilization only activates when errors are truly visible
2. **Guard `onErrorVisibleChanged`** — only clear `marginBottom` when errors are truly no longer present, preventing rapid toggling

## Related

- Fixes #58992
- Dosu analysis: root cause identified as timing mismatch between `useDebounce` (0ms vs 10ms) and `marginBottom` state management

## Verification

The fix ensures that:
- Error appearance triggers `marginBottom` calculation once
- Error disappearance only clears `marginBottom` after the error is truly gone
- Rapid validation toggling no longer causes height fluctuation