### PR TITLE
style(Notification): improve notification stack motion

### DIFF
--- a/components/notification/style/index.ts
+++ b/components/notification/style/index.ts
@@ -262,6 +262,7 @@ const genNotificationListStyle = <Token extends NotificationToken>(
         [`&:not(${componentCls}-stack-expanded)`]: {
           [noticeCls]: {
             '--notification-scale': 'calc(1 - min(var(--notification-index, 0), 2) * 0.06)',
+            '--notification-opacity': 'calc(1 - min(var(--notification-index, 0), 2) * 0.12)',
           } as CSSObject,
 
           [`${noticeCls}:not(${noticeCls}-stack-in-threshold)`]: {

--- a/components/notification/style/notification.ts
+++ b/components/notification/style/notification.ts
@@ -10,14 +10,23 @@ import type { NotificationToken } from '.';
 
 /** Generate motion transitions shared by notification-like notice cards. */
 const genNotificationItemMotionStyle = (token: NotificationToken): CSSObject => {
-  const { motionDurationMid, motionEaseInOut } = token;
-  const transition = `${motionDurationMid} ${motionEaseInOut}`;
+  const {
+    motionDurationMid,
+    motionDurationSlow,
+    motionEaseInOut,
+    motionEaseInOutCirc,
+    motionEaseOut,
+  } = token;
 
   return {
+    opacity: 'var(--notification-opacity, 1)',
     transform: 'scale(var(--notification-scale, 1))',
-    transition: ['transform', 'inset', 'clip-path', 'opacity']
-      .map((property) => `${property} ${transition}`)
-      .join(', '),
+    transition: [
+      `transform ${motionDurationSlow} ${motionEaseOut}`,
+      `inset ${motionDurationSlow} ${motionEaseInOutCirc}`,
+      `clip-path ${motionDurationMid} ${motionEaseInOut}`,
+      `opacity ${motionDurationMid} ${motionEaseOut}`,
+    ].join(', '),
   };
 };
 

--- a/components/notification/style/placement.ts
+++ b/components/notification/style/placement.ts
@@ -25,6 +25,7 @@ type PlacementStyleConfig = {
   horizontal: HorizontalPlacement;
   inlineEnd: HorizontalPlacement;
   motionOffset: PlacementMotionOffset;
+  leaveMotionOffset: PlacementMotionOffset;
   baseMotionOffset?: PlacementMotionOffset;
   isCenterPlacement: boolean;
 };
@@ -43,11 +44,12 @@ const getPlacementOffset = (
 });
 
 /** Convert placement offsets into the transform used by notice motion. */
-const getMotionTransform = (motionOffset?: PlacementMotionOffset) => {
+const getMotionTransform = (motionOffset?: PlacementMotionOffset, config?: { scale?: string }) => {
   const x = motionOffset?.x ?? '0';
   const y = motionOffset?.y ?? '0';
+  const scale = config?.scale ?? 'var(--notification-scale, 1)';
 
-  return `translate3d(${x}, ${y}, 0) scale(var(--notification-scale, 1))`;
+  return `translate3d(${x}, ${y}, 0) scale(${scale})`;
 };
 
 /** Build the placement metadata used by position and motion styles. */
@@ -69,6 +71,9 @@ const getPlacementStyleConfig = (
     horizontal,
     inlineEnd,
     motionOffset: isCenterPlacement ? { x: '-50%', y: offset } : { x: offset },
+    leaveMotionOffset: isCenterPlacement
+      ? { x: '-50%', y: `calc(${offset} / 2)` }
+      : { x: `calc(${offset} / 2)` },
     baseMotionOffset: isCenterPlacement ? { x: '-50%' } : undefined,
     isCenterPlacement,
   };
@@ -130,6 +135,9 @@ const genPlacementStyle = (token: NotificationToken, config: PlacementStyleConfi
   const enterTransform = getMotionTransform(config.motionOffset);
   // Transform used when fully visible; top/bottom keep translateX(-50%) for centering.
   const baseTransform = getMotionTransform(config.baseMotionOffset);
+  const leaveTransform = getMotionTransform(config.leaveMotionOffset, {
+    scale: 'calc(var(--notification-scale, 1) - 0.05)',
+  });
   const transformOrigin = getPlacementTransformOrigin(vertical);
 
   return {
@@ -175,18 +183,18 @@ const genPlacementStyle = (token: NotificationToken, config: PlacementStyleConfi
       },
 
       [`${noticeMotionCls}-appear-active, ${noticeMotionCls}-enter-active`]: {
-        opacity: 1,
+        opacity: 'var(--notification-opacity, 1)',
         transform: baseTransform,
       },
 
       [`${noticeMotionCls}-leave-start`]: {
-        opacity: 1,
+        opacity: 'var(--notification-opacity, 1)',
         transform: baseTransform,
       },
 
       [`${noticeMotionCls}-leave-active`]: {
         opacity: 0,
-        transform: enterTransform,
+        transform: leaveTransform,
       },
 
       [`&${componentCls}-stack:not(${componentCls}-stack-expanded)`]: {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Ref #56236

### 💡 需求背景和解决方案

Notification 的堆叠动画在收起态和退场补位时不够连贯，尤其是最后一张通知淡出时缺少足够的远近层次，视觉上会比较突兀。

这次改动主要调整了 Notification 堆叠场景下的动效细节：

1. 为收起态的堆叠卡片增加按层级递减的透明度，强化远近关系。
2. 调整 notice 的过渡组合，让 `transform`、`opacity` 和 `clip-path` 的节奏更平滑。
3. 将退场动画从复用入场位移改为沿当前堆叠态继续轻微后退并淡出，改善补位时的连续性。

对比：

旧版本：

https://github.com/user-attachments/assets/b6fd378f-0670-4d47-9498-47793cd2de26

新版本：

https://github.com/user-attachments/assets/b40b66d6-a4e7-460c-8c8f-57f86c174e7d

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Improve Notification stack motion with depth-aware opacity and smoother leave transitions. |
| 🇨🇳 中文 | 优化 Notification 堆叠态的层次透明度与退场补位动画。 |
