### PR TITLE
fix(Descriptions): preserve item state when key is 0

### DIFF
--- a/components/descriptions/Row.tsx
+++ b/components/descriptions/Row.tsx
@@ -45,7 +45,7 @@ function renderCells(
       if (typeof component === 'string') {
         return (
           <Cell
-            key={`${type}-${key || index}`}
+            key={`${type}-${key ?? index}`}
             className={className}
             style={style}
             classNames={classNames}
@@ -91,7 +91,7 @@ function renderCells(
       };
       return [
         <Cell
-          key={`label-${key || index}`}
+          key={`label-${key ?? index}`}
           className={className}
           style={style}
           classNames={classNames}
@@ -105,7 +105,7 @@ function renderCells(
           type="label"
         />,
         <Cell
-          key={`content-${key || index}`}
+          key={`content-${key ?? index}`}
           className={className}
           style={style}
           classNames={classNames}

--- a/components/descriptions/Row.tsx
+++ b/components/descriptions/Row.tsx
@@ -42,10 +42,12 @@ function renderCells(
       },
       index,
     ) => {
+      const mergedKey = key ?? index;
+
       if (typeof component === 'string') {
         return (
           <Cell
-            key={`${type}-${key ?? index}`}
+            key={`${type}-${mergedKey}`}
             className={className}
             style={style}
             classNames={classNames}
@@ -91,7 +93,7 @@ function renderCells(
       };
       return [
         <Cell
-          key={`label-${key ?? index}`}
+          key={`label-${mergedKey}`}
           className={className}
           style={style}
           classNames={classNames}
@@ -105,7 +107,7 @@ function renderCells(
           type="label"
         />,
         <Cell
-          key={`content-${key ?? index}`}
+          key={`content-${mergedKey}`}
           className={className}
           style={style}
           classNames={classNames}

--- a/components/descriptions/__tests__/index.test.tsx
+++ b/components/descriptions/__tests__/index.test.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import MockDate from 'mockdate';
 
 import Descriptions from '..';
+import { matchScreen } from '../../_util/responsiveObserver';
 import { resetWarned } from '../../_util/warning';
 import mountTest from '../../../tests/shared/mountTest';
-import { render } from '../../../tests/utils';
+import { fireEvent, render } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
-import { matchScreen } from '../../_util/responsiveObserver';
 import DEFAULT_COLUMN_MAP from '../constant';
 
 describe('Descriptions', () => {
@@ -282,6 +282,29 @@ describe('Descriptions', () => {
       </Descriptions>,
     );
     expect(jest.spyOn(document, 'createElement')).not.toHaveBeenCalled();
+  });
+
+  it('should preserve item state after reordering when key is 0', () => {
+    const items = [
+      {
+        key: 0,
+        label: 'Zero',
+        children: <input aria-label="Zero value" defaultValue="zero" />,
+      },
+      {
+        key: 2,
+        label: 'Two',
+        children: <input aria-label="Two value" defaultValue="two" />,
+      },
+    ];
+    const { getByLabelText, rerender } = render(<Descriptions column={2} items={items} />);
+    const input = getByLabelText('Zero value');
+
+    fireEvent.change(input, { target: { value: 'edited' } });
+    rerender(<Descriptions column={2} items={[...items].reverse()} />);
+
+    expect(getByLabelText('Zero value')).toBe(input);
+    expect(getByLabelText('Zero value')).toHaveValue('edited');
   });
 
   // https://github.com/ant-design/ant-design/issues/19887


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

暂无关联 Issue。

[在线最小复现](https://codesandbox.io/p/sandbox/descriptions-chong-pai-key-wei-0-de-item-shi-hui-chong-zhi-qi-nei-rong-zhuang-tai-6zkfwl?file=%2Findex.tsx)

### 💡 需求背景和解决方案

Descriptions 的 `items[].key` 支持 `React.Key`，但渲染单元格时使用 `key || index`，导致合法的数值 `0` 被替换为数组索引。重排同一行中的 items 后，该项会被重新挂载并丢失内部状态。

本次改为仅在 key 为 `null` 或 `undefined` 时回退到数组索引，并新增回归测试，验证重排后输入节点和内容状态保持不变。不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述                                                                      |
| ------- | ----------------------------------------------------------------------------- |
| 🇺🇸 英文 | 🐞 Fix Descriptions resetting item state when reordering an item with `key: 0`. |
| 🇨🇳 中文 | 🐞 修复 Descriptions 重排 `key: 0` 的 item 时内容状态被重置的问题。          |