### PR TITLE
fix(Menu): stop icon drift after inline collapse

### DIFF
--- a/components/menu/style/vertical.ts
+++ b/components/menu/style/vertical.ts
@@ -168,7 +168,9 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
 
         [`&${componentCls}-root`]: {
           [`${componentCls}-item, ${componentCls}-submenu ${componentCls}-submenu-title`]: {
-            transition: [
+            transition: [`border-color`, `background-color`]
+              .map((prop) => `${prop} ${motionDurationSlow}`)
+              .join(','),
               `border-color ${motionDurationSlow}`,
               `background-color ${motionDurationSlow}`,
             ].join(','),

--- a/components/menu/style/vertical.ts
+++ b/components/menu/style/vertical.ts
@@ -171,9 +171,6 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
             transition: [`border-color`, `background-color`]
               .map((prop) => `${prop} ${motionDurationSlow}`)
               .join(','),
-              `border-color ${motionDurationSlow}`,
-              `background-color ${motionDurationSlow}`,
-            ].join(','),
 
             [`> ${componentCls}-inline-collapsed-noicon`]: {
               fontSize: fontSizeLG,

--- a/components/menu/style/vertical.ts
+++ b/components/menu/style/vertical.ts
@@ -168,6 +168,11 @@ const getVerticalStyle: GenerateStyle<MenuToken> = (token) => {
 
         [`&${componentCls}-root`]: {
           [`${componentCls}-item, ${componentCls}-submenu ${componentCls}-submenu-title`]: {
+            transition: [
+              `border-color ${motionDurationSlow}`,
+              `background-color ${motionDurationSlow}`,
+            ].join(','),
+
             [`> ${componentCls}-inline-collapsed-noicon`]: {
               fontSize: fontSizeLG,
               textAlign: 'center',


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #59082

### 💡 需求背景和解决方案

PR #59018 移除了 inline Menu 展开状态下的 `padding` 过渡，但 Menu 折叠后会切换为 vertical 模式，折叠态仍会命中通用的 `padding` transition。

该过渡时间长于 Layout.Sider 的宽度动画，导致 Sider 已经完成收缩后，菜单图标仍继续轻微位移。

本次为 inline collapsed 根菜单补充 transition 覆盖，仅保留边框色和背景色过渡，使折叠完成后图标位置同步稳定。本次改动不涉及 API 或静态视觉变化。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Menu icons continuing to move after an inline menu finishes collapsing. |
| 🇨🇳 中文 | 🐞 修复 Menu 内联菜单收缩完成后图标仍继续位移的问题。 |
