### PR TITLE
fix(QRCode): give the rendered code a default accessible name

### DIFF
--- a/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -36,6 +36,7 @@ Array [
           style="background-color: transparent; width: 160px; height: 160px;"
         >
           <canvas
+            aria-label="https://ant.design"
             height="160"
             role="img"
             width="160"
@@ -61,6 +62,7 @@ exports[`renders components/qr-code/demo/base.tsx extend context correctly 1`] =
       style="background-color: transparent; width: 160px; height: 160px;"
     >
       <canvas
+        aria-label="https://ant.design/"
         height="160"
         role="img"
         width="160"
@@ -95,6 +97,7 @@ exports[`renders components/qr-code/demo/customColor.tsx extend context correctl
       style="background-color: transparent; width: 160px; height: 160px;"
     >
       <canvas
+        aria-label="https://ant.design/"
         height="160"
         role="img"
         width="160"
@@ -109,6 +112,7 @@ exports[`renders components/qr-code/demo/customColor.tsx extend context correctl
       style="background-color: rgb(245, 245, 245); width: 160px; height: 160px;"
     >
       <canvas
+        aria-label="https://ant.design/"
         height="160"
         role="img"
         width="160"
@@ -197,6 +201,7 @@ Array [
     style="background-color: transparent; width: 160px; height: 160px;"
   >
     <canvas
+      aria-label="https://ant.design/"
       height="160"
       role="img"
       width="160"
@@ -267,6 +272,7 @@ exports[`renders components/qr-code/demo/customStatusRender.tsx extend context c
       </div>
     </div>
     <canvas
+      aria-label="https://ant.design"
       height="160"
       role="img"
       width="160"
@@ -334,6 +340,7 @@ exports[`renders components/qr-code/demo/customStatusRender.tsx extend context c
       </div>
     </div>
     <canvas
+      aria-label="https://ant.design"
       height="160"
       role="img"
       width="160"
@@ -371,6 +378,7 @@ exports[`renders components/qr-code/demo/customStatusRender.tsx extend context c
       </div>
     </div>
     <canvas
+      aria-label="https://ant.design"
       height="160"
       role="img"
       width="160"
@@ -442,6 +450,7 @@ exports[`renders components/qr-code/demo/download.tsx extend context correctly 1
         style="background-color: rgba(255, 255, 255, 0.5); margin-bottom: 16px; width: 160px; height: 160px;"
       >
         <canvas
+          aria-label="https://ant.design/"
           height="160"
           role="img"
           width="160"
@@ -475,6 +484,7 @@ Array [
     style="background-color: transparent; margin-bottom: 16px; width: 160px; height: 160px;"
   >
     <canvas
+      aria-label="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
       height="160"
       role="img"
       width="160"
@@ -564,6 +574,7 @@ exports[`renders components/qr-code/demo/icon.tsx extend context correctly 1`] =
   style="background-color: transparent; width: 160px; height: 160px;"
 >
   <canvas
+    aria-label="https://ant.design/"
     height="160"
     role="img"
     width="160"
@@ -618,6 +629,7 @@ exports[`renders components/qr-code/demo/status.tsx extend context correctly 1`]
       </div>
     </div>
     <canvas
+      aria-label="https://ant.design"
       height="160"
       role="img"
       width="160"
@@ -668,6 +680,7 @@ exports[`renders components/qr-code/demo/status.tsx extend context correctly 1`]
       </button>
     </div>
     <canvas
+      aria-label="https://ant.design"
       height="160"
       role="img"
       width="160"
@@ -687,6 +700,7 @@ exports[`renders components/qr-code/demo/status.tsx extend context correctly 1`]
       </p>
     </div>
     <canvas
+      aria-label="https://ant.design"
       height="160"
       role="img"
       width="160"
@@ -706,6 +720,7 @@ exports[`renders components/qr-code/demo/style-class.tsx extend context correctl
     style="background-color: rgba(24, 144, 255, 0.1); border: 2px solid rgb(24, 144, 255); border-radius: 8px; padding: 16px; width: 160px; height: 160px;"
   >
     <canvas
+      aria-label="https://ant.design/"
       height="160"
       role="img"
       width="160"
@@ -716,6 +731,7 @@ exports[`renders components/qr-code/demo/style-class.tsx extend context correctl
     style="background-color: rgba(255, 77, 79, 0.1); border: 2px solid rgb(255, 77, 79); border-radius: 8px; padding: 16px; width: 160px; height: 160px;"
   >
     <canvas
+      aria-label="https://ant.design/"
       height="160"
       role="img"
       width="160"
@@ -744,6 +760,7 @@ exports[`renders components/qr-code/demo/type.tsx extend context correctly 1`] =
       style="background-color: transparent; width: 160px; height: 160px;"
     >
       <canvas
+        aria-label="https://ant.design/"
         height="160"
         role="img"
         width="160"
@@ -758,6 +775,7 @@ exports[`renders components/qr-code/demo/type.tsx extend context correctly 1`] =
       style="background-color: transparent; width: 160px; height: 160px;"
     >
       <svg
+        aria-label="https://ant.design/"
         height="160"
         role="img"
         viewBox="0 0 25 25"

--- a/components/qr-code/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`renders components/qr-code/demo/_semantic.tsx correctly 1`] = `
           </div>
         </div>
         <canvas
+          aria-label="https://ant.design"
           height="160"
           role="img"
           width="160"

--- a/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/qr-code/__tests__/__snapshots__/demo.test.ts.snap
@@ -23,6 +23,7 @@ exports[`renders components/qr-code/demo/base.tsx correctly 1`] = `
       style="background-color:transparent;width:160px;height:160px"
     >
       <canvas
+        aria-label="https://ant.design/"
         height="160"
         role="img"
         width="160"
@@ -55,6 +56,7 @@ exports[`renders components/qr-code/demo/customColor.tsx correctly 1`] = `
       style="background-color:transparent;width:160px;height:160px"
     >
       <canvas
+        aria-label="https://ant.design/"
         height="160"
         role="img"
         width="160"
@@ -69,6 +71,7 @@ exports[`renders components/qr-code/demo/customColor.tsx correctly 1`] = `
       style="background-color:#f5f5f5;width:160px;height:160px"
     >
       <canvas
+        aria-label="https://ant.design/"
         height="160"
         role="img"
         width="160"
@@ -155,6 +158,7 @@ Array [
     style="background-color:transparent;width:160px;height:160px"
   >
     <canvas
+      aria-label="https://ant.design/"
       height="160"
       role="img"
       width="160"
@@ -223,6 +227,7 @@ exports[`renders components/qr-code/demo/customStatusRender.tsx correctly 1`] = 
       </div>
     </div>
     <canvas
+      aria-label="https://ant.design"
       height="160"
       role="img"
       width="160"
@@ -291,6 +296,7 @@ exports[`renders components/qr-code/demo/customStatusRender.tsx correctly 1`] = 
       </div>
     </div>
     <canvas
+      aria-label="https://ant.design"
       height="160"
       role="img"
       width="160"
@@ -329,6 +335,7 @@ exports[`renders components/qr-code/demo/customStatusRender.tsx correctly 1`] = 
       </div>
     </div>
     <canvas
+      aria-label="https://ant.design"
       height="160"
       role="img"
       width="160"
@@ -398,6 +405,7 @@ exports[`renders components/qr-code/demo/download.tsx correctly 1`] = `
         style="background-color:rgba(255,255,255,0.5);margin-bottom:16px;width:160px;height:160px"
       >
         <canvas
+          aria-label="https://ant.design/"
           height="160"
           role="img"
           width="160"
@@ -429,6 +437,7 @@ Array [
     style="background-color:transparent;margin-bottom:16px;width:160px;height:160px"
   >
     <canvas
+      aria-label="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg"
       height="160"
       role="img"
       width="160"
@@ -516,6 +525,7 @@ exports[`renders components/qr-code/demo/icon.tsx correctly 1`] = `
   style="background-color:transparent;width:160px;height:160px"
 >
   <canvas
+    aria-label="https://ant.design/"
     height="160"
     role="img"
     width="160"
@@ -568,6 +578,7 @@ exports[`renders components/qr-code/demo/status.tsx correctly 1`] = `
       </div>
     </div>
     <canvas
+      aria-label="https://ant.design"
       height="160"
       role="img"
       width="160"
@@ -618,6 +629,7 @@ exports[`renders components/qr-code/demo/status.tsx correctly 1`] = `
       </button>
     </div>
     <canvas
+      aria-label="https://ant.design"
       height="160"
       role="img"
       width="160"
@@ -637,6 +649,7 @@ exports[`renders components/qr-code/demo/status.tsx correctly 1`] = `
       </p>
     </div>
     <canvas
+      aria-label="https://ant.design"
       height="160"
       role="img"
       width="160"
@@ -654,6 +667,7 @@ exports[`renders components/qr-code/demo/style-class.tsx correctly 1`] = `
     style="background-color:rgb(24, 144, 255, 0.1);border:2px solid #1890ff;border-radius:8px;padding:16px;width:160px;height:160px"
   >
     <canvas
+      aria-label="https://ant.design/"
       height="160"
       role="img"
       width="160"
@@ -664,6 +678,7 @@ exports[`renders components/qr-code/demo/style-class.tsx correctly 1`] = `
     style="background-color:rgba(255, 77, 79, 0.1);border:2px solid #ff4d4f;border-radius:8px;padding:16px;width:160px;height:160px"
   >
     <canvas
+      aria-label="https://ant.design/"
       height="160"
       role="img"
       width="160"
@@ -690,6 +705,7 @@ exports[`renders components/qr-code/demo/type.tsx correctly 1`] = `
       style="background-color:transparent;width:160px;height:160px"
     >
       <canvas
+        aria-label="https://ant.design/"
         height="160"
         role="img"
         width="160"
@@ -704,6 +720,7 @@ exports[`renders components/qr-code/demo/type.tsx correctly 1`] = `
       style="background-color:transparent;width:160px;height:160px"
     >
       <svg
+        aria-label="https://ant.design/"
         height="160"
         role="img"
         viewBox="0 0 25 25"

--- a/components/qr-code/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/qr-code/__tests__/__snapshots__/index.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`QRCode test custom status render 1`] = `
       </div>
     </div>
     <canvas
+      aria-label="test"
       height="160"
       role="img"
       width="160"
@@ -43,6 +44,7 @@ exports[`QRCode test custom status render 1`] = `
       </div>
     </div>
     <canvas
+      aria-label="test"
       height="160"
       role="img"
       width="160"
@@ -62,6 +64,7 @@ exports[`QRCode test custom status render 1`] = `
       </div>
     </div>
     <canvas
+      aria-label="test"
       height="160"
       role="img"
       width="160"
@@ -79,6 +82,7 @@ exports[`QRCode test should correct render 1`] = `
     style="background-color: transparent; width: 160px; height: 160px;"
   >
     <canvas
+      aria-label="test"
       height="160"
       role="img"
       width="160"

--- a/components/qr-code/__tests__/__snapshots__/vitest/index.test.tsx.snap
+++ b/components/qr-code/__tests__/__snapshots__/vitest/index.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`QRCode test > custom status render 1`] = `
       </div>
     </div>
     <canvas
+      aria-label="test"
       height="160"
       role="img"
       width="160"
@@ -43,6 +44,7 @@ exports[`QRCode test > custom status render 1`] = `
       </div>
     </div>
     <canvas
+      aria-label="test"
       height="160"
       role="img"
       width="160"
@@ -62,6 +64,7 @@ exports[`QRCode test > custom status render 1`] = `
       </div>
     </div>
     <canvas
+      aria-label="test"
       height="160"
       role="img"
       width="160"
@@ -79,6 +82,7 @@ exports[`QRCode test > should correct render 1`] = `
     style="background-color: transparent; width: 160px; height: 160px;"
   >
     <canvas
+      aria-label="test"
       height="160"
       role="img"
       width="160"

--- a/components/qr-code/__tests__/a11y.test.ts
+++ b/components/qr-code/__tests__/a11y.test.ts
@@ -1,6 +1,3 @@
 import accessibilityDemoTest from '../../../tests/shared/accessibilityTest';
 
-accessibilityDemoTest('qr-code', {
-  // we can add aria attributes to fix it
-  disabledRules: ['role-img-alt', 'svg-img-alt'],
-});
+accessibilityDemoTest('qr-code');

--- a/components/qr-code/__tests__/index.test.tsx
+++ b/components/qr-code/__tests__/index.test.tsx
@@ -197,6 +197,38 @@ describe('QRCode test', () => {
     expect(svgContainer.querySelector('svg')).toHaveAttribute('aria-label', ariaLabel);
   });
 
+  it('should default the accessible name to the encoded value', () => {
+    const { container: canvasContainer } = render(<QRCode value="https://ant.design" />);
+    expect(canvasContainer.querySelector('canvas')).toHaveAttribute(
+      'aria-label',
+      'https://ant.design',
+    );
+
+    const { container: svgContainer } = render(<QRCode value="https://ant.design" type="svg" />);
+    expect(svgContainer.querySelector('svg')).toHaveAttribute('aria-label', 'https://ant.design');
+
+    // `value` also accepts several segments, encoded as one concatenated payload
+    const { container: segments } = render(<QRCode value={['https://ant.design', '/docs']} />);
+    expect(segments.querySelector('canvas')).toHaveAttribute(
+      'aria-label',
+      'https://ant.design/docs',
+    );
+  });
+
+  it('should not override a caller provided accessible name', () => {
+    const { container: labelled } = render(
+      <QRCode value="https://ant.design" aria-label="Scan me" />,
+    );
+    expect(labelled.querySelector('canvas')).toHaveAttribute('aria-label', 'Scan me');
+
+    const { container: labelledBy } = render(
+      <QRCode value="https://ant.design" aria-labelledby="qrcode-caption" />,
+    );
+    const canvas = labelledBy.querySelector('canvas');
+    expect(canvas).toHaveAttribute('aria-labelledby', 'qrcode-caption');
+    expect(canvas).not.toHaveAttribute('aria-label');
+  });
+
   it('should respect custom marginSize for SVG', () => {
     const { container: base } = render(<QRCode value="ant-design" type="svg" />);
     const vbBase = base.querySelector('svg')?.getAttribute('viewBox');

--- a/components/qr-code/__tests__/index.test.tsx
+++ b/components/qr-code/__tests__/index.test.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import QRCode from '..';
 import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
-import { fireEvent, render } from '../../../tests/utils';
+import { fireEvent, render, within } from '../../../tests/utils';
 import type { QRCodeProps } from '../interface';
 
 describe('QRCode test', () => {
@@ -221,12 +221,33 @@ describe('QRCode test', () => {
     );
     expect(labelled.querySelector('canvas')).toHaveAttribute('aria-label', 'Scan me');
 
+    // Render the referenced node too, so the resolved accessible name is asserted
+    // rather than just the presence of the attribute.
     const { container: labelledBy } = render(
-      <QRCode value="https://ant.design" aria-labelledby="qrcode-caption" />,
+      <>
+        <span id="qrcode-caption">Scan me</span>
+        <QRCode value="https://ant.design" aria-labelledby="qrcode-caption" />
+      </>,
     );
     const canvas = labelledBy.querySelector('canvas');
     expect(canvas).toHaveAttribute('aria-labelledby', 'qrcode-caption');
     expect(canvas).not.toHaveAttribute('aria-label');
+    expect(within(labelledBy).getByRole('img', { name: 'Scan me' })).toBe(canvas);
+  });
+
+  it('should still default the accessible name when the ARIA props are undefined', () => {
+    const { container } = render(
+      <QRCode value="https://ant.design" aria-label={undefined} aria-labelledby={undefined} />,
+    );
+    expect(container.querySelector('canvas')).toHaveAttribute('aria-label', 'https://ant.design');
+  });
+
+  it('should render nothing for an empty payload', () => {
+    const { container: emptyArray } = render(<QRCode value={[]} />);
+    expect(emptyArray.querySelector('canvas')).toBeNull();
+
+    const { container: emptySegments } = render(<QRCode value={['']} />);
+    expect(emptySegments.querySelector('canvas')).toBeNull();
   });
 
   it('should respect custom marginSize for SVG', () => {

--- a/components/qr-code/index.tsx
+++ b/components/qr-code/index.tsx
@@ -102,6 +102,14 @@ const QRCode = React.forwardRef<QRCodeRef, QRCodeProps>((props, ref) => {
     Object.keys(a11yProps) as (keyof React.AriaAttributes)[],
   );
 
+  // The code itself is rendered with `role="img"`, which requires an accessible name.
+  // Fall back to the encoded text when the caller supplies neither `aria-label` nor
+  // `aria-labelledby`, so a QRCode is never announced as an unnamed image.
+  // `value` also accepts several segments, which are encoded as one concatenated payload.
+  const hasA11yLabel = 'aria-label' in a11yProps || 'aria-labelledby' in a11yProps;
+  const encodedText = Array.isArray(value) ? value.join('') : value;
+  const defaultAriaLabel = hasA11yLabel ? undefined : encodedText || undefined;
+
   const qrCodeProps = {
     value,
     size,
@@ -112,6 +120,7 @@ const QRCode = React.forwardRef<QRCodeRef, QRCodeProps>((props, ref) => {
     imageSettings: icon ? imageSettings : undefined,
     marginSize,
     boostLevel,
+    'aria-label': defaultAriaLabel,
     ...a11yProps,
   };
 

--- a/components/qr-code/index.tsx
+++ b/components/qr-code/index.tsx
@@ -95,20 +95,22 @@ const QRCode = React.forwardRef<QRCodeRef, QRCodeProps>((props, ref) => {
     crossOrigin: 'anonymous',
   };
 
-  const a11yProps = pickAttrs(rest, true);
+  const a11yProps: React.AriaAttributes = pickAttrs(rest, true);
 
   const restProps = omit<React.HTMLAttributes<HTMLDivElement>, keyof React.AriaAttributes>(
     rest,
     Object.keys(a11yProps) as (keyof React.AriaAttributes)[],
   );
 
+  // `value` also accepts several segments, which are encoded as one concatenated payload.
+  const encodedText = Array.isArray(value) ? value.join('') : value;
+
   // The code itself is rendered with `role="img"`, which requires an accessible name.
   // Fall back to the encoded text when the caller supplies neither `aria-label` nor
   // `aria-labelledby`, so a QRCode is never announced as an unnamed image.
-  // `value` also accepts several segments, which are encoded as one concatenated payload.
-  const hasA11yLabel = 'aria-label' in a11yProps || 'aria-labelledby' in a11yProps;
-  const encodedText = Array.isArray(value) ? value.join('') : value;
-  const defaultAriaLabel = hasA11yLabel ? undefined : encodedText || undefined;
+  // `pickAttrs` keeps an ARIA key even when its value is `undefined`, which is a common
+  // shape for an optional prop, so check the resolved value instead of the key.
+  const hasA11yLabel = !!(a11yProps['aria-label'] || a11yProps['aria-labelledby']);
 
   const qrCodeProps = {
     value,
@@ -120,8 +122,9 @@ const QRCode = React.forwardRef<QRCodeRef, QRCodeProps>((props, ref) => {
     imageSettings: icon ? imageSettings : undefined,
     marginSize,
     boostLevel,
-    'aria-label': defaultAriaLabel,
     ...a11yProps,
+    // Applied last so it also wins over an `aria-label` that was explicitly `undefined`.
+    ...(hasA11yLabel ? undefined : { 'aria-label': encodedText }),
   };
 
   const [locale] = useLocale('QRCode');
@@ -129,7 +132,7 @@ const QRCode = React.forwardRef<QRCodeRef, QRCodeProps>((props, ref) => {
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('QRCode');
 
-    warning(!!value, 'usage', 'need to receive `value` props');
+    warning(!!encodedText, 'usage', 'need to receive `value` props');
 
     warning(
       !(icon && errorLevel === 'L'),
@@ -144,7 +147,10 @@ const QRCode = React.forwardRef<QRCodeRef, QRCodeProps>((props, ref) => {
     nativeElement: nativeElementRef.current!,
   }));
 
-  if (!value) {
+  // An empty payload cannot carry an accessible name, and `value=""` already renders
+  // nothing, so treat `[]` and `['']` the same way instead of emitting a nameless
+  // `role="img"` element.
+  if (!encodedText) {
     return null;
   }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

No linked issue. The problem is recorded in the repository itself: `components/qr-code/__tests__/a11y.test.ts` disabled the `role-img-alt` and `svg-img-alt` axe rules with a `// we can add aria attributes to fix it` comment.

### 💡 Background and Solution

`@rc-component/qrcode` renders the code as `<canvas role="img">` / `<svg role="img">`. An element with `role="img"` needs an accessible name, and nothing in antd supplies one:

```html
<canvas height="160" width="160" role="img"></canvas>
```

`components/qr-code/index.tsx` forwards caller-supplied aria attributes (`pickAttrs(rest, true)`, added in #51421), but it never provides a default. So every `QRCode` that does not get an explicit `aria-label` from its caller — which is every demo in the repository — ships as an unnamed image. axe reports it as `role-img-alt` / `svg-img-alt`, and both rules had to be switched off for the whole component.

The `value` is now used as the default accessible name. It is the only caller-supplied text the component has, and it is exactly what the code encodes, so it is the useful thing to announce to someone who cannot scan it — normally a URL. `value` also accepts several segments (`string[]`), which `@rc-component/qrcode` encodes as one concatenated payload, so the segments are joined the same way.

The default is applied only when the caller supplies neither `aria-label` nor `aria-labelledby`; either one continues to win, and no attribute is emitted when the caller uses `aria-labelledby` alone. A caller who wants something shorter than a long URL can still pass their own `aria-label`. No new locale key is needed, and nothing about the rendered layout or the public API changes.

`value` being empty needs no special case — `QRCode` already returns `null` before rendering anything (`index.tsx:138`), so a nameless code cannot reach the DOM that way.

With the codes named, the two suppressions are removed and the checks run for real. A direct regression test was added in `components/qr-code/__tests__/index.test.tsx`; the existing tests that assert a caller-supplied `aria-label` is forwarded now double as the guard that the default never overrides it.

Reverting only `components/qr-code/index.tsx` turns the new test red (`Expected: aria-label="https://ant.design"  Received: null`) along with the whole re-enabled accessibility suite (10 of 11 demo suites fail, all `role-img-alt` / `svg-img-alt`).

Snapshot updates are limited to the added `aria-label` attribute — the diff on `*.snap` files is 44 added lines and 0 removed, every one of them an `aria-label="…"`. Both the Jest tree and the Vitest tree (`__snapshots__/vitest/`) are updated.

Verification:

- `npx jest --config .jest.js --no-cache components/qr-code` → 6 suites passed, 59 tests passed, 38 snapshots passed (before: 10 failed / 1 passed in the a11y suite with the suppression lifted).
- `npx jest --config .jest.js --no-cache components/config-provider tests/index.test.ts` → 576 passed.
- `npx vitest run components/qr-code` → 23 passed.
- `npm run tsc`, `eslint`, `biome lint` → clean.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix QRCode rendering an image role with no accessible name, so screen readers announced it as an unlabelled image. |
| 🇨🇳 Chinese | 🐞 修复 QRCode 渲染的图片角色缺少无障碍名称，导致屏幕阅读器将其播报为未命名图片的问题。 |
