### PR TITLE
fix(Menu): keep horizontal submenu open while crossing hover path

### DIFF
--- a/components/menu/style/theme.ts
+++ b/components/menu/style/theme.ts
@@ -195,6 +195,7 @@ const getThemeStyle = (token: MenuToken, themeSuffix: string): CSSInterpolation 
             position: 'absolute',
             insetInline: itemPaddingInline,
             bottom: 0,
+            pointerEvents: 'none',
             borderBottom: `${unit(activeBarHeight)} solid transparent`,
             transition: `border-color ${motionDurationSlow} ${motionEaseInOut}`,
             content: '""',


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

fix #40337

### 💡 需求背景和解决方案

水平 Menu（`mode="horizontal"`）下，鼠标从某 menu 项缓慢移动到其展开的子菜单 popup 过程中，子菜单会意外关闭。根因是该 item 底部的 `::after` 高亮下划线（hover/selected 时显色，默认宽 `activeBarHeight`）是一个可命中的实体伪元素，横在 item 与 popup 之间的鼠标通道上，会在穿越瞬间触发 `subMenuCloseDelay`（默认 0.1s）的离开计时器，鼠标尚未进入 popup 即跳闸，导致 popup 关闭。

暗黑模式不受影响，因其 `activeBarHeight` 被置为 `0`（`components/menu/style/index.ts`），该 `::after` 宽度为 0，不存在实体拦截。

解决方案：给该 `::after` 增加 `pointer-events: none`，让装饰性下划线对鼠标透明，命中目标回归 item 主体本身，消除截断窗口。仅影响命中测试，不影响任何视觉/选中/键盘/无障碍表现。

> 复现手法：悬停含子菜单的横向菜单项 → 鼠标贴着该 item 底边线缓慢滑向下方 popup，修复前会偶发关闭，修复后保持打开。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix horizontal Menu submenu unexpectedly closing while moving the cursor from the item to its popup. |
| 🇨🇳 中文 | 🐞 修复 Menu 横向菜单下，鼠标从菜单项移动到展开的子菜单时子菜单意外关闭的问题。 |