### PR TITLE
docs: correct Tabs tabPosition API type

### DIFF
--- a/components/tabs/index.en-US.md
+++ b/components/tabs/index.en-US.md
@@ -67,7 +67,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | tabBarGutter | The gap between tabs | number | - |  | × |
 | tabBarStyle | Tab bar style object | CSSProperties | - |  | × |
 | tabPlacement | Placement of tabs | `top` \| `end` \| `bottom` \| `start` | `top` |  | × |
-| ~~tabPosition~~ | Position of tabs | `top` \| `right` \| `bottom` \| `left`, please use `tabPlacement` instead | `top` |  | × |
+| ~~tabPosition~~ | Position of tabs, please use `tabPlacement` instead | `top` \| `right` \| `bottom` \| `left` | `top` |  | × |
 | ~~destroyInactiveTabPane~~ | Whether destroy inactive TabPane when change tab, use `destroyOnHidden` instead | boolean | false |  | × |
 | destroyOnHidden | Whether destroy inactive TabPane when change tab | boolean | false | 5.25.0 | × |
 | type | Basic style of tabs | `line` \| `card` \| `editable-card` | `line` |  | × |


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

None

### 💡 需求背景和解决方案

英文文档里 Tabs 已废弃的 `tabPosition` 把「please use `tabPlacement` instead」写进了 Type 列，类型列因此不准确。这次把它挪到 Description 列，Type 列只保留 `top | right | bottom | left`，与中文文档对齐。不涉及组件实现或公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述              |
| ------- | --------------------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志          |

Made with [Cursor](https://cursor.com)