### PR TITLE
feat(Splitter): support keyboard resizing

### DIFF
--- a/components/splitter/SplitBar.tsx
+++ b/components/splitter/SplitBar.tsx
@@ -97,7 +97,15 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
   const stopKeyboardResize = () => {
     if (keyboardResize) {
       setKeyboardResize(null);
-      onOffsetEnd();
+      if (lazy) {
+        const offsetX = vertical ? 0 : keyboardResize.offset;
+        const offsetY = vertical ? keyboardResize.offset : 0;
+        onOffsetUpdate(index, offsetX, offsetY, true);
+        setConstrainedOffset(0);
+        onOffsetEnd(true);
+      } else {
+        onOffsetEnd();
+      }
     }
   };
 
@@ -225,7 +233,11 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
     }
 
     setKeyboardResize({ ...keyboardResize, offset: nextOffset });
-    onOffsetUpdate(index, vertical ? 0 : nextOffset, vertical ? nextOffset : 0);
+    if (lazy) {
+      setConstrainedOffset(nextOffset);
+    } else {
+      onOffsetUpdate(index, vertical ? 0 : nextOffset, vertical ? nextOffset : 0);
+    }
   };
 
   const getVisibilityClass = (mode: ShowCollapsibleIconMode): string => {

--- a/components/splitter/SplitBar.tsx
+++ b/components/splitter/SplitBar.tsx
@@ -20,6 +20,7 @@ export interface SplitBarProps {
   prefixCls: string;
   rootPrefixCls: string;
   resizable: boolean;
+  reverse: boolean;
   startCollapsible: boolean;
   endCollapsible: boolean;
   draggerIcon?: SplitterProps['draggerIcon'];
@@ -44,6 +45,7 @@ const getValidNumber = (num?: number) => {
 };
 
 const DOUBLE_CLICK_TIME_GAP = 300;
+const KEYBOARD_STEP = 10;
 
 const SplitBar: React.FC<SplitBarProps> = (props) => {
   const {
@@ -56,6 +58,7 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
     ariaMin,
     ariaMax,
     resizable,
+    reverse,
     draggerIcon,
     draggerStyle,
     draggerClassName,
@@ -81,9 +84,22 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
   // ======================== Resize ========================
   const [startPos, setStartPos] = useState<[x: number, y: number] | null>(null);
   const [constrainedOffset, setConstrainedOffset] = useState<number>(0);
+  const [keyboardResize, setKeyboardResize] = useState<{
+    offset: number;
+    ariaNow: number;
+    ariaMin: number;
+    ariaMax: number;
+  } | null>(null);
 
   const constrainedOffsetX = vertical ? 0 : constrainedOffset;
   const constrainedOffsetY = vertical ? constrainedOffset : 0;
+
+  const stopKeyboardResize = () => {
+    if (keyboardResize) {
+      setKeyboardResize(null);
+      onOffsetEnd();
+    }
+  };
 
   const onMouseDown: React.MouseEventHandler<HTMLDivElement> = (e) => {
     e.stopPropagation();
@@ -99,6 +115,7 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
     lastClickTimeRef.current = currentTime;
 
     if (resizable && e.currentTarget) {
+      stopKeyboardResize();
       setStartPos([e.pageX, e.pageY]);
       onOffsetStart(index);
     }
@@ -106,6 +123,7 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
 
   const onTouchStart: React.TouchEventHandler<HTMLDivElement> = (e) => {
     if (resizable && e.touches.length === 1) {
+      stopKeyboardResize();
       const touch = e.touches[0];
       setStartPos([touch.pageX, touch.pageY]);
       onOffsetStart(index);
@@ -142,6 +160,72 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
       e.preventDefault();
       onCollapse(index, type);
     }
+  };
+
+  const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (e) => {
+    if (!resizable) {
+      return;
+    }
+
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+
+      if (keyboardResize) {
+        stopKeyboardResize();
+      } else {
+        setKeyboardResize({
+          offset: 0,
+          ariaNow,
+          ariaMin,
+          ariaMax,
+        });
+        onOffsetStart(index);
+      }
+      return;
+    }
+
+    if (!keyboardResize) {
+      return;
+    }
+
+    let direction = 0;
+    if (vertical) {
+      if (e.key === 'ArrowUp') {
+        direction = -1;
+      } else if (e.key === 'ArrowDown') {
+        direction = 1;
+      }
+    } else if (e.key === 'ArrowLeft') {
+      direction = -1;
+    } else if (e.key === 'ArrowRight') {
+      direction = 1;
+    }
+
+    if (!direction) {
+      return;
+    }
+
+    e.preventDefault();
+
+    // Keep the accumulated offset within the movable range so the opposite arrow responds
+    // immediately at a boundary. ARIA bounds follow logical order, so invert them for RTL.
+    const logicalMinOffset =
+      ((keyboardResize.ariaMin - keyboardResize.ariaNow) / 100) * containerSize;
+    const logicalMaxOffset =
+      ((keyboardResize.ariaMax - keyboardResize.ariaNow) / 100) * containerSize;
+    const minOffset = reverse ? -logicalMaxOffset : logicalMinOffset;
+    const maxOffset = reverse ? -logicalMinOffset : logicalMaxOffset;
+    const nextOffset = Math.max(
+      minOffset,
+      Math.min(maxOffset, keyboardResize.offset + direction * KEYBOARD_STEP),
+    );
+
+    if (nextOffset === keyboardResize.offset) {
+      return;
+    }
+
+    setKeyboardResize({ ...keyboardResize, offset: nextOffset });
+    onOffsetUpdate(index, vertical ? 0 : nextOffset, vertical ? nextOffset : 0);
   };
 
   const getVisibilityClass = (mode: ShowCollapsibleIconMode): string => {
@@ -225,6 +309,8 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
     [varName('bar-preview-offset')]: `${constrainedOffset}px`,
   };
 
+  const mergedActive = active || !!keyboardResize;
+
   // ======================== Render ========================
   const [startIcon, endIcon, startCustomize, endCustomize] = React.useMemo(() => {
     let startIcon = null;
@@ -254,22 +340,26 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
         />
       )}
 
+      {/* eslint-disable jsx-a11y/no-noninteractive-tabindex -- Adjustable ARIA separators must be keyboard focusable. */}
       <div
         style={draggerStyle?.default}
         className={clsx(
           `${splitBarPrefixCls}-dragger`,
           {
             [`${splitBarPrefixCls}-dragger-disabled`]: !resizable,
-            [`${splitBarPrefixCls}-dragger-active`]: active,
+            [`${splitBarPrefixCls}-dragger-active`]: mergedActive,
             [`${splitBarPrefixCls}-dragger-customize`]: draggerIcon !== undefined,
           },
           draggerClassName?.default,
-          active && draggerClassName?.active,
+          mergedActive && draggerClassName?.active,
         )}
         onMouseDown={onMouseDown}
         onTouchStart={onTouchStart}
         onDoubleClick={() => onDraggerDoubleClick?.(index)}
+        onKeyDown={onKeyDown}
+        onBlur={stopKeyboardResize}
         role="separator"
+        tabIndex={resizable ? 0 : undefined}
         aria-disabled={!resizable}
         aria-orientation={vertical ? 'horizontal' : 'vertical'}
         aria-valuenow={getValidNumber(ariaNow)}

--- a/components/splitter/SplitBar.tsx
+++ b/components/splitter/SplitBar.tsx
@@ -105,7 +105,15 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
   const stopKeyboardResize = () => {
     if (keyboardResize) {
       setKeyboardResize(null);
-      onOffsetEnd();
+      if (lazy) {
+        const offsetX = vertical ? 0 : keyboardResize.offset;
+        const offsetY = vertical ? keyboardResize.offset : 0;
+        onOffsetUpdate(index, offsetX, offsetY, true);
+        setConstrainedOffset(0);
+        onOffsetEnd(true);
+      } else {
+        onOffsetEnd();
+      }
     }
   };
 
@@ -233,7 +241,11 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
     }
 
     setKeyboardResize({ ...keyboardResize, offset: nextOffset });
-    onOffsetUpdate(index, vertical ? 0 : nextOffset, vertical ? nextOffset : 0);
+    if (lazy) {
+      setConstrainedOffset(nextOffset);
+    } else {
+      onOffsetUpdate(index, vertical ? 0 : nextOffset, vertical ? nextOffset : 0);
+    }
   };
 
   const getVisibilityClass = (mode: ShowCollapsibleIconMode): string => {

--- a/components/splitter/SplitBar.tsx
+++ b/components/splitter/SplitBar.tsx
@@ -21,6 +21,7 @@ export interface SplitBarProps {
   prefixCls: string;
   rootPrefixCls: string;
   resizable: boolean;
+  reverse: boolean;
   startCollapsible: boolean;
   endCollapsible: boolean;
   draggerIcon?: SplitterProps['draggerIcon'];
@@ -51,6 +52,7 @@ const getAriaLabel = (icon: React.ReactNode, defaultLabel?: string) => {
 };
 
 const DOUBLE_CLICK_TIME_GAP = 300;
+const KEYBOARD_STEP = 10;
 
 const SplitBar: React.FC<SplitBarProps> = (props) => {
   const {
@@ -63,6 +65,7 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
     ariaMin,
     ariaMax,
     resizable,
+    reverse,
     draggerIcon,
     draggerStyle,
     draggerClassName,
@@ -89,9 +92,22 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
   // ======================== Resize ========================
   const [startPos, setStartPos] = useState<[x: number, y: number] | null>(null);
   const [constrainedOffset, setConstrainedOffset] = useState<number>(0);
+  const [keyboardResize, setKeyboardResize] = useState<{
+    offset: number;
+    ariaNow: number;
+    ariaMin: number;
+    ariaMax: number;
+  } | null>(null);
 
   const constrainedOffsetX = vertical ? 0 : constrainedOffset;
   const constrainedOffsetY = vertical ? constrainedOffset : 0;
+
+  const stopKeyboardResize = () => {
+    if (keyboardResize) {
+      setKeyboardResize(null);
+      onOffsetEnd();
+    }
+  };
 
   const onMouseDown: React.MouseEventHandler<HTMLDivElement> = (e) => {
     e.stopPropagation();
@@ -107,6 +123,7 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
     lastClickTimeRef.current = currentTime;
 
     if (resizable && e.currentTarget) {
+      stopKeyboardResize();
       setStartPos([e.pageX, e.pageY]);
       onOffsetStart(index);
     }
@@ -114,6 +131,7 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
 
   const onTouchStart: React.TouchEventHandler<HTMLDivElement> = (e) => {
     if (resizable && e.touches.length === 1) {
+      stopKeyboardResize();
       const touch = e.touches[0];
       setStartPos([touch.pageX, touch.pageY]);
       onOffsetStart(index);
@@ -150,6 +168,72 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
       e.preventDefault();
       onCollapse(index, type);
     }
+  };
+
+  const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (e) => {
+    if (!resizable) {
+      return;
+    }
+
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+
+      if (keyboardResize) {
+        stopKeyboardResize();
+      } else {
+        setKeyboardResize({
+          offset: 0,
+          ariaNow,
+          ariaMin,
+          ariaMax,
+        });
+        onOffsetStart(index);
+      }
+      return;
+    }
+
+    if (!keyboardResize) {
+      return;
+    }
+
+    let direction = 0;
+    if (vertical) {
+      if (e.key === 'ArrowUp') {
+        direction = -1;
+      } else if (e.key === 'ArrowDown') {
+        direction = 1;
+      }
+    } else if (e.key === 'ArrowLeft') {
+      direction = -1;
+    } else if (e.key === 'ArrowRight') {
+      direction = 1;
+    }
+
+    if (!direction) {
+      return;
+    }
+
+    e.preventDefault();
+
+    // Keep the accumulated offset within the movable range so the opposite arrow responds
+    // immediately at a boundary. ARIA bounds follow logical order, so invert them for RTL.
+    const logicalMinOffset =
+      ((keyboardResize.ariaMin - keyboardResize.ariaNow) / 100) * containerSize;
+    const logicalMaxOffset =
+      ((keyboardResize.ariaMax - keyboardResize.ariaNow) / 100) * containerSize;
+    const minOffset = reverse ? -logicalMaxOffset : logicalMinOffset;
+    const maxOffset = reverse ? -logicalMinOffset : logicalMaxOffset;
+    const nextOffset = Math.max(
+      minOffset,
+      Math.min(maxOffset, keyboardResize.offset + direction * KEYBOARD_STEP),
+    );
+
+    if (nextOffset === keyboardResize.offset) {
+      return;
+    }
+
+    setKeyboardResize({ ...keyboardResize, offset: nextOffset });
+    onOffsetUpdate(index, vertical ? 0 : nextOffset, vertical ? nextOffset : 0);
   };
 
   const getVisibilityClass = (mode: ShowCollapsibleIconMode): string => {
@@ -233,6 +317,8 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
     [varName('bar-preview-offset')]: `${constrainedOffset}px`,
   };
 
+  const mergedActive = active || !!keyboardResize;
+
   // ======================== Render ========================
   const [startIcon, endIcon, startCustomize, endCustomize] = React.useMemo(() => {
     let startIcon = null;
@@ -262,22 +348,26 @@ const SplitBar: React.FC<SplitBarProps> = (props) => {
         />
       )}
 
+      {/* eslint-disable jsx-a11y/no-noninteractive-tabindex -- Adjustable ARIA separators must be keyboard focusable. */}
       <div
         style={draggerStyle?.default}
         className={clsx(
           `${splitBarPrefixCls}-dragger`,
           {
             [`${splitBarPrefixCls}-dragger-disabled`]: !resizable,
-            [`${splitBarPrefixCls}-dragger-active`]: active,
+            [`${splitBarPrefixCls}-dragger-active`]: mergedActive,
             [`${splitBarPrefixCls}-dragger-customize`]: draggerIcon !== undefined,
           },
           draggerClassName?.default,
-          active && draggerClassName?.active,
+          mergedActive && draggerClassName?.active,
         )}
         onMouseDown={onMouseDown}
         onTouchStart={onTouchStart}
         onDoubleClick={() => onDraggerDoubleClick?.(index)}
+        onKeyDown={onKeyDown}
+        onBlur={stopKeyboardResize}
         role="separator"
+        tabIndex={resizable ? 0 : undefined}
         aria-disabled={!resizable}
         aria-orientation={vertical ? 'horizontal' : 'vertical'}
         aria-valuenow={getValidNumber(ariaNow)}

--- a/components/splitter/Splitter.tsx
+++ b/components/splitter/Splitter.tsx
@@ -258,6 +258,7 @@ const InternalSplitter = (
                 prefixCls={prefixCls}
                 rootPrefixCls={rootPrefixCls}
                 vertical={isVertical}
+                reverse={reverse}
                 resizable={resizableInfo.resizable}
                 draggerStyle={mergedStyles.dragger}
                 draggerClassName={mergedClassNames.dragger}

--- a/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -273,6 +273,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx extend context cor
         aria-valuenow="67"
         class="ant-splitter-bar-dragger"
         role="separator"
+        tabindex="0"
       />
     </div>
     <div
@@ -332,6 +333,7 @@ exports[`renders components/splitter/demo/control.tsx extend context correctly 1
         aria-valuenow="50"
         class="ant-splitter-bar-dragger"
         role="separator"
+        tabindex="0"
       />
     </div>
     <div
@@ -624,6 +626,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
         aria-valuenow="0"
         class="ant-splitter-bar-dragger"
         role="separator"
+        tabindex="0"
       />
     </div>
     <div
@@ -737,6 +740,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
         aria-valuenow="0"
         class="ant-splitter-bar-dragger"
         role="separator"
+        tabindex="0"
       />
     </div>
     <div
@@ -792,6 +796,7 @@ exports[`renders components/splitter/demo/debug.tsx extend context correctly 1`]
         aria-valuenow="0"
         class="ant-splitter-bar-dragger"
         role="separator"
+        tabindex="0"
       />
     </div>
     <div
@@ -903,6 +908,7 @@ exports[`renders components/splitter/demo/group.tsx extend context correctly 1`]
       aria-valuenow="50"
       class="ant-splitter-bar-dragger"
       role="separator"
+      tabindex="0"
     />
   </div>
   <div
@@ -939,6 +945,7 @@ exports[`renders components/splitter/demo/group.tsx extend context correctly 1`]
           aria-valuenow="50"
           class="ant-splitter-bar-dragger"
           role="separator"
+          tabindex="0"
         />
       </div>
       <div
@@ -1122,6 +1129,7 @@ exports[`renders components/splitter/demo/multiple.tsx extend context correctly 
       aria-valuenow="33"
       class="ant-splitter-bar-dragger"
       role="separator"
+      tabindex="0"
     />
   </div>
   <div
@@ -1151,6 +1159,7 @@ exports[`renders components/splitter/demo/multiple.tsx extend context correctly 
       aria-valuenow="67"
       class="ant-splitter-bar-dragger"
       role="separator"
+      tabindex="0"
     />
   </div>
   <div
@@ -1331,6 +1340,7 @@ exports[`renders components/splitter/demo/reset.tsx extend context correctly 1`]
       aria-valuenow="30"
       class="ant-splitter-bar-dragger"
       role="separator"
+      tabindex="0"
     />
   </div>
   <div
@@ -1360,6 +1370,7 @@ exports[`renders components/splitter/demo/reset.tsx extend context correctly 1`]
       aria-valuenow="70"
       class="ant-splitter-bar-dragger"
       role="separator"
+      tabindex="0"
     />
   </div>
   <div
@@ -1605,6 +1616,7 @@ exports[`renders components/splitter/demo/style-class.tsx extend context correct
         class="ant-splitter-bar-dragger"
         role="separator"
         style="background-color: rgba(194, 223, 252, 0.4);"
+        tabindex="0"
       />
     </div>
     <div
@@ -1654,6 +1666,7 @@ exports[`renders components/splitter/demo/style-class.tsx extend context correct
         aria-valuenow="50"
         class="ant-splitter-bar-dragger"
         role="separator"
+        tabindex="0"
       />
     </div>
     <div
@@ -1709,6 +1722,7 @@ exports[`renders components/splitter/demo/vertical.tsx extend context correctly 
       aria-valuenow="50"
       class="ant-splitter-bar-dragger"
       role="separator"
+      tabindex="0"
     />
   </div>
   <div

--- a/components/splitter/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/splitter/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -41,6 +41,7 @@ exports[`renders components/splitter/demo/_semantic.tsx correctly 1`] = `
             aria-valuenow="50"
             class="ant-splitter-bar-dragger semantic-mark-dragger"
             role="separator"
+            tabindex="0"
           />
         </div>
         <div

--- a/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
@@ -271,6 +271,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx correctly 1`] = `
         aria-valuenow="67"
         class="ant-splitter-bar-dragger"
         role="separator"
+        tabindex="0"
       />
     </div>
     <div
@@ -328,6 +329,7 @@ exports[`renders components/splitter/demo/control.tsx correctly 1`] = `
         aria-valuenow="50"
         class="ant-splitter-bar-dragger"
         role="separator"
+        tabindex="0"
       />
     </div>
     <div
@@ -618,6 +620,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
         aria-valuenow="0"
         class="ant-splitter-bar-dragger"
         role="separator"
+        tabindex="0"
       />
     </div>
     <div
@@ -739,6 +742,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
         aria-valuenow="0"
         class="ant-splitter-bar-dragger"
         role="separator"
+        tabindex="0"
       />
     </div>
     <div
@@ -798,6 +802,7 @@ exports[`renders components/splitter/demo/debug.tsx correctly 1`] = `
         aria-valuenow="0"
         class="ant-splitter-bar-dragger"
         role="separator"
+        tabindex="0"
       />
     </div>
     <div
@@ -913,6 +918,7 @@ exports[`renders components/splitter/demo/group.tsx correctly 1`] = `
       aria-valuenow="50"
       class="ant-splitter-bar-dragger"
       role="separator"
+      tabindex="0"
     />
   </div>
   <div
@@ -949,6 +955,7 @@ exports[`renders components/splitter/demo/group.tsx correctly 1`] = `
           aria-valuenow="50"
           class="ant-splitter-bar-dragger"
           role="separator"
+          tabindex="0"
         />
       </div>
       <div
@@ -1130,6 +1137,7 @@ exports[`renders components/splitter/demo/multiple.tsx correctly 1`] = `
       aria-valuenow="33"
       class="ant-splitter-bar-dragger"
       role="separator"
+      tabindex="0"
     />
   </div>
   <div
@@ -1161,6 +1169,7 @@ exports[`renders components/splitter/demo/multiple.tsx correctly 1`] = `
       aria-valuenow="67"
       class="ant-splitter-bar-dragger"
       role="separator"
+      tabindex="0"
     />
   </div>
   <div
@@ -1318,6 +1327,7 @@ exports[`renders components/splitter/demo/reset.tsx correctly 1`] = `
       aria-valuenow="30"
       class="ant-splitter-bar-dragger"
       role="separator"
+      tabindex="0"
     />
   </div>
   <div
@@ -1349,6 +1359,7 @@ exports[`renders components/splitter/demo/reset.tsx correctly 1`] = `
       aria-valuenow="70"
       class="ant-splitter-bar-dragger"
       role="separator"
+      tabindex="0"
     />
   </div>
   <div
@@ -1590,6 +1601,7 @@ exports[`renders components/splitter/demo/style-class.tsx correctly 1`] = `
         class="ant-splitter-bar-dragger"
         role="separator"
         style="background-color:rgba(194,223,252,0.4)"
+        tabindex="0"
       />
     </div>
     <div
@@ -1639,6 +1651,7 @@ exports[`renders components/splitter/demo/style-class.tsx correctly 1`] = `
         aria-valuenow="50"
         class="ant-splitter-bar-dragger"
         role="separator"
+        tabindex="0"
       />
     </div>
     <div
@@ -1692,6 +1705,7 @@ exports[`renders components/splitter/demo/vertical.tsx correctly 1`] = `
       aria-valuenow="50"
       class="ant-splitter-bar-dragger"
       role="separator"
+      tabindex="0"
     />
   </div>
   <div

--- a/components/splitter/__tests__/index.test.tsx
+++ b/components/splitter/__tests__/index.test.tsx
@@ -273,7 +273,11 @@ describe('Splitter', () => {
       expect(container.querySelector('.ant-splitter-bar-dragger')).toHaveAttribute('tabindex', '0');
 
       rerender(<SplitterDemo items={[{}, { resizable: false }]} />);
-      expect(container.querySelector('.ant-splitter-bar-dragger')).not.toHaveAttribute('tabindex');
+      const disabledDragger = container.querySelector('.ant-splitter-bar-dragger')!;
+      expect(disabledDragger).not.toHaveAttribute('tabindex');
+
+      fireEvent.keyDown(disabledDragger, { key: 'Enter' });
+      expect(disabledDragger).not.toHaveClass('ant-splitter-bar-dragger-active');
     });
 
     it('should resize horizontally with keyboard and respect limits', async () => {
@@ -335,8 +339,11 @@ describe('Splitter', () => {
       fireEvent.keyDown(dragger, { key: 'ArrowDown' });
       expect(onResize).toHaveBeenCalledWith([60, 40]);
 
+      fireEvent.keyDown(dragger, { key: 'ArrowUp' });
+      expect(onResize).toHaveBeenLastCalledWith([50, 50]);
+
       fireEvent.keyDown(dragger, { key: 'Enter' });
-      expect(onResizeEnd).toHaveBeenCalledWith([60, 40]);
+      expect(onResizeEnd).toHaveBeenCalledWith([50, 50]);
     });
 
     it('should stop resizing when the dragger loses focus', async () => {

--- a/components/splitter/__tests__/index.test.tsx
+++ b/components/splitter/__tests__/index.test.tsx
@@ -209,6 +209,7 @@ describe('Splitter', () => {
           prefixCls="ant-splitter"
           rootPrefixCls="ant"
           resizable
+          reverse={false}
           vertical={false}
           startCollapsible
           endCollapsible
@@ -261,6 +262,123 @@ describe('Splitter', () => {
     rerender(<SplitterDemo items={[{ size: 20 }, {}, { resizable: false }]} />);
     expect(container.querySelectorAll('.ant-splitter-bar-dragger')).toHaveLength(2);
     expect(container.querySelectorAll('.ant-splitter-bar-dragger-disabled')).toHaveLength(1);
+  });
+
+  describe('keyboard resize', () => {
+    it('should only make resizable draggers focusable', () => {
+      const { container, rerender } = render(<SplitterDemo />);
+      expect(container.querySelector('.ant-splitter-bar-dragger')).toHaveAttribute('tabindex', '0');
+
+      rerender(<SplitterDemo items={[{}, { resizable: false }]} />);
+      expect(container.querySelector('.ant-splitter-bar-dragger')).not.toHaveAttribute('tabindex');
+    });
+
+    it('should resize horizontally with keyboard and respect limits', async () => {
+      containerSize = 500;
+      const onResizeStart = jest.fn();
+      const onResize = jest.fn();
+      const onResizeEnd = jest.fn();
+      const { container } = render(
+        <SplitterDemo
+          items={[{ min: 100, max: 260 }, {}]}
+          onResizeStart={onResizeStart}
+          onResize={onResize}
+          onResizeEnd={onResizeEnd}
+        />,
+      );
+
+      await resizeSplitter();
+      const dragger = container.querySelector('.ant-splitter-bar-dragger')!;
+
+      fireEvent.keyDown(dragger, { key: 'ArrowRight' });
+      expect(onResize).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(dragger, { key: 'Enter' });
+      expect(dragger).toHaveClass('ant-splitter-bar-dragger-active');
+      expect(onResizeStart).toHaveBeenCalledWith([250, 250]);
+
+      fireEvent.keyDown(dragger, { key: 'ArrowUp' });
+      expect(onResize).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(dragger, { key: 'ArrowRight' });
+      expect(onResize).toHaveBeenLastCalledWith([260, 240]);
+
+      const callCountAtMax = onResize.mock.calls.length;
+      fireEvent.keyDown(dragger, { key: 'ArrowRight' });
+      expect(onResize).toHaveBeenCalledTimes(callCountAtMax);
+
+      fireEvent.keyDown(dragger, { key: 'ArrowLeft' });
+      expect(onResize).toHaveBeenLastCalledWith([250, 250]);
+
+      fireEvent.keyDown(dragger, { key: ' ' });
+      expect(dragger).not.toHaveClass('ant-splitter-bar-dragger-active');
+      expect(onResizeEnd).toHaveBeenCalledWith([250, 250]);
+    });
+
+    it('should use vertical arrow keys', async () => {
+      const onResize = jest.fn();
+      const onResizeEnd = jest.fn();
+      const { container } = render(
+        <SplitterDemo orientation="vertical" onResize={onResize} onResizeEnd={onResizeEnd} />,
+      );
+
+      await resizeSplitter();
+      const dragger = container.querySelector('.ant-splitter-bar-dragger')!;
+
+      fireEvent.keyDown(dragger, { key: ' ' });
+      fireEvent.keyDown(dragger, { key: 'ArrowRight' });
+      expect(onResize).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(dragger, { key: 'ArrowDown' });
+      expect(onResize).toHaveBeenCalledWith([60, 40]);
+
+      fireEvent.keyDown(dragger, { key: 'Enter' });
+      expect(onResizeEnd).toHaveBeenCalledWith([60, 40]);
+    });
+
+    it('should stop resizing when the dragger loses focus', async () => {
+      const onResizeEnd = jest.fn();
+      const { container } = render(
+        <div>
+          <button type="button">Outside</button>
+          <SplitterDemo onResizeEnd={onResizeEnd} />
+        </div>,
+      );
+
+      await resizeSplitter();
+      const dragger = container.querySelector<HTMLElement>('.ant-splitter-bar-dragger')!;
+      const outside = container.querySelector('button')!;
+
+      dragger.focus();
+      fireEvent.keyDown(dragger, { key: 'Enter' });
+      expect(dragger).toHaveClass('ant-splitter-bar-dragger-active');
+      expect(container.querySelector('.ant-splitter-mask')).toBeTruthy();
+
+      fireEvent.blur(dragger, { relatedTarget: outside });
+      expect(dragger).not.toHaveClass('ant-splitter-bar-dragger-active');
+      expect(container.querySelector('.ant-splitter-mask')).toBeFalsy();
+      expect(onResizeEnd).toHaveBeenCalledWith([50, 50]);
+    });
+
+    it('should follow the visual direction in RTL', async () => {
+      containerSize = 500;
+      const onResize = jest.fn();
+      const { container } = render(
+        <ConfigProvider direction="rtl">
+          <SplitterDemo onResize={onResize} />
+        </ConfigProvider>,
+      );
+
+      await resizeSplitter();
+      const dragger = container.querySelector('.ant-splitter-bar-dragger')!;
+
+      fireEvent.keyDown(dragger, { key: 'Enter' });
+      fireEvent.keyDown(dragger, { key: 'ArrowLeft' });
+      expect(onResize).toHaveBeenLastCalledWith([260, 240]);
+
+      fireEvent.keyDown(dragger, { key: 'ArrowRight' });
+      expect(onResize).toHaveBeenLastCalledWith([250, 250]);
+    });
   });
 
   it('Splitter.Panel is syntactic sugar', () => {

--- a/components/splitter/__tests__/index.test.tsx
+++ b/components/splitter/__tests__/index.test.tsx
@@ -270,7 +270,11 @@ describe('Splitter', () => {
       expect(container.querySelector('.ant-splitter-bar-dragger')).toHaveAttribute('tabindex', '0');
 
       rerender(<SplitterDemo items={[{}, { resizable: false }]} />);
-      expect(container.querySelector('.ant-splitter-bar-dragger')).not.toHaveAttribute('tabindex');
+      const disabledDragger = container.querySelector('.ant-splitter-bar-dragger')!;
+      expect(disabledDragger).not.toHaveAttribute('tabindex');
+
+      fireEvent.keyDown(disabledDragger, { key: 'Enter' });
+      expect(disabledDragger).not.toHaveClass('ant-splitter-bar-dragger-active');
     });
 
     it('should resize horizontally with keyboard and respect limits', async () => {
@@ -332,8 +336,11 @@ describe('Splitter', () => {
       fireEvent.keyDown(dragger, { key: 'ArrowDown' });
       expect(onResize).toHaveBeenCalledWith([60, 40]);
 
+      fireEvent.keyDown(dragger, { key: 'ArrowUp' });
+      expect(onResize).toHaveBeenLastCalledWith([50, 50]);
+
       fireEvent.keyDown(dragger, { key: 'Enter' });
-      expect(onResizeEnd).toHaveBeenCalledWith([60, 40]);
+      expect(onResizeEnd).toHaveBeenCalledWith([50, 50]);
     });
 
     it('should stop resizing when the dragger loses focus', async () => {

--- a/components/splitter/__tests__/index.test.tsx
+++ b/components/splitter/__tests__/index.test.tsx
@@ -212,6 +212,7 @@ describe('Splitter', () => {
           prefixCls="ant-splitter"
           rootPrefixCls="ant"
           resizable
+          reverse={false}
           vertical={false}
           startCollapsible
           endCollapsible
@@ -264,6 +265,123 @@ describe('Splitter', () => {
     rerender(<SplitterDemo items={[{ size: 20 }, {}, { resizable: false }]} />);
     expect(container.querySelectorAll('.ant-splitter-bar-dragger')).toHaveLength(2);
     expect(container.querySelectorAll('.ant-splitter-bar-dragger-disabled')).toHaveLength(1);
+  });
+
+  describe('keyboard resize', () => {
+    it('should only make resizable draggers focusable', () => {
+      const { container, rerender } = render(<SplitterDemo />);
+      expect(container.querySelector('.ant-splitter-bar-dragger')).toHaveAttribute('tabindex', '0');
+
+      rerender(<SplitterDemo items={[{}, { resizable: false }]} />);
+      expect(container.querySelector('.ant-splitter-bar-dragger')).not.toHaveAttribute('tabindex');
+    });
+
+    it('should resize horizontally with keyboard and respect limits', async () => {
+      containerSize = 500;
+      const onResizeStart = jest.fn();
+      const onResize = jest.fn();
+      const onResizeEnd = jest.fn();
+      const { container } = render(
+        <SplitterDemo
+          items={[{ min: 100, max: 260 }, {}]}
+          onResizeStart={onResizeStart}
+          onResize={onResize}
+          onResizeEnd={onResizeEnd}
+        />,
+      );
+
+      await resizeSplitter();
+      const dragger = container.querySelector('.ant-splitter-bar-dragger')!;
+
+      fireEvent.keyDown(dragger, { key: 'ArrowRight' });
+      expect(onResize).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(dragger, { key: 'Enter' });
+      expect(dragger).toHaveClass('ant-splitter-bar-dragger-active');
+      expect(onResizeStart).toHaveBeenCalledWith([250, 250]);
+
+      fireEvent.keyDown(dragger, { key: 'ArrowUp' });
+      expect(onResize).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(dragger, { key: 'ArrowRight' });
+      expect(onResize).toHaveBeenLastCalledWith([260, 240]);
+
+      const callCountAtMax = onResize.mock.calls.length;
+      fireEvent.keyDown(dragger, { key: 'ArrowRight' });
+      expect(onResize).toHaveBeenCalledTimes(callCountAtMax);
+
+      fireEvent.keyDown(dragger, { key: 'ArrowLeft' });
+      expect(onResize).toHaveBeenLastCalledWith([250, 250]);
+
+      fireEvent.keyDown(dragger, { key: ' ' });
+      expect(dragger).not.toHaveClass('ant-splitter-bar-dragger-active');
+      expect(onResizeEnd).toHaveBeenCalledWith([250, 250]);
+    });
+
+    it('should use vertical arrow keys', async () => {
+      const onResize = jest.fn();
+      const onResizeEnd = jest.fn();
+      const { container } = render(
+        <SplitterDemo orientation="vertical" onResize={onResize} onResizeEnd={onResizeEnd} />,
+      );
+
+      await resizeSplitter();
+      const dragger = container.querySelector('.ant-splitter-bar-dragger')!;
+
+      fireEvent.keyDown(dragger, { key: ' ' });
+      fireEvent.keyDown(dragger, { key: 'ArrowRight' });
+      expect(onResize).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(dragger, { key: 'ArrowDown' });
+      expect(onResize).toHaveBeenCalledWith([60, 40]);
+
+      fireEvent.keyDown(dragger, { key: 'Enter' });
+      expect(onResizeEnd).toHaveBeenCalledWith([60, 40]);
+    });
+
+    it('should stop resizing when the dragger loses focus', async () => {
+      const onResizeEnd = jest.fn();
+      const { container } = render(
+        <div>
+          <button type="button">Outside</button>
+          <SplitterDemo onResizeEnd={onResizeEnd} />
+        </div>,
+      );
+
+      await resizeSplitter();
+      const dragger = container.querySelector<HTMLElement>('.ant-splitter-bar-dragger')!;
+      const outside = container.querySelector('button')!;
+
+      dragger.focus();
+      fireEvent.keyDown(dragger, { key: 'Enter' });
+      expect(dragger).toHaveClass('ant-splitter-bar-dragger-active');
+      expect(container.querySelector('.ant-splitter-mask')).toBeTruthy();
+
+      fireEvent.blur(dragger, { relatedTarget: outside });
+      expect(dragger).not.toHaveClass('ant-splitter-bar-dragger-active');
+      expect(container.querySelector('.ant-splitter-mask')).toBeFalsy();
+      expect(onResizeEnd).toHaveBeenCalledWith([50, 50]);
+    });
+
+    it('should follow the visual direction in RTL', async () => {
+      containerSize = 500;
+      const onResize = jest.fn();
+      const { container } = render(
+        <ConfigProvider direction="rtl">
+          <SplitterDemo onResize={onResize} />
+        </ConfigProvider>,
+      );
+
+      await resizeSplitter();
+      const dragger = container.querySelector('.ant-splitter-bar-dragger')!;
+
+      fireEvent.keyDown(dragger, { key: 'Enter' });
+      fireEvent.keyDown(dragger, { key: 'ArrowLeft' });
+      expect(onResize).toHaveBeenLastCalledWith([260, 240]);
+
+      fireEvent.keyDown(dragger, { key: 'ArrowRight' });
+      expect(onResize).toHaveBeenLastCalledWith([250, 250]);
+    });
   });
 
   it('Splitter.Panel is syntactic sugar', () => {

--- a/components/splitter/__tests__/lazy.test.tsx
+++ b/components/splitter/__tests__/lazy.test.tsx
@@ -141,6 +141,58 @@ describe('Splitter lazy', () => {
     expect(container.querySelector('.ant-splitter-mask')).toBeFalsy();
   });
 
+  it('should only update after keyboard resize ends when lazy is true', async () => {
+    const onResize = jest.fn();
+    const onResizeEnd = jest.fn();
+    const { container } = render(
+      <SplitterDemo onResize={onResize} onResizeEnd={onResizeEnd} lazy />,
+    );
+
+    await resizeSplitter();
+
+    const dragger = container.querySelector<HTMLElement>('.ant-splitter-bar-dragger')!;
+    const preview = container.querySelector<HTMLElement>('.ant-splitter-bar-preview')!;
+
+    fireEvent.keyDown(dragger, { key: 'Enter' });
+    fireEvent.keyDown(dragger, { key: 'ArrowRight' });
+    expect(preview.style.getPropertyValue('--ant-splitter-bar-preview-offset')).toBe('10px');
+    expect(onResize).not.toHaveBeenCalled();
+    expect(onResizeEnd).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(dragger, { key: 'ArrowRight' });
+    expect(preview.style.getPropertyValue('--ant-splitter-bar-preview-offset')).toBe('20px');
+    expect(onResize).not.toHaveBeenCalled();
+    expect(onResizeEnd).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(dragger, { key: 'Enter' });
+    expect(preview.style.getPropertyValue('--ant-splitter-bar-preview-offset')).toBe('0px');
+    expect(onResize).not.toHaveBeenCalled();
+    expect(onResizeEnd).toHaveBeenCalledWith([70, 30]);
+  });
+
+  it('should commit lazy keyboard resize when the dragger loses focus', async () => {
+    const onResize = jest.fn();
+    const onResizeEnd = jest.fn();
+    const { container } = render(
+      <div>
+        <button type="button">Outside</button>
+        <SplitterDemo onResize={onResize} onResizeEnd={onResizeEnd} lazy />
+      </div>,
+    );
+
+    await resizeSplitter();
+
+    const dragger = container.querySelector<HTMLElement>('.ant-splitter-bar-dragger')!;
+    const outside = container.querySelector('button')!;
+    dragger.focus();
+    fireEvent.keyDown(dragger, { key: 'Enter' });
+    fireEvent.keyDown(dragger, { key: 'ArrowLeft' });
+    fireEvent.blur(dragger, { relatedTarget: outside });
+
+    expect(onResize).not.toHaveBeenCalled();
+    expect(onResizeEnd).toHaveBeenCalledWith([40, 60]);
+  });
+
   it('should not move preview when adjacent panels have zero size', async () => {
     const onResize = jest.fn();
     const onResizeEnd = jest.fn();

--- a/components/splitter/index.en-US.md
+++ b/components/splitter/index.en-US.md
@@ -33,6 +33,10 @@ Can be used to separate areas horizontally or vertically. When you need to freel
 <code src="./demo/debug.tsx" debug>Debug</code>
 <code src="./demo/size-mix.tsx" debug>Size Mix</code>
 
+## Keyboard
+
+After focusing a resizable dragger, press `Enter` or `Space` to start resizing. Use `ArrowLeft` and `ArrowRight` for a horizontal Splitter, or `ArrowUp` and `ArrowDown` for a vertical Splitter. Press `Enter` or `Space` again, or move focus away, to finish resizing.
+
 ## API
 
 Common props ref：[Common props](/docs/react/common-props)

--- a/components/splitter/index.zh-CN.md
+++ b/components/splitter/index.zh-CN.md
@@ -34,6 +34,10 @@ demo:
 <code src="./demo/debug.tsx" debug>调试</code>
 <code src="./demo/size-mix.tsx" debug>尺寸混合</code>
 
+## 键盘操作 {#keyboard}
+
+聚焦可调整的拖拽条后，按 `Enter` 或 `Space` 开始调整。水平方向使用 `ArrowLeft` 和 `ArrowRight`，垂直方向使用 `ArrowUp` 和 `ArrowDown`。再次按下 `Enter`、`Space` 或移开焦点可结束调整。
+
 ## API
 
 通用属性参考：[通用属性](/docs/react/common-props)

--- a/components/splitter/style/index.ts
+++ b/components/splitter/style/index.ts
@@ -95,6 +95,8 @@ const genSplitterStyle: GenerateStyle<SplitterToken, CSSObject> = (token) => {
           ...centerStyle,
           zIndex: 1,
 
+          '&:focus-visible': genFocusOutline(token),
+
           // Hover background
           '&::before': {
             content: '""',


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [x] 📝 站点、文档改进
- [x] ✅ 测试用例
- [x] ⌨️ 无障碍改进

### 🔗 相关 Issue

close #55930

### 💡 需求背景和解决方案

Splitter 的拖拽条目前无法通过键盘调整，键盘用户不能独立完成面板尺寸调整。

本次改动为可调整的拖拽条增加键盘访问能力：

- 支持通过 Tab 聚焦拖拽条。
- 支持使用 Enter 或 Space 开始和结束调整。
- 水平模式支持 ArrowLeft 和 ArrowRight。
- 垂直模式支持 ArrowUp 和 ArrowDown。
- 遵循面板的 min/max 限制，并正确处理 RTL。
- 拖拽条失焦时自动结束调整并清理激活状态。
- 补充聚焦、边界、方向、RTL 和失焦行为测试。
- 补充中英文键盘操作文档。

本次改动没有新增公开 API。

### 📝 更新日志

| 语言    | 更新描述                                                               |
| ------- | ---------------------------------------------------------------------- |
| 🇺🇸 英文 | ⌨️ Add Splitter keyboard resizing with Enter/Space and arrow keys.     |
| 🇨🇳 中文 | ⌨️ 新增 Splitter 键盘调整能力，支持 Enter/Space 与方向键操作。         |