### PR TITLE
fix(radio): trigger option onChange when using options in radio-group

### DIFF
--- a/components/radio/__tests__/group.test.tsx
+++ b/components/radio/__tests__/group.test.tsx
@@ -247,6 +247,18 @@ describe('Radio Group', () => {
     expect(container.querySelector('.ant-radio-group label')).toHaveAttribute('title', 'bamboo');
   });
 
+  it('options support onChange', () => {
+    const onChange = jest.fn();
+    const options = [
+      { label: 'A', value: 'A', onChange },
+      { label: 'B', value: 'B' },
+    ];
+    const { container } = render(<Radio.Group options={options} />);
+
+    fireEvent.click(container.querySelectorAll('input')[0]);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
   it('should use FormItem name', () => {
     const RadioForm: React.FC = () => (
       <Form name="preference-form">

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -105,6 +105,7 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
           className={option.className} // 👈 5.25.0+
           id={option.id}
           required={option.required}
+          onChange={option.onChange}
         >
           {option.label}
         </Radio>


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | trigger option onChange when using options in radio-group |
| 🇨🇳 Chinese | radio-group 的 options 中的 onChange 现在会在选中时被触发 |
