### PR TITLE
docs: update v4 Upload demo endpoint

### DIFF
--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -1530,7 +1530,7 @@ describe('Form', () => {
   it('form child components should be given priority to own disabled props when it in a disabled form', () => {
     const props = {
       name: 'file',
-      action: 'https://www.mocky.io/v2/5cc8019d300000980a055e76',
+      action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
       headers: {
         authorization: 'authorization-text',
       },

--- a/components/upload/__tests__/uploadlist.test.tsx
+++ b/components/upload/__tests__/uploadlist.test.tsx
@@ -1254,7 +1254,7 @@ describe('Upload List', () => {
         <Upload
           ref={uploadRef}
           fileList={testFileList}
-          action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
+          action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload"
           multiple
           onChange={info => {
             setTestFileList([...info.fileList]);

--- a/components/upload/demo/avatar.md
+++ b/components/upload/demo/avatar.md
@@ -73,7 +73,7 @@ const App: React.FC = () => {
       listType="picture-card"
       className="avatar-uploader"
       showUploadList={false}
-      action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
+      action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload"
       beforeUpload={beforeUpload}
       onChange={handleChange}
     >

--- a/components/upload/demo/basic.md
+++ b/components/upload/demo/basic.md
@@ -21,7 +21,7 @@ import React from 'react';
 
 const props: UploadProps = {
   name: 'file',
-  action: 'https://www.mocky.io/v2/5cc8019d300000980a055e76',
+  action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
   headers: {
     authorization: 'authorization-text',
   },

--- a/components/upload/demo/crop-image.md
+++ b/components/upload/demo/crop-image.md
@@ -51,7 +51,7 @@ const App: React.FC = () => {
   return (
     <ImgCrop rotationSlider>
       <Upload
-        action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
+        action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload"
         listType="picture-card"
         fileList={fileList}
         onChange={onChange}

--- a/components/upload/demo/customize-progress-bar.md
+++ b/components/upload/demo/customize-progress-bar.md
@@ -21,7 +21,7 @@ import React from 'react';
 
 const props: UploadProps = {
   name: 'file',
-  action: 'https://www.mocky.io/v2/5cc8019d300000980a055e76',
+  action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
   headers: {
     authorization: 'authorization-text',
   },

--- a/components/upload/demo/defaultFileList.md
+++ b/components/upload/demo/defaultFileList.md
@@ -20,7 +20,7 @@ import { Button, Upload } from 'antd';
 import React from 'react';
 
 const props: UploadProps = {
-  action: 'https://www.mocky.io/v2/5cc8019d300000980a055e76',
+  action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
   onChange({ file, fileList }) {
     if (file.status !== 'uploading') {
       console.log(file, fileList);

--- a/components/upload/demo/directory.md
+++ b/components/upload/demo/directory.md
@@ -19,7 +19,7 @@ import { Button, Upload } from 'antd';
 import React from 'react';
 
 const App: React.FC = () => (
-  <Upload action="https://www.mocky.io/v2/5cc8019d300000980a055e76" directory>
+  <Upload action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload" directory>
     <Button icon={<UploadOutlined />}>Upload Directory</Button>
   </Upload>
 );

--- a/components/upload/demo/drag-sorting.md
+++ b/components/upload/demo/drag-sorting.md
@@ -130,7 +130,7 @@ const App: React.FC = () => {
   return (
     <DndProvider backend={HTML5Backend}>
       <Upload
-        action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
+        action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload"
         fileList={fileList}
         onChange={onChange}
         itemRender={(originNode, file, currFileList) => (

--- a/components/upload/demo/drag.md
+++ b/components/upload/demo/drag.md
@@ -28,7 +28,7 @@ const { Dragger } = Upload;
 const props: UploadProps = {
   name: 'file',
   multiple: true,
-  action: 'https://www.mocky.io/v2/5cc8019d300000980a055e76',
+  action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
   onChange(info) {
     const { status } = info.file;
     if (status !== 'uploading') {

--- a/components/upload/demo/file-type.md
+++ b/components/upload/demo/file-type.md
@@ -119,7 +119,7 @@ const App: React.FC = () => {
   return (
     <>
       <Upload
-        action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
+        action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload"
         listType="picture-card"
         fileList={fileList}
         onPreview={handlePreview}

--- a/components/upload/demo/fileList.md
+++ b/components/upload/demo/fileList.md
@@ -58,7 +58,7 @@ const App: React.FC = () => {
   };
 
   const props = {
-    action: 'https://www.mocky.io/v2/5cc8019d300000980a055e76',
+    action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
     onChange: handleChange,
     multiple: true,
   };

--- a/components/upload/demo/max-count.md
+++ b/components/upload/demo/max-count.md
@@ -21,14 +21,14 @@ import React from 'react';
 const App: React.FC = () => (
   <Space direction="vertical" style={{ width: '100%' }} size="large">
     <Upload
-      action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
+      action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload"
       listType="picture"
       maxCount={1}
     >
       <Button icon={<UploadOutlined />}>Upload (Max: 1)</Button>
     </Upload>
     <Upload
-      action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
+      action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload"
       listType="picture"
       maxCount={3}
       multiple

--- a/components/upload/demo/picture-card.md
+++ b/components/upload/demo/picture-card.md
@@ -95,7 +95,7 @@ const App: React.FC = () => {
   return (
     <>
       <Upload
-        action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
+        action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload"
         listType="picture-card"
         fileList={fileList}
         onPreview={handlePreview}

--- a/components/upload/demo/picture-style.md
+++ b/components/upload/demo/picture-style.md
@@ -37,7 +37,7 @@ const fileList: UploadFile[] = [
 const App: React.FC = () => (
   <>
     <Upload
-      action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
+      action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload"
       listType="picture"
       defaultFileList={[...fileList]}
     >
@@ -46,7 +46,7 @@ const App: React.FC = () => (
     <br />
     <br />
     <Upload
-      action="https://www.mocky.io/v2/5cc8019d300000980a055e76"
+      action="https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload"
       listType="picture"
       defaultFileList={[...fileList]}
       className="upload-list-inline"

--- a/components/upload/demo/transform-file.md
+++ b/components/upload/demo/transform-file.md
@@ -20,7 +20,7 @@ import { Button, Upload } from 'antd';
 import React from 'react';
 
 const props: UploadProps = {
-  action: 'https://www.mocky.io/v2/5cc8019d300000980a055e76',
+  action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
   listType: 'picture',
   beforeUpload(file) {
     return new Promise(resolve => {

--- a/components/upload/demo/upload-custom-action-icon.md
+++ b/components/upload/demo/upload-custom-action-icon.md
@@ -20,7 +20,7 @@ import { Button, Upload } from 'antd';
 import React from 'react';
 
 const props: UploadProps = {
-  action: 'https://www.mocky.io/v2/5cc8019d300000980a055e76',
+  action: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
   onChange({ file, fileList }) {
     if (file.status !== 'uploading') {
       console.log(file, fileList);

--- a/components/upload/demo/upload-manually.md
+++ b/components/upload/demo/upload-manually.md
@@ -30,7 +30,7 @@ const App: React.FC = () => {
     });
     setUploading(true);
     // You can use any AJAX library you like
-    fetch('https://www.mocky.io/v2/5cc8019d300000980a055e76', {
+    fetch('https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload', {
       method: 'POST',
       body: formData,
     })

--- a/components/upload/demo/upload-with-aliyun-oss.md
+++ b/components/upload/demo/upload-with-aliyun-oss.md
@@ -42,7 +42,7 @@ const AliyunOSSUpload = ({ value, onChange }: AliyunOSSUploadProps) => {
   const mockGetOSSData = () => ({
     dir: 'user-dir/',
     expire: '1577811661',
-    host: '//www.mocky.io/v2/5cc8019d300000980a055e76',
+    host: 'https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload',
     accessId: 'c2hhb2RhaG9uZw==',
     policy: 'eGl4aWhhaGFrdWt1ZGFkYQ==',
     signature: 'ZGFob25nc2hhbw==',


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

Closes #52026

### 💡 Background and solution

The Ant Design 4.x Upload demos still post files to an expired Mocky v2 endpoint, which currently returns HTTP 404.

This PR replaces all 21 references in the v4 Upload demos and related test fixtures with the working MockAPI endpoint already used by the current Ant Design branch. A multipart POST to the replacement endpoint returns HTTP 201.

### 📝 Changelog

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Fix the upload endpoint used by Ant Design 4.x Upload demos. |
| 🇨🇳 Chinese | 修复 Ant Design 4.x Upload 演示中失效的上传地址。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Verification

- `npm test -- components/upload/__tests__ components/form/__tests__/index.test.tsx --runInBand`: 7 suites, 217 tests passed
- `npm run tsc`
- ESLint on changed files
- Remark on Upload demo Markdown files