### PR TITLE
fix(Menu): prevent icon jitter when toggling inline collapse

### DIFF
--- a/components/menu/style/vertical.ts
+++ b/components/menu/style/vertical.ts
@@ -58,12 +58,10 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
     colorTextLightSolid,
     dropdownWidth,
     controlHeightLG,
-    motionEaseOut,
     padding,
     paddingXL,
     itemMarginInline,
     fontSizeLG,
-    motionDurationFast,
     motionDurationSlow,
     paddingXS,
     boxShadowSecondary,
@@ -129,7 +127,6 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
             transition: [
               `border-color ${motionDurationSlow}`,
               `background-color ${motionDurationSlow}`,
-              `padding ${motionDurationFast} ${motionEaseOut}`,
             ].join(','),
 
             [`> ${componentCls}-title-content`]: {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] 💄 组件样式/交互改进

### 🔗 相关 Issue

close #56196

参考此前的修复方案 #58543。

### 💡 需求背景和解决方案

#58271 修复了 Menu 折叠时图标瞬移到中间的问题，但当前 `master` 仍存在残余的过冲和回弹。

一级 inline Menu 在宽度变化的同时，会在百分比折叠间距与固定展开间距之间过渡 `padding`，导致图标轨迹发生反向。本次移除 `padding` transition，仅保留边框色和背景色过渡，使图标在展开和收起时保持单调移动。

本次改动不涉及 API 或静态视觉变化。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Menu icons jittering when expanding or collapsing an inline menu. |
| 🇨🇳 中文 | 🐞 修复 Menu 内联菜单展开或收起时图标抖动的问题。 |
