### PR TITLE
fix(Tree): handle zero key in DirectoryTree range selection

### DIFF
--- a/components/tree/__tests__/directory.test.tsx
+++ b/components/tree/__tests__/directory.test.tsx
@@ -146,6 +146,28 @@ describe('Directory Tree', () => {
     expect(leaf3).not.toHaveClass('ant-tree-node-selected');
   });
 
+  it('select range when the first selected key is 0', () => {
+    const onSelect = jest.fn();
+    const treeData = [
+      { title: 'Zero', key: 0 },
+      { title: 'One', key: 1 },
+      { title: 'Two', key: 2 },
+    ];
+    const { container } = render(
+      <DirectoryTree multiple treeData={treeData} onSelect={onSelect} />,
+    );
+    const nodes = container.querySelectorAll('.ant-tree-node-content-wrapper');
+
+    fireEvent.click(nodes[0]);
+    fireEvent.click(nodes[2], { shiftKey: true });
+
+    expect(container.querySelectorAll('.ant-tree-node-selected')).toHaveLength(3);
+    expect(onSelect).toHaveBeenLastCalledWith(
+      [0, 1, 2],
+      expect.objectContaining({ selectedNodes: treeData }),
+    );
+  });
+
   it('DirectoryTree should expend all when use treeData and defaultExpandAll is true', () => {
     const treeData = [
       {

--- a/components/tree/utils/dictUtil.ts
+++ b/components/tree/utils/dictUtil.ts
@@ -1,7 +1,8 @@
+import type React from 'react';
 import { fillFieldNames } from '@rc-component/tree';
 import type { DataNode } from '@rc-component/tree';
-import type React from 'react';
 
+import { isNonNullable } from '../../_util/is';
 import type { TreeProps } from '../Tree';
 
 const RECORD_NONE = 0;
@@ -47,11 +48,11 @@ export function calcRangeKeys({
   const keys: React.Key[] = [];
   let record: Record = RECORD_NONE;
 
-  if (startKey && startKey === endKey) {
-    return [startKey];
-  }
-  if (!startKey || !endKey) {
+  if (!isNonNullable(startKey) || !isNonNullable(endKey)) {
     return [];
+  }
+  if (startKey === endKey) {
+    return [startKey];
   }
 
   function matchKey(key: React.Key) {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

在线复现：https://codesandbox.io/p/sandbox/directorytree-de-shu-zhi-key-0-hui-dao-zhi-shift-fan-wei-xuan-ze-shi-xiao-5ph3dc?file=%2Findex.tsx

### 💡 需求背景和解决方案

DirectoryTree 支持使用 React Key 作为节点 key，但范围选择原先通过 truthy 判断 key 是否存在，导致数值 `0` 被误判为未提供。

本次改为仅将 `null` 和 `undefined` 视为缺省值，使数值 key `0` 能正常参与 Shift 范围选择，并补充回归测试验证节点选中状态及 `onSelect` 返回值。不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Tree DirectoryTree Shift range selection when the starting node uses numeric key `0`. |
| 🇨🇳 中文 | 🐞 修复 Tree DirectoryTree 起始节点使用数值 key `0` 时 Shift 范围选择失效的问题。 |
