### PR TITLE
fix(Form): render numeric zero labels

### DIFF
--- a/components/form/FormItemLabel.tsx
+++ b/components/form/FormItemLabel.tsx
@@ -3,7 +3,7 @@ import QuestionCircleOutlined from '@ant-design/icons/QuestionCircleOutlined';
 import { clsx } from 'clsx';
 
 import convertToTooltipProps from '../_util/convertToTooltipProps';
-import { isFunction } from '../_util/is';
+import { isFunction, isReactRenderable } from '../_util/is';
 import type { ColProps } from '../grid/col';
 import Col from '../grid/col';
 import { useLocale } from '../locale';
@@ -59,7 +59,7 @@ const FormItemLabel: React.FC<FormItemLabelProps & { required?: boolean; prefixC
     tooltip: contextTooltip,
   } = React.useContext<FormContextProps>(FormContext);
 
-  if (!label) {
+  if (!isReactRenderable(label)) {
     return null;
   }
 

--- a/components/form/__tests__/index.test.tsx
+++ b/components/form/__tests__/index.test.tsx
@@ -1009,6 +1009,16 @@ describe('Form', () => {
     expect(screen.getByLabelText('0')).toBeInTheDocument();
   });
 
+  it('0 is a valid label', () => {
+    render(
+      <Form.Item name="field" label={0}>
+        <input />
+      </Form.Item>,
+    );
+
+    expect(screen.getByLabelText('0')).toBeInTheDocument();
+  });
+
   it('`null` triggers warning and is treated as `undefined`', () => {
     render(
       <Form.Item name={null as unknown as NamePath} label="test">


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] ✅ 测试用例

### 🔗 相关 Issue

[在线最小复现](https://codesandbox.io/p/sandbox/form-item-hui-hu-lue-shu-zhi-wei-0-de-label-74jgdd?file=%2Findex.tsx)

### 💡 需求背景和解决方案

Form.Item 的 `label` 类型为 `ReactNode`，但原有真假值判断会将数值 `0` 当作未配置，导致标签节点和标签列无法渲染。

本次改用统一的 `isReactRenderable` 判断，使数值 `0` 可以正常显示并与表单控件关联，同时保持 `null`、`undefined`、`false` 和空字符串原有的不渲染行为。新增回归测试覆盖该场景，无公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Form.Item not rendering numeric `0` labels. |
| 🇨🇳 中文 | 🐞 修复 Form.Item 不渲染数值 `0` 标签的问题。 |
