### PR TITLE
feat(Checkbox): support classNames and styles in Checkbox.Group

### DIFF
--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -196,9 +196,19 @@ const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProp
     CheckboxSemanticAllType['classNames'],
     CheckboxSemanticAllType['styles'],
     CheckboxProps
-  >([contextClassNames, classNames], [contextStyles, contextStyleRoot, styles, styleRoot], {
-    props: mergedProps,
-  });
+  >(
+    [contextClassNames, skipGroup ? undefined : checkboxGroup?.classNames, classNames],
+    [
+      contextStyles,
+      contextStyleRoot,
+      skipGroup ? undefined : checkboxGroup?.styles,
+      styles,
+      styleRoot,
+    ],
+    {
+      props: mergedProps,
+    },
+  );
 
   const classString = clsx(
     `${prefixCls}-wrapper`,

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -7,6 +7,7 @@ import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeS
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { isNonNullable, isNumber, isString } from '../_util/is';
 import { ConfigContext } from '../config-provider';
+import DisabledContext from '../config-provider/DisabledContext';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import type { CheckboxChangeEvent } from './Checkbox';
 import Checkbox from './Checkbox';
@@ -87,6 +88,8 @@ const CheckboxGroup = React.forwardRef(
       ...restProps
     } = props;
     const { getPrefixCls, direction } = React.useContext(ConfigContext);
+    const contextDisabled = React.useContext(DisabledContext);
+    const mergedDisabled = restProps.disabled ?? contextDisabled;
 
     const [value, setValue] = React.useState<T[]>(restProps.value || defaultValue || []);
     const [registeredValues, setRegisteredValues] = React.useState<T[]>([]);
@@ -150,6 +153,7 @@ const CheckboxGroup = React.forwardRef(
       ...props,
       options,
       value,
+      disabled: mergedDisabled,
     };
 
     const styleRoot = useSemanticRootStyle(style);

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -3,6 +3,8 @@ import { omit } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { HTMLAriaDataAttributes } from '../_util/aria-data-attrs';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
+import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { isNonNullable, isNumber, isString } from '../_util/is';
 import { ConfigContext } from '../config-provider';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
@@ -33,12 +35,34 @@ export interface AbstractCheckboxGroupProps<T = any> extends HTMLAriaDataAttribu
   style?: React.CSSProperties;
 }
 
+export type CheckboxGroupSemanticType = {
+  classNames?: {
+    root?: string;
+    item?: string;
+    itemIcon?: string;
+    itemLabel?: string;
+  };
+  styles?: {
+    root?: React.CSSProperties;
+    item?: React.CSSProperties;
+    itemIcon?: React.CSSProperties;
+    itemLabel?: React.CSSProperties;
+  };
+};
+
+export type CheckboxGroupSemanticAllType<T = any> = GenerateSemantic<
+  CheckboxGroupSemanticType,
+  CheckboxGroupProps<T>
+>;
+
 export interface CheckboxGroupProps<T = any> extends AbstractCheckboxGroupProps<T> {
   name?: string;
   defaultValue?: T[];
   value?: T[];
   onChange?: (checkedValue: T[]) => void;
   children?: React.ReactNode;
+  classNames?: CheckboxGroupSemanticAllType<T>['classNamesAndFn'];
+  styles?: CheckboxGroupSemanticAllType<T>['stylesAndFn'];
 }
 
 type InternalCheckboxValueType = string | number | boolean;
@@ -55,6 +79,8 @@ const CheckboxGroup = React.forwardRef(
       prefixCls: customizePrefixCls,
       className,
       rootClassName,
+      classNames,
+      styles,
       style,
       onChange,
       role = 'group',
@@ -120,6 +146,21 @@ const CheckboxGroup = React.forwardRef(
     const rootCls = useCSSVarCls(prefixCls);
     const [hashId, cssVarCls] = useStyle(prefixCls, rootCls);
 
+    const mergedProps: CheckboxGroupProps<T> = {
+      ...props,
+      options,
+      value,
+    };
+
+    const styleRoot = useSemanticRootStyle(style);
+    const [mergedClassNames, mergedStyles] = useMergeSemantic<
+      CheckboxGroupSemanticAllType<T>['classNames'],
+      CheckboxGroupSemanticAllType<T>['styles'],
+      CheckboxGroupProps<T>
+    >([classNames], [styles, styleRoot], {
+      props: mergedProps,
+    });
+
     const domProps = omit(restProps, ['value', 'disabled']);
 
     const childrenNode =
@@ -149,11 +190,30 @@ const CheckboxGroup = React.forwardRef(
         value,
         disabled: restProps.disabled,
         name: restProps.name,
+        classNames: {
+          root: mergedClassNames.item,
+          icon: mergedClassNames.itemIcon,
+          label: mergedClassNames.itemLabel,
+        },
+        styles: {
+          root: mergedStyles.item,
+          icon: mergedStyles.itemIcon,
+          label: mergedStyles.itemLabel,
+        },
         // https://github.com/ant-design/ant-design/issues/16376
         registerValue,
         cancelValue,
       }),
-      [toggleOption, value, restProps.disabled, restProps.name, registerValue, cancelValue],
+      [
+        toggleOption,
+        value,
+        restProps.disabled,
+        restProps.name,
+        mergedClassNames,
+        mergedStyles,
+        registerValue,
+        cancelValue,
+      ],
     );
 
     const classString = clsx(
@@ -163,13 +223,14 @@ const CheckboxGroup = React.forwardRef(
       },
       className,
       rootClassName,
+      mergedClassNames.root,
       cssVarCls,
       rootCls,
       hashId,
     );
 
     return (
-      <div className={classString} style={style} role={role} {...domProps} ref={ref}>
+      <div className={classString} style={mergedStyles.root} role={role} {...domProps} ref={ref}>
         <GroupContext.Provider value={memoizedContext}>{childrenNode}</GroupContext.Provider>
       </div>
     );

--- a/components/checkbox/GroupContext.ts
+++ b/components/checkbox/GroupContext.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import type { CheckboxSemanticType } from './Checkbox';
 import type { CheckboxOptionType } from './Group';
 
 export interface CheckboxGroupContext<T = any> {
@@ -7,6 +8,8 @@ export interface CheckboxGroupContext<T = any> {
   toggleOption?: (option: CheckboxOptionType<T>) => void;
   value?: any;
   disabled?: boolean;
+  classNames?: CheckboxSemanticType['classNames'];
+  styles?: CheckboxSemanticType['styles'];
   registerValue: (val: T) => void;
   cancelValue: (val: T) => void;
 }

--- a/components/checkbox/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -333,3 +333,460 @@ exports[`renders components/checkbox/demo/_semantic.tsx correctly 1`] = `
   </div>
 </div>
 `;
+
+exports[`renders components/checkbox/demo/_semantic_group.tsx correctly 1`] = `
+<div
+  class="acss-1ucck97"
+>
+  <div
+    class="ant-row css-var-test-id"
+  >
+    <div
+      class="ant-col ant-col-16 acss-my3sst css-var-test-id"
+    >
+      <div
+        class="ant-checkbox-group semantic-mark-root css-var-test-id ant-checkbox-css-var"
+        role="group"
+      >
+        <label
+          class="ant-checkbox-wrapper ant-checkbox-wrapper-checked ant-checkbox-group-item semantic-mark-item css-var-test-id ant-checkbox-css-var"
+        >
+          <span
+            class="ant-checkbox semantic-mark-itemIcon ant-wave-target ant-checkbox-checked"
+          >
+            <input
+              checked=""
+              class="ant-checkbox-input"
+              type="checkbox"
+              value="Apple"
+            />
+          </span>
+          <span
+            class="ant-checkbox-label semantic-mark-itemLabel"
+          >
+            Apple
+          </span>
+        </label>
+        <label
+          class="ant-checkbox-wrapper ant-checkbox-group-item semantic-mark-item css-var-test-id ant-checkbox-css-var"
+        >
+          <span
+            class="ant-checkbox semantic-mark-itemIcon ant-wave-target"
+          >
+            <input
+              class="ant-checkbox-input"
+              type="checkbox"
+              value="Pear"
+            />
+          </span>
+          <span
+            class="ant-checkbox-label semantic-mark-itemLabel"
+          >
+            Pear
+          </span>
+        </label>
+      </div>
+    </div>
+    <div
+      class="ant-col ant-col-8 css-var-test-id"
+    >
+      <ul
+        class="acss-11b5qta"
+      >
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
+                  root
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-test-id"
+                >
+                  6.7.0
+                </span>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              根元素，复选框组合容器，包含布局、间距和排列等组合样式
+            </div>
+          </div>
+        </li>
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
+                  item
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-test-id"
+                >
+                  6.7.0
+                </span>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              选项元素，单个 Checkbox 的包裹容器，包含选中、禁用等选项样式
+            </div>
+          </div>
+        </li>
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
+                  itemIcon
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-test-id"
+                >
+                  6.7.0
+                </span>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              选项勾选框元素，包含尺寸、背景、边框、圆角和选中状态等图标样式
+            </div>
+          </div>
+        </li>
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
+                  itemLabel
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-test-id"
+                >
+                  6.7.0
+                </span>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              选项文本元素，包含内边距、文字颜色和对齐方式等文本样式
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;

--- a/components/checkbox/__tests__/semantic.test.tsx
+++ b/components/checkbox/__tests__/semantic.test.tsx
@@ -121,4 +121,159 @@ describe('Checkbox.Semantic', () => {
 
     expectSemanticRootStylePriority(container.querySelector('.ant-checkbox-wrapper'));
   });
+
+  describe('Checkbox.Group', () => {
+    const options = [
+      { label: 'Apple', value: 'apple' },
+      { label: 'Pear', value: 'pear' },
+    ];
+
+    it('should support classNames and styles as objects', () => {
+      const { container } = render(
+        <Checkbox.Group
+          options={options}
+          classNames={{
+            root: 'custom-group-root',
+            item: 'custom-group-item',
+            itemIcon: 'custom-group-item-icon',
+            itemLabel: 'custom-group-item-label',
+          }}
+          styles={{
+            root: { backgroundColor: 'rgb(0, 255, 0)' },
+            item: { color: 'rgb(255, 0, 0)' },
+            itemIcon: { borderColor: 'rgb(0, 0, 255)' },
+            itemLabel: { fontWeight: 'bold' },
+          }}
+        />,
+      );
+
+      const group = container.querySelector('.ant-checkbox-group');
+      const items = container.querySelectorAll('.ant-checkbox-wrapper');
+      const icons = container.querySelectorAll('.ant-checkbox');
+      const labels = container.querySelectorAll('.ant-checkbox-label');
+
+      expect(group).toHaveClass('custom-group-root');
+      expect(group).toHaveStyle({ backgroundColor: 'rgb(0, 255, 0)' });
+
+      items.forEach((item) => {
+        expect(item).toHaveClass('custom-group-item');
+        expect(item).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+      });
+      icons.forEach((icon) => {
+        expect(icon).toHaveClass('custom-group-item-icon');
+        expect(icon).toHaveStyle({ borderColor: 'rgb(0, 0, 255)' });
+      });
+      labels.forEach((label) => {
+        expect(label).toHaveClass('custom-group-item-label');
+        expect(label).toHaveStyle({ fontWeight: 'bold' });
+      });
+    });
+
+    it('should support classNames and styles as functions', () => {
+      const { container } = render(
+        <Checkbox.Group
+          disabled={false}
+          options={options}
+          classNames={({ props }) => ({
+            root: props.disabled ? 'group-disabled' : 'group-enabled',
+            item: props.value?.includes('apple') ? 'item-checked' : 'item-unchecked',
+          })}
+          styles={({ props }) => ({
+            root: { padding: props.disabled ? '4px' : '8px' },
+            itemLabel: { fontWeight: props.options?.length === 2 ? 'bold' : 'normal' },
+          })}
+          value={['apple']}
+        />,
+      );
+
+      expect(container.querySelector('.ant-checkbox-group')).toHaveClass('group-enabled');
+      expect(container.querySelector('.ant-checkbox-group')).toHaveStyle({ padding: '8px' });
+
+      container.querySelectorAll('.ant-checkbox-wrapper').forEach((item) => {
+        expect(item).toHaveClass('item-checked');
+      });
+      container.querySelectorAll('.ant-checkbox-label').forEach((label) => {
+        expect(label).toHaveStyle({ fontWeight: 'bold' });
+      });
+    });
+
+    it('should allow option style to override group item styles', () => {
+      const { container } = render(
+        <Checkbox.Group
+          styles={{
+            item: { color: 'rgb(255, 0, 0)', backgroundColor: 'rgb(0, 255, 0)' },
+          }}
+          options={[
+            { label: 'Apple', value: 'apple', style: { color: 'rgb(0, 0, 255)' } },
+            { label: 'Pear', value: 'pear' },
+          ]}
+        />,
+      );
+
+      const items = container.querySelectorAll<HTMLElement>('.ant-checkbox-wrapper');
+      expect(items[0]).toHaveStyle({
+        color: 'rgb(0, 0, 255)',
+        backgroundColor: 'rgb(0, 255, 0)',
+      });
+      expect(items[1]).toHaveStyle({
+        color: 'rgb(255, 0, 0)',
+        backgroundColor: 'rgb(0, 255, 0)',
+      });
+    });
+
+    it('should allow Checkbox styles to override group item styles', () => {
+      const { container } = render(
+        <Checkbox.Group
+          styles={{
+            item: { color: 'rgb(255, 0, 0)' },
+            itemIcon: { borderColor: 'rgb(0, 255, 0)' },
+          }}
+        >
+          <Checkbox value="A" styles={{ root: { color: 'rgb(0, 0, 255)' } }}>
+            A
+          </Checkbox>
+          <Checkbox value="B">B</Checkbox>
+        </Checkbox.Group>,
+      );
+
+      const items = container.querySelectorAll<HTMLElement>('.ant-checkbox-wrapper');
+      const icons = container.querySelectorAll<HTMLElement>('.ant-checkbox');
+
+      expect(items[0]).toHaveStyle({ color: 'rgb(0, 0, 255)' });
+      expect(items[1]).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+      expect(icons[0]).toHaveStyle({ borderColor: 'rgb(0, 255, 0)' });
+      expect(icons[1]).toHaveStyle({ borderColor: 'rgb(0, 255, 0)' });
+    });
+
+    it('should not apply item semantics when skipGroup is true', () => {
+      const { container } = render(
+        <Checkbox.Group classNames={{ item: 'custom-group-item' }}>
+          <Checkbox value="A">A</Checkbox>
+          <Checkbox value="B" skipGroup>
+            B
+          </Checkbox>
+        </Checkbox.Group>,
+      );
+
+      const items = container.querySelectorAll('.ant-checkbox-wrapper');
+      expect(items[0]).toHaveClass('custom-group-item');
+      expect(items[1]).not.toHaveClass('custom-group-item');
+    });
+
+    it('should follow root style priority', () => {
+      const { container } = render(
+        <Checkbox.Group
+          options={options}
+          styles={semanticRootStylePriority.styles}
+          style={semanticRootStylePriority.style}
+        />,
+      );
+
+      const group = container.querySelector('.ant-checkbox-group');
+      expect(group).toHaveStyle({
+        backgroundColor: semanticRootStylePriority.style.backgroundColor,
+        marginTop: semanticRootStylePriority.styles.root.marginTop,
+      });
+    });
+  });
 });

--- a/components/checkbox/__tests__/semantic.test.tsx
+++ b/components/checkbox/__tests__/semantic.test.tsx
@@ -172,10 +172,9 @@ describe('Checkbox.Semantic', () => {
     it('should support classNames and styles as functions', () => {
       const { container } = render(
         <Checkbox.Group
-          disabled={false}
           options={options}
           classNames={({ props }) => ({
-            root: props.disabled ? 'group-disabled' : 'group-enabled',
+            root: props.disabled === false ? 'group-enabled' : 'group-disabled',
             item: props.value?.includes('apple') ? 'item-checked' : 'item-unchecked',
           })}
           styles={({ props }) => ({
@@ -195,6 +194,21 @@ describe('Checkbox.Semantic', () => {
       container.querySelectorAll('.ant-checkbox-label').forEach((label) => {
         expect(label).toHaveStyle({ fontWeight: 'bold' });
       });
+    });
+
+    it('should provide componentDisabled to semantic functions', () => {
+      const { container } = render(
+        <ConfigProvider componentDisabled>
+          <Checkbox.Group
+            options={options}
+            classNames={({ props }) => ({
+              root: props.disabled ? 'group-disabled' : 'group-enabled',
+            })}
+          />
+        </ConfigProvider>,
+      );
+
+      expect(container.querySelector('.ant-checkbox-group')).toHaveClass('group-disabled');
     });
 
     it('should allow option style to override group item styles', () => {

--- a/components/checkbox/__tests__/type.test.tsx
+++ b/components/checkbox/__tests__/type.test.tsx
@@ -15,12 +15,14 @@ describe('Checkbox.typescript', () => {
   it('Checkbox.Group', () => {
     const group = (
       <Checkbox.Group<'test-type-1' | 'test-type-2' | 'test-type-3'>
+        classNames={{ root: 'group-root', item: 'group-item' }}
         options={[
           {
             label: <span>test</span>,
             value: 'test-type-1',
           },
         ]}
+        styles={{ root: { gap: 8 }, itemIcon: { color: 'red' } }}
       >
         <Input />
       </Checkbox.Group>

--- a/components/checkbox/demo/_semantic_group.tsx
+++ b/components/checkbox/demo/_semantic_group.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Checkbox } from 'antd';
+
+import SemanticPreview from '../../../.dumi/theme/common/SemanticPreview';
+import useLocale from '../../../.dumi/hooks/useLocale';
+
+const locales = {
+  cn: {
+    root: '根元素，复选框组合容器，包含布局、间距和排列等组合样式',
+    item: '选项元素，单个 Checkbox 的包裹容器，包含选中、禁用等选项样式',
+    itemIcon: '选项勾选框元素，包含尺寸、背景、边框、圆角和选中状态等图标样式',
+    itemLabel: '选项文本元素，包含内边距、文字颜色和对齐方式等文本样式',
+  },
+  en: {
+    root: 'Root element of the checkbox group container, including layout, spacing and arrangement styles',
+    item: 'Item element wrapping a single Checkbox, including checked, disabled and other option styles',
+    itemIcon:
+      'Item icon element with size, background, border, border radius, checked state and other icon styles',
+    itemLabel: 'Item label element with padding, text color, alignment and other text styles',
+  },
+};
+
+const App: React.FC = () => {
+  const [locale] = useLocale(locales);
+  return (
+    <SemanticPreview
+      componentName="Checkbox.Group"
+      semantics={[
+        { name: 'root', desc: locale.root, version: '6.7.0' },
+        { name: 'item', desc: locale.item, version: '6.7.0' },
+        { name: 'itemIcon', desc: locale.itemIcon, version: '6.7.0' },
+        { name: 'itemLabel', desc: locale.itemLabel, version: '6.7.0' },
+      ]}
+    >
+      <Checkbox.Group
+        defaultValue={['Apple']}
+        options={[
+          { value: 'Apple', label: 'Apple' },
+          { value: 'Pear', label: 'Pear' },
+        ]}
+      />
+    </SemanticPreview>
+  );
+};
+
+export default App;

--- a/components/checkbox/index.en-US.md
+++ b/components/checkbox/index.en-US.md
@@ -51,10 +51,12 @@ Common props ref：[Common props](/docs/react/common-props)
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
+| classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-group), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-group), string> | - | 6.7.0 |
 | defaultValue | Default selected value | (string \| number)\[] | \[] |  |
 | disabled | If disable all checkboxes | boolean | false |  |
 | name | The `name` property of all `input[type="checkbox"]` children | string | - |  |
 | options | Specifies options | string\[] \| number\[] \| Option\[] | \[] |  |
+| styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-group), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-group), CSSProperties> | - | 6.7.0 |
 | value | Used for setting the currently selected value | (string \| number \| boolean)\[] | \[] |  |
 | title | title of the option | `string` | - |  |
 | className | className of the option | `string` | - | 5.25.0 |
@@ -83,7 +85,13 @@ interface Option {
 
 ## Semantic DOM
 
+### Checkbox
+
 <code src="./demo/_semantic.tsx" simplify="true"></code>
+
+### Checkbox.Group {#semantic-group}
+
+<code src="./demo/_semantic_group.tsx" simplify="true"></code>
 
 ## Design Token
 

--- a/components/checkbox/index.zh-CN.md
+++ b/components/checkbox/index.zh-CN.md
@@ -52,10 +52,12 @@ demo:
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
+| classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-group), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-group), string> | - | 6.7.0 |
 | defaultValue | 默认选中的选项 | (string \| number)\[] | \[] |  |
 | disabled | 整组失效 | boolean | false |  |
 | name | CheckboxGroup 下所有 `input[type="checkbox"]` 的 `name` 属性 | string | - |  |
 | options | 指定可选项 | string\[] \| number\[] \| Option\[] | \[] |  |
+| styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-group), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-group), CSSProperties> | - | 6.7.0 |
 | value | 指定选中的选项 | (string \| number \| boolean)\[] | \[] |  |
 | title | 选项的 title | `string` | - |  |
 | className | 选项的类名 | `string` | - | 5.25.0 |
@@ -84,7 +86,13 @@ interface Option {
 
 ## Semantic DOM
 
+### Checkbox
+
 <code src="./demo/_semantic.tsx" simplify="true"></code>
+
+### Checkbox.Group {#semantic-group}
+
+<code src="./demo/_semantic_group.tsx" simplify="true"></code>
 
 ## 主题变量（Design Token）{#design-token}
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交

### 🔗 相关 Issue

关联 #59053，并保持 Checkbox.Group 与 #59058 中 Radio.Group 的 Semantic API 一致。

### 💡 需求背景和解决方案

Checkbox.Group 此前不支持语义化 `classNames` 和 `styles`。

本次新增 `root`、`item`、`itemIcon` 和 `itemLabel` 语义化结构，并通过 Group Context 将选项级配置传递给子 Checkbox。同时处理 `skipGroup` 隔离和样式覆盖优先级，并补充中英文文档、语义化示例、类型测试及行为测试。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🆕 Checkbox.Group supports semantic `classNames` and `styles`. |
| 🇨🇳 中文 | 🆕 Checkbox.Group 支持语义化 `classNames` 和 `styles`。 |
