### PR TITLE
test(Card): enable button-name accessibility checks

### DIFF
--- a/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -951,6 +951,7 @@ exports[`renders components/card/demo/loading.tsx extend context correctly 1`] =
 >
   <button
     aria-checked="false"
+    aria-label="Show card content"
     class="ant-switch css-var-test-id"
     role="switch"
     type="button"

--- a/components/card/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/card/__tests__/__snapshots__/demo.test.ts.snap
@@ -912,6 +912,7 @@ exports[`renders components/card/demo/loading.tsx correctly 1`] = `
 >
   <button
     aria-checked="false"
+    aria-label="Show card content"
     class="ant-switch css-var-test-id"
     role="switch"
     type="button"

--- a/components/card/__tests__/a11y.test.ts
+++ b/components/card/__tests__/a11y.test.ts
@@ -1,6 +1,6 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('card', {
-  disabledRules: ['button-name', 'image-alt'],
+  disabledRules: ['image-alt'],
   skip: ['tabs.tsx'],
 });

--- a/components/card/demo/loading.tsx
+++ b/components/card/demo/loading.tsx
@@ -12,7 +12,11 @@ const App: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(true);
   return (
     <Flex gap="medium" align="start" vertical>
-      <Switch checked={!loading} onChange={(checked) => setLoading(!checked)} />
+      <Switch
+        aria-label="Show card content"
+        checked={!loading}
+        onChange={(checked) => setLoading(!checked)}
+      />
       <Card loading={loading} actions={actions} style={{ minWidth: 300 }}>
         <Card.Meta
           avatar={<Avatar src="https://api.dicebear.com/10.x/lorelei/svg?seed=1" />}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Related to #22343.

### 💡 Background and Solution

The Card accessibility demo suite disabled the axe `button-name` rule for every demo. Removing that exemption on current master identified exactly one unnamed control: the switch that toggles loading skeletons in `loading.tsx`.

This change gives the switch a stable accessible name whose checked state means that card content is shown, then restores `button-name` enforcement across all 10 Card demos. The separate existing `image-alt` exemption remains scoped as before. This does not change the Card runtime API or component behavior.

Validation:

- Card accessibility demos: 10/10 passed with `button-name` enabled
- Complete Card Jest scope: 7 suites, 64/64 tests, 49/49 snapshots
- Focused demo and accessibility scope on the rebased head: 3 suites, 40/40 tests, 42/42 snapshots
- Card Vitest scope: 2 files, 21/21 tests
- ESLint, Biome, Prettier, and `git diff --check` passed
- All 63 open pull requests were checked immediately before submission; none touches these four files

The full local typecheck also reports the same unrelated Table demo `FullToken.antCls` and shared Puppeteer type-resolution errors seen on the existing workspace; none points to a changed Card file.

AI assistance disclosure: Codex reproduced the disabled-rule baseline, traced the single failing control, prepared the focused change, ran the validation above, and audited open pull requests for overlap. The resulting diff was independently checked for accessible-name semantics and snapshot scope.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | - |
| 🇨🇳 Chinese | - |