### PR TITLE
feat(Carousel): localize default arrow aria-labels via ConfigProvider locale

### DIFF
--- a/components/carousel/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/carousel/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -10,7 +10,7 @@ Array [
       dir="ltr"
     >
       <button
-        aria-label="prev"
+        aria-label="Previous slide"
         class="slick-arrow slick-prev slick-disabled"
         data-role="none"
         style="display: block;"
@@ -106,7 +106,7 @@ Array [
         </div>
       </div>
       <button
-        aria-label="next"
+        aria-label="Next slide"
         class="slick-arrow slick-next"
         data-role="none"
         style="display: block;"
@@ -156,7 +156,7 @@ Array [
       dir="ltr"
     >
       <button
-        aria-label="prev"
+        aria-label="Previous slide"
         class="slick-arrow slick-prev slick-disabled"
         data-role="none"
         style="display: block;"
@@ -253,7 +253,7 @@ Array [
         </div>
       </div>
       <button
-        aria-label="next"
+        aria-label="Next slide"
         class="slick-arrow slick-next"
         data-role="none"
         style="display: block;"

--- a/components/carousel/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/carousel/__tests__/__snapshots__/demo.test.ts.snap
@@ -10,7 +10,7 @@ Array [
       dir="ltr"
     >
       <button
-        aria-label="prev"
+        aria-label="Previous slide"
         class="slick-arrow slick-prev slick-disabled"
         data-role="none"
         style="display:block"
@@ -106,7 +106,7 @@ Array [
         </div>
       </div>
       <button
-        aria-label="next"
+        aria-label="Next slide"
         class="slick-arrow slick-next"
         data-role="none"
         style="display:block"
@@ -156,7 +156,7 @@ Array [
       dir="ltr"
     >
       <button
-        aria-label="prev"
+        aria-label="Previous slide"
         class="slick-arrow slick-prev slick-disabled"
         data-role="none"
         style="display:block"
@@ -252,7 +252,7 @@ Array [
         </div>
       </div>
       <button
-        aria-label="next"
+        aria-label="Next slide"
         class="slick-arrow slick-next"
         data-role="none"
         style="display:block"

--- a/components/carousel/__tests__/index.test.tsx
+++ b/components/carousel/__tests__/index.test.tsx
@@ -6,6 +6,7 @@ import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
+import zhCN from '../../locale/zh_CN';
 
 describe('Carousel', () => {
   mountTest(Carousel);
@@ -274,6 +275,40 @@ describe('Carousel', () => {
     errSpy.mockRestore();
   });
 
+  it('should use localized aria-labels for arrows by default', async () => {
+    const { container } = render(
+      <Carousel arrows>
+        <div>Slide 1</div>
+        <div>Slide 2</div>
+        <div>Slide 3</div>
+      </Carousel>,
+    );
+    await waitFakeTimer();
+
+    const prevArrow = container.querySelector<HTMLDivElement>('.slick-prev');
+    const nextArrow = container.querySelector<HTMLDivElement>('.slick-next');
+    expect(prevArrow).toHaveAttribute('aria-label', 'Previous slide');
+    expect(nextArrow).toHaveAttribute('aria-label', 'Next slide');
+  });
+
+  it('should use localized aria-labels when a custom locale is provided', async () => {
+    const { container } = render(
+      <ConfigProvider locale={zhCN}>
+        <Carousel arrows>
+          <div>Slide 1</div>
+          <div>Slide 2</div>
+          <div>Slide 3</div>
+        </Carousel>
+      </ConfigProvider>,
+    );
+    await waitFakeTimer();
+
+    const prevArrow = container.querySelector<HTMLDivElement>('.slick-prev');
+    const nextArrow = container.querySelector<HTMLDivElement>('.slick-next');
+    expect(prevArrow).toHaveAttribute('aria-label', '上一张幻灯片');
+    expect(nextArrow).toHaveAttribute('aria-label', '下一张幻灯片');
+  });
+
   describe('should works for dotDuration', () => {
     it('should not show dot duration', () => {
       const { container } = render(
@@ -404,8 +439,8 @@ describe('Carousel', () => {
       const prevArrow = container.querySelector<HTMLDivElement>('.slick-prev');
       const nextArrow = container.querySelector<HTMLDivElement>('.slick-next');
 
-      expect(prevArrow).toHaveAttribute('aria-label', 'next');
-      expect(nextArrow).toHaveAttribute('aria-label', 'prev');
+      expect(prevArrow).toHaveAttribute('aria-label', 'Next slide');
+      expect(nextArrow).toHaveAttribute('aria-label', 'Previous slide');
 
       expect(container.querySelector('.slick-active')?.textContent).toBe('Slide 2');
       fireEvent.click(prevArrow!);

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -7,6 +7,8 @@ import { clsx } from 'clsx';
 import { isPlainObject } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
+import { useLocale } from '../locale';
+import defaultLocale from '../locale/en_US';
 import useStyle, { DotDuration } from './style';
 
 export type CarouselEffect = 'scrollx' | 'fade';
@@ -91,6 +93,7 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>((props, ref) => {
     className: contextClassName,
     style: contextStyle,
   } = useComponentConfig('carousel');
+  const [contextLocale] = useLocale('Carousel', defaultLocale.Carousel);
   const slickRef = React.useRef<any>(null);
   const nativeElementRef = React.useRef<HTMLDivElement>(null);
 
@@ -177,8 +180,8 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>((props, ref) => {
         dots={enableDots}
         dotsClass={dsClass}
         arrows={arrows}
-        prevArrow={prevArrow ?? <ArrowButton aria-label={isRTL ? 'next' : 'prev'} />}
-        nextArrow={nextArrow ?? <ArrowButton aria-label={isRTL ? 'prev' : 'next'} />}
+        prevArrow={prevArrow ?? <ArrowButton aria-label={isRTL ? contextLocale.nextSlide : contextLocale.prevSlide} />}
+        nextArrow={nextArrow ?? <ArrowButton aria-label={isRTL ? contextLocale.prevSlide : contextLocale.nextSlide} />}
         draggable={draggable}
         verticalSwiping={mergedVertical}
         autoplaySpeed={autoplaySpeed}

--- a/components/locale/en_US.ts
+++ b/components/locale/en_US.ts
@@ -86,6 +86,10 @@ const localeValues: Locale = {
     expand: 'Expand',
     collapse: 'Collapse',
   },
+  Carousel: {
+    prevSlide: 'Previous slide',
+    nextSlide: 'Next slide',
+  },
   Form: {
     optional: '(optional)',
     defaultValidateMessages: {

--- a/components/locale/index.tsx
+++ b/components/locale/index.tsx
@@ -56,6 +56,10 @@ export interface Locale {
     refresh?: string;
     scanned?: string;
   };
+  Carousel?: {
+    prevSlide: string;
+    nextSlide: string;
+  };
   ColorPicker?: {
     presetEmpty: string;
     transparent: string;

--- a/components/locale/zh_CN.ts
+++ b/components/locale/zh_CN.ts
@@ -87,6 +87,10 @@ const localeValues: Locale = {
     expand: '展开',
     collapse: '收起',
   },
+  Carousel: {
+    prevSlide: '上一张幻灯片',
+    nextSlide: '下一张幻灯片',
+  },
   Form: {
     optional: '（可选）',
     defaultValidateMessages: {


### PR DESCRIPTION
## Summary

The default Carousel arrow controls hardcode English `aria-label`s (`prev` / `next`). Under a non-English `ConfigProvider` locale, screen readers and accessibility tools still announce English labels.

This PR adds a `Carousel` section to the Ant Design locale system so the default arrow buttons use localized accessible names:

- `Carousel.prevSlide` / `Carousel.nextSlide` (e.g. "Previous slide" / "Next slide" in en-US, "上一张幻灯片" / "下一张幻灯片" in zh-CN)
- The component reads the active locale via `useLocale('Carousel', defaultLocale.Carousel)`
- Custom `prevArrow` / `nextArrow` elements keep their existing override behavior — the locale only applies to the default arrows

## RTL / vertical behavior

The existing RTL label-swap semantics are preserved:

| Arrow | LTR announces | RTL announces |
|---|---|---|
| `.slick-prev` | `prevSlide` | `nextSlide` |
| `.slick-next` | `nextSlide` | `prevSlide` |

Vertical layout (non-RTL) keeps the LTR mapping, matching the previous behavior.

## Files changed

- `components/carousel/index.tsx` — consume locale for default arrow aria-labels
- `components/locale/index.tsx` — add `Carousel` locale type
- `components/locale/en_US.ts` — add `Carousel` locale values
- `components/locale/zh_CN.ts` — add `Carousel` locale values
- `components/carousel/__tests__/index.test.tsx` — update RTL assertions + add locale tests
- `components/carousel/__tests__/__snapshots__/demo.test.ts.snap` — update snapshots
- `components/carousel/__tests__/__snapshots__/demo-extend.test.ts.snap` — update snapshots

## Note on other languages

Only `en_US` and `zh_CN` have been updated so far. The remaining locale files still need `Carousel` entries — happy to add them on request or if the maintainers prefer, the translations can be contributed in a follow-up.

Fixes #59003
