### PR TITLE
docs: align notFoundContent default values across components

### DIFF
--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -76,7 +76,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | maxTagCount | Max tag count to show. `responsive` will cost render performance | number \| `responsive` | - | 4.17.0 | × |
 | maxTagPlaceholder | Placeholder for not showing tags | ReactNode \| function(omittedValues) | - | 4.17.0 | × |
 | maxTagTextLength | Max tag text length to show | number | - | 4.17.0 | × |
-| notFoundContent | Specify content to show when no result matches | ReactNode | `Not Found` |  | × |
+| notFoundContent | Specify content to show when no result matches | ReactNode | `No data` |  | × |
 | open | Set visible of cascader popup | boolean | - | 4.17.0 | × |
 | options | The data options of cascade | [Option](#option)\[] | - |  | × |
 | placeholder | The input placeholder | string | - |  | × |

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -77,7 +77,7 @@ demo:
 | maxTagCount | 最多显示多少个 tag，响应式模式会对性能产生损耗 | number \| `responsive` | - | 4.17.0 | × |
 | maxTagPlaceholder | 隐藏 tag 时显示的内容 | ReactNode \| function(omittedValues) | - | 4.17.0 | × |
 | maxTagTextLength | 最大显示的 tag 文本长度 | number | - | 4.17.0 | × |
-| notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | `Not Found` |  | × |
+| notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | `暂无数据` |  | × |
 | open | 控制浮层显隐 | boolean | - | 4.17.0 | × |
 | options | 可选项数据源 | [Option](#option)\[] | - |  | × |
 | placeholder | 输入框占位文本 | string | - |  | × |

--- a/components/mentions/index.en-US.md
+++ b/components/mentions/index.en-US.md
@@ -47,7 +47,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | defaultValue | Default value | string | - |  | × |
 | filterOption | Customize filter option logic | false \| (input: string, option: OptionProps) => boolean | - |  | × |
 | getPopupContainer | Set the mount HTML node for suggestions | () => HTMLElement | - |  | × |
-| notFoundContent | Set mentions content when not match | ReactNode | `Not Found` |  | × |
+| notFoundContent | Set mentions content when not match | ReactNode | `No data` |  | × |
 | placement | Set popup placement | `top` \| `bottom` | `bottom` |  | × |
 | popupRender | Customize the dropdown menu rendering | (menu: React.ReactElement) => ReactNode | - | 6.6.0 | × |
 | prefix | Set trigger prefix keyword | string \| string\[] | `@` |  | × |

--- a/components/mentions/index.zh-CN.md
+++ b/components/mentions/index.zh-CN.md
@@ -48,7 +48,7 @@ demo:
 | defaultValue | 默认值 | string | - |  | × |
 | filterOption | 自定义过滤逻辑 | false \| (input: string, option: OptionProps) => boolean | - |  | × |
 | getPopupContainer | 指定建议框挂载的 HTML 节点 | () => HTMLElement | - |  | × |
-| notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | `Not Found` |  | × |
+| notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | `暂无数据` |  | × |
 | placement | 弹出层展示位置 | `top` \| `bottom` | `bottom` |  | × |
 | popupRender | 自定义下拉菜单渲染 | (menu: React.ReactElement) => ReactNode | - | 6.6.0 | × |
 | prefix | 设置触发关键字 | string \| string\[] | `@` |  | × |

--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -91,7 +91,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | maxTagTextLength | Max tag text length to show | number | - |  | × |
 | menuItemSelectedIcon | The custom menuItemSelected icon with multiple options | ReactNode | `<CheckOutlined />` |  | 6.4.0 |
 | mode | Set mode of Select | `multiple` \| `tags` | - |  | × |
-| notFoundContent | Specify content to show when no result matches | ReactNode | `Not Found` |  | × |
+| notFoundContent | Specify content to show when no result matches | ReactNode | `No data` |  | × |
 | open | Controlled open state of dropdown | boolean | - |  | × |
 | ~~optionFilterProp~~ | Deprecated, see `showSearch.optionFilterProp` |  |  |  | × |
 | optionLabelProp | Which prop value of option will render as content of select. [Example](https://codesandbox.io/s/antd-reproduction-template-tk678) | string | `children` |  | × |

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -92,7 +92,7 @@ demo:
 | maxTagTextLength | 最大显示的 tag 文本长度 | number | - |  | × |
 | menuItemSelectedIcon | 自定义多选时当前选中的条目图标 | ReactNode | `<CheckOutlined />` |  | 6.4.0 |
 | mode | 设置 Select 的模式为多选或标签 | `multiple` \| `tags` | - |  | × |
-| notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | `Not Found` |  | × |
+| notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | `暂无数据` |  | × |
 | open | 是否展开下拉菜单 | boolean | - |  | × |
 | ~~optionFilterProp~~ | 已废弃，见 `showSearch.optionFilterProp` |  |  |  | × |
 | optionLabelProp | 回填到选择框的 Option 的属性值，默认是 Option 的子元素。比如在子元素需要高亮效果时，此值可以设为 `value`。[示例](https://codesandbox.io/s/antd-reproduction-template-tk678) | string | `children` |  | × |

--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -51,7 +51,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | filterOption | A function to determine whether an item should show in search result list, only works when searching, (add `direction` support since 5.9.0+) | (inputValue, option, direction: `left` \| `right`): boolean | - |  | × |
 | footer | A function used for rendering the footer | (props, { direction }) => ReactNode | - | direction: 4.17.0 | × |
 | ~~listStyle~~ | A custom CSS style used for rendering the transfer columns. Use `styles.section` instead | object \| ({direction: `left` \| `right`}) => object | - |  | × |
-| locale | The i18n text including filter, empty text, item unit, etc | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode \| ReactNode[]; } | { itemUnit: `item`, itemsUnit: `items`, notFoundContent: `The list is empty`, searchPlaceholder: `Search here` } |  | × |
+| locale | The i18n text including filter, empty text, item unit, etc | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode \| ReactNode[]; } | { itemUnit: `item`, itemsUnit: `items`, notFoundContent: `No data`, searchPlaceholder: `Search here` } |  | × |
 | oneWay | Display as single direction style | boolean | false | 4.3.0 | × |
 | ~~operations~~ | A set of operations that are sorted from top to bottom. Use `actions` instead. | string\[] | \[`>`, `<`] |  | × |
 | ~~operationStyle~~ | A custom CSS style used for rendering the operations column. Use `styles.actions` instead. | object | - |  | × |

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -52,7 +52,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*g9vUQq2nkpEAAA
 | filterOption | 根据搜索内容进行筛选，接收 `inputValue` `option` `direction` 三个参数，(`direction` 自5.9.0+支持)，当 `option` 符合筛选条件时，应返回 true，反之则返回 false | (inputValue, option, direction: `left` \| `right`): boolean | - |  | × |
 | footer | 底部渲染函数 | (props, { direction }) => ReactNode | - | direction: 4.17.0 | × |
 | ~~listStyle~~ | 两个穿梭框的自定义样式，使用 `styles.section` 代替 | object\|({direction: `left` \| `right`}) => object | - |  | × |
-| locale | 各种语言 | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode \| ReactNode[]; } | { itemUnit: `项`, itemsUnit: `项`, searchPlaceholder: `请输入搜索内容`, notFoundContent: `该项列表为空` } |  | × |
+| locale | 各种语言 | { itemUnit: string; itemsUnit: string; searchPlaceholder: string; notFoundContent: ReactNode \| ReactNode[]; } | { itemUnit: `项`, itemsUnit: `项`, searchPlaceholder: `请输入搜索内容`, notFoundContent: `暂无数据` } |  | × |
 | oneWay | 展示为单向样式 | boolean | false | 4.3.0 | × |
 | ~~operations~~ | 操作文案集合，顺序从上至下。使用 `actions` 代替 | string\[] | \[`>`, `<`] |  | × |
 | ~~operationStyle~~ | 操作栏的自定义样式，使用 `styles.actions` 代替 | CSSProperties | - |  | × |

--- a/components/tree-select/index.en-US.md
+++ b/components/tree-select/index.en-US.md
@@ -64,7 +64,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | maxTagPlaceholder | Placeholder for not showing tags | ReactNode \| function(omittedValues) | - |  | × |
 | maxTagTextLength | Max tag text length to show | number | - |  | × |
 | multiple | Support multiple or not, will be `true` when enable `treeCheckable` | boolean | false |  | × |
-| notFoundContent | Specify content to show when no result matches | ReactNode | `Not Found` |  | × |
+| notFoundContent | Specify content to show when no result matches | ReactNode | `No data` |  | × |
 | open | Controlled open state of dropdown | boolean | - |  | × |
 | placeholder | Placeholder of the select input | string | - |  | × |
 | placement | The position where the selection box pops up | `bottomLeft` `bottomRight` `topLeft` `topRight` | bottomLeft |  | × |

--- a/components/tree-select/index.zh-CN.md
+++ b/components/tree-select/index.zh-CN.md
@@ -65,7 +65,7 @@ demo:
 | maxTagPlaceholder | 隐藏 tag 时显示的内容 | ReactNode \| function(omittedValues) | - |  | × |
 | maxTagTextLength | 最大显示的 tag 文本长度 | number | - |  | × |
 | multiple | 支持多选（当设置 treeCheckable 时自动变为 true） | boolean | false |  | × |
-| notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | `Not Found` |  | × |
+| notFoundContent | 当下拉列表为空时显示的内容 | ReactNode | `暂无数据` |  | × |
 | open | 是否展开下拉菜单 | boolean | - |  | × |
 | placeholder | 选择框默认文字 | string | - |  | × |
 | placement | 选择框弹出的位置 | `bottomLeft` `bottomRight` `topLeft` `topRight` | bottomLeft |  | × |


### PR DESCRIPTION
## 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

## 🔗 Related issue link

#59066

## 💡 Background and solution

Update \
otFoundContent\ default value documentation to reflect actual behavior:
- All affected components use \DefaultRenderEmpty\ which renders the Empty component
- Empty component has locale-aware defaults: \'No data'\ (en) and \'暂无数据'\ (zh-CN)
- Documentation previously showed \'Not Found'\ which was incorrect

### Affected Components

- **Select** (\components/select/index.*.md\)
- **TreeSelect** (\components/tree-select/index.*.md\)
- **Cascader** (\components/cascader/index.*.md\)
- **Mentions** (\components/mentions/index.*.md\)
- **Transfer** (\components/transfer/index.*.md\)

## 📝 Changelog

| Language | Component | API | From | To |
|---|---|---|---|---|
| en-US | Select, TreeSelect, Cascader, Mentions, Transfer | notFoundContent default | \'Not Found'\ | \'No data'\ |
| zh-CN | Select, TreeSelect, Cascader, Mentions, Transfer | notFoundContent default | \'Not Found'\ | \'暂无数据'\ |

## ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed