### PR TITLE
feat(Typography): support shimmer effect

### DIFF
--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -18,9 +18,9 @@ import { isFunction, isReactRenderable } from '../../_util/is';
 import { isStyleSupport } from '../../_util/styleChecker';
 import type { DirectionType } from '../../config-provider';
 import useLocale from '../../locale/useLocale';
+import { genCssVar } from '../../theme/util/genStyleUtils';
 import type { TooltipProps } from '../../tooltip';
 import Tooltip from '../../tooltip';
-import { genCssVar } from '../../theme/util/genStyleUtils';
 import Editable from '../Editable';
 import useCopyClick from '../hooks/useCopyClick';
 import useMergedConfig from '../hooks/useMergedConfig';
@@ -113,7 +113,7 @@ export interface EllipsisConfig {
 }
 
 export interface ShimmerConfig {
-  duration?: number;
+  duration?: number | [motionTime: number, waitTime: number];
 }
 
 export interface BlockProps<C extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements>
@@ -166,7 +166,8 @@ function wrapperDecorations(
 
 const ELLIPSIS_STR = '...';
 
-const DEFAULT_SHIMMER_CONFIG: ShimmerConfig = { duration: 3 };
+const DEFAULT_SHIMMER_DURATION = 1;
+const DEFAULT_SHIMMER_CONFIG: ShimmerConfig = { duration: DEFAULT_SHIMMER_DURATION };
 
 const DECORATION_PROPS = [
   'delete',
@@ -255,6 +256,12 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
     shimmer,
     DEFAULT_SHIMMER_CONFIG,
   );
+  const shimmerDuration = shimmerConfig?.duration;
+  const [shimmerMotionTime = DEFAULT_SHIMMER_DURATION, shimmerWaitTime = 1] = Array.isArray(
+    shimmerDuration,
+  )
+    ? shimmerDuration
+    : [shimmerDuration];
 
   const { placement = 'end' } = actions ?? {};
 
@@ -575,9 +582,8 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
             styles={mergedStyles}
             prefixCls={prefixCls}
             style={{
-              [varName('shimmer-duration')]: shimmerConfig.duration
-                ? `${shimmerConfig.duration}s`
-                : undefined,
+              [varName('shimmer-motion-time')]: enableShimmer ? shimmerMotionTime : undefined,
+              [varName('shimmer-wait-time')]: enableShimmer ? shimmerWaitTime : undefined,
               ...style,
               WebkitLineClamp: cssLineClamp ? rows : undefined,
             }}

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -14,7 +14,7 @@ import {
 import { clsx } from 'clsx';
 
 import type { GenerateSemantic } from '../../_util/hooks/useMergeSemantic/semanticType';
-import { isFunction, isNumber, isReactRenderable } from '../../_util/is';
+import { isFunction, isReactRenderable } from '../../_util/is';
 import { isStyleSupport } from '../../_util/styleChecker';
 import type { DirectionType } from '../../config-provider';
 import useLocale from '../../locale/useLocale';
@@ -249,11 +249,11 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
   const [enableCopy, copyConfig] = useMergedConfig<CopyConfig>(copyable);
 
   // ========================== Shimmer ===========================
-  const [enableShimmer, shimmerConfig] = useMergedConfig<ShimmerConfig>(shimmer);
-  const shimmerDuration =
-    isNumber(shimmerConfig.duration) && shimmerConfig.duration > 0
-      ? shimmerConfig.duration
-      : undefined;
+  const [enableShimmer, shimmerConfig] = useMergedConfig<ShimmerConfig>(
+    shimmer,
+    { duration: 3 },
+    { duration: 0 },
+  );
 
   const { placement = 'end' } = actions ?? {};
 
@@ -562,8 +562,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
               {
                 [`${prefixCls}-${type}`]: type,
                 [`${prefixCls}-disabled`]: disabled,
-                [`${prefixCls}-shimmer`]: enableShimmer,
-                [`${prefixCls}-shimmer-disabled`]: enableShimmer && disabled,
+                [`${prefixCls}-shimmer`]: enableShimmer && !disabled,
                 [`${prefixCls}-ellipsis`]: enableEllipsis,
                 [`${prefixCls}-ellipsis-single-line`]: cssTextOverflow,
                 [`${prefixCls}-ellipsis-multiple-line`]: cssLineClamp,
@@ -575,11 +574,9 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
             styles={mergedStyles}
             prefixCls={prefixCls}
             style={{
-              ...(enableShimmer && shimmerDuration
-                ? {
-                    [varName('shimmer-duration')]: `${shimmerDuration}s`,
-                  }
-                : null),
+              [varName('shimmer-duration')]: shimmerConfig.duration
+                ? `${shimmerConfig.duration}s`
+                : undefined,
               ...style,
               WebkitLineClamp: cssLineClamp ? rows : undefined,
             }}

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -166,6 +166,8 @@ function wrapperDecorations(
 
 const ELLIPSIS_STR = '...';
 
+const DEFAULT_SHIMMER_CONFIG: ShimmerConfig = { duration: 3 };
+
 const DECORATION_PROPS = [
   'delete',
   'mark',
@@ -251,8 +253,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
   // ========================== Shimmer ===========================
   const [enableShimmer, shimmerConfig] = useMergedConfig<ShimmerConfig>(
     shimmer,
-    { duration: 3 },
-    { duration: 0 },
+    DEFAULT_SHIMMER_CONFIG,
   );
 
   const { placement = 'end' } = actions ?? {};

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -14,7 +14,7 @@ import {
 import { clsx } from 'clsx';
 
 import type { GenerateSemantic } from '../../_util/hooks/useMergeSemantic/semanticType';
-import { isFunction, isReactRenderable } from '../../_util/is';
+import { isFunction, isNumber, isReactRenderable } from '../../_util/is';
 import { isStyleSupport } from '../../_util/styleChecker';
 import type { DirectionType } from '../../config-provider';
 import useLocale from '../../locale/useLocale';
@@ -111,9 +111,12 @@ export interface EllipsisConfig {
   tooltip?: React.ReactNode | TooltipProps;
 }
 
-export interface BlockProps<
-  C extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements,
-> extends TypographyProps<C> {
+export interface ShimmerConfig {
+  duration?: number;
+}
+
+export interface BlockProps<C extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements>
+  extends TypographyProps<C> {
   /**
    * @since 6.4.0
    */
@@ -124,6 +127,7 @@ export interface BlockProps<
   type?: BaseType;
   disabled?: boolean;
   ellipsis?: boolean | EllipsisConfig;
+  shimmer?: boolean | ShimmerConfig;
   // decorations
   code?: boolean;
   mark?: boolean;
@@ -183,6 +187,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
     disabled,
     children,
     ellipsis,
+    shimmer,
     editable,
     copyable,
     actions,
@@ -245,6 +250,13 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
 
   // ========================== Copyable ==========================
   const [enableCopy, copyConfig] = useMergedConfig<CopyConfig>(copyable);
+
+  // ========================== Shimmer ===========================
+  const [enableShimmer, shimmerConfig] = useMergedConfig<ShimmerConfig>(shimmer);
+  const shimmerDuration =
+    isNumber(shimmerConfig.duration) && shimmerConfig.duration > 0
+      ? shimmerConfig.duration
+      : undefined;
 
   const { placement = 'end' } = actions ?? {};
 
@@ -553,6 +565,8 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
               {
                 [`${prefixCls}-${type}`]: type,
                 [`${prefixCls}-disabled`]: disabled,
+                [`${prefixCls}-shimmer`]: enableShimmer,
+                [`${prefixCls}-shimmer-disabled`]: enableShimmer && disabled,
                 [`${prefixCls}-ellipsis`]: enableEllipsis,
                 [`${prefixCls}-ellipsis-single-line`]: cssTextOverflow,
                 [`${prefixCls}-ellipsis-multiple-line`]: cssLineClamp,
@@ -564,6 +578,11 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
             styles={mergedStyles}
             prefixCls={prefixCls}
             style={{
+              ...(enableShimmer && shimmerDuration
+                ? {
+                    ['--ant-typography-shimmer-duration' as string]: `${shimmerDuration}s`,
+                  }
+                : null),
               ...style,
               WebkitLineClamp: cssLineClamp ? rows : undefined,
             }}
@@ -573,6 +592,8 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
             onClick={triggerType.includes('text') ? onEditClick : undefined}
             aria-label={topAriaLabel?.toString()}
             title={title}
+            aria-busy={enableShimmer ? !disabled : undefined}
+            aria-disabled={enableShimmer && disabled ? true : undefined}
             {...textProps}
           >
             <Ellipsis

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -20,6 +20,7 @@ import type { DirectionType } from '../../config-provider';
 import useLocale from '../../locale/useLocale';
 import type { TooltipProps } from '../../tooltip';
 import Tooltip from '../../tooltip';
+import { genCssVar } from '../../theme/util/genStyleUtils';
 import Editable from '../Editable';
 import useCopyClick from '../hooks/useCopyClick';
 import useMergedConfig from '../hooks/useMergedConfig';
@@ -202,13 +203,9 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
   const typographyRef = React.useRef<HTMLElement>(null);
   const editIconRef = React.useRef<HTMLButtonElement>(null);
 
-  const [mergedClassNames, mergedStyles, prefixCls, direction] = useTypographySemantic(
-    customizePrefixCls,
-    classNames,
-    styles,
-    typographyDirection,
-    props,
-  );
+  const [mergedClassNames, mergedStyles, prefixCls, direction, rootPrefixCls] =
+    useTypographySemantic(customizePrefixCls, classNames, styles, typographyDirection, props);
+  const [varName] = genCssVar(rootPrefixCls, 'typography');
 
   const textProps = omit(restProps, DECORATION_PROPS);
 
@@ -580,7 +577,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
             style={{
               ...(enableShimmer && shimmerDuration
                 ? {
-                    ['--ant-typography-shimmer-duration' as string]: `${shimmerDuration}s`,
+                    [varName('shimmer-duration')]: `${shimmerDuration}s`,
                   }
                 : null),
               ...style,

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2641,13 +2641,14 @@ exports[`renders components/typography/demo/shimmer.tsx extend context correctly
   <span
     aria-busy="true"
     class="ant-typography ant-typography-shimmer css-var-test-id"
+    style="--ant-typography-shimmer-duration: 3s;"
   >
     Thinking...
   </span>
   <div
     aria-busy="true"
     class="ant-typography ant-typography-shimmer css-var-test-id"
-    style="margin-bottom: 0px;"
+    style="--ant-typography-shimmer-duration: 3s; margin-bottom: 0px;"
   >
     Ant Design is analyzing your request and preparing the next response.
   </div>
@@ -2655,6 +2656,7 @@ exports[`renders components/typography/demo/shimmer.tsx extend context correctly
     aria-busy="true"
     class="ant-typography ant-typography-shimmer ant-typography-link css-var-test-id"
     href="https://ant.design"
+    style="--ant-typography-shimmer-duration: 3s;"
   >
     Loading link
   </a>

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2638,7 +2638,7 @@ exports[`renders components/typography/demo/shimmer.tsx extend context correctly
 <span
   aria-busy="true"
   class="ant-typography ant-typography-shimmer css-var-test-id"
-  style="--ant-typography-shimmer-duration: 3s;"
+  style="--ant-typography-shimmer-motion-time: 1; --ant-typography-shimmer-wait-time: 1;"
 >
   Thinking...
 </span>

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2634,6 +2634,42 @@ Array [
 
 exports[`renders components/typography/demo/paragraph-debug.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/typography/demo/shimmer.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+>
+  <span
+    aria-busy="true"
+    class="ant-typography ant-typography-shimmer css-var-test-id"
+  >
+    Thinking...
+  </span>
+  <div
+    aria-busy="true"
+    class="ant-typography ant-typography-shimmer css-var-test-id"
+    style="margin-bottom: 0px;"
+  >
+    Ant Design is analyzing your request and preparing the next response.
+  </div>
+  <a
+    aria-busy="true"
+    class="ant-typography ant-typography-shimmer ant-typography-link css-var-test-id"
+    href="https://ant.design"
+  >
+    Loading link
+  </a>
+  <h4
+    aria-busy="true"
+    class="ant-typography ant-typography-shimmer css-var-test-id"
+    style="--ant-typography-shimmer-duration: 2s; margin: 0px;"
+  >
+    Generating title
+  </h4>
+</div>
+`;
+
+exports[`renders components/typography/demo/shimmer.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/typography/demo/suffix.tsx extend context correctly 1`] = `
 Array [
   <div

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2635,39 +2635,13 @@ Array [
 exports[`renders components/typography/demo/paragraph-debug.tsx extend context correctly 2`] = `[]`;
 
 exports[`renders components/typography/demo/shimmer.tsx extend context correctly 1`] = `
-<div
-  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+<span
+  aria-busy="true"
+  class="ant-typography ant-typography-shimmer css-var-test-id"
+  style="--ant-typography-shimmer-duration: 3s;"
 >
-  <span
-    aria-busy="true"
-    class="ant-typography ant-typography-shimmer css-var-test-id"
-    style="--ant-typography-shimmer-duration: 3s;"
-  >
-    Thinking...
-  </span>
-  <div
-    aria-busy="true"
-    class="ant-typography ant-typography-shimmer css-var-test-id"
-    style="--ant-typography-shimmer-duration: 3s; margin-bottom: 0px;"
-  >
-    Ant Design is analyzing your request and preparing the next response.
-  </div>
-  <a
-    aria-busy="true"
-    class="ant-typography ant-typography-shimmer ant-typography-link css-var-test-id"
-    href="https://ant.design"
-    style="--ant-typography-shimmer-duration: 3s;"
-  >
-    Loading link
-  </a>
-  <h4
-    aria-busy="true"
-    class="ant-typography ant-typography-shimmer css-var-test-id"
-    style="--ant-typography-shimmer-duration: 2s; margin: 0px;"
-  >
-    Generating title
-  </h4>
-</div>
+  Thinking...
+</span>
 `;
 
 exports[`renders components/typography/demo/shimmer.tsx extend context correctly 2`] = `[]`;

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2004,39 +2004,13 @@ Array [
 `;
 
 exports[`renders components/typography/demo/shimmer.tsx correctly 1`] = `
-<div
-  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+<span
+  aria-busy="true"
+  class="ant-typography ant-typography-shimmer css-var-test-id"
+  style="--ant-typography-shimmer-duration:3s"
 >
-  <span
-    aria-busy="true"
-    class="ant-typography ant-typography-shimmer css-var-test-id"
-    style="--ant-typography-shimmer-duration:3s"
-  >
-    Thinking...
-  </span>
-  <div
-    aria-busy="true"
-    class="ant-typography ant-typography-shimmer css-var-test-id"
-    style="--ant-typography-shimmer-duration:3s;margin-bottom:0"
-  >
-    Ant Design is analyzing your request and preparing the next response.
-  </div>
-  <a
-    aria-busy="true"
-    class="ant-typography ant-typography-shimmer ant-typography-link css-var-test-id"
-    href="https://ant.design"
-    style="--ant-typography-shimmer-duration:3s"
-  >
-    Loading link
-  </a>
-  <h4
-    aria-busy="true"
-    class="ant-typography ant-typography-shimmer css-var-test-id"
-    style="--ant-typography-shimmer-duration:2s;margin:0"
-  >
-    Generating title
-  </h4>
-</div>
+  Thinking...
+</span>
 `;
 
 exports[`renders components/typography/demo/suffix.tsx correctly 1`] = `

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2003,6 +2003,40 @@ Array [
 ]
 `;
 
+exports[`renders components/typography/demo/shimmer.tsx correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-vertical"
+>
+  <span
+    aria-busy="true"
+    class="ant-typography ant-typography-shimmer css-var-test-id"
+  >
+    Thinking...
+  </span>
+  <div
+    aria-busy="true"
+    class="ant-typography ant-typography-shimmer css-var-test-id"
+    style="margin-bottom:0"
+  >
+    Ant Design is analyzing your request and preparing the next response.
+  </div>
+  <a
+    aria-busy="true"
+    class="ant-typography ant-typography-shimmer ant-typography-link css-var-test-id"
+    href="https://ant.design"
+  >
+    Loading link
+  </a>
+  <h4
+    aria-busy="true"
+    class="ant-typography ant-typography-shimmer css-var-test-id"
+    style="--ant-typography-shimmer-duration:2s;margin:0"
+  >
+    Generating title
+  </h4>
+</div>
+`;
+
 exports[`renders components/typography/demo/suffix.tsx correctly 1`] = `
 Array [
   <div

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2007,7 +2007,7 @@ exports[`renders components/typography/demo/shimmer.tsx correctly 1`] = `
 <span
   aria-busy="true"
   class="ant-typography ant-typography-shimmer css-var-test-id"
-  style="--ant-typography-shimmer-duration:3s"
+  style="--ant-typography-shimmer-motion-time:1;--ant-typography-shimmer-wait-time:1"
 >
   Thinking...
 </span>

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2010,13 +2010,14 @@ exports[`renders components/typography/demo/shimmer.tsx correctly 1`] = `
   <span
     aria-busy="true"
     class="ant-typography ant-typography-shimmer css-var-test-id"
+    style="--ant-typography-shimmer-duration:3s"
   >
     Thinking...
   </span>
   <div
     aria-busy="true"
     class="ant-typography ant-typography-shimmer css-var-test-id"
-    style="margin-bottom:0"
+    style="--ant-typography-shimmer-duration:3s;margin-bottom:0"
   >
     Ant Design is analyzing your request and preparing the next response.
   </div>
@@ -2024,6 +2025,7 @@ exports[`renders components/typography/demo/shimmer.tsx correctly 1`] = `
     aria-busy="true"
     class="ant-typography ant-typography-shimmer ant-typography-link css-var-test-id"
     href="https://ant.design"
+    style="--ant-typography-shimmer-duration:3s"
   >
     Loading link
   </a>

--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -141,6 +141,8 @@ describe('Typography', () => {
         'background-image:linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.95), transparent),linear-gradient(currentColor, currentColor)',
       );
       expect(styleText).toContain('animation-duration:var(--ant-typography-shimmer-duration, 3s)');
+      expect(styleText).toContain('0%{background-position:-25% 100%,0 0;}');
+      expect(styleText).toContain('100%{background-position:200% 100%,0 0;}');
     });
   });
 

--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -140,9 +140,10 @@ describe('Typography', () => {
       expect(styleText).toContain(
         'background-image:linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.95), transparent),linear-gradient(currentColor, currentColor)',
       );
+      expect(styleText).toContain('background-size:40% 100%,100% 100%');
       expect(styleText).toContain('animation-duration:var(--ant-typography-shimmer-duration, 3s)');
-      expect(styleText).toContain('0%{background-position:-25% 100%,0 0;}');
-      expect(styleText).toContain('100%{background-position:200% 100%,0 0;}');
+      expect(styleText).toContain('0%{background-position:-40% 100%,0 0;}');
+      expect(styleText).toContain('100%{background-position:270% 100%,0 0;}');
     });
   });
 

--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 import { CheckOutlined, HighlightOutlined, LikeOutlined, SmileOutlined } from '@ant-design/icons';
 import { KeyCode, warning } from '@rc-component/util';
 import userEvent from '@testing-library/user-event';
@@ -108,7 +107,8 @@ describe('Typography', () => {
       const { container } = render(<Text shimmer={{ duration: 1.5 }}>Text</Text>);
 
       expect(container.firstElementChild).toHaveStyle({
-        '--ant-typography-shimmer-duration': '1.5s',
+        '--ant-typography-shimmer-motion-time': '1.5',
+        '--ant-typography-shimmer-wait-time': '1',
       });
     });
 
@@ -123,27 +123,6 @@ describe('Typography', () => {
       expect(element).not.toHaveClass('ant-typography-shimmer');
       expect(element).toHaveAttribute('aria-busy', 'false');
       expect(element).toHaveAttribute('aria-disabled', 'true');
-    });
-
-    it('should generate shimmer styles', () => {
-      const cache = createCache();
-
-      render(
-        <StyleProvider cache={cache}>
-          <Text shimmer>Text</Text>
-        </StyleProvider>,
-      );
-
-      const styleText = extractStyle(cache, { plain: true });
-
-      expect(styleText).toContain('.ant-typography.ant-typography-shimmer{');
-      expect(styleText).toContain(
-        'background-image:linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.95), transparent),linear-gradient(currentColor, currentColor)',
-      );
-      expect(styleText).toContain('background-size:40% 100%,100% 100%');
-      expect(styleText).toContain('animation-duration:var(--ant-typography-shimmer-duration, 3s)');
-      expect(styleText).toContain('0%{background-position:-40% 100%,0 0;}');
-      expect(styleText).toContain('100%{background-position:270% 100%,0 0;}');
     });
   });
 

--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
 import { CheckOutlined, HighlightOutlined, LikeOutlined, SmileOutlined } from '@ant-design/icons';
 import { KeyCode, warning } from '@rc-component/util';
 import userEvent from '@testing-library/user-event';
@@ -86,6 +87,60 @@ describe('Typography', () => {
       expect(errorSpy).toHaveBeenCalledWith(
         'Warning: [antd: Typography.Title] Title only accept `1 | 2 | 3 | 4 | 5` as `level` value. And `5` need 4.6.0+ version.',
       );
+    });
+  });
+
+  describe('shimmer', () => {
+    it.each([
+      ['Text', () => <Text shimmer>Text</Text>],
+      ['Title', () => <Title shimmer>Title</Title>],
+      ['Paragraph', () => <Paragraph shimmer>Paragraph</Paragraph>],
+      ['Link', () => <Link shimmer>Link</Link>],
+    ])('should support shimmer on %s', (_, renderNode) => {
+      const { container } = render(renderNode());
+      const element = container.firstElementChild;
+
+      expect(element).toHaveClass('ant-typography-shimmer');
+      expect(element).not.toHaveAttribute('shimmer');
+    });
+
+    it('should support custom shimmer duration', () => {
+      const { container } = render(<Text shimmer={{ duration: 1.5 }}>Text</Text>);
+
+      expect(container.firstElementChild).toHaveStyle({
+        '--ant-typography-shimmer-duration': '1.5s',
+      });
+    });
+
+    it('should disable shimmer animation for disabled text', () => {
+      const { container } = render(
+        <Text shimmer disabled>
+          Text
+        </Text>,
+      );
+      const element = container.firstElementChild;
+
+      expect(element).toHaveClass('ant-typography-shimmer-disabled');
+      expect(element).toHaveAttribute('aria-busy', 'false');
+      expect(element).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('should generate shimmer styles', () => {
+      const cache = createCache();
+
+      render(
+        <StyleProvider cache={cache}>
+          <Text shimmer>Text</Text>
+        </StyleProvider>,
+      );
+
+      const styleText = extractStyle(cache, { plain: true });
+
+      expect(styleText).toContain('.ant-typography.ant-typography-shimmer{');
+      expect(styleText).toContain(
+        'background-image:linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.95), transparent),linear-gradient(currentColor, currentColor)',
+      );
+      expect(styleText).toContain('animation-duration:var(--ant-typography-shimmer-duration, 3s)');
     });
   });
 

--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -104,11 +104,11 @@ describe('Typography', () => {
     });
 
     it('should support custom shimmer duration', () => {
-      const { container } = render(<Text shimmer={{ duration: 1.5 }}>Text</Text>);
+      const { container } = render(<Text shimmer={{ duration: [1.5, 0.5] }}>Text</Text>);
 
       expect(container.firstElementChild).toHaveStyle({
         '--ant-typography-shimmer-motion-time': '1.5',
-        '--ant-typography-shimmer-wait-time': '1',
+        '--ant-typography-shimmer-wait-time': '0.5',
       });
     });
 

--- a/components/typography/__tests__/index.test.tsx
+++ b/components/typography/__tests__/index.test.tsx
@@ -112,7 +112,7 @@ describe('Typography', () => {
       });
     });
 
-    it('should disable shimmer animation for disabled text', () => {
+    it('should not enable shimmer for disabled text', () => {
       const { container } = render(
         <Text shimmer disabled>
           Text
@@ -120,7 +120,7 @@ describe('Typography', () => {
       );
       const element = container.firstElementChild;
 
-      expect(element).toHaveClass('ant-typography-shimmer-disabled');
+      expect(element).not.toHaveClass('ant-typography-shimmer');
       expect(element).toHaveAttribute('aria-busy', 'false');
       expect(element).toHaveAttribute('aria-disabled', 'true');
     });

--- a/components/typography/demo/shimmer.md
+++ b/components/typography/demo/shimmer.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+文字闪烁效果，常用于展示“正在思考/加载”状态。通过 `shimmer` 为 Text、Title、Paragraph 和 Link 开启效果。
+
+## en-US
+
+Shimmering text effect, commonly used to indicate a “thinking/loading” state. Use `shimmer` to enable it on Text, Title, Paragraph, and Link.

--- a/components/typography/demo/shimmer.tsx
+++ b/components/typography/demo/shimmer.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Flex, Typography } from 'antd';
+
+const App: React.FC = () => (
+  <Flex vertical>
+    <Typography.Text shimmer>Thinking...</Typography.Text>
+    <Typography.Paragraph shimmer style={{ marginBottom: 0 }}>
+      Ant Design is analyzing your request and preparing the next response.
+    </Typography.Paragraph>
+    <Typography.Link href="https://ant.design" shimmer>
+      Loading link
+    </Typography.Link>
+    <Typography.Title level={4} shimmer={{ duration: 2 }} style={{ margin: 0 }}>
+      Generating title
+    </Typography.Title>
+  </Flex>
+);
+
+export default App;

--- a/components/typography/demo/shimmer.tsx
+++ b/components/typography/demo/shimmer.tsx
@@ -1,19 +1,6 @@
 import React from 'react';
-import { Flex, Typography } from 'antd';
+import { Typography } from 'antd';
 
-const App: React.FC = () => (
-  <Flex vertical>
-    <Typography.Text shimmer>Thinking...</Typography.Text>
-    <Typography.Paragraph shimmer style={{ marginBottom: 0 }}>
-      Ant Design is analyzing your request and preparing the next response.
-    </Typography.Paragraph>
-    <Typography.Link href="https://ant.design" shimmer>
-      Loading link
-    </Typography.Link>
-    <Typography.Title level={4} shimmer={{ duration: 2 }} style={{ margin: 0 }}>
-      Generating title
-    </Typography.Title>
-  </Flex>
-);
+const App: React.FC = () => <Typography.Text shimmer>Thinking...</Typography.Text>;
 
 export default App;

--- a/components/typography/hooks/useMergedConfig.ts
+++ b/components/typography/hooks/useMergedConfig.ts
@@ -2,16 +2,20 @@ import * as React from 'react';
 
 import { isPlainObject } from '../../_util/is';
 
-const useMergedConfig = <Target>(propConfig?: boolean | Target, templateConfig?: Target) => {
+const useMergedConfig = <Target>(
+  propConfig?: boolean | Target,
+  templateConfig?: Target,
+  falseConfig?: Target,
+) => {
   const support = Boolean(propConfig);
 
   return React.useMemo<readonly [boolean, Target]>(() => {
     const config = {
-      ...templateConfig,
+      ...(support ? templateConfig : (falseConfig ?? templateConfig)),
       ...(support && isPlainObject(propConfig) ? propConfig : null),
     } as Target;
     return [support, config] as const;
-  }, [support, propConfig, templateConfig]);
+  }, [support, propConfig, templateConfig, falseConfig]);
 };
 
 export default useMergedConfig;

--- a/components/typography/hooks/useMergedConfig.ts
+++ b/components/typography/hooks/useMergedConfig.ts
@@ -2,20 +2,16 @@ import * as React from 'react';
 
 import { isPlainObject } from '../../_util/is';
 
-const useMergedConfig = <Target>(
-  propConfig?: boolean | Target,
-  templateConfig?: Target,
-  falseConfig?: Target,
-) => {
+const useMergedConfig = <Target>(propConfig?: boolean | Target, templateConfig?: Target) => {
   const support = Boolean(propConfig);
 
   return React.useMemo<readonly [boolean, Target]>(() => {
     const config = {
-      ...(support ? templateConfig : (falseConfig ?? templateConfig)),
+      ...(support ? templateConfig : null),
       ...(support && isPlainObject(propConfig) ? propConfig : null),
     } as Target;
     return [support, config] as const;
-  }, [support, propConfig, templateConfig, falseConfig]);
+  }, [support, propConfig, templateConfig]);
 };
 
 export default useMergedConfig;

--- a/components/typography/hooks/useTypographySemantic.ts
+++ b/components/typography/hooks/useTypographySemantic.ts
@@ -22,6 +22,7 @@ export const useTypographySemantic = (
   } = useComponentConfig('typography');
 
   const direction = typographyDirection ?? contextDirection;
+  const rootPrefixCls = getPrefixCls();
   const prefixCls = getPrefixCls('typography', customizePrefixCls);
 
   const mergedProps: BaseTypographyProps = {
@@ -48,5 +49,5 @@ export const useTypographySemantic = (
     },
   );
 
-  return [mergedClassNames, mergedStyles, prefixCls, direction] as const;
+  return [mergedClassNames, mergedStyles, prefixCls, direction, rootPrefixCls] as const;
 };

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -19,6 +19,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 <code src="./demo/title.tsx">Title Component</code>
 <code src="./demo/paragraph-debug.tsx" debug>Title and Paragraph</code>
 <code src="./demo/text.tsx">Text and Link Component</code>
+<code src="./demo/shimmer.tsx" version="6.7.0">Shimmer Text</code>
 <code src="./demo/editable.tsx">Editable</code>
 <code src="./demo/copyable.tsx">Copyable</code>
 <code src="./demo/ellipsis.tsx">Ellipsis</code>
@@ -49,6 +50,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | italic | Italic style | boolean | false | 4.16.0 | × |
 | keyboard | Keyboard style | boolean | false | 4.3.0 | × |
 | mark | Marked style | boolean | false |  | × |
+| shimmer | Show a shimmer effect, or configure its animation duration | boolean \| { duration?: number } | false | 6.7.0 | × |
 | strong | Bold style | boolean | false |  | × |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.4.0 | 6.4.0 |
 | type | Content type | `secondary` \| `success` \| `warning` \| `danger` | - | success: 4.6.0 | × |
@@ -70,6 +72,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | italic | Italic style | boolean | false | 4.16.0 | × |
 | level | Set content importance. Match with `h1`, `h2`, `h3`, `h4`, `h5` | number: 1, 2, 3, 4, 5 | 1 | 5: 4.6.0 | × |
 | mark | Marked style | boolean | false |  | × |
+| shimmer | Show a shimmer effect, or configure its animation duration | boolean \| { duration?: number } | false | 6.7.0 | × |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.4.0 | 6.4.0 |
 | type | Content type | `secondary` \| `success` \| `warning` \| `danger` | - | success: 4.6.0 | × |
 | underline | Underlined style | boolean | false |  | × |
@@ -89,6 +92,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | ellipsis | Display ellipsis when text overflows, can configure rows and expandable by using object | boolean \| [ellipsis](#ellipsis) | false |  | × |
 | italic | Italic style | boolean | false | 4.16.0 | × |
 | mark | Marked style | boolean | false |  | × |
+| shimmer | Show a shimmer effect, or configure its animation duration | boolean \| { duration?: number } | false | 6.7.0 | × |
 | strong | Bold style | boolean | false |  | × |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.4.0 | 6.4.0 |
 | type | Content type | `secondary` \| `success` \| `warning` \| `danger` | - | success: 4.6.0 | × |

--- a/components/typography/index.en-US.md
+++ b/components/typography/index.en-US.md
@@ -50,7 +50,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | italic | Italic style | boolean | false | 4.16.0 | × |
 | keyboard | Keyboard style | boolean | false | 4.3.0 | × |
 | mark | Marked style | boolean | false |  | × |
-| shimmer | Show a shimmer effect, or configure its animation duration | boolean \| { duration?: number } | false | 6.7.0 | × |
+| shimmer | Show a shimmer effect, customizable via an object | boolean \| [shimmer](#shimmer) | false | 6.7.0 | × |
 | strong | Bold style | boolean | false |  | × |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.4.0 | 6.4.0 |
 | type | Content type | `secondary` \| `success` \| `warning` \| `danger` | - | success: 4.6.0 | × |
@@ -72,7 +72,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | italic | Italic style | boolean | false | 4.16.0 | × |
 | level | Set content importance. Match with `h1`, `h2`, `h3`, `h4`, `h5` | number: 1, 2, 3, 4, 5 | 1 | 5: 4.6.0 | × |
 | mark | Marked style | boolean | false |  | × |
-| shimmer | Show a shimmer effect, or configure its animation duration | boolean \| { duration?: number } | false | 6.7.0 | × |
+| shimmer | Show a shimmer effect, customizable via an object | boolean \| [shimmer](#shimmer) | false | 6.7.0 | × |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.4.0 | 6.4.0 |
 | type | Content type | `secondary` \| `success` \| `warning` \| `danger` | - | success: 4.6.0 | × |
 | underline | Underlined style | boolean | false |  | × |
@@ -92,7 +92,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | ellipsis | Display ellipsis when text overflows, can configure rows and expandable by using object | boolean \| [ellipsis](#ellipsis) | false |  | × |
 | italic | Italic style | boolean | false | 4.16.0 | × |
 | mark | Marked style | boolean | false |  | × |
-| shimmer | Show a shimmer effect, or configure its animation duration | boolean \| { duration?: number } | false | 6.7.0 | × |
+| shimmer | Show a shimmer effect, customizable via an object | boolean \| [shimmer](#shimmer) | false | 6.7.0 | × |
 | strong | Bold style | boolean | false |  | × |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.4.0 | 6.4.0 |
 | type | Content type | `secondary` \| `success` \| `warning` \| `danger` | - | success: 4.6.0 | × |
@@ -195,6 +195,18 @@ interface EllipsisConfig {
 | tooltip | Show tooltip when ellipsis | ReactNode \| [TooltipProps](/components/tooltip/#api) | - | 4.11.0 |
 | onEllipsis | Called when enter or leave ellipsis state | function(ellipsis) | - | 4.2.0 |
 | onExpand | Called when expand content | function(event, { expanded: boolean }) | - | `info`: 5.16.0 |
+
+### shimmer
+
+```tsx
+interface ShimmerConfig {
+  duration?: number | [motionTime: number, waitTime: number];
+}
+```
+
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| duration | Motion time in seconds. A number uses a 1-second wait; a tuple sets the motion and wait times separately | number \| \[motionTime: number, waitTime: number\] | 1 | 6.7.0 |
 
 ## Semantic DOM
 

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -51,7 +51,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 | italic | 是否斜体 | boolean | false | 4.16.0 | × |
 | keyboard | 添加键盘样式 | boolean | false | 4.3.0 | × |
 | mark | 添加标记样式 | boolean | false |  | × |
-| shimmer | 展示闪烁文字效果，或配置动画持续时间 | boolean \| { duration?: number } | false | 6.7.0 | × |
+| shimmer | 展示闪烁文字效果，为对象时可进行配置 | boolean \| [shimmer](#shimmer) | false | 6.7.0 | × |
 | strong | 是否加粗 | boolean | false |  | × |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.4.0 | 6.4.0 |
 | type | 文本类型 | `secondary` \| `success` \| `warning` \| `danger` | - | success: 4.6.0 | × |
@@ -73,7 +73,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 | italic | 是否斜体 | boolean | false | 4.16.0 | × |
 | level | 重要程度，相当于 `h1`、`h2`、`h3`、`h4`、`h5` | number: 1, 2, 3, 4, 5 | 1 | 5: 4.6.0 | × |
 | mark | 添加标记样式 | boolean | false |  | × |
-| shimmer | 展示闪烁文字效果，或配置动画持续时间 | boolean \| { duration?: number } | false | 6.7.0 | × |
+| shimmer | 展示闪烁文字效果，为对象时可进行配置 | boolean \| [shimmer](#shimmer) | false | 6.7.0 | × |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.4.0 | 6.4.0 |
 | type | 文本类型 | `secondary` \| `success` \| `warning` \| `danger` | - | success: 4.6.0 | × |
 | underline | 添加下划线样式 | boolean | false |  | × |
@@ -93,7 +93,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 | ellipsis | 自动溢出省略，为对象时可设置省略行数、是否可展开、添加后缀等 | boolean \| [ellipsis](#ellipsis) | false |  | × |
 | italic | 是否斜体 | boolean | false | 4.16.0 | × |
 | mark | 添加标记样式 | boolean | false |  | × |
-| shimmer | 展示闪烁文字效果，或配置动画持续时间 | boolean \| { duration?: number } | false | 6.7.0 | × |
+| shimmer | 展示闪烁文字效果，为对象时可进行配置 | boolean \| [shimmer](#shimmer) | false | 6.7.0 | × |
 | strong | 是否加粗 | boolean | false |  | × |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.4.0 | 6.4.0 |
 | type | 文本类型 | `secondary` \| `success` \| `warning` \| `danger` | - | success: 4.6.0 | × |
@@ -196,6 +196,18 @@ interface EllipsisConfig {
 | tooltip | 省略时，展示提示信息 | ReactNode \| [TooltipProps](/components/tooltip-cn/#api) | - | 4.11.0 |
 | onEllipsis | 触发省略时的回调 | function(ellipsis) | - | 4.2.0 |
 | onExpand | 点击展开或收起时的回调 | function(event, { expanded: boolean }) | - | `info`: 5.16.0 |
+
+### shimmer
+
+```tsx
+interface ShimmerConfig {
+  duration?: number | [motionTime: number, waitTime: number];
+}
+```
+
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| duration | 光斑扫过时间，单位为秒。数字默认等待 1 秒，数组可分别设置扫过和等待时间 | number \| \[motionTime: number, waitTime: number\] | 1 | 6.7.0 |
 
 ## Semantic DOM
 

--- a/components/typography/index.zh-CN.md
+++ b/components/typography/index.zh-CN.md
@@ -20,6 +20,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 <code src="./demo/title.tsx">标题组件</code>
 <code src="./demo/paragraph-debug.tsx" debug>标题与段落</code>
 <code src="./demo/text.tsx">文本与超链接组件</code>
+<code src="./demo/shimmer.tsx" version="6.7.0">闪烁文字</code>
 <code src="./demo/editable.tsx">可编辑</code>
 <code src="./demo/copyable.tsx">可复制</code>
 <code src="./demo/ellipsis.tsx">省略号</code>
@@ -50,6 +51,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 | italic | 是否斜体 | boolean | false | 4.16.0 | × |
 | keyboard | 添加键盘样式 | boolean | false | 4.3.0 | × |
 | mark | 添加标记样式 | boolean | false |  | × |
+| shimmer | 展示闪烁文字效果，或配置动画持续时间 | boolean \| { duration?: number } | false | 6.7.0 | × |
 | strong | 是否加粗 | boolean | false |  | × |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.4.0 | 6.4.0 |
 | type | 文本类型 | `secondary` \| `success` \| `warning` \| `danger` | - | success: 4.6.0 | × |
@@ -71,6 +73,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 | italic | 是否斜体 | boolean | false | 4.16.0 | × |
 | level | 重要程度，相当于 `h1`、`h2`、`h3`、`h4`、`h5` | number: 1, 2, 3, 4, 5 | 1 | 5: 4.6.0 | × |
 | mark | 添加标记样式 | boolean | false |  | × |
+| shimmer | 展示闪烁文字效果，或配置动画持续时间 | boolean \| { duration?: number } | false | 6.7.0 | × |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.4.0 | 6.4.0 |
 | type | 文本类型 | `secondary` \| `success` \| `warning` \| `danger` | - | success: 4.6.0 | × |
 | underline | 添加下划线样式 | boolean | false |  | × |
@@ -90,6 +93,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LT2jR41Uj2EAAA
 | ellipsis | 自动溢出省略，为对象时可设置省略行数、是否可展开、添加后缀等 | boolean \| [ellipsis](#ellipsis) | false |  | × |
 | italic | 是否斜体 | boolean | false | 4.16.0 | × |
 | mark | 添加标记样式 | boolean | false |  | × |
+| shimmer | 展示闪烁文字效果，或配置动画持续时间 | boolean \| { duration?: number } | false | 6.7.0 | × |
 | strong | 是否加粗 | boolean | false |  | × |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.4.0 | 6.4.0 |
 | type | 文本类型 | `secondary` \| `success` \| `warning` \| `danger` | - | success: 4.6.0 | × |

--- a/components/typography/style/index.ts
+++ b/components/typography/style/index.ts
@@ -120,7 +120,7 @@ const genTypographyStyle: GenerateStyle<TypographyToken, CSSObject> = (token) =>
       ...getEllipsisStyles(),
 
       // Shimmer
-      [`&${componentCls}-shimmer`]: getShimmerStyles(),
+      [`&${componentCls}-shimmer`]: getShimmerStyles(token),
 
       '&-rtl': {
         direction: 'rtl',

--- a/components/typography/style/index.ts
+++ b/components/typography/style/index.ts
@@ -9,6 +9,7 @@ import {
   getEllipsisStyles,
   getLinkStyles,
   getResetStyles,
+  getShimmerStyles,
   getTitleStyles,
 } from './mixins';
 
@@ -117,6 +118,9 @@ const genTypographyStyle: GenerateStyle<TypographyToken, CSSObject> = (token) =>
       ...getCopyableStyles(token),
 
       ...getEllipsisStyles(),
+
+      // Shimmer
+      [`&${componentCls}-shimmer`]: getShimmerStyles(),
 
       '&-rtl': {
         direction: 'rtl',

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -18,16 +18,7 @@ import { genCssVar } from '../../theme/util/genStyleUtils';
 
 const shimmerAnimation = new Keyframes('antTypographyShimmer', {
   '0%': {
-    backgroundPosition: '-200% 100%, 0 0',
-  },
-  '25%': {
-    backgroundPosition: '-100% 100%, 0 0',
-  },
-  '50%': {
-    backgroundPosition: '0% 100%, 0 0',
-  },
-  '75%': {
-    backgroundPosition: '100% 100%, 0 0',
+    backgroundPosition: '-25% 100%, 0 0',
   },
   '100%': {
     backgroundPosition: '200% 100%, 0 0',

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -16,15 +16,6 @@ import { operationUnit, textEllipsis } from '../../style';
 import type { GenerateStyle } from '../../theme/internal';
 import { genCssVar } from '../../theme/util/genStyleUtils';
 
-const shimmerAnimation = new Keyframes('antTypographyShimmer', {
-  '0%': {
-    backgroundPosition: '-40% 100%, 0 0',
-  },
-  '100%': {
-    backgroundPosition: '270% 100%, 0 0',
-  },
-});
-
 const getTitleStyle = (
   fontSize: number | string,
   lineHeight: number,
@@ -349,19 +340,29 @@ export const getEllipsisStyles = (): CSSObject => ({
 
 export const getShimmerStyles = (token: TypographyToken): CSSObject => {
   const [, varRef] = genCssVar(token.antCls, 'typography');
+  const motionTime = varRef('shimmer-motion-time', '1');
+  const waitTime = varRef('shimmer-wait-time', '1');
+  const shimmerAnimation = new Keyframes('antTypographyShimmer', {
+    '0%': {
+      backgroundPosition: '-66.6667% 100%, 0 0',
+    },
+    '100%': {
+      backgroundPosition: `calc(166.6667% + 233.3334% * ${waitTime} / ${motionTime}) 100%, 0 0`,
+    },
+  });
 
   return {
     backgroundClip: 'text, text',
     WebkitBackgroundClip: 'text, text',
     WebkitTextFillColor: 'transparent',
     backgroundImage: [
-      'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.95), transparent)',
+      'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.8), white, rgba(255, 255, 255, 0.8), transparent)',
       'linear-gradient(currentColor, currentColor)',
     ].join(', '),
     backgroundSize: '40% 100%, 100% 100%',
     backgroundRepeat: 'no-repeat',
     animationName: shimmerAnimation,
-    animationDuration: varRef('shimmer-duration', '3s'),
+    animationDuration: `calc((${motionTime} + ${waitTime}) * 1s)`,
     animationIterationCount: 'infinite',
     animationTimingFunction: 'linear',
     animationFillMode: 'forwards',

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -8,12 +8,30 @@
 }
 */
 import { gold } from '@ant-design/colors';
-import { unit } from '@ant-design/cssinjs';
+import { Keyframes, unit } from '@ant-design/cssinjs';
 import type { CSSObject } from '@ant-design/cssinjs';
 
 import type { TypographyToken } from '.';
 import { operationUnit, textEllipsis } from '../../style';
 import type { GenerateStyle } from '../../theme/internal';
+
+const shimmerAnimation = new Keyframes('antTypographyShimmer', {
+  '0%': {
+    backgroundPosition: '-200% 100%, 0 0',
+  },
+  '25%': {
+    backgroundPosition: '-100% 100%, 0 0',
+  },
+  '50%': {
+    backgroundPosition: '0% 100%, 0 0',
+  },
+  '75%': {
+    backgroundPosition: '100% 100%, 0 0',
+  },
+  '100%': {
+    backgroundPosition: '200% 100%, 0 0',
+  },
+});
 
 const getTitleStyle = (
   fontSize: number | string,
@@ -334,5 +352,30 @@ export const getEllipsisStyles = (): CSSObject => ({
     overflow: 'hidden',
     WebkitLineClamp: 3,
     WebkitBoxOrient: 'vertical',
+  },
+});
+
+export const getShimmerStyles = (): CSSObject => ({
+  backgroundClip: 'text, text',
+  WebkitBackgroundClip: 'text, text',
+  WebkitTextFillColor: 'transparent',
+  backgroundImage: [
+    'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.95), transparent)',
+    'linear-gradient(currentColor, currentColor)',
+  ].join(', '),
+  backgroundSize: '25% 100%, 100% 100%',
+  backgroundRepeat: 'no-repeat',
+  animationName: shimmerAnimation,
+  animationDuration: 'var(--ant-typography-shimmer-duration, 3s)',
+  animationIterationCount: 'infinite',
+  animationTimingFunction: 'linear',
+  animationFillMode: 'forwards',
+
+  '&-disabled': {
+    animation: 'none',
+    backgroundImage: 'none',
+    WebkitTextFillColor: 'currentColor',
+    WebkitBackgroundClip: 'unset',
+    backgroundClip: 'unset',
   },
 });

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -374,13 +374,5 @@ export const getShimmerStyles = (token: TypographyToken): CSSObject => {
     animationIterationCount: 'infinite',
     animationTimingFunction: 'linear',
     animationFillMode: 'forwards',
-
-    '&-disabled': {
-      animation: 'none',
-      backgroundImage: 'none',
-      WebkitTextFillColor: 'currentColor',
-      WebkitBackgroundClip: 'unset',
-      backgroundClip: 'unset',
-    },
   };
 };

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -14,6 +14,7 @@ import type { CSSObject } from '@ant-design/cssinjs';
 import type { TypographyToken } from '.';
 import { operationUnit, textEllipsis } from '../../style';
 import type { GenerateStyle } from '../../theme/internal';
+import { genCssVar } from '../../theme/util/genStyleUtils';
 
 const shimmerAnimation = new Keyframes('antTypographyShimmer', {
   '0%': {
@@ -355,27 +356,31 @@ export const getEllipsisStyles = (): CSSObject => ({
   },
 });
 
-export const getShimmerStyles = (): CSSObject => ({
-  backgroundClip: 'text, text',
-  WebkitBackgroundClip: 'text, text',
-  WebkitTextFillColor: 'transparent',
-  backgroundImage: [
-    'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.95), transparent)',
-    'linear-gradient(currentColor, currentColor)',
-  ].join(', '),
-  backgroundSize: '25% 100%, 100% 100%',
-  backgroundRepeat: 'no-repeat',
-  animationName: shimmerAnimation,
-  animationDuration: 'var(--ant-typography-shimmer-duration, 3s)',
-  animationIterationCount: 'infinite',
-  animationTimingFunction: 'linear',
-  animationFillMode: 'forwards',
+export const getShimmerStyles = (token: TypographyToken): CSSObject => {
+  const [, varRef] = genCssVar(token.antCls, 'typography');
 
-  '&-disabled': {
-    animation: 'none',
-    backgroundImage: 'none',
-    WebkitTextFillColor: 'currentColor',
-    WebkitBackgroundClip: 'unset',
-    backgroundClip: 'unset',
-  },
-});
+  return {
+    backgroundClip: 'text, text',
+    WebkitBackgroundClip: 'text, text',
+    WebkitTextFillColor: 'transparent',
+    backgroundImage: [
+      'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.95), transparent)',
+      'linear-gradient(currentColor, currentColor)',
+    ].join(', '),
+    backgroundSize: '25% 100%, 100% 100%',
+    backgroundRepeat: 'no-repeat',
+    animationName: shimmerAnimation,
+    animationDuration: varRef('shimmer-duration', '3s'),
+    animationIterationCount: 'infinite',
+    animationTimingFunction: 'linear',
+    animationFillMode: 'forwards',
+
+    '&-disabled': {
+      animation: 'none',
+      backgroundImage: 'none',
+      WebkitTextFillColor: 'currentColor',
+      WebkitBackgroundClip: 'unset',
+      backgroundClip: 'unset',
+    },
+  };
+};

--- a/components/typography/style/mixins.ts
+++ b/components/typography/style/mixins.ts
@@ -18,10 +18,10 @@ import { genCssVar } from '../../theme/util/genStyleUtils';
 
 const shimmerAnimation = new Keyframes('antTypographyShimmer', {
   '0%': {
-    backgroundPosition: '-25% 100%, 0 0',
+    backgroundPosition: '-40% 100%, 0 0',
   },
   '100%': {
-    backgroundPosition: '200% 100%, 0 0',
+    backgroundPosition: '270% 100%, 0 0',
   },
 });
 
@@ -358,7 +358,7 @@ export const getShimmerStyles = (token: TypographyToken): CSSObject => {
       'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.95), transparent)',
       'linear-gradient(currentColor, currentColor)',
     ].join(', '),
-    backgroundSize: '25% 100%, 100% 100%',
+    backgroundSize: '40% 100%, 100% 100%',
     backgroundRepeat: 'no-repeat',
     animationName: shimmerAnimation,
     animationDuration: varRef('shimmer-duration', '3s'),

--- a/package.json
+++ b/package.json
@@ -339,7 +339,7 @@
   "size-limit": [
     {
       "path": "./dist/antd.min.js",
-      "limit": "443 KiB",
+      "limit": "444 KiB",
       "gzip": true
     },
     {

--- a/scripts/__snapshots__/check-site.ts.snap
+++ b/scripts/__snapshots__/check-site.ts.snap
@@ -276,9 +276,9 @@ exports[`site test Component components/tree-select en Page 1`] = `4`;
 
 exports[`site test Component components/tree-select zh Page 1`] = `4`;
 
-exports[`site test Component components/typography en Page 1`] = `7`;
+exports[`site test Component components/typography en Page 1`] = `8`;
 
-exports[`site test Component components/typography zh Page 1`] = `7`;
+exports[`site test Component components/typography zh Page 1`] = `8`;
 
 exports[`site test Component components/upload en Page 1`] = `5`;
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [x] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [x] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- close #55780

### 💡 需求背景和解决方案

为 Typography 文本组件增加通用的加载/思考态渐变闪烁效果，避免引入独立组件，并保留 Text、Title、Paragraph、Link 的既有能力组合。

新增 `shimmer` 属性：

```tsx
<Typography.Text shimmer>Thinking...</Typography.Text>
<Typography.Title shimmer={{ duration: 2 }}>Generating title</Typography.Title>
```

`shimmer` 支持布尔值或 `{ duration?: number }`，默认动画周期为 3 秒；禁用文本会停止动画。同步补充中英文文档、示例和回归测试。

验证：

- Typography 测试：10 个测试套件、172 个测试通过
- ESLint、Biome、Remark、Prettier 和 `git diff --check` 通过

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | 🆕 Add Typography `shimmer` prop for animated loading text. |
| 🇨🇳 中文 | 🆕 新增 Typography `shimmer` 属性，用于展示加载态渐变文字效果。 |
