### PR TITLE
feat(Radio): support classNames and styles in Radio.Group

### DIFF
--- a/components/radio/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -333,3 +333,462 @@ exports[`renders components/radio/demo/_semantic.tsx correctly 1`] = `
   </div>
 </div>
 `;
+
+exports[`renders components/radio/demo/_semantic_group.tsx correctly 1`] = `
+<div
+  class="acss-1ucck97"
+>
+  <div
+    class="ant-row css-var-test-id"
+  >
+    <div
+      class="ant-col ant-col-16 acss-my3sst css-var-test-id"
+    >
+      <div
+        class="ant-radio-group ant-radio-group-outline semantic-mark-root css-var-test-id ant-radio-css-var"
+        role="radiogroup"
+      >
+        <label
+          class="ant-radio-wrapper ant-radio-wrapper-checked semantic-mark-item css-var-test-id ant-radio-css-var"
+        >
+          <span
+            class="ant-radio semantic-mark-itemIcon ant-wave-target ant-radio-checked"
+          >
+            <input
+              checked=""
+              class="ant-radio-input"
+              name="test-id"
+              type="radio"
+              value="apple"
+            />
+          </span>
+          <span
+            class="ant-radio-label semantic-mark-itemLabel"
+          >
+            Apple
+          </span>
+        </label>
+        <label
+          class="ant-radio-wrapper semantic-mark-item css-var-test-id ant-radio-css-var"
+        >
+          <span
+            class="ant-radio semantic-mark-itemIcon ant-wave-target"
+          >
+            <input
+              class="ant-radio-input"
+              name="test-id"
+              type="radio"
+              value="pear"
+            />
+          </span>
+          <span
+            class="ant-radio-label semantic-mark-itemLabel"
+          >
+            Pear
+          </span>
+        </label>
+      </div>
+    </div>
+    <div
+      class="ant-col ant-col-8 css-var-test-id"
+    >
+      <ul
+        class="acss-11b5qta"
+      >
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
+                  root
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-test-id"
+                >
+                  6.7.0
+                </span>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              根元素，单选组合容器，包含排列方向、间距、按钮风格等组合布局样式
+            </div>
+          </div>
+        </li>
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
+                  item
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-test-id"
+                >
+                  6.7.0
+                </span>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              选项元素，单个 Radio 的包裹容器，包含选中、禁用、块级排列等选项样式
+            </div>
+          </div>
+        </li>
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
+                  itemIcon
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-test-id"
+                >
+                  6.7.0
+                </span>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              选项选中框元素，包含圆角、边框、过渡动画、悬停与焦点等交互样式
+            </div>
+          </div>
+        </li>
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
+                  itemLabel
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-test-id"
+                >
+                  6.7.0
+                </span>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              选项文本元素，包含内边距、文字颜色、禁用状态、对齐方式等文本样式
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;

--- a/components/radio/__tests__/semantic.test.tsx
+++ b/components/radio/__tests__/semantic.test.tsx
@@ -79,4 +79,175 @@ describe('Radio.Semantic', () => {
 
     expectSemanticRootStylePriority(container.querySelector('.ant-radio-wrapper'));
   });
+
+  describe('Radio.Group', () => {
+    const options = [
+      { label: 'Apple', value: 'apple' },
+      { label: 'Pear', value: 'pear' },
+    ];
+
+    it('support classNames and styles as objects', () => {
+      const { container } = render(
+        <Radio.Group
+          options={options}
+          classNames={{
+            root: 'custom-group-root',
+            item: 'custom-group-item',
+            itemIcon: 'custom-group-item-icon',
+            itemLabel: 'custom-group-item-label',
+          }}
+          styles={{
+            root: { backgroundColor: 'rgb(0, 255, 0)' },
+            item: { color: 'rgb(255, 0, 0)' },
+            itemIcon: { borderColor: 'rgb(0, 0, 255)' },
+            itemLabel: { fontWeight: 'bold' },
+          }}
+        />,
+      );
+
+      const group = container.querySelector('.ant-radio-group');
+      const items = container.querySelectorAll('.ant-radio-wrapper');
+      const icons = container.querySelectorAll('.ant-radio');
+      const labels = container.querySelectorAll('.ant-radio-label');
+
+      expect(group).toHaveClass('custom-group-root');
+      expect(group).toHaveStyle({ backgroundColor: 'rgb(0, 255, 0)' });
+
+      items.forEach((item) => {
+        expect(item).toHaveClass('custom-group-item');
+        expect(item).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+      });
+      icons.forEach((icon) => {
+        expect(icon).toHaveClass('custom-group-item-icon');
+        expect(icon).toHaveStyle({ borderColor: 'rgb(0, 0, 255)' });
+      });
+      labels.forEach((label) => {
+        expect(label).toHaveClass('custom-group-item-label');
+        expect(label).toHaveStyle({ fontWeight: 'bold' });
+      });
+    });
+
+    it('should apply semantic classNames to children Radio', () => {
+      const { container } = render(
+        <Radio.Group
+          classNames={{
+            root: 'custom-group-root',
+            item: 'custom-group-item',
+            itemIcon: 'custom-group-item-icon',
+            itemLabel: 'custom-group-item-label',
+          }}
+        >
+          <Radio value="A">A</Radio>
+          <Radio.Button value="B">B</Radio.Button>
+        </Radio.Group>,
+      );
+
+      expect(container.querySelector('.ant-radio-group')).toHaveClass('custom-group-root');
+      expect(container.querySelector('.ant-radio-wrapper')).toHaveClass('custom-group-item');
+      expect(container.querySelector('.ant-radio')).toHaveClass('custom-group-item-icon');
+      expect(container.querySelector('.ant-radio-label')).toHaveClass('custom-group-item-label');
+      expect(container.querySelector('.ant-radio-button-wrapper')).toHaveClass('custom-group-item');
+      expect(container.querySelector('.ant-radio-button')).toHaveClass('custom-group-item-icon');
+      expect(container.querySelector('.ant-radio-button-label')).toHaveClass(
+        'custom-group-item-label',
+      );
+    });
+
+    it('support classNames and styles as functions', () => {
+      const { container } = render(
+        <Radio.Group
+          disabled={false}
+          optionType="default"
+          options={options}
+          classNames={(info) => ({
+            root: info.props.disabled ? 'group-disabled' : 'group-enabled',
+            item: `item-${info.props.optionType}`,
+          })}
+          styles={(info) => ({
+            root: {
+              padding: info.props.disabled ? '4px' : '8px',
+            },
+            itemLabel: {
+              fontWeight: info.props.optionType === 'button' ? 'normal' : 'bold',
+            },
+          })}
+        />,
+      );
+
+      const group = container.querySelector('.ant-radio-group');
+      expect(group).toHaveClass('group-enabled');
+      expect(group).toHaveStyle({ padding: '8px' });
+
+      container.querySelectorAll('.ant-radio-wrapper').forEach((item) => {
+        expect(item).toHaveClass('item-default');
+      });
+      container.querySelectorAll('.ant-radio-label').forEach((label) => {
+        expect(label).toHaveStyle({ fontWeight: 'bold' });
+      });
+    });
+
+    it('should allow option style to override group item styles', () => {
+      const { container } = render(
+        <Radio.Group
+          styles={{
+            item: { color: 'rgb(255, 0, 0)', backgroundColor: 'rgb(0, 255, 0)' },
+          }}
+          options={[
+            { label: 'Apple', value: 'apple', style: { color: 'rgb(0, 0, 255)' } },
+            { label: 'Pear', value: 'pear' },
+          ]}
+        />,
+      );
+
+      const items = container.querySelectorAll<HTMLElement>('.ant-radio-wrapper');
+      expect(items[0]).toHaveStyle({
+        color: 'rgb(0, 0, 255)',
+        backgroundColor: 'rgb(0, 255, 0)',
+      });
+      expect(items[1]).toHaveStyle({
+        color: 'rgb(255, 0, 0)',
+        backgroundColor: 'rgb(0, 255, 0)',
+      });
+    });
+
+    it('should allow Radio styles to override group item styles', () => {
+      const { container } = render(
+        <Radio.Group
+          styles={{
+            item: { color: 'rgb(255, 0, 0)' },
+            itemIcon: { borderColor: 'rgb(0, 255, 0)' },
+          }}
+        >
+          <Radio value="A" styles={{ root: { color: 'rgb(0, 0, 255)' } }}>
+            A
+          </Radio>
+          <Radio value="B">B</Radio>
+        </Radio.Group>,
+      );
+
+      const items = container.querySelectorAll<HTMLElement>('.ant-radio-wrapper');
+      const icons = container.querySelectorAll<HTMLElement>('.ant-radio');
+
+      expect(items[0]).toHaveStyle({ color: 'rgb(0, 0, 255)' });
+      expect(items[1]).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+      expect(icons[0]).toHaveStyle({ borderColor: 'rgb(0, 255, 0)' });
+      expect(icons[1]).toHaveStyle({ borderColor: 'rgb(0, 255, 0)' });
+    });
+
+    it('should follow root style priority', () => {
+      const { container } = render(
+        <Radio.Group
+          options={options}
+          styles={semanticRootStylePriority.styles}
+          style={semanticRootStylePriority.style}
+        />,
+      );
+
+      const group = container.querySelector('.ant-radio-group');
+      expect(group).toHaveStyle({
+        backgroundColor: semanticRootStylePriority.style.backgroundColor,
+        marginTop: semanticRootStylePriority.styles.root.marginTop,
+      });
+    });
+  });
 });

--- a/components/radio/__tests__/semantic.test.tsx
+++ b/components/radio/__tests__/semantic.test.tsx
@@ -153,15 +153,13 @@ describe('Radio.Semantic', () => {
       );
     });
 
-    it('support classNames and styles as functions', () => {
+    it('support classNames and styles as functions with merged props', () => {
       const { container } = render(
         <Radio.Group
-          disabled={false}
-          optionType="default"
           options={options}
           classNames={(info) => ({
-            root: info.props.disabled ? 'group-disabled' : 'group-enabled',
-            item: `item-${info.props.optionType}`,
+            root: info.props.disabled === false ? 'group-enabled' : 'group-disabled',
+            item: `item-${info.props.optionType}-${info.props.orientation}`,
           })}
           styles={(info) => ({
             root: {
@@ -179,11 +177,26 @@ describe('Radio.Semantic', () => {
       expect(group).toHaveStyle({ padding: '8px' });
 
       container.querySelectorAll('.ant-radio-wrapper').forEach((item) => {
-        expect(item).toHaveClass('item-default');
+        expect(item).toHaveClass('item-default-horizontal');
       });
       container.querySelectorAll('.ant-radio-label').forEach((label) => {
         expect(label).toHaveStyle({ fontWeight: 'bold' });
       });
+    });
+
+    it('should provide componentDisabled to semantic functions', () => {
+      const { container } = render(
+        <ConfigProvider componentDisabled>
+          <Radio.Group
+            options={options}
+            classNames={({ props }) => ({
+              root: props.disabled ? 'group-disabled' : 'group-enabled',
+            })}
+          />
+        </ConfigProvider>,
+      );
+
+      expect(container.querySelector('.ant-radio-group')).toHaveClass('group-disabled');
     });
 
     it('should allow option style to override group item styles', () => {

--- a/components/radio/__tests__/type.test.tsx
+++ b/components/radio/__tests__/type.test.tsx
@@ -13,7 +13,10 @@ describe('Radio.typescript', () => {
 
   it('Radio.Group', () => {
     const group = (
-      <Radio.Group>
+      <Radio.Group
+        classNames={{ root: 'group-root', item: 'group-item' }}
+        styles={{ root: { gap: 8 }, itemIcon: { color: 'red' } }}
+      >
         <Radio />
       </Radio.Group>
     );

--- a/components/radio/demo/_semantic_group.tsx
+++ b/components/radio/demo/_semantic_group.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Radio } from 'antd';
+
+import SemanticPreview from '../../../.dumi/theme/common/SemanticPreview';
+import useLocale from '../../../.dumi/hooks/useLocale';
+
+const locales = {
+  cn: {
+    root: '根元素，单选组合容器，包含排列方向、间距、按钮风格等组合布局样式',
+    item: '选项元素，单个 Radio 的包裹容器，包含选中、禁用、块级排列等选项样式',
+    itemIcon: '选项选中框元素，包含圆角、边框、过渡动画、悬停与焦点等交互样式',
+    itemLabel: '选项文本元素，包含内边距、文字颜色、禁用状态、对齐方式等文本样式',
+  },
+  en: {
+    root: 'Root element of the radio group container, including layout direction, spacing, button style and other group layout styles',
+    item: 'Item element wrapping a single Radio, including checked, disabled, block layout and other option styles',
+    itemIcon:
+      'Item icon element with border radius, border, transition animations, hover and focus interactive styles',
+    itemLabel:
+      'Item label element with padding, text color, disabled states, alignment and other text styles',
+  },
+};
+
+const App: React.FC = () => {
+  const [locale] = useLocale(locales);
+  return (
+    <SemanticPreview
+      componentName="Radio.Group"
+      semantics={[
+        { name: 'root', desc: locale.root, version: '6.7.0' },
+        { name: 'item', desc: locale.item, version: '6.7.0' },
+        { name: 'itemIcon', desc: locale.itemIcon, version: '6.7.0' },
+        { name: 'itemLabel', desc: locale.itemLabel, version: '6.7.0' },
+      ]}
+    >
+      <Radio.Group
+        defaultValue="apple"
+        options={[
+          { value: 'apple', label: 'Apple' },
+          { value: 'pear', label: 'Pear' },
+        ]}
+      />
+    </SemanticPreview>
+  );
+};
+
+export default App;

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -3,6 +3,7 @@ import { pickAttrs, useControlledState, useId } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useOrientation } from '../_util/hooks';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import { isNumber } from '../_util/is';
 import { ConfigContext } from '../config-provider';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
@@ -15,6 +16,7 @@ import type {
   RadioGroupButtonStyle,
   RadioGroupContextProps,
   RadioGroupProps,
+  RadioGroupSemanticAllType,
 } from './interface';
 import Radio from './radio';
 import useStyle from './style';
@@ -29,6 +31,8 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
     prefixCls: customizePrefixCls,
     className,
     rootClassName,
+    classNames,
+    styles,
     options,
     buttonStyle = 'outline' as RadioGroupButtonStyle,
     disabled,
@@ -115,6 +119,27 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
 
   const mergedSize = useSize(customizeSize);
   const [, mergedVertical] = useOrientation(orientation, vertical);
+
+  const mergedProps: RadioGroupProps = {
+    ...props,
+    value,
+    disabled,
+    size: mergedSize,
+    buttonStyle,
+    block,
+    name,
+    vertical: mergedVertical,
+  };
+
+  const styleRoot = useSemanticRootStyle(style);
+  const [mergedClassNames, mergedStyles] = useMergeSemantic<
+    RadioGroupSemanticAllType['classNames'],
+    RadioGroupSemanticAllType['styles'],
+    RadioGroupProps
+  >([classNames], [styles, styleRoot], {
+    props: mergedProps,
+  });
+
   const classString = clsx(
     groupPrefixCls,
     `${groupPrefixCls}-${buttonStyle}`,
@@ -126,14 +151,32 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
     },
     className,
     rootClassName,
+    mergedClassNames.root,
     hashId,
     cssVarCls,
     rootCls,
   );
 
   const memoizedValue = React.useMemo<RadioGroupContextProps>(
-    () => ({ onChange: onRadioChange, value, disabled, name, optionType, block }),
-    [onRadioChange, value, disabled, name, optionType, block],
+    () => ({
+      onChange: onRadioChange,
+      value,
+      disabled,
+      name,
+      optionType,
+      block,
+      classNames: {
+        root: mergedClassNames.item,
+        icon: mergedClassNames.itemIcon,
+        label: mergedClassNames.itemLabel,
+      },
+      styles: {
+        root: mergedStyles.item,
+        icon: mergedStyles.itemIcon,
+        label: mergedStyles.itemLabel,
+      },
+    }),
+    [onRadioChange, value, disabled, name, optionType, block, mergedClassNames, mergedStyles],
   );
 
   return (
@@ -141,7 +184,7 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
       {...pickAttrs(props, { aria: true, data: true })}
       role={role}
       className={clsx(classString, { [`${prefixCls}-group-vertical`]: mergedVertical })}
-      style={style}
+      style={mergedStyles.root}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       onFocus={onFocus}

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -6,6 +6,7 @@ import { useOrientation } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import { isNumber } from '../_util/is';
 import { ConfigContext } from '../config-provider';
+import DisabledContext from '../config-provider/DisabledContext';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import useSize from '../config-provider/hooks/useSize';
 import { FormItemInputContext } from '../form/context';
@@ -54,6 +55,9 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
     vertical,
     role = 'radiogroup',
   } = props;
+
+  const contextDisabled = React.useContext(DisabledContext);
+  const mergedDisabled = disabled ?? contextDisabled;
 
   const [value, setValue] = useControlledState(defaultValue, customizedValue);
 
@@ -118,16 +122,18 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
   }
 
   const mergedSize = useSize(customizeSize);
-  const [, mergedVertical] = useOrientation(orientation, vertical);
+  const [mergedOrientation, mergedVertical] = useOrientation(orientation, vertical);
 
   const mergedProps: RadioGroupProps = {
     ...props,
     value,
-    disabled,
+    disabled: mergedDisabled,
     size: mergedSize,
     buttonStyle,
     block,
     name,
+    optionType: optionType ?? 'default',
+    orientation: mergedOrientation,
     vertical: mergedVertical,
   };
 

--- a/components/radio/index.en-US.md
+++ b/components/radio/index.en-US.md
@@ -81,7 +81,7 @@ Radio group can wrap a group of `Radio`.
 | --- | --- | --- | --- | --- |
 | block | Option to fit RadioGroup width to its parent width | boolean | false | 5.21.0 |
 | buttonStyle | The style type of radio button | `outline` \| `solid` | `outline` |  |
-| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | 6.0.0 |
+| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-group), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-group), string> | - | 6.7.0 |
 | defaultValue | Default selected value | any | - |  |
 | disabled | Disable all radio buttons | boolean | false |  |
 | name | The `name` property of all `input[type="radio"]` children. If not set, it will fallback to a randomly generated name | string | - |  |
@@ -89,7 +89,7 @@ Radio group can wrap a group of `Radio`.
 | optionType | Set Radio optionType | `default` \| `button` | `default` | 4.4.0 |
 | orientation | Orientation | `horizontal` \| `vertical` | `horizontal` |  |
 | size | The size of radio button style | `large` \| `medium` \| `small` | - |  |
-| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.0.0 |
+| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-group), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-group), CSSProperties> | - | 6.7.0 |
 | value | Used for setting the currently selected value | any | - |  |
 | vertical | If true, the Radio group will be vertical. Simultaneously existing with `orientation`, `orientation` takes priority | boolean | false |  |
 | onChange | The callback function that is triggered when the state changes | function(e:Event) | - |  |
@@ -119,7 +119,13 @@ Radio group can wrap a group of `Radio`.
 
 ## Semantic DOM
 
+### Radio
+
 <code src="./demo/_semantic.tsx" simplify="true"></code>
+
+### Radio.Group {#semantic-group}
+
+<code src="./demo/_semantic_group.tsx" simplify="true"></code>
 
 ## Design Token
 

--- a/components/radio/index.zh-CN.md
+++ b/components/radio/index.zh-CN.md
@@ -84,7 +84,7 @@ return (
 | --- | --- | --- | --- | --- |
 | block | 将 RadioGroup 宽度调整为其父宽度的选项 | boolean | false | 5.21.0 |
 | buttonStyle | RadioButton 的风格样式，目前有描边和填色两种风格 | `outline` \| `solid` | `outline` |  |
-| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | 6.0.0 |
+| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-group), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-group), string> | - | 6.7.0 |
 | defaultValue | 默认选中的值 | any | - |  |
 | disabled | 禁选所有子单选器 | boolean | false |  |
 | name | RadioGroup 下所有 `input[type="radio"]` 的 `name` 属性。若未设置，则将回退到随机生成的名称 | string | - |  |
@@ -92,7 +92,7 @@ return (
 | optionType | 用于设置 Radio `options` 类型 | `default` \| `button` | `default` | 4.4.0 |
 | orientation | 排列方向 | `horizontal` \| `vertical` | `horizontal` |  |
 | size | 大小，只对按钮样式生效 | `large` \| `medium` \| `small` | - |  |
-| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), CSSProperties> | - | 6.0.0 |
+| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-group), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-group), CSSProperties> | - | 6.7.0 |
 | value | 用于设置当前选中的值 | any | - |  |
 | vertical | 值为 true，Radio Group 为垂直方向。与 `orientation` 同时存在，以 `orientation` 优先 | boolean | false |  |
 | onChange | 选项变化时的回调函数 | function(e:Event) | - |  |
@@ -122,7 +122,13 @@ return (
 
 ## Semantic DOM
 
+### Radio
+
 <code src="./demo/_semantic.tsx" simplify="true"></code>
+
+### Radio.Group {#semantic-group}
+
+<code src="./demo/_semantic_group.tsx" simplify="true"></code>
 
 ## 主题变量（Design Token）{#design-token}
 

--- a/components/radio/interface.ts
+++ b/components/radio/interface.ts
@@ -10,6 +10,23 @@ export type { CheckboxRef as RadioRef } from '@rc-component/checkbox';
 export type RadioGroupButtonStyle = 'outline' | 'solid';
 export type RadioGroupOptionType = 'default' | 'button';
 
+export type RadioGroupSemanticType = {
+  classNames?: {
+    root?: string;
+    item?: string;
+    itemIcon?: string;
+    itemLabel?: string;
+  };
+  styles?: {
+    root?: React.CSSProperties;
+    item?: React.CSSProperties;
+    itemIcon?: React.CSSProperties;
+    itemLabel?: React.CSSProperties;
+  };
+};
+
+export type RadioGroupSemanticAllType = GenerateSemantic<RadioGroupSemanticType, RadioGroupProps>;
+
 export interface RadioGroupProps extends AbstractCheckboxGroupProps {
   defaultValue?: any;
   value?: any;
@@ -28,6 +45,8 @@ export interface RadioGroupProps extends AbstractCheckboxGroupProps {
   onBlur?: React.FocusEventHandler<HTMLDivElement>;
   block?: boolean;
   vertical?: boolean;
+  classNames?: RadioGroupSemanticAllType['classNamesAndFn'];
+  styles?: RadioGroupSemanticAllType['stylesAndFn'];
 }
 
 export interface RadioGroupContextProps {
@@ -43,6 +62,8 @@ export interface RadioGroupContextProps {
    */
   optionType?: RadioGroupOptionType;
   block?: boolean;
+  classNames?: RadioSemanticType['classNames'];
+  styles?: RadioSemanticType['styles'];
 }
 
 export type RadioSemanticType = {

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -99,9 +99,13 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
     RadioSemanticAllType['classNames'],
     RadioSemanticAllType['styles'],
     RadioProps
-  >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles, styleRoot], {
-    props: mergedProps,
-  });
+  >(
+    [contextClassNames, groupContext?.classNames, classNames],
+    [contextStyles, contextStyleRoot, groupContext?.styles, styles, styleRoot],
+    {
+      props: mergedProps,
+    },
+  );
 
   const wrapperClassString = clsx(
     `${prefixCls}-wrapper`,


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #59053

### 💡 需求背景和解决方案

Radio.Group 文档中包含 `classNames` 和 `styles`，但组件此前缺少对应的类型与运行时支持。

本次为 Radio.Group 增加 `root`、`item`、`itemIcon` 和 `itemLabel` 语义化结构，并将选项级配置传递给 Radio 与 Radio.Button。同时补充中英文文档、语义化示例、类型测试及样式优先级测试。

### 📝 更新日志

| 语言    | 更新描述                                                   |
| ------- | ---------------------------------------------------------- |
| 🇺🇸 英文 | 🆕 Radio.Group supports semantic `classNames` and `styles`. |
| 🇨🇳 中文 | 🆕 Radio.Group 支持语义化 `classNames` 和 `styles`。        |