### PR TITLE
fix(Table): avoid duplicate filter close callbacks

### DIFF
--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -407,8 +407,9 @@ describe('Table.filter', () => {
       }),
     );
     fireEvent.click(container.querySelector('.ant-dropdown-trigger')!);
-    expect(onOpenChange).toHaveBeenCalledWith(true);
-    expect(onFilterDropdownOpenChange).toHaveBeenCalledWith(true);
+    fireEvent.click(container.querySelector('.ant-dropdown-trigger')!);
+    expect(onOpenChange.mock.calls).toEqual([[true], [false]]);
+    expect(onFilterDropdownOpenChange.mock.calls).toEqual([[true], [false]]);
   });
 
   it('can be controlled by filteredValue', () => {

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -328,10 +328,10 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
         setFilteredKeysSync(wrapStringListType(propFilteredKeys));
       }
 
-      triggerVisible(newVisible);
-
       if (!newVisible && !column.filterDropdown && filterOnClose) {
         onConfirm();
+      } else {
+        triggerVisible(newVisible);
       }
     }
   };


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] ✅ 测试用例

### 🔗 相关 Issue

close #58988

### 💡 需求背景和解决方案

Table 列同时使用内置 `filters` 和 `filterDropdownProps.onOpenChange` 时，关闭筛选面板会重复触发两次 `onOpenChange(false)`。

关闭内置筛选面板且 `filterOnClose` 生效时，改为直接通过 `onConfirm` 完成关闭和筛选确认；其他可见状态变化继续调用 `triggerVisible`，避免重复关闭回调。

补充打开、关闭筛选面板的回归断言，确保回调参数严格为 `[true, false]`。

验证结果：

- Table.filter 测试：92 passed
- 快照：10 passed
- ESLint：通过
- diff check：通过

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Table triggering `filterDropdownProps.onOpenChange(false)` twice when closing the built-in filter dropdown. |
| 🇨🇳 中文 | 🐞 修复 Table 关闭内置筛选面板时重复触发 `filterDropdownProps.onOpenChange(false)` 的问题。 |