### PR TITLE
fix(DirectoryTree): treat undefined expandedKeys as uncontrolled

### DIFF
--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -74,14 +74,14 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
   const [expandedKeys, setExpandedKeys] = React.useState(() => getInitExpandedKeys());
 
   React.useEffect(() => {
-    if ('selectedKeys' in props) {
-      setSelectedKeys(props.selectedKeys!);
+    if (props.selectedKeys !== undefined) {
+      setSelectedKeys(props.selectedKeys);
     }
   }, [props.selectedKeys]);
 
   React.useEffect(() => {
-    if ('expandedKeys' in props) {
-      setExpandedKeys(props.expandedKeys!);
+    if (props.expandedKeys !== undefined) {
+      setExpandedKeys(props.expandedKeys);
     }
   }, [props.expandedKeys]);
 
@@ -93,7 +93,7 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
       nativeEvent: MouseEvent;
     },
   ) => {
-    if (!('expandedKeys' in props)) {
+    if (props.expandedKeys === undefined) {
       setExpandedKeys(keys);
     }
     // Call origin function
@@ -158,7 +158,7 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
     }
 
     props.onSelect?.(newSelectedKeys, newEvent);
-    if (!('selectedKeys' in props)) {
+    if (props.selectedKeys === undefined) {
       setSelectedKeys(newSelectedKeys);
     }
   };

--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -5,6 +5,7 @@ import FolderOutlined from '@ant-design/icons/FolderOutlined';
 import { conductExpandParent, convertDataToEntities, convertTreeToData } from '@rc-component/tree';
 import type RcTree from '@rc-component/tree';
 import type { BasicDataNode, DataNode, EventDataNode } from '@rc-component/tree';
+import { useControlledState } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { ConfigContext } from '../config-provider';
@@ -67,23 +68,15 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
     return initExpandedKeys;
   };
 
-  const [selectedKeys, setSelectedKeys] = React.useState(
-    props.selectedKeys || props.defaultSelectedKeys || [],
+  const [selectedKeys, setSelectedKeys] = useControlledState<React.Key[]>(
+    props.defaultSelectedKeys || [],
+    props.selectedKeys,
   );
 
-  const [expandedKeys, setExpandedKeys] = React.useState(() => getInitExpandedKeys());
-
-  React.useEffect(() => {
-    if (props.selectedKeys !== undefined) {
-      setSelectedKeys(props.selectedKeys);
-    }
-  }, [props.selectedKeys]);
-
-  React.useEffect(() => {
-    if (props.expandedKeys !== undefined) {
-      setExpandedKeys(props.expandedKeys);
-    }
-  }, [props.expandedKeys]);
+  const [expandedKeys, setExpandedKeys] = useControlledState<React.Key[]>(
+    getInitExpandedKeys,
+    props.expandedKeys,
+  );
 
   const onExpand = (
     keys: React.Key[],
@@ -93,9 +86,7 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
       nativeEvent: MouseEvent;
     },
   ) => {
-    if (props.expandedKeys === undefined) {
-      setExpandedKeys(keys);
-    }
+    setExpandedKeys(keys);
     // Call origin function
     return props.onExpand?.(keys, info);
   };
@@ -158,9 +149,7 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
     }
 
     props.onSelect?.(newSelectedKeys, newEvent);
-    if (props.selectedKeys === undefined) {
-      setSelectedKeys(newSelectedKeys);
-    }
+    setSelectedKeys(newSelectedKeys);
   };
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
 

--- a/components/tree/__tests__/directory.test.tsx
+++ b/components/tree/__tests__/directory.test.tsx
@@ -310,6 +310,53 @@ describe('Directory Tree', () => {
     );
   });
 
+  // https://github.com/ant-design/ant-design/issues/49668
+  it('should stay uncontrolled when expandedKeys is undefined', () => {
+    const { container } = render(createTree({ expandedKeys: undefined }));
+    expect(container.querySelectorAll('[role="treeitem"]')).toHaveLength(2);
+
+    fireEvent.click(container.querySelector('.ant-tree-node-content-wrapper')!);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(container.querySelectorAll('[role="treeitem"]')).toHaveLength(4);
+  });
+
+  it('should stay controlled when expandedKeys is provided', () => {
+    const onExpand = jest.fn();
+    const { container } = render(createTree({ expandedKeys: [], onExpand }));
+    expect(container.querySelectorAll('[role="treeitem"]')).toHaveLength(2);
+
+    fireEvent.click(container.querySelector('.ant-tree-node-content-wrapper')!);
+    act(() => {
+      jest.runAllTimers();
+    });
+    // The caller owns the state, so nothing expands until it feeds new keys back in
+    expect(onExpand).toHaveBeenCalledWith(['0-0'], expect.anything());
+    expect(container.querySelectorAll('[role="treeitem"]')).toHaveLength(2);
+  });
+
+  it('should support shift range selection when expandedKeys is undefined', () => {
+    const onSelect = jest.fn();
+    const treeData = [
+      { title: 'Zero', key: 0 },
+      { title: 'One', key: 1 },
+      { title: 'Two', key: 2 },
+    ];
+    const { container } = render(
+      <DirectoryTree multiple expandedKeys={undefined} treeData={treeData} onSelect={onSelect} />,
+    );
+    const nodes = container.querySelectorAll('.ant-tree-node-content-wrapper');
+
+    fireEvent.click(nodes[0]);
+    fireEvent.click(nodes[2], { shiftKey: true });
+
+    expect(onSelect).toHaveBeenLastCalledWith(
+      [0, 1, 2],
+      expect.objectContaining({ selectedNodes: treeData }),
+    );
+  });
+
   it('ref support', () => {
     const treeRef = React.createRef<RcTree>();
     render(createTree({ ref: treeRef }));


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

close #49668

### 💡 Background and Solution

`DirectoryTree` keeps `expandedKeys` and `selectedKeys` in local state and decides whether it is controlled with the `in` operator:

```tsx
React.useEffect(() => {
  if ('expandedKeys' in props) {
    setExpandedKeys(props.expandedKeys!);
  }
}, [props.expandedKeys]);

const onExpand = (keys, info) => {
  if (!('expandedKeys' in props)) {
    setExpandedKeys(keys);
  }
  return props.onExpand?.(keys, info);
};
```

`<DirectoryTree expandedKeys={undefined} />` still creates an own property, so `in` reports controlled. Two things follow:

1. the effect writes `undefined` into state, where the declared type is `React.Key[]`;
2. `onExpand` stops advancing the state, so nothing ever expands.

Passing `expandedKeys={undefined}` is the normal way to write "this is uncontrolled for now" — a state value that has not been decided yet, or a prop threaded through a wrapper. Everywhere else in antd that decision is made with `useControlledState`, which checks `value !== undefined`. This aligns `DirectoryTree` with that, for `selectedKeys` as well as `expandedKeys` — `selectedKeys={undefined}` has the identical symptom on selection.

#### On the `rc-tree` pointer in the issue

@zombieJ noted that `rc-tree` also uses `in` for this check. That is correct, and it is a real bug on its own — I measured it:

| render | expandable after clicking the switcher |
| --- | --- |
| `<Tree>` (prop omitted) | yes |
| `<Tree expandedKeys={undefined}>` | no |

So a plain `Tree` is affected too, and that part does need a change in `@rc-component/tree` (`Tree.tsx`, `this.props.hasOwnProperty('expandedKeys')` in `setExpandedKeys`). This PR does not close that, and I am happy to send it there as well.

It is not a substitute for this change, though. `DirectoryTree` owns a second, independent copy of the check, and the `undefined` it puts into its own state breaks antd's own code regardless of what `rc-tree` does — `calcRangeKeys` reads that state directly, so shift-click range selection throws:

```
TypeError: Cannot read properties of undefined (reading 'includes')
  at components/tree/utils/dictUtil.ts:83:27
  at onSelect (components/tree/DirectoryTree.tsx:142:27)
```

No change in `rc-tree` reaches that. The state is `DirectoryTree`'s, so the check that decides whether to advance it belongs here.

#### Tests

Three cases added to `components/tree/__tests__/directory.test.tsx`:

- `expandedKeys={undefined}` stays uncontrolled and expands on click;
- `expandedKeys={[]}` stays controlled — `onExpand` fires but nothing expands until the caller feeds new keys back in, so genuinely controlled usage is unchanged;
- shift-click range selection works with `expandedKeys={undefined}`.

Reverting only `components/tree/DirectoryTree.tsx` turns the first red (`Expected length: 4 / Received length: 2`) and the third red with the `TypeError` above, while the controlled case keeps passing.

Verification:

- `npx jest --config .jest.js --no-cache components/tree` → 17 suites passed, 180 tests passed, 117 snapshots passed (baseline on master: 177 passed; the 3 new tests are the difference). No snapshot changed.
- `npx jest --config .jest.js --no-cache components/config-provider` → 575 passed.
- `npx vitest run components/tree` → 41 passed.
- `npm run tsc`, `eslint`, `biome lint` → clean. The two `!` non-null assertions are no longer needed and are dropped.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix DirectoryTree becoming unexpandable and unselectable when `expandedKeys` or `selectedKeys` is explicitly `undefined`. |
| 🇨🇳 Chinese | 🐞 修复 DirectoryTree 在 `expandedKeys` 或 `selectedKeys` 显式传入 `undefined` 时无法展开和选择的问题。 |
