### PR TITLE
test(Badge): enable button-name accessibility checks

### DIFF
--- a/components/badge/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/badge/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -277,6 +277,7 @@ exports[`renders components/badge/demo/change.tsx extend context correctly 1`] =
       >
         <button
           aria-checked="true"
+          aria-label="Show badge dot"
           class="ant-switch css-var-test-id ant-switch-checked"
           role="switch"
           type="button"
@@ -2023,6 +2024,7 @@ exports[`renders components/badge/demo/no-wrapper.tsx extend context correctly 1
   >
     <button
       aria-checked="true"
+      aria-label="Show badge counts"
       class="ant-switch css-var-test-id ant-switch-checked"
       role="switch"
       type="button"

--- a/components/badge/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/badge/__tests__/__snapshots__/demo.test.tsx.snap
@@ -275,6 +275,7 @@ exports[`renders components/badge/demo/change.tsx correctly 1`] = `
       >
         <button
           aria-checked="true"
+          aria-label="Show badge dot"
           class="ant-switch css-var-test-id ant-switch-checked"
           role="switch"
           type="button"
@@ -2007,6 +2008,7 @@ exports[`renders components/badge/demo/no-wrapper.tsx correctly 1`] = `
   >
     <button
       aria-checked="true"
+      aria-label="Show badge counts"
       class="ant-switch css-var-test-id ant-switch-checked"
       role="switch"
       type="button"

--- a/components/badge/__tests__/a11y.test.ts
+++ b/components/badge/__tests__/a11y.test.ts
@@ -1,3 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('badge', { disabledRules: ['button-name'] });
+accessibilityDemoTest('badge');

--- a/components/badge/demo/change.tsx
+++ b/components/badge/demo/change.tsx
@@ -43,7 +43,7 @@ const App: React.FC = () => {
         <Badge dot={show}>
           <Avatar shape="square" size="large" />
         </Badge>
-        <Switch onChange={onChange} checked={show} />
+        <Switch aria-label="Show badge dot" onChange={onChange} checked={show} />
       </Space>
     </Space>
   );

--- a/components/badge/demo/no-wrapper.tsx
+++ b/components/badge/demo/no-wrapper.tsx
@@ -7,7 +7,7 @@ const App: React.FC = () => {
 
   return (
     <Space>
-      <Switch checked={show} onChange={() => setShow(!show)} />
+      <Switch aria-label="Show badge counts" checked={show} onChange={() => setShow(!show)} />
       <Badge count={show ? 11 : 0} showZero color="#faad14" />
       <Badge count={show ? 25 : 0} />
       <Badge count={show ? <ClockCircleOutlined style={{ color: '#f5222d' }} /> : 0} />


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Related to #22343.

### 💡 Background and Solution

The Badge accessibility demo suite disabled the axe `button-name` rule for every demo. Removing that exemption on current master identified exactly two unnamed controls: the visibility switches in `change.tsx` and `no-wrapper.tsx`.

This change gives those switches stable accessible names that describe what they control, then restores `button-name` enforcement across all 14 Badge demos. It does not change the Badge runtime API or component behavior.

Validation:

- Badge accessibility demos: 14/14 passed with `button-name` enabled
- Complete Badge Jest scope: 7 suites, 90/90 tests, 67/67 snapshots
- Focused demo and accessibility scope on the rebased head: 3 suites, 51/51 tests, 51/51 snapshots
- Badge Vitest scope: 2 files, 33/33 tests
- ESLint, Biome, Prettier, and `git diff --check` passed
- All 66 open pull requests were checked immediately before submission; none touches these five files

The full local typecheck also reports the same unrelated Table demo `FullToken.antCls` and shared Puppeteer type-resolution errors seen in the existing workspace; none points to a changed Badge file.

AI assistance disclosure: Codex reproduced the disabled-rule baseline, traced the two failing controls, prepared the focused change, ran the validation above, and audited open pull requests for overlap. The resulting diff was also independently checked for label semantics and snapshot scope.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Badge demos now expose accessible names for visibility switches and enforce axe `button-name` checks. |
| 🇨🇳 Chinese | Badge 示例中的显示开关现在具有无障碍名称，并启用 axe `button-name` 检查。 |