### PR TITLE
fix(Skeleton): hide decorative title placeholder from assistive technology

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -23902,6 +23902,7 @@ exports[`ConfigProvider components Skeleton configProvider 1`] = `
     class="config-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="config-skeleton-title"
       style="width: 50%;"
     />
@@ -23930,6 +23931,7 @@ exports[`ConfigProvider components Skeleton configProvider componentDisabled 1`]
     class="config-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="config-skeleton-title"
       style="width: 50%;"
     />
@@ -23958,6 +23960,7 @@ exports[`ConfigProvider components Skeleton configProvider componentSize large 1
     class="config-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="config-skeleton-title"
       style="width: 50%;"
     />
@@ -23986,6 +23989,7 @@ exports[`ConfigProvider components Skeleton configProvider componentSize medium 
     class="config-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="config-skeleton-title"
       style="width: 50%;"
     />
@@ -24014,6 +24018,7 @@ exports[`ConfigProvider components Skeleton configProvider componentSize small 1
     class="config-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="config-skeleton-title"
       style="width: 50%;"
     />
@@ -24042,6 +24047,7 @@ exports[`ConfigProvider components Skeleton normal 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 50%;"
     />
@@ -24070,6 +24076,7 @@ exports[`ConfigProvider components Skeleton prefixCls 1`] = `
     class="prefix-Skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="prefix-Skeleton-title"
       style="width: 50%;"
     />

--- a/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2939,6 +2939,7 @@ exports[`renders components/list/demo/infinite-load.tsx extend context correctly
           class="ant-skeleton-section"
         >
           <h3
+            aria-hidden="true"
             class="ant-skeleton-title"
             style="width: 50%;"
           />

--- a/components/list/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.ts.snap
@@ -2877,6 +2877,7 @@ exports[`renders components/list/demo/infinite-load.tsx correctly 1`] = `
           class="ant-skeleton-section"
         >
           <h3
+            aria-hidden="true"
             class="ant-skeleton-title"
             style="width:50%"
           />

--- a/components/skeleton/Title.tsx
+++ b/components/skeleton/Title.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/heading-has-content */
 import * as React from 'react';
 import { clsx } from 'clsx';
 
@@ -10,8 +9,8 @@ export interface SkeletonTitleProps {
 }
 
 const Title: React.FC<SkeletonTitleProps> = ({ prefixCls, className, width, style }) => (
-  // biome-ignore lint/a11y/useHeadingContent: HOC here
-  <h3 className={clsx(prefixCls, className)} style={{ width, ...style }} />
+  // biome-ignore lint/a11y/useHeadingContent: decorative placeholder, hidden from assistive tech
+  <h3 aria-hidden className={clsx(prefixCls, className)} style={{ width, ...style }} />
 );
 
 export default Title;

--- a/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -8,6 +8,7 @@ exports[`renders components/skeleton/demo/active.tsx extend context correctly 1`
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 38%;"
     />
@@ -34,6 +35,7 @@ exports[`renders components/skeleton/demo/basic.tsx extend context correctly 1`]
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 38%;"
     />
@@ -101,6 +103,7 @@ exports[`renders components/skeleton/demo/complex.tsx extend context correctly 1
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 50%;"
     />
@@ -126,6 +129,7 @@ exports[`renders components/skeleton/demo/componentToken.tsx extend context corr
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 38%;"
     />
@@ -744,6 +748,7 @@ Array [
                 class="ant-skeleton-section"
               >
                 <h3
+                  aria-hidden="true"
                   class="ant-skeleton-title"
                   style="width: 50%;"
                 />
@@ -773,6 +778,7 @@ Array [
                 class="ant-skeleton-section"
               >
                 <h3
+                  aria-hidden="true"
                   class="ant-skeleton-title"
                   style="width: 50%;"
                 />
@@ -802,6 +808,7 @@ Array [
                 class="ant-skeleton-section"
               >
                 <h3
+                  aria-hidden="true"
                   class="ant-skeleton-title"
                   style="width: 50%;"
                 />
@@ -846,6 +853,7 @@ exports[`renders components/skeleton/demo/style-class.tsx extend context correct
       class="ant-skeleton-section"
     >
       <h3
+        aria-hidden="true"
         class="ant-skeleton-title"
         style="border: 1px solid rgb(170, 170, 170);"
       />
@@ -859,6 +867,7 @@ exports[`renders components/skeleton/demo/style-class.tsx extend context correct
       class="ant-skeleton-section"
     >
       <h3
+        aria-hidden="true"
         class="ant-skeleton-title"
         style="width: 38%; background-color: rgba(229, 243, 254, 0.5); height: 20px; border-radius: 20px;"
       />

--- a/components/skeleton/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`renders components/skeleton/demo/_semantic.tsx correctly 1`] = `
           class="semantic-mark-section ant-skeleton-section"
         >
           <h3
+            aria-hidden="true"
             class="ant-skeleton-title semantic-mark-title"
             style="width: 50%;"
           />

--- a/components/skeleton/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`renders components/skeleton/demo/active.tsx correctly 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width:38%"
     />
@@ -32,6 +33,7 @@ exports[`renders components/skeleton/demo/basic.tsx correctly 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width:38%"
     />
@@ -95,6 +97,7 @@ exports[`renders components/skeleton/demo/complex.tsx correctly 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width:50%"
     />
@@ -118,6 +121,7 @@ exports[`renders components/skeleton/demo/componentToken.tsx correctly 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width:38%"
     />
@@ -732,6 +736,7 @@ Array [
                 class="ant-skeleton-section"
               >
                 <h3
+                  aria-hidden="true"
                   class="ant-skeleton-title"
                   style="width:50%"
                 />
@@ -761,6 +766,7 @@ Array [
                 class="ant-skeleton-section"
               >
                 <h3
+                  aria-hidden="true"
                   class="ant-skeleton-title"
                   style="width:50%"
                 />
@@ -790,6 +796,7 @@ Array [
                 class="ant-skeleton-section"
               >
                 <h3
+                  aria-hidden="true"
                   class="ant-skeleton-title"
                   style="width:50%"
                 />
@@ -828,6 +835,7 @@ exports[`renders components/skeleton/demo/style-class.tsx correctly 1`] = `
       class="ant-skeleton-section"
     >
       <h3
+        aria-hidden="true"
         class="ant-skeleton-title"
         style="border:1px solid #aaa"
       />
@@ -841,6 +849,7 @@ exports[`renders components/skeleton/demo/style-class.tsx correctly 1`] = `
       class="ant-skeleton-section"
     >
       <h3
+        aria-hidden="true"
         class="ant-skeleton-title"
         style="width:38%;background-color:rgba(229, 243, 254, 0.5);height:20px;border-radius:20px"
       />

--- a/components/skeleton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/skeleton/__tests__/__snapshots__/index.test.tsx.snap
@@ -86,6 +86,7 @@ exports[`Skeleton avatar shape 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 50%;"
     />
@@ -114,6 +115,7 @@ exports[`Skeleton avatar shape 2`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 50%;"
     />
@@ -142,6 +144,7 @@ exports[`Skeleton avatar size 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 50%;"
     />
@@ -170,6 +173,7 @@ exports[`Skeleton avatar size 2`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 50%;"
     />
@@ -198,6 +202,7 @@ exports[`Skeleton avatar size 3`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 50%;"
     />
@@ -227,6 +232,7 @@ exports[`Skeleton avatar size 4`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 50%;"
     />
@@ -416,6 +422,7 @@ exports[`Skeleton paragraph rows 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 38%;"
     />
@@ -442,6 +449,7 @@ exports[`Skeleton paragraph width 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 38%;"
     />
@@ -466,6 +474,7 @@ exports[`Skeleton paragraph width 2`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 38%;"
     />
@@ -492,6 +501,7 @@ exports[`Skeleton rtl render component should be rendered correctly in RTL direc
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 38%;"
     />
@@ -518,6 +528,7 @@ exports[`Skeleton should round title and paragraph 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 38%;"
     />
@@ -549,6 +560,7 @@ exports[`Skeleton should square avatar 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
     />
   </div>
@@ -564,6 +576,7 @@ exports[`Skeleton should support style 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 38%;"
     />
@@ -588,6 +601,7 @@ exports[`Skeleton should without avatar and paragraph 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
     />
   </div>
@@ -602,6 +616,7 @@ exports[`Skeleton title width 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 93%;"
     />

--- a/components/skeleton/__tests__/__snapshots__/vitest/index.test.tsx.snap
+++ b/components/skeleton/__tests__/__snapshots__/vitest/index.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Skeleton > avatar > shape 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 50%;"
     />
@@ -43,6 +44,7 @@ exports[`Skeleton > avatar > shape 2`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 50%;"
     />
@@ -71,6 +73,7 @@ exports[`Skeleton > avatar > size 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 50%;"
     />
@@ -99,6 +102,7 @@ exports[`Skeleton > avatar > size 2`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 50%;"
     />
@@ -127,6 +131,7 @@ exports[`Skeleton > avatar > size 3`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 50%;"
     />
@@ -156,6 +161,7 @@ exports[`Skeleton > avatar > size 4`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 50%;"
     />
@@ -416,6 +422,7 @@ exports[`Skeleton > paragraph > rows 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 38%;"
     />
@@ -442,6 +449,7 @@ exports[`Skeleton > paragraph > width 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 38%;"
     />
@@ -466,6 +474,7 @@ exports[`Skeleton > paragraph > width 2`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 38%;"
     />
@@ -492,6 +501,7 @@ exports[`Skeleton > rtl render > component should be rendered correctly in RTL d
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 38%;"
     />
@@ -518,6 +528,7 @@ exports[`Skeleton > should round title and paragraph 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 38%;"
     />
@@ -549,6 +560,7 @@ exports[`Skeleton > should square avatar 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
     />
   </div>
@@ -564,6 +576,7 @@ exports[`Skeleton > should support style 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 38%;"
     />
@@ -588,6 +601,7 @@ exports[`Skeleton > should without avatar and paragraph 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
     />
   </div>
@@ -602,6 +616,7 @@ exports[`Skeleton > title > width 1`] = `
     class="ant-skeleton-section"
   >
     <h3
+      aria-hidden="true"
       class="ant-skeleton-title"
       style="width: 93%;"
     />

--- a/components/skeleton/__tests__/a11y.test.ts
+++ b/components/skeleton/__tests__/a11y.test.ts
@@ -1,8 +1,6 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
 accessibilityDemoTest('skeleton', {
-  // waiting for fix
-  disabledRules: ['empty-heading'],
   // we can set aria attribute to fix it
   skip: ['list.tsx', 'element.tsx'],
 });

--- a/components/skeleton/__tests__/index.test.tsx
+++ b/components/skeleton/__tests__/index.test.tsx
@@ -23,6 +23,13 @@ describe('Skeleton', () => {
   mountTest(Skeleton);
   rtlTest(Skeleton);
 
+  it('should hide the decorative title placeholder from assistive technology', () => {
+    const { container } = render(<Skeleton loading title paragraph={false} />);
+    const title = container.querySelector<HTMLElement>('.ant-skeleton-title')!;
+    expect(title).toBeTruthy();
+    expect(title.getAttribute('aria-hidden')).toBe('true');
+  });
+
   it('should support nativeElement ref', () => {
     const ref = React.createRef<React.ComponentRef<typeof Skeleton>>();
     const { container } = render(<Skeleton ref={ref} />);

--- a/components/statistic/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/statistic/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -172,6 +172,7 @@ exports[`renders components/statistic/demo/basic.tsx extend context correctly 1`
           class="ant-skeleton-section"
         >
           <h3
+            aria-hidden="true"
             class="ant-skeleton-title"
           />
         </div>
@@ -443,6 +444,7 @@ exports[`renders components/statistic/demo/component-token.tsx extend context co
           class="ant-skeleton-section"
         >
           <h3
+            aria-hidden="true"
             class="ant-skeleton-title"
           />
         </div>

--- a/components/statistic/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/statistic/__tests__/__snapshots__/demo.test.ts.snap
@@ -166,6 +166,7 @@ exports[`renders components/statistic/demo/basic.tsx correctly 1`] = `
           class="ant-skeleton-section"
         >
           <h3
+            aria-hidden="true"
             class="ant-skeleton-title"
           />
         </div>
@@ -433,6 +434,7 @@ exports[`renders components/statistic/demo/component-token.tsx correctly 1`] = `
           class="ant-skeleton-section"
         >
           <h3
+            aria-hidden="true"
             class="ant-skeleton-title"
           />
         </div>

--- a/components/statistic/__tests__/a11y.test.ts
+++ b/components/statistic/__tests__/a11y.test.ts
@@ -1,6 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('statistic', {
-  // wait for skeleton fix
-  skip: ['basic.tsx'],
-});
+accessibilityDemoTest('statistic');


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

No linked issue. The problem is recorded in the repository itself:

- `components/skeleton/__tests__/a11y.test.ts` carried `disabledRules: ['empty-heading']` with a `// waiting for fix` comment.
- `components/statistic/__tests__/a11y.test.ts` skipped `basic.tsx` with a `// wait for skeleton fix` comment.

### 💡 Background and Solution

`Skeleton`'s title placeholder renders an empty `<h3 class="ant-skeleton-title" />` (`components/skeleton/Title.tsx`). It is purely decorative, but assistive technology sees a real heading with no accessible name, so screen readers announce an empty heading and it shows up in the document outline. axe reports it as `empty-heading`, and both linters had to be silenced on that element (`/* eslint-disable jsx-a11y/heading-has-content */` and a `biome-ignore`).

The placeholder is now marked `aria-hidden`, matching how other decorative elements are handled in the library. Nothing about the rendered layout or the public API changes.

Because the placeholder is no longer exposed, the two suppressions above are removed and the checks now run for real:

- `components/skeleton/__tests__/a11y.test.ts`: `empty-heading` is enabled again (the `list.tsx` / `element.tsx` skips are unrelated — those demos fail on `button-name` from a `Switch` without a label).
- `components/statistic/__tests__/a11y.test.ts`: `basic.tsx` is no longer skipped, since its `<Statistic loading />` was the only reason it failed.

A direct regression test was added in `components/skeleton/__tests__/index.test.tsx`. Reverting only `Title.tsx` turns it red (`Expected: "true"  Received: null`) together with both a11y suites (6 failures, all `empty-heading`).

The `eslint-disable` is dropped because `jsx-a11y/heading-has-content` accepts elements hidden from screen readers. The `biome-ignore` is kept, since `lint/a11y/useHeadingContent` does not consider `aria-hidden`, and its reason was updated.

Snapshot updates are limited to the added `aria-hidden="true"` attribute — the diff on `*.snap` files contains 62 added lines and nothing else.

Verification:

- `npm test -- components/skeleton components/statistic components/list components/config-provider` → 47 suites passed, 801 tests passed, 547 snapshots passed.
- `npx vitest run components/skeleton/__tests__/index.test.tsx` → 32 passed.
- `npm run tsc`, `eslint`, `biome lint` → clean.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Skeleton exposing its title placeholder to screen readers as an empty heading. |
| 🇨🇳 Chinese | 🐞 修复 Skeleton 标题占位元素被屏幕阅读器识别为空标题的问题。 |
