### PR TITLE
fix(DatePicker): make RangePicker separator decorative instead of hardcoded English aria-label

### DIFF
--- a/components/date-picker/__tests__/RangePicker.test.tsx
+++ b/components/date-picker/__tests__/RangePicker.test.tsx
@@ -62,6 +62,24 @@ describe('RangePicker', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it('default separator should be decorative and hidden from accessibility tree', () => {
+    const { container } = render(<RangePicker />);
+    expect(container.querySelector('.ant-picker-separator')?.getAttribute('aria-hidden')).toBe(
+      'true',
+    );
+    expect(container.querySelector('.ant-picker-separator')?.getAttribute('aria-label')).toBeNull();
+  });
+
+  it('custom separator should not be hidden and should preserve its own semantics', () => {
+    const { container } = render(
+      <RangePicker separator={<span aria-label="自定义分隔符">→</span>} />,
+    );
+    const sepSpan = container.querySelector('.ant-picker-separator');
+    expect(sepSpan?.getAttribute('aria-hidden')).not.toBe('true');
+    // The custom separator's own accessible name should survive (parent no longer overrides it)
+    expect(sepSpan?.querySelector('[aria-label="自定义分隔符"]')).toBeTruthy();
+  });
+
   it('the left selection is before the right selection', () => {
     let rangePickerValue: dayjs.Dayjs[] = [];
     const Test: React.FC = () => {

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -162,7 +162,10 @@ const generateRangePicker = <DateType extends AnyObject = AnyObject>(
       <ContextIsolator space>
         <RCRangePicker<DateType>
           separator={
-            <span aria-label="to" className={`${prefixCls}-separator`}>
+            <span
+              className={`${prefixCls}-separator`}
+              aria-hidden={!mergedSeparator}
+            >
               {mergedSeparator ?? <SwapRightOutlined />}
             </span>
           }


### PR DESCRIPTION
## Description

Fix [ant-design#58998](https://github.com/ant-design/ant-design/issues/58998):

The default range separator renders a hardcoded `aria-label="to"` on the wrapper span. This exposes hardcoded English to screen reader users in every non-English locale (WCAG 3.3.1 / 4.1.2), and also overrides the accessible name of a custom separator because a parent label wins over descendant content.

## Changes

- `generateRangePicker.tsx`: the separator wrapper now gets `aria-hidden={!mergedSeparator}`:
  - Default separator (no custom one) → decorative, hidden from the accessibility tree.
  - Custom separator via `separator` prop or `ConfigProvider.datePicker.rangePicker` → keeps its own semantics, no parent label override.
- `RangePicker.test.tsx`: two focused regression tests covering the default arrow (aria-hidden, no aria-label) and a custom separator with its own accessible name.

No locale API was added — the default arrow stays decorative, per the issue's suggested scope.
