### PR TITLE
feat(Progress): support custom circle start position

### DIFF
--- a/components/progress/Circle.tsx
+++ b/components/progress/Circle.tsx
@@ -13,7 +13,7 @@ import type {
   ProgressProps,
   ProgressSemanticAllType,
 } from './progress';
-import { getPercentage, getSize, getStrokeColor } from './utils';
+import { getPercentage, getSize, getStrokeColor, validProgress } from './utils';
 
 const CIRCLE_MIN_STROKE_WIDTH = 3;
 
@@ -46,6 +46,7 @@ const Circle: React.FC<CircleProps> = (props) => {
     children,
     success,
     size = originWidth,
+    startPosition = 0,
     steps,
   } = props;
 
@@ -61,6 +62,7 @@ const Circle: React.FC<CircleProps> = (props) => {
   }
 
   const circleStyle: React.CSSProperties = { width, height, fontSize: width * 0.15 + 6 };
+  const rotateDegree = validProgress(startPosition) * 3.6;
 
   const realGapDegree = React.useMemo<RcProgressProps['gapDegree']>(() => {
     // Support gapDeg = 0 when type = 'dashboard'
@@ -110,6 +112,11 @@ const Circle: React.FC<CircleProps> = (props) => {
       prefixCls={prefixCls}
       gapDegree={realGapDegree}
       gapPosition={gapPos}
+      style={
+        type === 'circle' && rotateDegree
+          ? { transform: `rotate(${rotateDegree}deg)`, transformOrigin: 'center' }
+          : undefined
+      }
       classNames={omit(classNames, OMIT_SEMANTIC_NAMES)}
       styles={omit(styles, OMIT_SEMANTIC_NAMES)}
     />

--- a/components/progress/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/progress/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -499,6 +499,124 @@ exports[`renders components/progress/demo/circle-mini.tsx extend context correct
 
 exports[`renders components/progress/demo/circle-mini.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/progress/demo/circle-start-position.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-small"
+>
+  <div
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow="75"
+    class="ant-progress ant-progress-status-normal ant-progress-circle ant-progress-show-info css-var-test-id"
+    role="progressbar"
+  >
+    <div
+      class="ant-progress-body"
+      style="width: 120px; height: 120px; font-size: 24px;"
+    >
+      <svg
+        class="ant-progress-circle"
+        role="presentation"
+        viewBox="0 0 100 100"
+      >
+        <circle
+          class="ant-progress-circle-rail"
+          cx="50"
+          cy="50"
+          r="47"
+          stroke-linecap="round"
+          stroke-width="6"
+          style="stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 0; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0;"
+        />
+        <circle
+          class="ant-progress-circle-path"
+          cx="50"
+          cy="50"
+          opacity="1"
+          r="47"
+          stroke-linecap="round"
+          stroke-width="6"
+          style="stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 76.82742735936014; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+        />
+        <circle
+          class="ant-progress-circle-path"
+          cx="50"
+          cy="50"
+          opacity="0"
+          r="47"
+          stroke-linecap="round"
+          stroke-width="6"
+          style="stroke: #52C41A; stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 295.2997094374406; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+        />
+      </svg>
+      <span
+        class="ant-progress-indicator"
+        title="75%"
+      >
+        75%
+      </span>
+    </div>
+  </div>
+  <div
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow="75"
+    class="ant-progress ant-progress-status-normal ant-progress-circle ant-progress-show-info css-var-test-id"
+    role="progressbar"
+  >
+    <div
+      class="ant-progress-body"
+      style="width: 120px; height: 120px; font-size: 24px;"
+    >
+      <svg
+        class="ant-progress-circle"
+        role="presentation"
+        style="transform: rotate(90deg); transform-origin: center;"
+        viewBox="0 0 100 100"
+      >
+        <circle
+          class="ant-progress-circle-rail"
+          cx="50"
+          cy="50"
+          r="47"
+          stroke-linecap="round"
+          stroke-width="6"
+          style="stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 0; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0;"
+        />
+        <circle
+          class="ant-progress-circle-path"
+          cx="50"
+          cy="50"
+          opacity="1"
+          r="47"
+          stroke-linecap="round"
+          stroke-width="6"
+          style="stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 76.82742735936014; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+        />
+        <circle
+          class="ant-progress-circle-path"
+          cx="50"
+          cy="50"
+          opacity="0"
+          r="47"
+          stroke-linecap="round"
+          stroke-width="6"
+          style="stroke: #52C41A; stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 295.2997094374406; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+        />
+      </svg>
+      <span
+        class="ant-progress-indicator"
+        title="75%"
+      >
+        75%
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/progress/demo/circle-start-position.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/progress/demo/circle-steps.tsx extend context correctly 1`] = `
 Array [
   <h5

--- a/components/progress/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/progress/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -504,113 +504,127 @@ exports[`renders components/progress/demo/circle-start-position.tsx extend conte
   class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-small"
 >
   <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    aria-valuenow="75"
-    class="ant-progress ant-progress-status-normal ant-progress-circle ant-progress-show-info css-var-test-id"
-    role="progressbar"
+    class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small ant-flex-vertical"
   >
     <div
-      class="ant-progress-body"
-      style="width: 120px; height: 120px; font-size: 24px;"
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="75"
+      class="ant-progress ant-progress-status-normal ant-progress-circle ant-progress-show-info css-var-test-id"
+      role="progressbar"
     >
-      <svg
-        class="ant-progress-circle"
-        role="presentation"
-        viewBox="0 0 100 100"
+      <div
+        class="ant-progress-body"
+        style="width: 120px; height: 120px; font-size: 24px;"
       >
-        <circle
-          class="ant-progress-circle-rail"
-          cx="50"
-          cy="50"
-          r="47"
-          stroke-linecap="round"
-          stroke-width="6"
-          style="stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 0; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0;"
-        />
-        <circle
-          class="ant-progress-circle-path"
-          cx="50"
-          cy="50"
-          opacity="1"
-          r="47"
-          stroke-linecap="round"
-          stroke-width="6"
-          style="stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 76.82742735936014; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
-        />
-        <circle
-          class="ant-progress-circle-path"
-          cx="50"
-          cy="50"
-          opacity="0"
-          r="47"
-          stroke-linecap="round"
-          stroke-width="6"
-          style="stroke: #52C41A; stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 295.2997094374406; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
-        />
-      </svg>
-      <span
-        class="ant-progress-indicator"
-        title="75%"
-      >
-        75%
-      </span>
+        <svg
+          class="ant-progress-circle"
+          role="presentation"
+          viewBox="0 0 100 100"
+        >
+          <circle
+            class="ant-progress-circle-rail"
+            cx="50"
+            cy="50"
+            r="47"
+            stroke-linecap="round"
+            stroke-width="6"
+            style="stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 0; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0;"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="50"
+            cy="50"
+            opacity="1"
+            r="47"
+            stroke-linecap="round"
+            stroke-width="6"
+            style="stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 76.82742735936014; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="50"
+            cy="50"
+            opacity="0"
+            r="47"
+            stroke-linecap="round"
+            stroke-width="6"
+            style="stroke: #52C41A; stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 295.2997094374406; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+        </svg>
+        <span
+          class="ant-progress-indicator"
+          title="75%"
+        >
+          75%
+        </span>
+      </div>
     </div>
+    <span>
+      startPosition: 0
+    </span>
   </div>
   <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    aria-valuenow="75"
-    class="ant-progress ant-progress-status-normal ant-progress-circle ant-progress-show-info css-var-test-id"
-    role="progressbar"
+    class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small ant-flex-vertical"
   >
     <div
-      class="ant-progress-body"
-      style="width: 120px; height: 120px; font-size: 24px;"
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="75"
+      class="ant-progress ant-progress-status-normal ant-progress-circle ant-progress-show-info css-var-test-id"
+      role="progressbar"
     >
-      <svg
-        class="ant-progress-circle"
-        role="presentation"
-        style="transform: rotate(90deg); transform-origin: center;"
-        viewBox="0 0 100 100"
+      <div
+        class="ant-progress-body"
+        style="width: 120px; height: 120px; font-size: 24px;"
       >
-        <circle
-          class="ant-progress-circle-rail"
-          cx="50"
-          cy="50"
-          r="47"
-          stroke-linecap="round"
-          stroke-width="6"
-          style="stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 0; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0;"
-        />
-        <circle
-          class="ant-progress-circle-path"
-          cx="50"
-          cy="50"
-          opacity="1"
-          r="47"
-          stroke-linecap="round"
-          stroke-width="6"
-          style="stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 76.82742735936014; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
-        />
-        <circle
-          class="ant-progress-circle-path"
-          cx="50"
-          cy="50"
-          opacity="0"
-          r="47"
-          stroke-linecap="round"
-          stroke-width="6"
-          style="stroke: #52C41A; stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 295.2997094374406; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
-        />
-      </svg>
-      <span
-        class="ant-progress-indicator"
-        title="75%"
-      >
-        75%
-      </span>
+        <svg
+          class="ant-progress-circle"
+          role="presentation"
+          style="transform: rotate(90deg); transform-origin: center;"
+          viewBox="0 0 100 100"
+        >
+          <circle
+            class="ant-progress-circle-rail"
+            cx="50"
+            cy="50"
+            r="47"
+            stroke-linecap="round"
+            stroke-width="6"
+            style="stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 0; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0;"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="50"
+            cy="50"
+            opacity="1"
+            r="47"
+            stroke-linecap="round"
+            stroke-width="6"
+            style="stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 76.82742735936014; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="50"
+            cy="50"
+            opacity="0"
+            r="47"
+            stroke-linecap="round"
+            stroke-width="6"
+            style="stroke: #52C41A; stroke-dasharray: 295.3097094374406px 295.3097094374406; stroke-dashoffset: 295.2997094374406; transform: rotate(-90deg); transform-origin: 50px 50px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s; fill-opacity: 0; transition-duration: 0s, 0s;"
+          />
+        </svg>
+        <span
+          class="ant-progress-indicator"
+          title="75%"
+        >
+          75%
+        </span>
+      </div>
     </div>
+    <span>
+      startPosition: 25
+    </span>
   </div>
 </div>
 `;

--- a/components/progress/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.ts.snap
@@ -472,113 +472,127 @@ exports[`renders components/progress/demo/circle-start-position.tsx correctly 1`
   class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-small"
 >
   <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    aria-valuenow="75"
-    class="ant-progress ant-progress-status-normal ant-progress-circle ant-progress-show-info css-var-test-id"
-    role="progressbar"
+    class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small ant-flex-vertical"
   >
     <div
-      class="ant-progress-body"
-      style="width:120px;height:120px;font-size:24px"
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="75"
+      class="ant-progress ant-progress-status-normal ant-progress-circle ant-progress-show-info css-var-test-id"
+      role="progressbar"
     >
-      <svg
-        class="ant-progress-circle"
-        role="presentation"
-        viewBox="0 0 100 100"
+      <div
+        class="ant-progress-body"
+        style="width:120px;height:120px;font-size:24px"
       >
-        <circle
-          class="ant-progress-circle-rail"
-          cx="50"
-          cy="50"
-          r="47"
-          stroke-linecap="round"
-          stroke-width="6"
-          style="stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:0;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
-        />
-        <circle
-          class="ant-progress-circle-path"
-          cx="50"
-          cy="50"
-          opacity="1"
-          r="47"
-          stroke-linecap="round"
-          stroke-width="6"
-          style="stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:76.82742735936014;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
-        />
-        <circle
-          class="ant-progress-circle-path"
-          cx="50"
-          cy="50"
-          opacity="0"
-          r="47"
-          stroke-linecap="round"
-          stroke-width="6"
-          style="stroke:#52C41A;stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:295.2997094374406;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
-        />
-      </svg>
-      <span
-        class="ant-progress-indicator"
-        title="75%"
-      >
-        75%
-      </span>
+        <svg
+          class="ant-progress-circle"
+          role="presentation"
+          viewBox="0 0 100 100"
+        >
+          <circle
+            class="ant-progress-circle-rail"
+            cx="50"
+            cy="50"
+            r="47"
+            stroke-linecap="round"
+            stroke-width="6"
+            style="stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:0;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="50"
+            cy="50"
+            opacity="1"
+            r="47"
+            stroke-linecap="round"
+            stroke-width="6"
+            style="stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:76.82742735936014;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="50"
+            cy="50"
+            opacity="0"
+            r="47"
+            stroke-linecap="round"
+            stroke-width="6"
+            style="stroke:#52C41A;stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:295.2997094374406;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+        </svg>
+        <span
+          class="ant-progress-indicator"
+          title="75%"
+        >
+          75%
+        </span>
+      </div>
     </div>
+    <span>
+      startPosition: 0
+    </span>
   </div>
   <div
-    aria-valuemax="100"
-    aria-valuemin="0"
-    aria-valuenow="75"
-    class="ant-progress ant-progress-status-normal ant-progress-circle ant-progress-show-info css-var-test-id"
-    role="progressbar"
+    class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small ant-flex-vertical"
   >
     <div
-      class="ant-progress-body"
-      style="width:120px;height:120px;font-size:24px"
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="75"
+      class="ant-progress ant-progress-status-normal ant-progress-circle ant-progress-show-info css-var-test-id"
+      role="progressbar"
     >
-      <svg
-        class="ant-progress-circle"
-        role="presentation"
-        style="transform:rotate(90deg);transform-origin:center"
-        viewBox="0 0 100 100"
+      <div
+        class="ant-progress-body"
+        style="width:120px;height:120px;font-size:24px"
       >
-        <circle
-          class="ant-progress-circle-rail"
-          cx="50"
-          cy="50"
-          r="47"
-          stroke-linecap="round"
-          stroke-width="6"
-          style="stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:0;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
-        />
-        <circle
-          class="ant-progress-circle-path"
-          cx="50"
-          cy="50"
-          opacity="1"
-          r="47"
-          stroke-linecap="round"
-          stroke-width="6"
-          style="stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:76.82742735936014;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
-        />
-        <circle
-          class="ant-progress-circle-path"
-          cx="50"
-          cy="50"
-          opacity="0"
-          r="47"
-          stroke-linecap="round"
-          stroke-width="6"
-          style="stroke:#52C41A;stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:295.2997094374406;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
-        />
-      </svg>
-      <span
-        class="ant-progress-indicator"
-        title="75%"
-      >
-        75%
-      </span>
+        <svg
+          class="ant-progress-circle"
+          role="presentation"
+          style="transform:rotate(90deg);transform-origin:center"
+          viewBox="0 0 100 100"
+        >
+          <circle
+            class="ant-progress-circle-rail"
+            cx="50"
+            cy="50"
+            r="47"
+            stroke-linecap="round"
+            stroke-width="6"
+            style="stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:0;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="50"
+            cy="50"
+            opacity="1"
+            r="47"
+            stroke-linecap="round"
+            stroke-width="6"
+            style="stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:76.82742735936014;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+          <circle
+            class="ant-progress-circle-path"
+            cx="50"
+            cy="50"
+            opacity="0"
+            r="47"
+            stroke-linecap="round"
+            stroke-width="6"
+            style="stroke:#52C41A;stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:295.2997094374406;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+          />
+        </svg>
+        <span
+          class="ant-progress-indicator"
+          title="75%"
+        >
+          75%
+        </span>
+      </div>
     </div>
+    <span>
+      startPosition: 25
+    </span>
   </div>
 </div>
 `;

--- a/components/progress/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.ts.snap
@@ -467,6 +467,122 @@ exports[`renders components/progress/demo/circle-mini.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/progress/demo/circle-start-position.tsx correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-small"
+>
+  <div
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow="75"
+    class="ant-progress ant-progress-status-normal ant-progress-circle ant-progress-show-info css-var-test-id"
+    role="progressbar"
+  >
+    <div
+      class="ant-progress-body"
+      style="width:120px;height:120px;font-size:24px"
+    >
+      <svg
+        class="ant-progress-circle"
+        role="presentation"
+        viewBox="0 0 100 100"
+      >
+        <circle
+          class="ant-progress-circle-rail"
+          cx="50"
+          cy="50"
+          r="47"
+          stroke-linecap="round"
+          stroke-width="6"
+          style="stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:0;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+        />
+        <circle
+          class="ant-progress-circle-path"
+          cx="50"
+          cy="50"
+          opacity="1"
+          r="47"
+          stroke-linecap="round"
+          stroke-width="6"
+          style="stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:76.82742735936014;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+        />
+        <circle
+          class="ant-progress-circle-path"
+          cx="50"
+          cy="50"
+          opacity="0"
+          r="47"
+          stroke-linecap="round"
+          stroke-width="6"
+          style="stroke:#52C41A;stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:295.2997094374406;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+        />
+      </svg>
+      <span
+        class="ant-progress-indicator"
+        title="75%"
+      >
+        75%
+      </span>
+    </div>
+  </div>
+  <div
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow="75"
+    class="ant-progress ant-progress-status-normal ant-progress-circle ant-progress-show-info css-var-test-id"
+    role="progressbar"
+  >
+    <div
+      class="ant-progress-body"
+      style="width:120px;height:120px;font-size:24px"
+    >
+      <svg
+        class="ant-progress-circle"
+        role="presentation"
+        style="transform:rotate(90deg);transform-origin:center"
+        viewBox="0 0 100 100"
+      >
+        <circle
+          class="ant-progress-circle-rail"
+          cx="50"
+          cy="50"
+          r="47"
+          stroke-linecap="round"
+          stroke-width="6"
+          style="stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:0;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+        />
+        <circle
+          class="ant-progress-circle-path"
+          cx="50"
+          cy="50"
+          opacity="1"
+          r="47"
+          stroke-linecap="round"
+          stroke-width="6"
+          style="stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:76.82742735936014;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+        />
+        <circle
+          class="ant-progress-circle-path"
+          cx="50"
+          cy="50"
+          opacity="0"
+          r="47"
+          stroke-linecap="round"
+          stroke-width="6"
+          style="stroke:#52C41A;stroke-dasharray:295.3097094374406px 295.3097094374406;stroke-dashoffset:295.2997094374406;transform:rotate(-90deg);transform-origin:50px 50px;transition:stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;fill-opacity:0"
+        />
+      </svg>
+      <span
+        class="ant-progress-indicator"
+        title="75%"
+      >
+        75%
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/progress/demo/circle-steps.tsx correctly 1`] = `
 Array [
   <h5

--- a/components/progress/__tests__/index.test.tsx
+++ b/components/progress/__tests__/index.test.tsx
@@ -41,6 +41,18 @@ describe('Progress', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('should start circle progress at the specified position', () => {
+    const { container, getByRole } = render(
+      <Progress type="circle" percent={30} startPosition={25} />,
+    );
+
+    expect(container.querySelector('svg')).toHaveStyle({
+      transform: 'rotate(90deg)',
+      transformOrigin: 'center',
+    });
+    expect(getByRole('progressbar')).not.toHaveAttribute('startPosition');
+  });
+
   it('render out-of-range progress with info', () => {
     const { container: wrapper } = render(<Progress percent={120} showInfo />);
     expect(wrapper.firstChild).toMatchSnapshot();

--- a/components/progress/demo/circle-start-position.md
+++ b/components/progress/demo/circle-start-position.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+通过 `startPosition` 设置圆形进度条的起点位置。
+
+## en-US
+
+Use `startPosition` to set the starting position of a circular progress bar.

--- a/components/progress/demo/circle-start-position.tsx
+++ b/components/progress/demo/circle-start-position.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Flex, Progress } from 'antd';
+
+const App: React.FC = () => (
+  <Flex gap="small" wrap>
+    <Progress type="circle" percent={75} />
+    <Progress type="circle" percent={75} startPosition={25} />
+  </Flex>
+);
+
+export default App;

--- a/components/progress/demo/circle-start-position.tsx
+++ b/components/progress/demo/circle-start-position.tsx
@@ -3,8 +3,14 @@ import { Flex, Progress } from 'antd';
 
 const App: React.FC = () => (
   <Flex gap="small" wrap>
-    <Progress type="circle" percent={75} />
-    <Progress type="circle" percent={75} startPosition={25} />
+    <Flex vertical align="center" gap="small">
+      <Progress type="circle" percent={75} />
+      <span>startPosition: 0</span>
+    </Flex>
+    <Flex vertical align="center" gap="small">
+      <Progress type="circle" percent={75} startPosition={25} />
+      <span>startPosition: 25</span>
+    </Flex>
   </Flex>
 );
 

--- a/components/progress/index.en-US.md
+++ b/components/progress/index.en-US.md
@@ -21,6 +21,7 @@ If it will take a long time to complete an operation, you can use `Progress` to 
 <!-- prettier-ignore -->
 <code src="./demo/line.tsx">Progress bar</code>
 <code src="./demo/circle.tsx">Circular progress bar</code>
+<code src="./demo/circle-start-position.tsx" version="6.7.0">Custom starting position</code>
 <code src="./demo/line-mini.tsx">Mini size progress bar</code>
 <code src="./demo/circle-micro.tsx">Responsive circular progress bar</code>
 <code src="./demo/circle-mini.tsx">Mini size circular progress bar</code>
@@ -71,6 +72,7 @@ Properties that shared by all types.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
+| startPosition | The starting position, as a percentage from 0 to 100 clockwise from 12 o'clock | number | 0 | 6.7.0 |
 | steps | The total step count. When passing an object, `count` refers to the number of steps, and `gap` refers to the distance between them. When passing a number, the default value for `gap` is 2. | number \| { count: number, gap: number } | - | 5.16.0 |
 | strokeColor | The color of circular progress, render gradient when passing an object | string \| { number%: string } | - | - |
 | strokeWidth | To set the width of the circular progress, unit: percentage of the canvas width | number | 6 | - |

--- a/components/progress/index.zh-CN.md
+++ b/components/progress/index.zh-CN.md
@@ -22,6 +22,7 @@ demo:
 <!-- prettier-ignore -->
 <code src="./demo/line.tsx">进度条</code>
 <code src="./demo/circle.tsx">进度圈</code>
+<code src="./demo/circle-start-position.tsx" version="6.7.0">自定义起点位置</code>
 <code src="./demo/line-mini.tsx">小型进度条</code>
 <code src="./demo/circle-micro.tsx">响应式进度圈</code>
 <code src="./demo/circle-mini.tsx">小型进度圈</code>
@@ -72,6 +73,7 @@ demo:
 
 | 属性 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
+| startPosition | 起点位置，以 12 点钟方向为 0，按顺时针方向取 0 到 100 之间的百分比 | number | 0 | 6.7.0 |
 | steps | 进度条总共步数，传入 object 时，count 指步数，gap 指间隔大小。传 number 类型时，gap 默认为 2。 | number \| { count: number, gap: number } | - | 5.16.0 |
 | strokeColor | 圆形进度条线的色彩，传入 object 时为渐变 | string \| { number%: string } | - | - |
 | strokeWidth | 圆形进度条线的宽度，单位是进度条画布宽度的百分比 | number | 6 | - |

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -91,6 +91,7 @@ export interface ProgressProps extends ProgressAriaProps {
   /** @deprecated please use `gapPlacement` instead */
   gapPosition?: GapPosition;
   size?: number | [number | string, number] | ProgressSize | { width?: number; height?: number };
+  startPosition?: number;
   steps?: number | { count: number; gap: number };
   percentPosition?: PercentPositionType;
   children?: React.ReactNode;
@@ -354,6 +355,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>((props, ref) =>
         'gapPosition',
         'gapPlacement',
         'strokeLinecap',
+        'startPosition',
         'success',
       ])}
     >


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #49401

### 💡 需求背景和解决方案

圆形 Progress 当前固定从 12 点钟方向开始，无法满足需要自定义进度起点的使用场景。

新增 `startPosition` 属性，以 12 点钟方向为 0，支持通过 0 到 100 之间的百分比按顺时针方向设置圆形进度条的起点。该属性仅作用于 `type="circle"`，不会影响中间的进度文本。

<img width="969" height="952" alt="image" src="https://github.com/user-attachments/assets/0c07f7f8-5b3e-4d0c-8a55-8c2d38d9ae7d" />


同时补充默认起点与自定义起点的对比 demo、中英文 API 文档及相关测试。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🆕 Add Progress `startPosition` to customize the starting position of circular progress. |
| 🇨🇳 中文 | 🆕 新增 Progress `startPosition` 属性，支持自定义圆形进度条的起点位置。 |