### PR TITLE
test(Tree): restore line demo accessibility coverage

### DIFF
--- a/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3582,6 +3582,7 @@ exports[`renders components/tree/demo/line.tsx extend context correctly 1`] = `
     showLine: 
     <button
       aria-checked="true"
+      aria-label="Show connecting lines"
       class="ant-switch css-var-test-id ant-switch-checked"
       role="switch"
       type="button"
@@ -3605,6 +3606,7 @@ exports[`renders components/tree/demo/line.tsx extend context correctly 1`] = `
     showIcon: 
     <button
       aria-checked="false"
+      aria-label="Show node icons"
       class="ant-switch css-var-test-id"
       role="switch"
       type="button"
@@ -3638,6 +3640,7 @@ exports[`renders components/tree/demo/line.tsx extend context correctly 1`] = `
           aria-autocomplete="list"
           aria-expanded="false"
           aria-haspopup="listbox"
+          aria-label="Leaf icon"
           autocomplete="new-password"
           class="ant-select-input"
           id="test-id"

--- a/components/tree/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo.test.ts.snap
@@ -3563,9 +3563,11 @@ exports[`renders components/tree/demo/line.tsx correctly 1`] = `
   <div
     style="margin-bottom:16px"
   >
-    showLine: 
+    showLine:
+    <!-- -->
     <button
       aria-checked="true"
+      aria-label="Show connecting lines"
       class="ant-switch css-var-test-id ant-switch-checked"
       role="switch"
       type="button"
@@ -3589,6 +3591,7 @@ exports[`renders components/tree/demo/line.tsx correctly 1`] = `
     showIcon: 
     <button
       aria-checked="false"
+      aria-label="Show node icons"
       class="ant-switch css-var-test-id"
       role="switch"
       type="button"
@@ -3623,6 +3626,7 @@ exports[`renders components/tree/demo/line.tsx correctly 1`] = `
           aria-autocomplete="list"
           aria-expanded="false"
           aria-haspopup="listbox"
+          aria-label="Leaf icon"
           autocomplete="new-password"
           class="ant-select-input"
           id="test-id"

--- a/components/tree/__tests__/a11y.test.ts
+++ b/components/tree/__tests__/a11y.test.ts
@@ -5,7 +5,5 @@ accessibilityDemoTest('tree', {
     // Skip large data demos to prevent test timeout
     'virtual-scroll.tsx',
     'big-data.tsx',
-    // we can set aria attributes to fix it
-    'line.tsx',
   ],
 });

--- a/components/tree/demo/line.tsx
+++ b/components/tree/demo/line.tsx
@@ -92,14 +92,16 @@ const App: React.FC = () => {
   return (
     <div>
       <div style={{ marginBottom: 16 }}>
-        showLine: <Switch checked={!!showLine} onChange={setShowLine} />
+        showLine:{' '}
+        <Switch aria-label="Show connecting lines" checked={!!showLine} onChange={setShowLine} />
         <br />
         <br />
-        showIcon: <Switch checked={showIcon} onChange={setShowIcon} />
+        showIcon: <Switch aria-label="Show node icons" checked={showIcon} onChange={setShowIcon} />
         <br />
         <br />
         showLeafIcon:{' '}
         <Select
+          aria-label="Leaf icon"
           defaultValue="true"
           onChange={handleLeafIconChange}
           options={[


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Related to #44667.

The original Ant Design 4.24.14 DirectoryTree failure is no longer reproducible on current master, so this PR deliberately does not close the issue. It restores a current regression guard for the equivalent Tree structure.

### 💡 Background and Solution

The connecting-line demo was excluded from the shared Tree accessibility suite. Removing that exclusion shows that the current Tree DOM passes the aria-required-children check, while three unnamed demo controls prevent the complete demo from passing axe.

This change:

- labels the two Switch controls and the leaf-icon Select in line.tsx;
- restores line.tsx to the shared accessibility demo suite;
- keeps the virtual-scroll and big-data timeout exclusions unchanged;
- makes no public API or runtime component change.

Verification:

- Tree Jest: 11 suites, 110 passed, 10 skipped, 72 snapshots;
- Tree Vitest: 5 files, 40 passed;
- focused Tree accessibility suite: 13/13 demos passed;
- ESLint, Biome, Prettier, and git diff --check passed.

The full workspace typecheck still reports the same unrelated Table demo FullToken.antCls and shared Puppeteer Page type mismatches; none involve the four changed Tree files.

AI assistance disclosure: Codex traced the historical exclusion, reproduced the current axe behavior, prepared the focused patch, ran the checks above, and performed an independent diff review.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Restore accessibility coverage for the Tree connecting-line demo and label its controls. |
| 🇨🇳 Chinese | 恢复 Tree 连线演示的无障碍检查，并为其控件添加名称。 |