### PR TITLE
fix(List): recommend Listy in deprecation warning

### DIFF
--- a/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
@@ -4857,6 +4857,6 @@ Array [
 
 exports[`renders components/drawer/demo/user-profile.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;

--- a/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
@@ -4857,6 +4857,6 @@ Array [
 
 exports[`renders components/drawer/demo/user-profile.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;

--- a/components/empty/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/empty/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -975,7 +975,7 @@ Array [
 
 exports[`renders components/empty/demo/config-provider.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;
 

--- a/components/empty/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/empty/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -975,7 +975,7 @@ Array [
 
 exports[`renders components/empty/demo/config-provider.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;
 

--- a/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -171,7 +171,7 @@ exports[`renders components/list/demo/basic.tsx extend context correctly 1`] = `
 
 exports[`renders components/list/demo/basic.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;
 
@@ -882,7 +882,7 @@ Array [
 
 exports[`renders components/list/demo/component-token.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;
 
@@ -1401,7 +1401,7 @@ exports[`renders components/list/demo/grid.tsx extend context correctly 1`] = `
 
 exports[`renders components/list/demo/grid.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;
 
@@ -2843,7 +2843,7 @@ Array [
 
 exports[`renders components/list/demo/grid-test.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;
 
@@ -2959,7 +2959,7 @@ exports[`renders components/list/demo/infinite-load.tsx extend context correctly
 
 exports[`renders components/list/demo/infinite-load.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;
 
@@ -3009,7 +3009,7 @@ exports[`renders components/list/demo/loadmore.tsx extend context correctly 1`] 
 
 exports[`renders components/list/demo/loadmore.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;
 
@@ -3438,7 +3438,7 @@ Array [
 
 exports[`renders components/list/demo/pagination.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;
 
@@ -3676,7 +3676,7 @@ exports[`renders components/list/demo/responsive.tsx extend context correctly 1`
 
 exports[`renders components/list/demo/responsive.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;
 
@@ -3941,7 +3941,7 @@ Array [
 
 exports[`renders components/list/demo/simple.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;
 
@@ -4005,7 +4005,7 @@ exports[`renders components/list/demo/spin-debug.tsx extend context correctly 1`
 
 exports[`renders components/list/demo/spin-debug.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;
 
@@ -4728,6 +4728,6 @@ exports[`renders components/list/demo/vertical.tsx extend context correctly 1`] 
 
 exports[`renders components/list/demo/vertical.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;

--- a/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -171,7 +171,7 @@ exports[`renders components/list/demo/basic.tsx extend context correctly 1`] = `
 
 exports[`renders components/list/demo/basic.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;
 
@@ -882,7 +882,7 @@ Array [
 
 exports[`renders components/list/demo/component-token.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;
 
@@ -1401,7 +1401,7 @@ exports[`renders components/list/demo/grid.tsx extend context correctly 1`] = `
 
 exports[`renders components/list/demo/grid.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;
 
@@ -2843,7 +2843,7 @@ Array [
 
 exports[`renders components/list/demo/grid-test.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;
 
@@ -2959,7 +2959,7 @@ exports[`renders components/list/demo/infinite-load.tsx extend context correctly
 
 exports[`renders components/list/demo/infinite-load.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;
 
@@ -3009,7 +3009,7 @@ exports[`renders components/list/demo/loadmore.tsx extend context correctly 1`] 
 
 exports[`renders components/list/demo/loadmore.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;
 
@@ -3438,7 +3438,7 @@ Array [
 
 exports[`renders components/list/demo/pagination.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;
 
@@ -3676,7 +3676,7 @@ exports[`renders components/list/demo/responsive.tsx extend context correctly 1`
 
 exports[`renders components/list/demo/responsive.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;
 
@@ -3941,7 +3941,7 @@ Array [
 
 exports[`renders components/list/demo/simple.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;
 
@@ -4005,7 +4005,7 @@ exports[`renders components/list/demo/spin-debug.tsx extend context correctly 1`
 
 exports[`renders components/list/demo/spin-debug.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;
 
@@ -4728,6 +4728,6 @@ exports[`renders components/list/demo/vertical.tsx extend context correctly 1`] 
 
 exports[`renders components/list/demo/vertical.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -308,7 +308,7 @@ const InternalList = <T,>(props: ListProps<T>, ref: React.ForwardedRef<HTMLDivEl
     warning(
       false,
       'deprecated',
-      'The `List` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use `Listy` instead.',
+      "The `List` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use `Listy` instead.",
     );
   }
 

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -308,7 +308,7 @@ const InternalList = <T,>(props: ListProps<T>, ref: React.ForwardedRef<HTMLDivEl
     warning(
       false,
       'deprecated',
-      'The `List` component is deprecated. And will be removed in next major version.',
+      'The `List` component is deprecated and will be removed in the next major version. Please use `Listy` instead.',
     );
   }
 

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -308,7 +308,7 @@ const InternalList = <T,>(props: ListProps<T>, ref: React.ForwardedRef<HTMLDivEl
     warning(
       false,
       'deprecated',
-      'The `List` component is deprecated and will be removed in the next major version. Please use `Listy` instead.',
+      'The `List` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use `Listy` instead.',
     );
   }
 

--- a/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -823,7 +823,7 @@ Array [
 
 exports[`renders components/skeleton/demo/list.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;
 

--- a/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -823,7 +823,7 @@ Array [
 
 exports[`renders components/skeleton/demo/list.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;
 

--- a/components/spin/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/spin/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -308,7 +308,7 @@ exports[`renders components/spin/demo/list-debug.tsx extend context correctly 1`
 
 exports[`renders components/spin/demo/list-debug.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;
 

--- a/components/spin/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/spin/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -308,7 +308,7 @@ exports[`renders components/spin/demo/list-debug.tsx extend context correctly 1`
 
 exports[`renders components/spin/demo/list-debug.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;
 

--- a/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2377,7 +2377,7 @@ exports[`renders components/steps/demo/inline.tsx extend context correctly 1`] =
 
 exports[`renders components/steps/demo/inline.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. If you're using version 6.6.0 or later, please use \`Listy\` instead.",
 ]
 `;
 

--- a/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2377,7 +2377,7 @@ exports[`renders components/steps/demo/inline.tsx extend context correctly 1`] =
 
 exports[`renders components/steps/demo/inline.tsx extend context correctly 2`] = `
 [
-  "Warning: [antd: List] The \`List\` component is deprecated. And will be removed in next major version.",
+  "Warning: [antd: List] The \`List\` component is deprecated and will be removed in the next major version. Please use \`Listy\` instead.",
 ]
 `;
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

None

### 💡 需求背景和解决方案

List 的废弃警告目前只提示将在下个 major 版本移除。由于 Listy 已经发布，本次调整警告文案，明确推荐开发者迁移至 Listy，并同步相关快照。不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🛎 Update List deprecation warning to recommend Listy. |
| 🇨🇳 中文 | 🛎 更新 List 废弃警告，推荐迁移至 Listy。 |