### PR TITLE
fix(Watermark): avoid drawing zero-sized canvas

### DIFF
--- a/components/watermark/__tests__/index.test.tsx
+++ b/components/watermark/__tests__/index.test.tsx
@@ -254,6 +254,19 @@ describe('Watermark', () => {
     spy.mockRestore();
   });
 
+  it('should not draw a zero-sized canvas if content is undefined', async () => {
+    const spy = jest.spyOn(CanvasRenderingContext2D.prototype, 'drawImage');
+    render(<Watermark className="watermark" />);
+    await waitFakeTimer();
+
+    expect(
+      spy.mock.calls.some(
+        ([image]) => image instanceof HTMLCanvasElement && (!image.width || !image.height),
+      ),
+    ).toBe(false);
+    spy.mockRestore();
+  });
+
   it('should call onRemove when watermark is hard removed', async () => {
     const onRemove = jest.fn();
     const { container } = render(<Watermark content="Ant" onRemove={onRemove} />);

--- a/components/watermark/useClips.ts
+++ b/components/watermark/useClips.ts
@@ -115,6 +115,10 @@ const useClips = () => {
     const [fCtx, fCanvas] = prepareCanvas(filledWidth, filledHeight);
 
     const drawImg = (targetX = 0, targetY = 0) => {
+      if (cutWidth <= 0 || cutHeight <= 0) {
+        return;
+      }
+
       fCtx.drawImage(
         rCanvas,
         cutLeft,


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] ✅ Test Case

### 🔗 Related Issues

No related issue.

### 💡 Background and Solution

When `Watermark` is rendered without `content` or `image`, it generates a zero-sized canvas and passes it to `CanvasRenderingContext2D.drawImage`, which causes an `InvalidStateError` in the browser.

This change skips drawing when the clipping area has zero width or height and adds a regression test for `content={undefined}`. Normal text and image watermark behavior remains unchanged.

Validation:

- Watermark tests: 19 passed
- Biome: passed
- ESLint: passed

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Watermark throwing an error when `content` is `undefined`. |
| 🇨🇳 Chinese | 🐞 修复 Watermark 在 `content` 为 `undefined` 时抛出错误的问题。 |