### PR TITLE
fix(Transfer): avoid duplicate onSearch calls when clearing

### DIFF
--- a/components/transfer/__tests__/search.test.tsx
+++ b/components/transfer/__tests__/search.test.tsx
@@ -48,6 +48,7 @@ describe('Transfer.Search', () => {
     expect(onSearch).toHaveBeenCalledWith('left', 'a');
     onSearch.mockReset();
     fireEvent.click(container.querySelectorAll('.ant-input-clear-icon').item(0));
+    expect(onSearch).toHaveBeenCalledTimes(1);
     expect(onSearch).toHaveBeenCalledWith('left', '');
     jest.useRealTimers();
   });

--- a/components/transfer/search.tsx
+++ b/components/transfer/search.tsx
@@ -17,12 +17,13 @@ const Search: React.FC<TransferSearchProps> = (props) => {
 
   const handleChange = React.useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      onChange?.(e);
-      if (e.target.value === '') {
+      if (e.type === 'click') {
         handleClear?.();
+      } else {
+        onChange?.(e);
       }
     },
-    [onChange],
+    [onChange, handleClear],
   );
 
   return (


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

- [在线最小复现](https://codesandbox.io/p/sandbox/transfer-qing-kong-sou-suo-kuang-shi-hui-chong-fu-chu-fa-onsearch-h9d6pn?file=%2Findex.tsx)

### 💡 需求背景和解决方案

Transfer 开启 `showSearch` 后，点击搜索框清除按钮会同时经过普通输入和清除处理，导致 `onSearch` 对同一次内容变化触发两次。

本次改动根据事件来源区分普通输入和清除操作，使两条路径分别处理，并补充回归断言，确保清空搜索框只调用一次 `onSearch`。不涉及 API 或视觉变化。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Transfer triggering `onSearch` twice when clearing the search input. |
| 🇨🇳 中文 | 🐞 修复 Transfer 清空搜索框时重复触发 `onSearch` 的问题。 |