### PR TITLE
docs(Typography): clarify editable onChange trigger description

### DIFF
--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -155,7 +155,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | tooltip | Custom tooltip text, hide when it is false | ReactNode | `Edit` | 4.6.0 |
 | triggerType | Edit mode trigger - icon, text or both (not specifying icon as trigger hides it) | Array&lt;`icon`\|`text`> | \[`icon`] |  |
 | onCancel | Called when type ESC to exit editable state | function | - |  |
-| onChange | Called when input at textarea | function(value: string) | - |  |
+| onChange | Called when editing is completed | function(value: string) | - |  |
 | onEnd | Called when type ENTER to exit editable state | function | - | 4.14.0 |
 | onStart | Called when enter editable state | function | - |  |
 

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -156,7 +156,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 | tooltip | 自定义提示文本，为 false 时关闭 | ReactNode | `编辑` | 4.6.0 |
 | triggerType | 编辑模式触发器类型，图标、文本或者两者都设置（不设置图标作为触发器时它会隐藏） | Array&lt;`icon`\|`text`> | \[`icon`] |  |
 | onCancel | 按 ESC 退出编辑状态时触发 | function | - |  |
-| onChange | 文本域编辑时触发 | function(value: string) | - |  |
+| onChange | 文本域编辑完成时触发 | function(value: string) | - |  |
 | onEnd | 按 ENTER 结束编辑状态时触发 | function | - | 4.14.0 |
 | onStart | 进入编辑中状态时触发 | function | - |  |
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

- ref #37829
- ref #36382

### 💡 需求背景和解决方案

Typography 的 `editable.onChange` 实际行为**仅在编辑完成时触发一次**（按 ENTER 确认或失焦），并返回 trim 后的值；并不是在编辑过程中随文本变化实时触发。但中英文文档原描述分别为「文本域编辑时触发」和「Called when input at textarea」，容易被误解为「输入过程中实时触发」，导致用户在编辑过程中无法拿到实时值时反复踩坑（见 #37829、#36382）。

本 PR 仅修正文档措辞，不改动源码与 API 行为：

- 中文：`文本域编辑时触发` → `文本域编辑完成时触发`
- 英文：`Called when input at textarea` → `Called when editing is completed`

措辞与同表中 `onCancel`/`onEnd`/`onStart` 的「动作 + 时触发」短句式保持一致，无 UI/API 变化。

### 📝 更新日志

N/A — 仅文档描述修正，无用户可感知的行为或 API 变更。