### PR TITLE
fix(Table): invoke custom header onKeyDown for all keys

### DIFF
--- a/components/table/__tests__/Table.sorter.test.tsx
+++ b/components/table/__tests__/Table.sorter.test.tsx
@@ -999,6 +999,20 @@ describe('Table.sorter', () => {
     expect(onClick).toHaveBeenCalled();
   });
 
+  it('should trigger onHeaderCell onKeyDown for every key in sort column', () => {
+    const onKeyDown = jest.fn();
+    const { container } = render(createTable({}, { onHeaderCell: () => ({ onKeyDown }) }));
+    const headerCell = container.querySelector('th')!;
+
+    fireEvent.keyDown(headerCell, { key: 'Escape' });
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(renderedNames(container)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
+
+    fireEvent.keyDown(headerCell, { key: 'Enter', keyCode: 13 });
+    expect(onKeyDown).toHaveBeenCalledTimes(2);
+    expect(renderedNames(container)).toEqual(['Jack', 'Jerry', 'Lucy', 'Tom']);
+  });
+
   it('could sort data with children', () => {
     const { container } = render(
       createTable(

--- a/components/table/hooks/useSorter.tsx
+++ b/components/table/hooks/useSorter.tsx
@@ -235,8 +235,8 @@ const injectSorter = <RecordType extends AnyObject = AnyObject>(
                 sortOrder: nextSortOrder,
                 multiplePriority: getMultiplePriority<RecordType>(column),
               });
-              originOKeyDown?.(event);
             }
+            originOKeyDown?.(event);
           };
 
           const renderTitle = safeColumnTitle(column.title, {});


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

[在线最小复现](https://codesandbox.io/p/sandbox/table-ke-pai-xu-lie-hui-hu-lue-biao-tou-shang-de-fei-enter-jian-pan-shi-jian-qrgh94?file=%2Findex.tsx)

### 💡 需求背景和解决方案

Table 可排序列只会在按下 Enter 时调用 `onHeaderCell` 配置的 `onKeyDown`，导致 Escape、空格和方向键等事件被忽略。

本次将自定义 `onKeyDown` 的调用移出 Enter 判断，使所有键盘事件都能传递给调用方，同时仍然只在按下 Enter 时触发排序，并补充了相应回归测试。不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Table sortable columns not invoking custom `onKeyDown` handlers for non-Enter keys. |
| 🇨🇳 中文 | 🐞 修复 Table 可排序列不触发非 Enter 键自定义 `onKeyDown` 回调的问题。 |