### PR TITLE
fix(Splitter): respect size limits when container resizes

### DIFF
--- a/components/splitter/__tests__/index.test.tsx
+++ b/components/splitter/__tests__/index.test.tsx
@@ -375,6 +375,24 @@ describe('Splitter', () => {
       expect(onResizeEnd).toHaveBeenCalledWith([10, 90]);
     });
 
+    it('should respect min when container shrinks after drag', async () => {
+      containerSize = 1000;
+
+      const { container } = render(<SplitterDemo items={[{ min: 200 }, {}]} />);
+
+      await resizeSplitter();
+
+      mockDrag(container.querySelector('.ant-splitter-bar-dragger')!, -300);
+
+      containerSize = 600;
+      await resizeSplitter();
+
+      const panels = container.querySelectorAll<HTMLElement>('.ant-splitter-panel');
+
+      expect(Number.parseFloat(panels[0].style.flexBasis)).toBeCloseTo(200);
+      expect(Number.parseFloat(panels[1].style.flexBasis)).toBeCloseTo(400);
+    });
+
     it('with max', async () => {
       const onResize = jest.fn();
       const onResizeEnd = jest.fn();

--- a/components/splitter/__tests__/size.test.tsx
+++ b/components/splitter/__tests__/size.test.tsx
@@ -92,6 +92,94 @@ describe('useSizes', () => {
     expect(sizes).toEqual([400, 600]);
   });
 
+  it('should respect min when container shrinks', () => {
+    const items = [
+      {
+        size: 200,
+        min: 200,
+      },
+      {
+        size: 800,
+      },
+    ];
+
+    const { result } = renderHook(() => useSizes(items, 600));
+    const [, postPxSizes] = result.current;
+
+    expect(postPxSizes[0]).toBeCloseTo(200);
+    expect(postPxSizes[1]).toBeCloseTo(400);
+  });
+
+  it('should respect percentage min when container shrinks', () => {
+    const items = [
+      {
+        size: 200,
+        min: '40%',
+      },
+      {
+        size: 800,
+      },
+    ];
+
+    const { result } = renderHook(() => useSizes(items, 600));
+    const [, postPxSizes] = result.current;
+
+    expect(postPxSizes[0]).toBeCloseTo(240);
+    expect(postPxSizes[1]).toBeCloseTo(360);
+  });
+
+  it('should respect max when container grows', () => {
+    const items = [
+      {
+        size: 100,
+        max: 200,
+      },
+      {
+        size: 100,
+      },
+    ];
+
+    const { result } = renderHook(() => useSizes(items, containerSize));
+    const [, postPxSizes] = result.current;
+
+    expect(postPxSizes).toEqual([200, 800]);
+  });
+
+  it('should keep collapsed panel at zero when container changes', () => {
+    const items = [
+      {
+        size: 0,
+        min: 200,
+      },
+      {
+        size: 1000,
+      },
+    ];
+
+    const { result } = renderHook(() => useSizes(items, 600));
+    const [, postPxSizes] = result.current;
+
+    expect(postPxSizes).toEqual([0, 600]);
+  });
+
+  it('should preserve proportions when limits cannot fit the container', () => {
+    const items = [
+      {
+        size: 200,
+        min: 400,
+      },
+      {
+        size: 800,
+        min: 400,
+      },
+    ];
+
+    const { result } = renderHook(() => useSizes(items, 600));
+    const [, postPxSizes] = result.current;
+
+    expect(postPxSizes).toEqual([120, 480]);
+  });
+
   it('should correct when all size is 0', () => {
     const items = [
       {

--- a/components/splitter/hooks/sizeUtil.ts
+++ b/components/splitter/hooks/sizeUtil.ts
@@ -1,5 +1,38 @@
 type SizeUnit = number | undefined;
 
+function fitPtgSizes(sizes: number[], minSizes: SizeUnit[], maxSizes: SizeUnit[]): number[] {
+  // Collapsed panels should stay at 0 even when they have a min size.
+  const mergedMinSizes = sizes.map((size, index) => (size === 0 ? 0 : (minSizes[index] ?? 0)));
+  const mergedMaxSizes = sizes.map((size, index) => (size === 0 ? 0 : (maxSizes[index] ?? 1)));
+
+  const invalidLimits = mergedMinSizes.some((min, index) => min > mergedMaxSizes[index]);
+  const totalMin = mergedMinSizes.reduce((sum, size) => sum + size, 0);
+  const totalMax = mergedMaxSizes.reduce((sum, size) => sum + size, 0);
+
+  // Keep the normalized proportions when the limits cannot fit the container.
+  if (invalidLimits || totalMin > 1 || totalMax < 1) {
+    return sizes;
+  }
+
+  const result = sizes.map((size, index) =>
+    Math.min(mergedMaxSizes[index], Math.max(mergedMinSizes[index], size)),
+  );
+  const total = result.reduce((sum, size) => sum + size, 0);
+
+  if (total === 1) {
+    return result;
+  }
+
+  const grow = total < 1;
+  const spaces = result.map((size, index) =>
+    grow ? mergedMaxSizes[index] - size : size - mergedMinSizes[index],
+  );
+  const totalSpace = spaces.reduce((sum, space) => sum + space, 0);
+  const rest = 1 - total;
+
+  return result.map((size, index) => size + rest * (spaces[index] / totalSpace));
+}
+
 export function autoPtgSizes(
   ptgSizes: SizeUnit[],
   minPtgSizes: SizeUnit[],
@@ -28,7 +61,8 @@ export function autoPtgSizes(
     }
     const scale = 1 / currentTotalPtg;
     // We know `size` is a number here because undefinedIndexes is empty.
-    return ptgSizes.map((size) => (size as number) * scale);
+    const scaledSizes = ptgSizes.map((size) => (size as number) * scale);
+    return fitPtgSizes(scaledSizes, minPtgSizes, maxPtgSizes);
   }
 
   // Fill if exceed


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- close #59083

### 💡 需求背景和解决方案

Splitter 面板拖动后会保存像素尺寸。当窗口或父容器尺寸变化时，这些尺寸会按比例重新计算，但未重新应用 Panel 的 `min` 和 `max` 约束，可能导致面板尺寸越界。

本次改动在按容器尺寸缩放后重新应用尺寸约束，并将产生的尺寸差额分配给仍有调整空间的其他面板，确保 Panel 遵守限制的同时继续填满容器。折叠面板保持为 0，不涉及 API 变更。

已补充数值及百分比限制、折叠状态、不可满足约束和拖动后缩放容器的测试。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Splitter Panel `min` and `max` constraints not being respected when its container resizes. |
| 🇨🇳 中文 | 🐞 修复 Splitter 容器尺寸变化时 Panel 的 `min` 和 `max` 约束失效的问题。 |
