### PR TITLE
fix(Select): keep single mode height independent of global lineHeight

### DIFF
--- a/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -6236,7 +6236,7 @@ exports[`renders components/select/demo/label-in-value.tsx extend context correc
 
 exports[`renders components/select/demo/line-height-debug.tsx extend context correctly 1`] = `
 <div
-  class="ant-flex css-var-test-id ant-flex-align-start ant-flex-gap-small"
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-start ant-flex-gap-small"
 >
   <div
     class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
@@ -6341,6 +6341,540 @@ exports[`renders components/select/demo/line-height-debug.tsx extend context cor
   </div>
   <div
     class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-multiple ant-select-show-arrow ant-select-show-search"
+    style="width: 180px;"
+  >
+    <div
+      class="ant-select-content"
+    >
+      <div
+        class="ant-select-content-item"
+        style="opacity: 1;"
+      >
+        <span
+          class="ant-select-selection-item"
+          title="Light"
+        >
+          <span
+            class="ant-select-selection-item-content"
+          >
+            Light
+          </span>
+          <span
+            aria-hidden="true"
+            class="ant-select-selection-item-remove"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              aria-label="close"
+              class="anticon anticon-close"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="close"
+                fill="currentColor"
+                fill-rule="evenodd"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-select-content-item ant-select-content-item-suffix"
+        style="opacity: 1;"
+      >
+        <input
+          aria-autocomplete="list"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          autocomplete="new-password"
+          class="ant-select-input"
+          id="test-id"
+          role="combobox"
+          style="--select-input-width: 0;"
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomLeft"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+  >
+    <div>
+      <div
+        id="test-id_list"
+        role="listbox"
+        style="height: 0px; width: 0px; overflow: hidden;"
+      >
+        <div
+          aria-label="Light"
+          aria-selected="true"
+          id="test-id_list_0"
+          role="option"
+        >
+          light
+        </div>
+      </div>
+      <div
+        class="ant-select-dropdown-list"
+        style="position: relative;"
+      >
+        <div
+          class="ant-select-dropdown-list-holder"
+          style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+        >
+          <div>
+            <div
+              class="ant-select-dropdown-list-holder-inner"
+              style="display: flex; flex-direction: column;"
+            >
+              <div
+                aria-disabled="false"
+                class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                title="Light"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  Light
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                >
+                  <span
+                    aria-label="check"
+                    class="anticon anticon-check"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="check"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-select ant-select-sm ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
+    style="width: 180px;"
+  >
+    <div
+      class="ant-select-content ant-select-content-has-value"
+      title="Light"
+    >
+      Light
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="new-password"
+        class="ant-select-input"
+        id="test-id"
+        readonly=""
+        role="combobox"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomLeft"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+  >
+    <div>
+      <div
+        id="test-id_list"
+        role="listbox"
+        style="height: 0px; width: 0px; overflow: hidden;"
+      >
+        <div
+          aria-label="Light"
+          aria-selected="true"
+          id="test-id_list_0"
+          role="option"
+        >
+          light
+        </div>
+      </div>
+      <div
+        class="ant-select-dropdown-list"
+        style="position: relative;"
+      >
+        <div
+          class="ant-select-dropdown-list-holder"
+          style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+        >
+          <div>
+            <div
+              class="ant-select-dropdown-list-holder-inner"
+              style="display: flex; flex-direction: column;"
+            >
+              <div
+                aria-disabled="false"
+                class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                title="Light"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  Light
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-select ant-select-sm ant-select-outlined css-var-test-id ant-select-css-var ant-select-multiple ant-select-show-arrow ant-select-show-search"
+    style="width: 180px;"
+  >
+    <div
+      class="ant-select-content"
+    >
+      <div
+        class="ant-select-content-item"
+        style="opacity: 1;"
+      >
+        <span
+          class="ant-select-selection-item"
+          title="Light"
+        >
+          <span
+            class="ant-select-selection-item-content"
+          >
+            Light
+          </span>
+          <span
+            aria-hidden="true"
+            class="ant-select-selection-item-remove"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              aria-label="close"
+              class="anticon anticon-close"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="close"
+                fill="currentColor"
+                fill-rule="evenodd"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-select-content-item ant-select-content-item-suffix"
+        style="opacity: 1;"
+      >
+        <input
+          aria-autocomplete="list"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          autocomplete="new-password"
+          class="ant-select-input"
+          id="test-id"
+          role="combobox"
+          style="--select-input-width: 0;"
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomLeft"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+  >
+    <div>
+      <div
+        id="test-id_list"
+        role="listbox"
+        style="height: 0px; width: 0px; overflow: hidden;"
+      >
+        <div
+          aria-label="Light"
+          aria-selected="true"
+          id="test-id_list_0"
+          role="option"
+        >
+          light
+        </div>
+      </div>
+      <div
+        class="ant-select-dropdown-list"
+        style="position: relative;"
+      >
+        <div
+          class="ant-select-dropdown-list-holder"
+          style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+        >
+          <div>
+            <div
+              class="ant-select-dropdown-list-holder-inner"
+              style="display: flex; flex-direction: column;"
+            >
+              <div
+                aria-disabled="false"
+                class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                title="Light"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  Light
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                >
+                  <span
+                    aria-label="check"
+                    class="anticon anticon-check"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="check"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-select ant-select-lg ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
+    style="width: 180px;"
+  >
+    <div
+      class="ant-select-content ant-select-content-has-value"
+      title="Light"
+    >
+      Light
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="new-password"
+        class="ant-select-input"
+        id="test-id"
+        readonly=""
+        role="combobox"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomLeft"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+  >
+    <div>
+      <div
+        id="test-id_list"
+        role="listbox"
+        style="height: 0px; width: 0px; overflow: hidden;"
+      >
+        <div
+          aria-label="Light"
+          aria-selected="true"
+          id="test-id_list_0"
+          role="option"
+        >
+          light
+        </div>
+      </div>
+      <div
+        class="ant-select-dropdown-list"
+        style="position: relative;"
+      >
+        <div
+          class="ant-select-dropdown-list-holder"
+          style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+        >
+          <div>
+            <div
+              class="ant-select-dropdown-list-holder-inner"
+              style="display: flex; flex-direction: column;"
+            >
+              <div
+                aria-disabled="false"
+                class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                title="Light"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  Light
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-select ant-select-lg ant-select-outlined css-var-test-id ant-select-css-var ant-select-multiple ant-select-show-arrow ant-select-show-search"
     style="width: 180px;"
   >
     <div

--- a/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -6240,7 +6240,7 @@ exports[`renders components/select/demo/line-height-debug.tsx extend context cor
 >
   <div
     class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
-    style="width: 200px;"
+    style="width: 180px;"
   >
     <div
       class="ant-select-content ant-select-content-has-value"
@@ -6341,7 +6341,7 @@ exports[`renders components/select/demo/line-height-debug.tsx extend context cor
   </div>
   <div
     class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-multiple ant-select-show-arrow ant-select-show-search"
-    style="width: 200px;"
+    style="width: 180px;"
   >
     <div
       class="ant-select-content"
@@ -6498,6 +6498,107 @@ exports[`renders components/select/demo/line-height-debug.tsx extend context cor
                     </svg>
                   </span>
                 </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
+    style="width: 180px;"
+  >
+    <div
+      class="ant-select-content ant-select-content-has-value"
+      title="Light"
+    >
+      Light
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="new-password"
+        class="ant-select-input"
+        id="test-id"
+        readonly=""
+        role="combobox"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomLeft"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+  >
+    <div>
+      <div
+        id="test-id_list"
+        role="listbox"
+        style="height: 0px; width: 0px; overflow: hidden;"
+      >
+        <div
+          aria-label="Light"
+          aria-selected="true"
+          id="test-id_list_0"
+          role="option"
+        >
+          light
+        </div>
+      </div>
+      <div
+        class="ant-select-dropdown-list"
+        style="position: relative;"
+      >
+        <div
+          class="ant-select-dropdown-list-holder"
+          style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+        >
+          <div>
+            <div
+              class="ant-select-dropdown-list-holder-inner"
+              style="display: flex; flex-direction: column;"
+            >
+              <div
+                aria-disabled="false"
+                class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                title="Light"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  Light
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
               </div>
             </div>
           </div>

--- a/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -6234,6 +6234,282 @@ Array [
 
 exports[`renders components/select/demo/label-in-value.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/select/demo/line-height-debug.tsx extend context correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-start ant-flex-gap-small"
+>
+  <div
+    class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
+    style="width: 200px;"
+  >
+    <div
+      class="ant-select-content ant-select-content-has-value"
+      title="Light"
+    >
+      Light
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="new-password"
+        class="ant-select-input"
+        id="test-id"
+        readonly=""
+        role="combobox"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomLeft"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+  >
+    <div>
+      <div
+        id="test-id_list"
+        role="listbox"
+        style="height: 0px; width: 0px; overflow: hidden;"
+      >
+        <div
+          aria-label="Light"
+          aria-selected="true"
+          id="test-id_list_0"
+          role="option"
+        >
+          light
+        </div>
+      </div>
+      <div
+        class="ant-select-dropdown-list"
+        style="position: relative;"
+      >
+        <div
+          class="ant-select-dropdown-list-holder"
+          style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+        >
+          <div>
+            <div
+              class="ant-select-dropdown-list-holder-inner"
+              style="display: flex; flex-direction: column;"
+            >
+              <div
+                aria-disabled="false"
+                class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                title="Light"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  Light
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-multiple ant-select-show-arrow ant-select-show-search"
+    style="width: 200px;"
+  >
+    <div
+      class="ant-select-content"
+    >
+      <div
+        class="ant-select-content-item"
+        style="opacity: 1;"
+      >
+        <span
+          class="ant-select-selection-item"
+          title="Light"
+        >
+          <span
+            class="ant-select-selection-item-content"
+          >
+            Light
+          </span>
+          <span
+            aria-hidden="true"
+            class="ant-select-selection-item-remove"
+            style="user-select: none;"
+            unselectable="on"
+          >
+            <span
+              aria-label="close"
+              class="anticon anticon-close"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="close"
+                fill="currentColor"
+                fill-rule="evenodd"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-select-content-item ant-select-content-item-suffix"
+        style="opacity: 1;"
+      >
+        <input
+          aria-autocomplete="list"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          autocomplete="new-password"
+          class="ant-select-input"
+          id="test-id"
+          role="combobox"
+          style="--select-input-width: 0;"
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-select-css-var ant-select-dropdown-placement-bottomLeft"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
+  >
+    <div>
+      <div
+        id="test-id_list"
+        role="listbox"
+        style="height: 0px; width: 0px; overflow: hidden;"
+      >
+        <div
+          aria-label="Light"
+          aria-selected="true"
+          id="test-id_list_0"
+          role="option"
+        >
+          light
+        </div>
+      </div>
+      <div
+        class="ant-select-dropdown-list"
+        style="position: relative;"
+      >
+        <div
+          class="ant-select-dropdown-list-holder"
+          style="max-height: 256px; overflow-y: auto; overflow-anchor: none;"
+        >
+          <div>
+            <div
+              class="ant-select-dropdown-list-holder-inner"
+              style="display: flex; flex-direction: column;"
+            >
+              <div
+                aria-disabled="false"
+                class="ant-select-item ant-select-item-option ant-select-item-option-active ant-select-item-option-selected"
+                title="Light"
+              >
+                <div
+                  class="ant-select-item-option-content"
+                >
+                  Light
+                </div>
+                <span
+                  aria-hidden="true"
+                  class="ant-select-item-option-state"
+                  style="user-select: none;"
+                  unselectable="on"
+                >
+                  <span
+                    aria-label="check"
+                    class="anticon anticon-check"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="check"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/select/demo/line-height-debug.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/select/demo/maxCount.tsx extend context correctly 1`] = `
 Array [
   <div

--- a/components/select/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/select/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1847,6 +1847,149 @@ exports[`renders components/select/demo/label-in-value.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/select/demo/line-height-debug.tsx correctly 1`] = `
+<div
+  class="ant-flex css-var-test-id ant-flex-align-start ant-flex-gap-small"
+>
+  <div
+    class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
+    style="width:200px"
+  >
+    <div
+      class="ant-select-content ant-select-content-has-value"
+      title="Light"
+    >
+      Light
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="new-password"
+        class="ant-select-input"
+        id="test-id"
+        readonly=""
+        role="combobox"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-multiple ant-select-show-arrow ant-select-show-search"
+    style="width:200px"
+  >
+    <div
+      class="ant-select-content"
+    >
+      <div
+        class="ant-select-content-item"
+        style="opacity:1"
+      >
+        <span
+          class="ant-select-selection-item"
+          title="Light"
+        >
+          <span
+            class="ant-select-selection-item-content"
+          >
+            Light
+          </span>
+          <span
+            aria-hidden="true"
+            class="ant-select-selection-item-remove"
+            style="user-select:none;-webkit-user-select:none"
+            unselectable="on"
+          >
+            <span
+              aria-label="close"
+              class="anticon anticon-close"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="close"
+                fill="currentColor"
+                fill-rule="evenodd"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-select-content-item ant-select-content-item-suffix"
+        style="opacity:1"
+      >
+        <input
+          aria-autocomplete="list"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          autocomplete="new-password"
+          class="ant-select-input"
+          id="test-id"
+          role="combobox"
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/select/demo/maxCount.tsx correctly 1`] = `
 <div
   class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-multiple ant-select-show-arrow ant-select-show-search"

--- a/components/select/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/select/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1849,7 +1849,7 @@ exports[`renders components/select/demo/label-in-value.tsx correctly 1`] = `
 
 exports[`renders components/select/demo/line-height-debug.tsx correctly 1`] = `
 <div
-  class="ant-flex css-var-test-id ant-flex-align-start ant-flex-gap-small"
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-align-start ant-flex-gap-small"
 >
   <div
     class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
@@ -1899,6 +1899,278 @@ exports[`renders components/select/demo/line-height-debug.tsx correctly 1`] = `
   </div>
   <div
     class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-multiple ant-select-show-arrow ant-select-show-search"
+    style="width:180px"
+  >
+    <div
+      class="ant-select-content"
+    >
+      <div
+        class="ant-select-content-item"
+        style="opacity:1"
+      >
+        <span
+          class="ant-select-selection-item"
+          title="Light"
+        >
+          <span
+            class="ant-select-selection-item-content"
+          >
+            Light
+          </span>
+          <span
+            aria-hidden="true"
+            class="ant-select-selection-item-remove"
+            style="user-select:none;-webkit-user-select:none"
+            unselectable="on"
+          >
+            <span
+              aria-label="close"
+              class="anticon anticon-close"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="close"
+                fill="currentColor"
+                fill-rule="evenodd"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-select-content-item ant-select-content-item-suffix"
+        style="opacity:1"
+      >
+        <input
+          aria-autocomplete="list"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          autocomplete="new-password"
+          class="ant-select-input"
+          id="test-id"
+          role="combobox"
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select ant-select-sm ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
+    style="width:180px"
+  >
+    <div
+      class="ant-select-content ant-select-content-has-value"
+      title="Light"
+    >
+      Light
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="new-password"
+        class="ant-select-input"
+        id="test-id"
+        readonly=""
+        role="combobox"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select ant-select-sm ant-select-outlined css-var-test-id ant-select-css-var ant-select-multiple ant-select-show-arrow ant-select-show-search"
+    style="width:180px"
+  >
+    <div
+      class="ant-select-content"
+    >
+      <div
+        class="ant-select-content-item"
+        style="opacity:1"
+      >
+        <span
+          class="ant-select-selection-item"
+          title="Light"
+        >
+          <span
+            class="ant-select-selection-item-content"
+          >
+            Light
+          </span>
+          <span
+            aria-hidden="true"
+            class="ant-select-selection-item-remove"
+            style="user-select:none;-webkit-user-select:none"
+            unselectable="on"
+          >
+            <span
+              aria-label="close"
+              class="anticon anticon-close"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="close"
+                fill="currentColor"
+                fill-rule="evenodd"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M799.86 166.31c.02 0 .04.02.08.06l57.69 57.7c.04.03.05.05.06.08a.12.12 0 010 .06c0 .03-.02.05-.06.09L569.93 512l287.7 287.7c.04.04.05.06.06.09a.12.12 0 010 .07c0 .02-.02.04-.06.08l-57.7 57.69c-.03.04-.05.05-.07.06a.12.12 0 01-.07 0c-.03 0-.05-.02-.09-.06L512 569.93l-287.7 287.7c-.04.04-.06.05-.09.06a.12.12 0 01-.07 0c-.02 0-.04-.02-.08-.06l-57.69-57.7c-.04-.03-.05-.05-.06-.07a.12.12 0 010-.07c0-.03.02-.05.06-.09L454.07 512l-287.7-287.7c-.04-.04-.05-.06-.06-.09a.12.12 0 010-.07c0-.02.02-.04.06-.08l57.7-57.69c.03-.04.05-.05.07-.06a.12.12 0 01.07 0c.03 0 .05.02.09.06L512 454.07l287.7-287.7c.04-.04.06-.05.09-.06a.12.12 0 01.07 0z"
+                />
+              </svg>
+            </span>
+          </span>
+        </span>
+      </div>
+      <div
+        class="ant-select-content-item ant-select-content-item-suffix"
+        style="opacity:1"
+      >
+        <input
+          aria-autocomplete="list"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          autocomplete="new-password"
+          class="ant-select-input"
+          id="test-id"
+          role="combobox"
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select ant-select-lg ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
+    style="width:180px"
+  >
+    <div
+      class="ant-select-content ant-select-content-has-value"
+      title="Light"
+    >
+      Light
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="new-password"
+        class="ant-select-input"
+        id="test-id"
+        readonly=""
+        role="combobox"
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select ant-select-lg ant-select-outlined css-var-test-id ant-select-css-var ant-select-multiple ant-select-show-arrow ant-select-show-search"
     style="width:180px"
   >
     <div

--- a/components/select/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/select/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1853,7 +1853,7 @@ exports[`renders components/select/demo/line-height-debug.tsx correctly 1`] = `
 >
   <div
     class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
-    style="width:200px"
+    style="width:180px"
   >
     <div
       class="ant-select-content ant-select-content-has-value"
@@ -1899,7 +1899,7 @@ exports[`renders components/select/demo/line-height-debug.tsx correctly 1`] = `
   </div>
   <div
     class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-multiple ant-select-show-arrow ant-select-show-search"
-    style="width:200px"
+    style="width:180px"
   >
     <div
       class="ant-select-content"
@@ -1962,6 +1962,52 @@ exports[`renders components/select/demo/line-height-debug.tsx correctly 1`] = `
           value=""
         />
       </div>
+    </div>
+    <div
+      class="ant-select-suffix"
+    >
+      <span
+        aria-label="down"
+        class="anticon anticon-down"
+        role="img"
+      >
+        <svg
+          aria-hidden="true"
+          data-icon="down"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
+    style="width:180px"
+  >
+    <div
+      class="ant-select-content ant-select-content-has-value"
+      title="Light"
+    >
+      Light
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        autocomplete="new-password"
+        class="ant-select-input"
+        id="test-id"
+        readonly=""
+        role="combobox"
+        type="text"
+        value=""
+      />
     </div>
     <div
       class="ant-select-suffix"

--- a/components/select/__tests__/image.test.ts
+++ b/components/select/__tests__/image.test.ts
@@ -8,8 +8,8 @@ import imageTest, { imageDemoTest } from '../../../tests/shared/imageTest';
 const clearSuffixDebugFilename = 'components/select/demo/clear-suffix-debug.tsx';
 const lineHeightDebugFilename = 'components/select/demo/line-height-debug.tsx';
 const interactiveSuffixSelector = '.ant-select-show-arrow';
+const selectSelector = '.ant-select';
 const singleSelector = '.ant-select-single';
-const multipleSelector = '.ant-select-multiple';
 
 const expectSuffixNotHitTarget = async (testPage: Page) => {
   const suffixHit = await testPage.evaluate((selector) => {
@@ -28,25 +28,39 @@ const expectSuffixNotHitTarget = async (testPage: Page) => {
   expect(suffixHit).toBe(false);
 };
 
-const expectHeightKeepsControlHeight = async (testPage: Page) => {
-  const heights = await testPage.evaluate(
-    (selectors) =>
-      selectors.map((selector) => {
-        const select = document.querySelector<HTMLElement>(selector);
+const expectLineHeightKeepsControlHeight = async (testPage: Page) => {
+  const selects = await testPage.evaluate(
+    (selector, singleClsSelector) =>
+      Array.from(document.querySelectorAll<HTMLElement>(selector)).map((select) => {
+        const content = select.querySelector<HTMLElement>(`${selector}-content`);
 
-        if (!select) {
-          throw new Error(`Missing select: ${selector}`);
+        if (!content) {
+          throw new Error(`Missing content: ${selector}`);
         }
 
-        const controlHeight = getComputedStyle(select).getPropertyValue('--ant-select-height');
+        const style = getComputedStyle(select);
+        const readVar = (name: string) => Number.parseFloat(style.getPropertyValue(name));
 
-        return [select.getBoundingClientRect().height, Number.parseFloat(controlHeight)];
+        return {
+          single: select.matches(singleClsSelector),
+          height: select.getBoundingClientRect().height,
+          controlHeight: readVar('--ant-select-height'),
+          contentLineHeight: Number.parseFloat(getComputedStyle(content).lineHeight),
+          tokenLineHeight: readVar('--ant-select-font-size') * readVar('--ant-select-line-height'),
+        };
       }),
-    [singleSelector, multipleSelector],
+    selectSelector,
+    singleSelector,
   );
 
-  heights.forEach(([height, controlHeight]) => {
+  expect(selects).not.toHaveLength(0);
+
+  selects.forEach(({ single, height, controlHeight, contentLineHeight, tokenLineHeight }) => {
     expect(height).toBe(controlHeight);
+
+    if (single) {
+      expect(contentLineHeight).toBeCloseTo(tokenLineHeight, 3);
+    }
   });
 };
 
@@ -79,7 +93,7 @@ describe('Select image', () => {
       React.createElement(LineHeightDebug),
       'select-line-height-debug',
       lineHeightDebugFilename,
-      { beforeScreenshot: expectHeightKeepsControlHeight },
+      { beforeScreenshot: expectLineHeightKeepsControlHeight },
     );
   });
 

--- a/components/select/__tests__/image.test.ts
+++ b/components/select/__tests__/image.test.ts
@@ -2,9 +2,11 @@ import React from 'react';
 import type { Page } from 'puppeteer';
 
 import ClearSuffixDebug from '../demo/clear-suffix-debug';
+import LineHeightDebug from '../demo/line-height-debug';
 import imageTest, { imageDemoTest } from '../../../tests/shared/imageTest';
 
 const clearSuffixDebugFilename = 'components/select/demo/clear-suffix-debug.tsx';
+const lineHeightDebugFilename = 'components/select/demo/line-height-debug.tsx';
 const interactiveSuffixSelector = '.ant-select-show-arrow';
 
 const expectSuffixNotHitTarget = async (testPage: Page) => {
@@ -22,6 +24,22 @@ const expectSuffixNotHitTarget = async (testPage: Page) => {
   }, `${interactiveSuffixSelector} .ant-select-suffix`);
 
   expect(suffixHit).toBe(false);
+};
+
+const expectSameHeight = async (testPage: Page) => {
+  const heights = await testPage.evaluate(() =>
+    ['.ant-select-single', '.ant-select-multiple'].map((selector) => {
+      const select = document.querySelector<HTMLElement>(selector);
+
+      if (!select) {
+        throw new Error(`Missing select: ${selector}`);
+      }
+
+      return select.getBoundingClientRect().height;
+    }),
+  );
+
+  expect(heights[0]).toBe(heights[1]);
 };
 
 describe('Select image', () => {
@@ -48,9 +66,18 @@ describe('Select image', () => {
     });
   });
 
+  describe('line height', () => {
+    imageTest(
+      React.createElement(LineHeightDebug),
+      'select-line-height-debug',
+      lineHeightDebugFilename,
+      { beforeScreenshot: expectSameHeight },
+    );
+  });
+
   imageDemoTest('select', {
     mobile: ['basic.tsx'],
-    skip: ['debug-flip-shift.tsx'],
+    skip: ['debug-flip-shift.tsx', 'line-height-debug.tsx'],
   });
 
   describe('clear suffix touch', () => {

--- a/components/select/__tests__/image.test.ts
+++ b/components/select/__tests__/image.test.ts
@@ -2,14 +2,10 @@ import React from 'react';
 import type { Page } from 'puppeteer';
 
 import ClearSuffixDebug from '../demo/clear-suffix-debug';
-import LineHeightDebug from '../demo/line-height-debug';
 import imageTest, { imageDemoTest } from '../../../tests/shared/imageTest';
 
 const clearSuffixDebugFilename = 'components/select/demo/clear-suffix-debug.tsx';
-const lineHeightDebugFilename = 'components/select/demo/line-height-debug.tsx';
 const interactiveSuffixSelector = '.ant-select-show-arrow';
-const selectSelector = '.ant-select';
-const singleSelector = '.ant-select-single';
 
 const expectSuffixNotHitTarget = async (testPage: Page) => {
   const suffixHit = await testPage.evaluate((selector) => {
@@ -26,42 +22,6 @@ const expectSuffixNotHitTarget = async (testPage: Page) => {
   }, `${interactiveSuffixSelector} .ant-select-suffix`);
 
   expect(suffixHit).toBe(false);
-};
-
-const expectLineHeightKeepsControlHeight = async (testPage: Page) => {
-  const selects = await testPage.evaluate(
-    (selector, singleClsSelector) =>
-      Array.from(document.querySelectorAll<HTMLElement>(selector)).map((select) => {
-        const content = select.querySelector<HTMLElement>(`${selector}-content`);
-
-        if (!content) {
-          throw new Error(`Missing content: ${selector}`);
-        }
-
-        const style = getComputedStyle(select);
-        const readVar = (name: string) => Number.parseFloat(style.getPropertyValue(name));
-
-        return {
-          single: select.matches(singleClsSelector),
-          height: select.getBoundingClientRect().height,
-          controlHeight: readVar('--ant-select-height'),
-          contentLineHeight: Number.parseFloat(getComputedStyle(content).lineHeight),
-          tokenLineHeight: readVar('--ant-select-font-size') * readVar('--ant-select-line-height'),
-        };
-      }),
-    selectSelector,
-    singleSelector,
-  );
-
-  expect(selects).not.toHaveLength(0);
-
-  selects.forEach(({ single, height, controlHeight, contentLineHeight, tokenLineHeight }) => {
-    expect(height).toBe(controlHeight);
-
-    if (single) {
-      expect(contentLineHeight).toBeCloseTo(tokenLineHeight, 3);
-    }
-  });
 };
 
 describe('Select image', () => {
@@ -88,18 +48,9 @@ describe('Select image', () => {
     });
   });
 
-  describe('custom line height token', () => {
-    imageTest(
-      React.createElement(LineHeightDebug),
-      'select-line-height-debug',
-      lineHeightDebugFilename,
-      { beforeScreenshot: expectLineHeightKeepsControlHeight },
-    );
-  });
-
   imageDemoTest('select', {
     mobile: ['basic.tsx'],
-    skip: ['debug-flip-shift.tsx', 'line-height-debug.tsx'],
+    skip: ['debug-flip-shift.tsx'],
   });
 
   describe('clear suffix touch', () => {

--- a/components/select/__tests__/image.test.ts
+++ b/components/select/__tests__/image.test.ts
@@ -8,6 +8,8 @@ import imageTest, { imageDemoTest } from '../../../tests/shared/imageTest';
 const clearSuffixDebugFilename = 'components/select/demo/clear-suffix-debug.tsx';
 const lineHeightDebugFilename = 'components/select/demo/line-height-debug.tsx';
 const interactiveSuffixSelector = '.ant-select-show-arrow';
+const singleSelector = '.ant-select-single';
+const multipleSelector = '.ant-select-multiple';
 
 const expectSuffixNotHitTarget = async (testPage: Page) => {
   const suffixHit = await testPage.evaluate((selector) => {
@@ -26,20 +28,26 @@ const expectSuffixNotHitTarget = async (testPage: Page) => {
   expect(suffixHit).toBe(false);
 };
 
-const expectSameHeight = async (testPage: Page) => {
-  const heights = await testPage.evaluate(() =>
-    ['.ant-select-single', '.ant-select-multiple'].map((selector) => {
-      const select = document.querySelector<HTMLElement>(selector);
+const expectHeightKeepsControlHeight = async (testPage: Page) => {
+  const heights = await testPage.evaluate(
+    (selectors) =>
+      selectors.map((selector) => {
+        const select = document.querySelector<HTMLElement>(selector);
 
-      if (!select) {
-        throw new Error(`Missing select: ${selector}`);
-      }
+        if (!select) {
+          throw new Error(`Missing select: ${selector}`);
+        }
 
-      return select.getBoundingClientRect().height;
-    }),
+        const controlHeight = getComputedStyle(select).getPropertyValue('--ant-select-height');
+
+        return [select.getBoundingClientRect().height, Number.parseFloat(controlHeight)];
+      }),
+    [singleSelector, multipleSelector],
   );
 
-  expect(heights[0]).toBe(heights[1]);
+  heights.forEach(([height, controlHeight]) => {
+    expect(height).toBe(controlHeight);
+  });
 };
 
 describe('Select image', () => {
@@ -66,12 +74,12 @@ describe('Select image', () => {
     });
   });
 
-  describe('line height', () => {
+  describe('custom line height token', () => {
     imageTest(
       React.createElement(LineHeightDebug),
       'select-line-height-debug',
       lineHeightDebugFilename,
-      { beforeScreenshot: expectSameHeight },
+      { beforeScreenshot: expectHeightKeepsControlHeight },
     );
   });
 

--- a/components/select/demo/line-height-debug.md
+++ b/components/select/demo/line-height-debug.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-全局 `lineHeight` 变化时，单选与多选的高度应保持一致。
+`lineHeight` 被覆盖时，选中文本应该采用该行高，而组件高度保持 `controlHeight`。
 
 ## en-US
 
-Single and multiple modes should keep the same height when the global `lineHeight` changes.
+Selected text should follow an overridden `lineHeight` while the control keeps its `controlHeight`.

--- a/components/select/demo/line-height-debug.md
+++ b/components/select/demo/line-height-debug.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+全局 `lineHeight` 变化时，单选与多选的高度应保持一致。
+
+## en-US
+
+Single and multiple mode should keep the same height when global `lineHeight` changes.

--- a/components/select/demo/line-height-debug.md
+++ b/components/select/demo/line-height-debug.md
@@ -4,4 +4,4 @@
 
 ## en-US
 
-Single and multiple mode should keep the same height when global `lineHeight` changes.
+Single and multiple modes should keep the same height when the global `lineHeight` changes.

--- a/components/select/demo/line-height-debug.tsx
+++ b/components/select/demo/line-height-debug.tsx
@@ -6,10 +6,28 @@ const options = [{ value: 'light', label: 'Light' }];
 const selectStyle: React.CSSProperties = { width: 180 };
 
 const App: React.FC = () => (
-  <Flex gap="small" align="start">
+  <Flex gap="small" align="start" wrap>
     <ConfigProvider theme={{ token: { lineHeight: 2 } }}>
       <Select style={selectStyle} defaultValue="light" options={options} />
       <Select style={selectStyle} mode="multiple" defaultValue={['light']} options={options} />
+      <Select style={selectStyle} size="small" defaultValue="light" options={options} />
+      <Select
+        style={selectStyle}
+        size="small"
+        mode="multiple"
+        defaultValue={['light']}
+        options={options}
+      />
+    </ConfigProvider>
+    <ConfigProvider theme={{ token: { lineHeightLG: 2 } }}>
+      <Select style={selectStyle} size="large" defaultValue="light" options={options} />
+      <Select
+        style={selectStyle}
+        size="large"
+        mode="multiple"
+        defaultValue={['light']}
+        options={options}
+      />
     </ConfigProvider>
     <ConfigProvider theme={{ components: { Select: { lineHeight: 2 } } }}>
       <Select style={selectStyle} defaultValue="light" options={options} />

--- a/components/select/demo/line-height-debug.tsx
+++ b/components/select/demo/line-height-debug.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { ConfigProvider, Flex, Select } from 'antd';
+
+const options = [{ value: 'light', label: 'Light' }];
+
+const selectStyle: React.CSSProperties = { width: 200 };
+
+const App: React.FC = () => (
+  <ConfigProvider theme={{ token: { lineHeight: 2 } }}>
+    <Flex gap="small" align="start">
+      <Select style={selectStyle} defaultValue="light" options={options} />
+      <Select style={selectStyle} mode="multiple" defaultValue={['light']} options={options} />
+    </Flex>
+  </ConfigProvider>
+);
+
+export default App;

--- a/components/select/demo/line-height-debug.tsx
+++ b/components/select/demo/line-height-debug.tsx
@@ -3,15 +3,18 @@ import { ConfigProvider, Flex, Select } from 'antd';
 
 const options = [{ value: 'light', label: 'Light' }];
 
-const selectStyle: React.CSSProperties = { width: 200 };
+const selectStyle: React.CSSProperties = { width: 180 };
 
 const App: React.FC = () => (
-  <ConfigProvider theme={{ token: { lineHeight: 2 } }}>
-    <Flex gap="small" align="start">
+  <Flex gap="small" align="start">
+    <ConfigProvider theme={{ token: { lineHeight: 2 } }}>
       <Select style={selectStyle} defaultValue="light" options={options} />
       <Select style={selectStyle} mode="multiple" defaultValue={['light']} options={options} />
-    </Flex>
-  </ConfigProvider>
+    </ConfigProvider>
+    <ConfigProvider theme={{ components: { Select: { lineHeight: 2 } } }}>
+      <Select style={selectStyle} defaultValue="light" options={options} />
+    </ConfigProvider>
+  </Flex>
 );
 
 export default App;

--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -39,6 +39,7 @@ demo:
 <code src="./demo/variant.tsx" version="5.13.0">Variants</code>
 <code src="./demo/filled-debug.tsx" debug>Filled debug</code>
 <code src="./demo/clear-suffix-debug.tsx" debug>Clear suffix</code>
+<code src="./demo/line-height-debug.tsx" debug>Line height</code>
 <code src="./demo/custom-tag-render.tsx">Custom Tag Render</code>
 <code src="./demo/custom-label-render.tsx">Custom Selected Label Render</code>
 <code src="./demo/responsive.tsx">Responsive maxTagCount</code>

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -40,6 +40,7 @@ demo:
 <code src="./demo/variant.tsx" version="5.13.0">形态变体</code>
 <code src="./demo/filled-debug.tsx" debug>Filled debug</code>
 <code src="./demo/clear-suffix-debug.tsx" debug>清除后缀</code>
+<code src="./demo/line-height-debug.tsx" debug>行高</code>
 <code src="./demo/custom-tag-render.tsx">自定义选择标签</code>
 <code src="./demo/custom-label-render.tsx">自定义选中 label</code>
 <code src="./demo/responsive.tsx">响应式 maxTagCount</code>

--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -305,6 +305,7 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
           [`${componentCls}-content`]: {
             ...textEllipsis,
             alignSelf: 'center',
+            lineHeight: varRef('font-height'),
 
             '&-has-value': {
               display: 'block',

--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -97,7 +97,6 @@ const genSelectInputFocusVisibleStyle = (token: SelectToken, outlineColor: strin
 const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
   const {
     componentCls,
-    fontHeight,
     controlHeight,
     fontSizeIcon,
     showArrowPaddingInlineEnd,
@@ -123,7 +122,7 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
         // Font
         [varName('font-size')]: token.fontSize,
         [varName('line-height')]: token.lineHeight,
-        [varName('font-height')]: fontHeight,
+        [varName('font-height')]: `calc(${varRef('font-size')} * ${varRef('line-height')})`,
         [varName('color')]: token.colorText,
         [varName('affix-color')]: token.colorText,
         // Size
@@ -131,7 +130,7 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
 
         [varName('padding-horizontal')]: calc(token.paddingSM).sub(token.lineWidth).equal(),
         [varName('padding-vertical')]:
-          `calc((${varRef('height')} - ${varRef('font-height')}) / 2 - ${varRef('border-size')})`,
+          `max(calc((${varRef('height')} - ${varRef('font-height')}) / 2 - ${varRef('border-size')}), 0px)`,
 
         // ==========================================================
         // ==                         Base                         ==
@@ -261,7 +260,6 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
           [varName('height')]: token.controlHeightLG,
           [varName('font-size')]: token.fontSizeLG,
           [varName('line-height')]: token.lineHeightLG,
-          [varName('font-height')]: token.fontHeightLG,
           [varName('border-radius')]: token.borderRadiusLG,
         },
       },
@@ -305,9 +303,6 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
           [`${componentCls}-content`]: {
             ...textEllipsis,
             alignSelf: 'center',
-            // Vertical padding assumes a `font-height` tall line box, so pin it here or a
-            // customized `line-height` stretches the box past `height`.
-            lineHeight: varRef('font-height'),
 
             '&-has-value': {
               display: 'block',

--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -305,6 +305,8 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
           [`${componentCls}-content`]: {
             ...textEllipsis,
             alignSelf: 'center',
+            // Vertical padding assumes a `font-height` tall line box, so pin it here or a
+            // customized `line-height` stretches the box past `height`.
             lineHeight: varRef('font-height'),
 
             '&-has-value': {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] 💄 Component style improvement
- [x] 📽️ Demo improvement

### 🔗 Related Issues

close #59091

### 💡 Background and Solution

Single mode renders its content with `var(--ant-select-line-height)`, but the vertical padding is `(height - font-height) / 2 - border-size`, and `font-height` is a px value derived when the theme is built. Overriding `lineHeight` moves one value and not the other, so the control grows past `controlHeight`. On master, single vs multiple measures 38 / 32 at `lineHeight: 2` and 24 / 32 at `lineHeight: 1`.

`--ant-select-font-height` now resolves to `calc(font-size * line-height)`, so the padding follows the configured line height instead of the one baked in at theme build time. The content keeps using the token, so overriding `lineHeight` still changes the selected text. The `font-height` override in `&-lg` is gone because it derives now, which also covers `lineHeightLG: 2`, where large stretched to 48px against a 40px control.

The padding is clamped at 0, since the recomputed value turns negative once `fontSize * lineHeight` passes the control height. In that case the line box no longer fits, so the control grows exactly as it does on master. `size="small"` at `lineHeight: 2` is one example: a 28px line box cannot sit inside a 24px control.

The default theme renders unchanged.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Select height changing when the `lineHeight` token is customized. |
| 🇨🇳 Chinese | 🐞 修复 Select 在自定义 `lineHeight` token 时高度变化的问题。 |
