### PR TITLE
feat(Affix): support stacking multiple Affix components

### DIFF
--- a/components/affix/__tests__/Affix.test.tsx
+++ b/components/affix/__tests__/Affix.test.tsx
@@ -13,6 +13,7 @@ const events: Partial<Record<keyof HTMLElementEventMap, (ev: Partial<Event>) => 
 interface AffixProps {
   offsetTop?: number;
   offsetBottom?: number;
+  stackable?: boolean;
   style?: React.CSSProperties;
   onChange?: () => void;
   onTestUpdatePosition?: () => void;
@@ -107,6 +108,106 @@ describe('Affix Render', () => {
 
     await movePlaceholder(300);
     expect(container.querySelector('.ant-affix')).toBeTruthy();
+  });
+
+  it('stacks top Affix components without overlapping', async () => {
+    classRect['stack-top-first'] = {
+      top: -100,
+      width: 100,
+      height: 20,
+    } as DOMRect;
+    classRect['stack-top-second'] = {
+      top: -80,
+      width: 100,
+      height: 30,
+    } as DOMRect;
+
+    const { container, rerender } = render(
+      <>
+        <Affix className="stack-top-first" offsetTop={10} stackable>
+          <div>first</div>
+        </Affix>
+        <Affix className="stack-top-second" offsetTop={10} stackable>
+          <div>second</div>
+        </Affix>
+      </>,
+    );
+
+    await waitFakeTimer();
+
+    expect(container.querySelector('.stack-top-first .ant-affix')).toHaveStyle({ top: '10px' });
+    expect(container.querySelector('.stack-top-second .ant-affix')).toHaveStyle({ top: '30px' });
+
+    classRect['stack-top-first'] = {
+      ...classRect['stack-top-first'],
+      height: 50,
+    } as DOMRect;
+    triggerResize(container.querySelector('.stack-top-first')!);
+    await waitFakeTimer();
+
+    expect(container.querySelector('.stack-top-second .ant-affix')).toHaveStyle({ top: '60px' });
+
+    rerender(
+      <>
+        <Affix className="stack-top-first" offsetTop={10}>
+          <div>first</div>
+        </Affix>
+        <Affix className="stack-top-second" offsetTop={10} stackable>
+          <div>second</div>
+        </Affix>
+      </>,
+    );
+    await waitFakeTimer();
+
+    expect(container.querySelector('.stack-top-second .ant-affix')).toHaveStyle({ top: '10px' });
+
+    rerender(
+      <>
+        <Affix className="stack-top-first" offsetTop={10} stackable>
+          <div>first</div>
+        </Affix>
+        <Affix className="stack-top-second" offsetTop={10} stackable>
+          <div>second</div>
+        </Affix>
+      </>,
+    );
+    await waitFakeTimer();
+
+    expect(container.querySelector('.stack-top-first .ant-affix')).toHaveStyle({ top: '10px' });
+    expect(container.querySelector('.stack-top-second .ant-affix')).toHaveStyle({ top: '60px' });
+  });
+
+  it('stacks bottom Affix components in reverse DOM order', async () => {
+    classRect['stack-bottom-first'] = {
+      bottom: 820,
+      width: 100,
+      height: 20,
+    } as DOMRect;
+    classRect['stack-bottom-second'] = {
+      bottom: 860,
+      width: 100,
+      height: 30,
+    } as DOMRect;
+
+    const { container } = render(
+      <>
+        <Affix className="stack-bottom-first" offsetBottom={10} stackable>
+          <div>first</div>
+        </Affix>
+        <Affix className="stack-bottom-second" offsetBottom={10} stackable>
+          <div>second</div>
+        </Affix>
+      </>,
+    );
+
+    await waitFakeTimer();
+
+    expect(container.querySelector('.stack-bottom-first .ant-affix')).toHaveStyle({
+      bottom: '40px',
+    });
+    expect(container.querySelector('.stack-bottom-second .ant-affix')).toHaveStyle({
+      bottom: '10px',
+    });
   });
 
   it('updatePosition when offsetTop changed', async () => {

--- a/components/affix/__tests__/Affix.test.tsx
+++ b/components/affix/__tests__/Affix.test.tsx
@@ -160,6 +160,21 @@ describe('Affix Render', () => {
     await waitFakeTimer();
 
     expect(container.querySelector('.stack-top-second .ant-affix')).toHaveStyle({ top: '10px' });
+
+    rerender(
+      <>
+        <Affix className="stack-top-first" offsetTop={10} stackable>
+          <div>first</div>
+        </Affix>
+        <Affix className="stack-top-second" offsetTop={10} stackable>
+          <div>second</div>
+        </Affix>
+      </>,
+    );
+    await waitFakeTimer();
+
+    expect(container.querySelector('.stack-top-first .ant-affix')).toHaveStyle({ top: '10px' });
+    expect(container.querySelector('.stack-top-second .ant-affix')).toHaveStyle({ top: '60px' });
   });
 
   it('stacks bottom Affix components in reverse DOM order', async () => {

--- a/components/affix/__tests__/Affix.test.tsx
+++ b/components/affix/__tests__/Affix.test.tsx
@@ -13,6 +13,7 @@ const events: Partial<Record<keyof HTMLElementEventMap, (ev: Partial<Event>) => 
 interface AffixProps {
   offsetTop?: number;
   offsetBottom?: number;
+  stackable?: boolean;
   style?: React.CSSProperties;
   onChange?: () => void;
   onTestUpdatePosition?: () => void;
@@ -107,6 +108,91 @@ describe('Affix Render', () => {
 
     await movePlaceholder(300);
     expect(container.querySelector('.ant-affix')).toBeTruthy();
+  });
+
+  it('stacks top Affix components without overlapping', async () => {
+    classRect['stack-top-first'] = {
+      top: -100,
+      width: 100,
+      height: 20,
+    } as DOMRect;
+    classRect['stack-top-second'] = {
+      top: -80,
+      width: 100,
+      height: 30,
+    } as DOMRect;
+
+    const { container, rerender } = render(
+      <>
+        <Affix className="stack-top-first" offsetTop={10} stackable>
+          <div>first</div>
+        </Affix>
+        <Affix className="stack-top-second" offsetTop={10} stackable>
+          <div>second</div>
+        </Affix>
+      </>,
+    );
+
+    await waitFakeTimer();
+
+    expect(container.querySelector('.stack-top-first .ant-affix')).toHaveStyle({ top: '10px' });
+    expect(container.querySelector('.stack-top-second .ant-affix')).toHaveStyle({ top: '30px' });
+
+    classRect['stack-top-first'] = {
+      ...classRect['stack-top-first'],
+      height: 50,
+    } as DOMRect;
+    triggerResize(container.querySelector('.stack-top-first')!);
+    await waitFakeTimer();
+
+    expect(container.querySelector('.stack-top-second .ant-affix')).toHaveStyle({ top: '60px' });
+
+    rerender(
+      <>
+        <Affix className="stack-top-first" offsetTop={10}>
+          <div>first</div>
+        </Affix>
+        <Affix className="stack-top-second" offsetTop={10} stackable>
+          <div>second</div>
+        </Affix>
+      </>,
+    );
+    await waitFakeTimer();
+
+    expect(container.querySelector('.stack-top-second .ant-affix')).toHaveStyle({ top: '10px' });
+  });
+
+  it('stacks bottom Affix components in reverse DOM order', async () => {
+    classRect['stack-bottom-first'] = {
+      bottom: 820,
+      width: 100,
+      height: 20,
+    } as DOMRect;
+    classRect['stack-bottom-second'] = {
+      bottom: 860,
+      width: 100,
+      height: 30,
+    } as DOMRect;
+
+    const { container } = render(
+      <>
+        <Affix className="stack-bottom-first" offsetBottom={10} stackable>
+          <div>first</div>
+        </Affix>
+        <Affix className="stack-bottom-second" offsetBottom={10} stackable>
+          <div>second</div>
+        </Affix>
+      </>,
+    );
+
+    await waitFakeTimer();
+
+    expect(container.querySelector('.stack-bottom-first .ant-affix')).toHaveStyle({
+      bottom: '40px',
+    });
+    expect(container.querySelector('.stack-bottom-second .ant-affix')).toHaveStyle({
+      bottom: '10px',
+    });
   });
 
   it('updatePosition when offsetTop changed', async () => {

--- a/components/affix/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/affix/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -96,6 +96,104 @@ exports[`renders components/affix/demo/on-change.tsx extend context correctly 1`
 
 exports[`renders components/affix/demo/on-change.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/affix/demo/stackable.tsx extend context correctly 1`] = `
+<div
+  style="width: 100%; height: 300px; overflow: auto; box-shadow: 0 0 0 1px #1677ff; scrollbar-width: thin; scrollbar-gutter: stable;"
+>
+  <div
+    style="height: 600px; padding: 8px;"
+  >
+    <div
+      class="ant-space ant-space-vertical css-var-test-id"
+      style="column-gap: 100px; row-gap: 100px;"
+    >
+      <div
+        class="ant-space-item"
+      >
+        <div
+          class=""
+        >
+          <div
+            class=""
+          >
+            <button
+              class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+              type="button"
+            >
+              <span>
+                Affix top 1
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <div
+          class=""
+        >
+          <div
+            class=""
+          >
+            <button
+              class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+              type="button"
+            >
+              <span>
+                Affix top 2
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <div
+          class=""
+        >
+          <div
+            class=""
+          >
+            <button
+              class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+              type="button"
+            >
+              <span>
+                Affix bottom 1
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <div
+          class=""
+        >
+          <div
+            class=""
+          >
+            <button
+              class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+              type="button"
+            >
+              <span>
+                Affix bottom 2
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/affix/demo/stackable.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/affix/demo/target.tsx extend context correctly 1`] = `
 <div
   style="width: 100%; height: 100px; overflow: auto; box-shadow: 0 0 0 1px #1677ff; scrollbar-width: thin; scrollbar-gutter: stable;"

--- a/components/affix/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/affix/__tests__/__snapshots__/demo.test.tsx.snap
@@ -90,6 +90,102 @@ exports[`renders components/affix/demo/on-change.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/affix/demo/stackable.tsx correctly 1`] = `
+<div
+  style="width:100%;height:300px;overflow:auto;box-shadow:0 0 0 1px #1677ff;scrollbar-width:thin;scrollbar-gutter:stable"
+>
+  <div
+    style="height:600px;padding:8px"
+  >
+    <div
+      class="ant-space ant-space-vertical css-var-test-id"
+      style="column-gap:100px;row-gap:100px"
+    >
+      <div
+        class="ant-space-item"
+      >
+        <div
+          class=""
+        >
+          <div
+            class=""
+          >
+            <button
+              class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+              type="button"
+            >
+              <span>
+                Affix top 1
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <div
+          class=""
+        >
+          <div
+            class=""
+          >
+            <button
+              class="ant-btn css-var-test-id ant-btn-primary ant-btn-color-primary ant-btn-variant-solid"
+              type="button"
+            >
+              <span>
+                Affix top 2
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <div
+          class=""
+        >
+          <div
+            class=""
+          >
+            <button
+              class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+              type="button"
+            >
+              <span>
+                Affix bottom 1
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-space-item"
+      >
+        <div
+          class=""
+        >
+          <div
+            class=""
+          >
+            <button
+              class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-outlined"
+              type="button"
+            >
+              <span>
+                Affix bottom 2
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/affix/demo/target.tsx correctly 1`] = `
 <div
   style="width:100%;height:100px;overflow:auto;box-shadow:0 0 0 1px #1677ff;scrollbar-width:thin;scrollbar-gutter:stable"

--- a/components/affix/demo/stackable.md
+++ b/components/affix/demo/stackable.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+同一滚动容器、相同固定方向下的多个 Affix 设置 `stackable` 后会依次堆叠，避免相互遮挡。
+
+## en-US
+
+Multiple Affix components with the same scroll container and offset direction stack without overlapping when `stackable` is enabled.

--- a/components/affix/demo/stackable.tsx
+++ b/components/affix/demo/stackable.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Affix, Button, Space } from 'antd';
+
+const containerStyle: React.CSSProperties = {
+  width: '100%',
+  height: 300,
+  overflow: 'auto',
+  boxShadow: '0 0 0 1px #1677ff',
+  scrollbarWidth: 'thin',
+  scrollbarGutter: 'stable',
+};
+
+const style: React.CSSProperties = {
+  height: 600,
+  padding: 8,
+};
+
+const App: React.FC = () => {
+  const [container, setContainer] = React.useState<HTMLDivElement | null>(null);
+
+  return (
+    <div style={containerStyle} ref={setContainer}>
+      <div style={style}>
+        <Space vertical size={100}>
+          <Affix target={() => container} offsetTop={8} stackable>
+            <Button type="primary">Affix top 1</Button>
+          </Affix>
+          <Affix target={() => container} offsetTop={8} stackable>
+            <Button type="primary">Affix top 2</Button>
+          </Affix>
+          <Affix target={() => container} offsetBottom={8} stackable>
+            <Button>Affix bottom 1</Button>
+          </Affix>
+          <Affix target={() => container} offsetBottom={8} stackable>
+            <Button>Affix bottom 2</Button>
+          </Affix>
+        </Space>
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/components/affix/index.en-US.md
+++ b/components/affix/index.en-US.md
@@ -25,6 +25,7 @@ Please note that Affix should not cover other content on the page, especially wh
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">Basic</code>
+<code src="./demo/stackable.tsx">Stackable</code>
 <code src="./demo/on-change.tsx">Callback</code>
 <code src="./demo/target.tsx">Container to scroll.</code>
 <code src="./demo/debug.tsx" debug>debug</code>
@@ -37,6 +38,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | --- | --- | --- | --- | --- | --- |
 | offsetBottom | Offset from the bottom of the viewport (in pixels) | number | - |  | × |
 | offsetTop | Offset from the top of the viewport (in pixels) | number | 0 |  | × |
+| stackable | Whether multiple Affix components with the same `target` and offset direction should stack without overlapping | boolean | false | 6.7.0 | × |
 | target | Specifies the scrollable area DOM node | () => Window \| HTMLElement \| null | () => window |  | × |
 | onChange | Callback for when Affix state is changed | (affixed?: boolean) => void | - |  | × |
 

--- a/components/affix/index.tsx
+++ b/components/affix/index.tsx
@@ -5,7 +5,15 @@ import { clsx } from 'clsx';
 import throttleByAnimationFrame from '../_util/throttleByAnimationFrame';
 import { ConfigContext, useComponentConfig } from '../config-provider/context';
 import useStyle from './style';
-import { getFixedBottom, getFixedTop, getTargetRect } from './utils';
+import type { AffixStackDirection, AffixStackEntry } from './utils';
+import {
+  getFixedBottom,
+  getFixedTop,
+  getStackOffset,
+  getTargetRect,
+  notifyAffixStack,
+  registerAffixStack,
+} from './utils';
 
 const TRIGGER_EVENTS: (keyof WindowEventMap)[] = [
   'resize',
@@ -27,6 +35,8 @@ export interface AffixProps {
   offsetTop?: number;
   /** Triggered when the specified offset is reached from the bottom of the window */
   offsetBottom?: number;
+  /** Whether multiple Affix components with the same target and offset direction should stack without overlapping */
+  stackable?: boolean;
   style?: React.CSSProperties;
   /** Callback function triggered when fixed state changes */
   onChange?: (affixed?: boolean) => void;
@@ -64,6 +74,7 @@ const Affix = React.forwardRef<AffixRef, InternalAffixProps>((props, ref) => {
     style,
     offsetTop,
     offsetBottom,
+    stackable,
     prefixCls,
     className,
     rootClassName,
@@ -95,10 +106,54 @@ const Affix = React.forwardRef<AffixRef, InternalAffixProps>((props, ref) => {
   const placeholderNodeRef = React.useRef<HTMLDivElement>(null);
   const fixedNodeRef = React.useRef<HTMLDivElement>(null);
   const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const stackEntryRef = React.useRef<AffixStackEntry | null>(null);
+  const stackTargetRef = React.useRef<Window | HTMLElement | null>(null);
+  const unregisterStackRef = React.useRef<(() => void) | null>(null);
+  const updatePositionRef = React.useRef<() => void>(() => {});
 
   const targetFunc = target ?? getTargetContainer ?? getDefaultTarget;
 
   const internalOffsetTop = offsetBottom === undefined && offsetTop === undefined ? 0 : offsetTop;
+
+  const unregisterStack = () => {
+    unregisterStackRef.current?.();
+    unregisterStackRef.current = null;
+    stackTargetRef.current = null;
+  };
+
+  const syncStack = (targetNode: Window | HTMLElement | null) => {
+    if (!stackable || !targetNode || !placeholderNodeRef.current) {
+      unregisterStack();
+      return null;
+    }
+
+    const stackEntry: AffixStackEntry = stackEntryRef.current ?? {
+      placeholder: placeholderNodeRef.current,
+      updatePosition: () => updatePositionRef.current(),
+    };
+    stackEntry.offsetBottom = offsetBottom;
+    stackEntry.offsetTop = internalOffsetTop;
+    stackEntry.placeholder = placeholderNodeRef.current;
+    stackEntryRef.current = stackEntry;
+
+    if (stackTargetRef.current !== targetNode) {
+      unregisterStack();
+      stackTargetRef.current = targetNode;
+      unregisterStackRef.current = registerAffixStack(targetNode, stackEntry);
+    }
+
+    return stackEntry;
+  };
+
+  const getMergedOffset = (
+    targetNode: Window | HTMLElement,
+    targetRect: DOMRect,
+    stackEntry: AffixStackEntry | null,
+    direction: AffixStackDirection,
+  ) => {
+    const offset = direction === 'top' ? internalOffsetTop : offsetBottom;
+    return stackEntry ? getStackOffset(targetNode, targetRect, stackEntry, direction) : offset;
+  };
 
   // =================== Measure ===================
   const measure = () => {
@@ -118,6 +173,8 @@ const Affix = React.forwardRef<AffixRef, InternalAffixProps>((props, ref) => {
       };
       const placeholderRect = getTargetRect(placeholderNodeRef.current);
 
+      const stackEntry = syncStack(targetNode);
+
       if (
         placeholderRect.top === 0 &&
         placeholderRect.left === 0 &&
@@ -128,8 +185,16 @@ const Affix = React.forwardRef<AffixRef, InternalAffixProps>((props, ref) => {
       }
 
       const targetRect = getTargetRect(targetNode);
-      const fixedTop = getFixedTop(placeholderRect, targetRect, internalOffsetTop);
-      const fixedBottom = getFixedBottom(placeholderRect, targetRect, offsetBottom);
+      const fixedTop = getFixedTop(
+        placeholderRect,
+        targetRect,
+        getMergedOffset(targetNode, targetRect, stackEntry, 'top'),
+      );
+      const fixedBottom = getFixedBottom(
+        placeholderRect,
+        targetRect,
+        getMergedOffset(targetNode, targetRect, stackEntry, 'bottom'),
+      );
 
       if (fixedTop !== undefined) {
         newState.affixStyle = {
@@ -179,6 +244,14 @@ const Affix = React.forwardRef<AffixRef, InternalAffixProps>((props, ref) => {
   const updatePosition = throttleByAnimationFrame(() => {
     prepareMeasure();
   });
+  updatePositionRef.current = updatePosition;
+
+  const onResize = () => {
+    if (stackTargetRef.current && stackEntryRef.current) {
+      notifyAffixStack(stackTargetRef.current, stackEntryRef.current);
+    }
+    updatePosition();
+  };
 
   const lazyUpdatePosition = throttleByAnimationFrame(() => {
     // Check position change before measure to make Safari smooth
@@ -187,8 +260,17 @@ const Affix = React.forwardRef<AffixRef, InternalAffixProps>((props, ref) => {
       if (targetNode && placeholderNodeRef.current) {
         const targetRect = getTargetRect(targetNode);
         const placeholderRect = getTargetRect(placeholderNodeRef.current);
-        const fixedTop = getFixedTop(placeholderRect, targetRect, internalOffsetTop);
-        const fixedBottom = getFixedBottom(placeholderRect, targetRect, offsetBottom);
+        const stackEntry = syncStack(targetNode);
+        const fixedTop = getFixedTop(
+          placeholderRect,
+          targetRect,
+          getMergedOffset(targetNode, targetRect, stackEntry, 'top'),
+        );
+        const fixedBottom = getFixedBottom(
+          placeholderRect,
+          targetRect,
+          getMergedOffset(targetNode, targetRect, stackEntry, 'bottom'),
+        );
 
         if (
           (fixedTop !== undefined && affixStyle.top === fixedTop) ||
@@ -232,6 +314,11 @@ const Affix = React.forwardRef<AffixRef, InternalAffixProps>((props, ref) => {
 
   React.useImperativeHandle(ref, () => ({ updatePosition }));
 
+  React.useEffect(() => {
+    syncStack(targetFunc?.());
+    return unregisterStack;
+  }, [stackable, targetFunc, internalOffsetTop, offsetBottom]);
+
   // mount & unmount
   React.useEffect(() => {
     // [Legacy] Wait for parent component ref has its value.
@@ -250,11 +337,11 @@ const Affix = React.forwardRef<AffixRef, InternalAffixProps>((props, ref) => {
   React.useEffect(() => {
     addListeners();
     return () => removeListeners();
-  }, [target, affixStyle, lastAffix, offsetTop, offsetBottom]);
+  }, [target, affixStyle, lastAffix, offsetTop, offsetBottom, stackable]);
 
   React.useEffect(() => {
     updatePosition();
-  }, [target, offsetTop, offsetBottom]);
+  }, [target, offsetTop, offsetBottom, stackable]);
 
   const [hashId, cssVarCls] = useStyle(affixPrefixCls);
 
@@ -263,7 +350,7 @@ const Affix = React.forwardRef<AffixRef, InternalAffixProps>((props, ref) => {
   const mergedCls = clsx({ [rootCls]: affixStyle });
 
   return (
-    <ResizeObserver onResize={updatePosition}>
+    <ResizeObserver onResize={onResize}>
       <div
         style={{ ...contextStyle, ...style }}
         className={clsx(className, contextClassName)}
@@ -272,7 +359,7 @@ const Affix = React.forwardRef<AffixRef, InternalAffixProps>((props, ref) => {
       >
         {affixStyle && <div style={placeholderStyle} aria-hidden="true" />}
         <div className={mergedCls} ref={fixedNodeRef} style={affixStyle}>
-          <ResizeObserver onResize={updatePosition}>{children}</ResizeObserver>
+          <ResizeObserver onResize={onResize}>{children}</ResizeObserver>
         </div>
       </div>
     </ResizeObserver>

--- a/components/affix/index.zh-CN.md
+++ b/components/affix/index.zh-CN.md
@@ -26,6 +26,7 @@ group:
 
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">基本</code>
+<code src="./demo/stackable.tsx">堆叠固定</code>
 <code src="./demo/on-change.tsx">固定状态改变的回调</code>
 <code src="./demo/target.tsx">滚动容器</code>
 <code src="./demo/debug.tsx" debug>调整浏览器大小，观察 Affix 容器是否发生变化。跟随变化为正常。#17678</code>
@@ -38,6 +39,7 @@ group:
 | --- | --- | --- | --- | --- | --- |
 | offsetBottom | 距离窗口底部达到指定偏移量后触发 | number | - |  | × |
 | offsetTop | 距离窗口顶部达到指定偏移量后触发 | number | 0 |  | × |
+| stackable | 同一 `target`、相同固定方向下的多个 Affix 是否依次堆叠以避免相互遮挡 | boolean | false | 6.7.0 | × |
 | target | 设置 `Affix` 需要监听其滚动事件的元素，值为一个返回对应 DOM 元素的函数 | () => Window \| HTMLElement \| null | () => window |  | × |
 | onChange | 固定状态改变时触发的回调函数 | (affixed?: boolean) => void | - |  | × |
 

--- a/components/affix/utils.ts
+++ b/components/affix/utils.ts
@@ -1,5 +1,18 @@
 export type BindElement = HTMLElement | Window | null | undefined;
 
+export type AffixStackDirection = 'top' | 'bottom';
+
+export interface AffixStackEntry {
+  offsetBottom?: number;
+  offsetTop?: number;
+  placeholder: HTMLElement;
+  updatePosition: () => void;
+}
+
+type AffixTarget = Exclude<BindElement, null | undefined>;
+
+const stackRegistry = new WeakMap<AffixTarget, Set<AffixStackEntry>>();
+
 export function getTargetRect(target: BindElement): DOMRect {
   return target !== window
     ? (target as HTMLElement).getBoundingClientRect()
@@ -29,4 +42,82 @@ export function getFixedBottom(
     return offsetBottom + targetBottomOffset;
   }
   return undefined;
+}
+
+export function notifyAffixStack(target: AffixTarget, source?: AffixStackEntry) {
+  stackRegistry.get(target)?.forEach((entry) => {
+    if (entry !== source) {
+      entry.updatePosition();
+    }
+  });
+}
+
+export function registerAffixStack(target: AffixTarget, entry: AffixStackEntry) {
+  let entries = stackRegistry.get(target);
+  if (!entries) {
+    entries = new Set();
+    stackRegistry.set(target, entries);
+  }
+
+  entries.add(entry);
+  notifyAffixStack(target, entry);
+
+  return () => {
+    const currentEntries = stackRegistry.get(target);
+    currentEntries?.delete(entry);
+
+    if (!currentEntries?.size) {
+      stackRegistry.delete(target);
+    } else {
+      notifyAffixStack(target);
+    }
+  };
+}
+
+export function getStackOffset(
+  target: AffixTarget,
+  targetRect: DOMRect,
+  currentEntry: AffixStackEntry,
+  direction: AffixStackDirection,
+) {
+  const getOffset = (entry: AffixStackEntry) =>
+    direction === 'top' ? entry.offsetTop : entry.offsetBottom;
+  const entries = Array.from(stackRegistry.get(target) || []).filter(
+    (entry) => getOffset(entry) !== undefined,
+  );
+
+  entries.sort((a, b) => {
+    const position = a.placeholder.compareDocumentPosition(b.placeholder);
+    let order = 0;
+
+    if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
+      order = -1;
+    } else if (position & Node.DOCUMENT_POSITION_PRECEDING) {
+      order = 1;
+    }
+
+    return direction === 'top' ? order : -order;
+  });
+
+  let nextOffset: number | undefined;
+
+  for (const entry of entries) {
+    const entryOffset = getOffset(entry)!;
+    const offset = nextOffset === undefined ? entryOffset : Math.max(entryOffset, nextOffset);
+    if (entry === currentEntry) {
+      return offset;
+    }
+
+    const placeholderRect = getTargetRect(entry.placeholder);
+    const fixedPosition =
+      direction === 'top'
+        ? getFixedTop(placeholderRect, targetRect, offset)
+        : getFixedBottom(placeholderRect, targetRect, offset);
+
+    if (fixedPosition !== undefined) {
+      nextOffset = offset + placeholderRect.height;
+    }
+  }
+
+  return getOffset(currentEntry);
 }


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close https://github.com/ant-design/ant-design/issues/21083

### 💡 需求背景和解决方案

多个 Affix 使用相同滚动容器和固定方向时，会固定在相同偏移位置并相互遮挡，目前需要业务侧手动计算各自的偏移量。

本次新增 `stackable` 属性，默认值为 `false`。为多个 Affix 启用该属性后，相同 `target` 和固定方向下的 Affix 会按照 DOM 顺序依次堆叠：

- 顶部固定时按照 DOM 正序堆叠。
- 底部固定时按照 DOM 倒序堆叠。
- 仅已达到固定条件的 Affix 参与偏移计算。
- 组件尺寸、目标容器、偏移配置或注册状态变化时会自动重新计算位置。
- 关闭 `stackable` 或卸载组件后，其余 Affix 会立即恢复正确偏移。

同时补充了中英文 API 文档、交互示例，以及顶部、底部、尺寸变化和关闭堆叠场景的测试覆盖。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 English | 🆕 Add Affix `stackable` prop to stack multiple fixed elements without overlapping. |
| 🇨🇳 中文 | 🆕 新增 Affix `stackable` 属性，支持多个固定元素依次堆叠，避免相互遮挡。 |