### PR TITLE
fix: keep transfer pagination on a valid page

### DIFF
--- a/components/transfer/ListBody.tsx
+++ b/components/transfer/ListBody.tsx
@@ -71,7 +71,7 @@ const TransferListBody: React.ForwardRefRenderFunction<
   React.useEffect(() => {
     if (mergedPagination) {
       const maxPageCount = Math.ceil(filteredRenderItems.length / pageSize!);
-      setCurrent(Math.min(current, maxPageCount));
+      setCurrent(Math.max(1, Math.min(current, maxPageCount)));
     }
   }, [filteredRenderItems, mergedPagination, pageSize]);
 

--- a/components/transfer/__tests__/list-body.test.tsx
+++ b/components/transfer/__tests__/list-body.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+
+import type { KeyWiseTransferItem } from '..';
+import ListBody from '../ListBody';
+import type { TransferListBodyProps } from '../ListBody';
+import type { RenderedItem } from '../Section';
+
+const items: RenderedItem<KeyWiseTransferItem>[] = [
+  {
+    item: { key: 'a', title: 'a' },
+    renderedEl: <span>a</span>,
+    renderedText: 'a',
+  },
+  {
+    item: { key: 'b', title: 'b' },
+    renderedEl: <span>b</span>,
+    renderedText: 'b',
+  },
+];
+
+const baseProps = {
+  prefixCls: 'ant-transfer-list',
+  classNames: { list: undefined },
+  styles: { list: undefined },
+  filteredItems: items.map(({ item }) => item),
+  selectedKeys: [],
+  pagination: { pageSize: 1 },
+  onScroll: jest.fn(),
+  onItemSelect: jest.fn(),
+  onItemRemove: jest.fn(),
+  remove: 'Remove',
+  showRemove: false,
+  disabled: false,
+} as unknown as TransferListBodyProps<KeyWiseTransferItem>;
+
+describe('TransferListBody', () => {
+  it('should reset current page when filtered items become empty and are restored', async () => {
+    const { container, getByTitle, rerender } = render(
+      <ListBody {...baseProps} filteredRenderItems={items} />,
+    );
+
+    await waitFor(() => getByTitle('1/2'));
+    fireEvent.click(container.querySelector('.ant-pagination-next .ant-pagination-item-link')!);
+    await waitFor(() => getByTitle('2/2'));
+
+    rerender(<ListBody {...baseProps} filteredRenderItems={[]} />);
+    await waitFor(() =>
+      expect(container.querySelectorAll('.ant-transfer-list-content-item')).toHaveLength(0),
+    );
+
+    rerender(<ListBody {...baseProps} filteredRenderItems={items} />);
+    await waitFor(() => {
+      expect(container.querySelectorAll('.ant-transfer-list-content-item')).toHaveLength(1);
+      expect(getByTitle('1/2')).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> No related issue.

### 💡 Background and Solution

> When the filtered Transfer list becomes empty, the pagination effect can clamp the current page to `0`. If the filtered data is restored afterwards, the current page remains invalid and the list renders no items.
>
> Minimal reproduction (pseudo code):
>
> ```ts
> const items = [{ key: 'a' }, { key: 'b' }];
> renderTransfer({ items, pagination: { pageSize: 1 } });
> goToPage(2);
> updateFilteredItems([]);    // current becomes 0
> updateFilteredItems(items); // current is still 0
>
> // Before: visible items = []
> // After: current is clamped to 1, visible items = ['a']
> ```
>
> The page state is now clamped to the valid range `1..maxPageCount`, so restoring filtered data renders the first available page.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Transfer pagination staying on page 0 after filtered data is restored. |
| 🇨🇳 Chinese | 修复 Transfer 过滤数据恢复后分页停留在第 0 页的问题。 |