### PR TITLE
fix(Drawer): render header when only extra is provided

### DIFF
--- a/components/drawer/Drawer.tsx
+++ b/components/drawer/Drawer.tsx
@@ -9,7 +9,7 @@ import ContextIsolator from '../_util/ContextIsolator';
 import { useMergedMask, useZIndex } from '../_util/hooks';
 import type { MaskType } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
-import { isNumber } from '../_util/is';
+import { isNumber, isReactRenderable } from '../_util/is';
 import { getTransitionName } from '../_util/motion';
 import { devUseWarning } from '../_util/warning';
 import zIndexContext from '../_util/zindexContext';
@@ -113,7 +113,7 @@ const Drawer: React.FC<DrawerProps> & {
 
   const { placement } = rest;
   const id = useId();
-  const ariaId = rest.title ? id : undefined;
+  const ariaId = isReactRenderable(rest.title) ? id : undefined;
 
   const {
     getPopupContainer,

--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -171,7 +171,7 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
   );
 
   const renderHeader = () => {
-    if (!title && !mergedClosable) {
+    if (!title && !mergedClosable && !extra) {
       return null;
     }
     return (

--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -7,7 +7,7 @@ import { pickClosable, useClosable } from '../_util/hooks';
 import type { ClosableType } from '../_util/hooks';
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isPlainObject } from '../_util/is';
+import { isPlainObject, isReactRenderable } from '../_util/is';
 import { cloneElement } from '../_util/reactNode';
 import { useComponentConfig } from '../config-provider/context';
 import Skeleton from '../skeleton';
@@ -169,21 +169,23 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
     mergedCloseIcon,
     { disabled: closeBtnIsDisabled },
   );
+  const hasTitle = isReactRenderable(title);
+  const hasExtra = isReactRenderable(extra);
 
   const renderHeader = () => {
-    if (!title && !mergedClosable && !extra) {
+    if (!hasTitle && !mergedClosable && !hasExtra) {
       return null;
     }
     return (
       <div
         style={{ ...mergedStyles.header, ...headerStyle }}
         className={clsx(`${prefixCls}-header`, mergedClassNames.header, {
-          [`${prefixCls}-header-close-only`]: mergedClosable && !title && !extra,
+          [`${prefixCls}-header-close-only`]: mergedClosable && !hasTitle && !hasExtra,
         })}
       >
         <div className={`${prefixCls}-header-title`}>
           {closablePlacement === 'start' && mergedCloseButton}
-          {title && (
+          {hasTitle && (
             <div
               className={clsx(`${prefixCls}-title`, mergedClassNames.title)}
               style={mergedStyles.title}
@@ -193,7 +195,7 @@ const DrawerPanel: React.FC<DrawerPanelProps> = (props) => {
             </div>
           )}
         </div>
-        {extra && (
+        {hasExtra && (
           <div
             className={clsx(`${prefixCls}-extra`, mergedClassNames.extra)}
             style={mergedStyles.extra}

--- a/components/drawer/__tests__/Drawer.test.tsx
+++ b/components/drawer/__tests__/Drawer.test.tsx
@@ -145,6 +145,17 @@ describe('Drawer', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it('render extra without title or close button', () => {
+    const { container } = render(
+      <Drawer open closable={false} extra="Extra" getContainer={false}>
+        Here is content of Drawer
+      </Drawer>,
+    );
+
+    expect(container.querySelector('.ant-drawer-header')).toBeTruthy();
+    expect(container.querySelector('.ant-drawer-extra')).toHaveTextContent('Extra');
+  });
+
   it('closable is false', () => {
     const { container: wrapper } = render(
       <Drawer open closable={false} getContainer={false}>

--- a/components/drawer/__tests__/Drawer.test.tsx
+++ b/components/drawer/__tests__/Drawer.test.tsx
@@ -147,13 +147,24 @@ describe('Drawer', () => {
 
   it('render extra without title or close button', () => {
     const { container } = render(
-      <Drawer open closable={false} extra="Extra" getContainer={false}>
+      <Drawer open closable={false} extra={0} getContainer={false}>
         Here is content of Drawer
       </Drawer>,
     );
 
     expect(container.querySelector('.ant-drawer-header')).toBeTruthy();
-    expect(container.querySelector('.ant-drawer-extra')).toHaveTextContent('Extra');
+    expect(container.querySelector('.ant-drawer-extra')).toHaveTextContent('0');
+  });
+
+  it('render title with zero value', () => {
+    const { container } = render(
+      <Drawer open closable={false} title={0} getContainer={false}>
+        Here is content of Drawer
+      </Drawer>,
+    );
+
+    expect(container.querySelector('.ant-drawer-header')).toBeTruthy();
+    expect(container.querySelector('.ant-drawer-title')).toHaveTextContent('0');
   });
 
   it('closable is false', () => {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

暂无关联 Issue。

### 💡 需求背景和解决方案

当 Drawer 未设置 `title` 且关闭按钮被禁用时，仅设置 `extra` 不会渲染 Header，导致额外操作区整体消失。

调整 Header 的渲染条件，将 `extra` 纳入判断。现在即使没有标题和关闭按钮，只要设置了 `extra`，操作区也会正常显示。未新增或修改 API。

新增回归测试覆盖该场景，Drawer 定向测试全部通过。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Drawer not rendering the action area when only `extra` is provided. |
| 🇨🇳 中文 | 🐞 修复 Drawer 仅设置 `extra` 时操作区不渲染的问题。 |