### PR TITLE
site: restore relative component LLMs links

### DIFF
--- a/.dumi/theme/builtins/ComponentMeta/index.tsx
+++ b/.dumi/theme/builtins/ComponentMeta/index.tsx
@@ -129,7 +129,7 @@ const ComponentMeta: React.FC<ComponentMetaProps> = (props) => {
       return [
         `https://github.com/${repo}/blob/master/components/${kebabComponent}`,
         `components/${kebabComponent}`,
-        `https://ant.design/components/${kebabComponent}${isZhCN ? '-cn' : ''}.md`,
+        `/components/${kebabComponent}${isZhCN ? '-cn' : ''}.md`,
       ];
     }
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Follow-up to https://github.com/ant-design/ant-design/pull/57725#discussion_r3820507865

### 💡 需求背景和解决方案

此前国内镜像无法访问组件文档的 Markdown 文件，因此组件 LLMs 链接被固定为 `ant.design` 域名。

目前国内镜像已经可以正常提供 Markdown 文件，继续使用固定域名会导致从 release 下载的 website 无法从本地加载对应内容。

本次将组件 LLMs 链接恢复为同源相对路径，使主站、国内镜像及本地部署均从当前站点加载 Markdown 文件。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Restore relative URLs for component LLMs links across website deployments. |
| 🇨🇳 中文 | 组件 LLMs 链接恢复使用相对 URL，以适配不同站点及本地部署。 |
