### PR TITLE
fix(Breadcrumb): handle route parameter replacement precisely

### DIFF
--- a/components/breadcrumb/Breadcrumb.tsx
+++ b/components/breadcrumb/Breadcrumb.tsx
@@ -18,6 +18,7 @@ import BreadcrumbSeparator from './BreadcrumbSeparator';
 import useStyle from './style';
 import useItemRender from './useItemRender';
 import useItems from './useItems';
+import { replaceParams } from './util';
 
 export interface BreadcrumbItemType extends React.AriaAttributes {
   key?: React.Key;
@@ -98,11 +99,7 @@ const getPath = <T extends AnyObject = AnyObject>(params: T, path?: string) => {
   if (path === undefined) {
     return path;
   }
-  let mergedPath = (path || '').replace(/^\//, '');
-  Object.keys(params).forEach((key) => {
-    mergedPath = mergedPath.replace(`:${key}`, params[key]!);
-  });
-  return mergedPath;
+  return replaceParams((path || '').replace(/^\//, ''), params);
 };
 
 const InternalBreadcrumb = <T extends AnyObject = AnyObject>(

--- a/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -396,6 +396,54 @@ describe('Breadcrumb', () => {
     expect(<Breadcrumb<Params> params={{ key1: 1, key2: 'test' }} />).toBeTruthy();
   });
 
+  it('should replace breadcrumb path params exactly and globally', () => {
+    const { container } = render(
+      <Breadcrumb
+        params={{ id: 'A', id2: 'B', value: '$&' }}
+        items={[{ path: ':id2/:id/:id/:value', title: ':id2/:id/:id/:value' }]}
+      />,
+    );
+
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('#/B/A/A/$&');
+    expect(container.querySelector('a')).toHaveTextContent('B/A/A/$&');
+  });
+
+  it('should preserve unmatched params when building nested paths', () => {
+    const { container } = render(
+      <Breadcrumb
+        params={{ id: 'A' }}
+        items={[
+          { path: ':id', title: 'First' },
+          { path: ':id2', title: 'Second' },
+          { path: ':idé', title: 'Third' },
+        ]}
+      />,
+    );
+
+    expect(
+      Array.from(container.querySelectorAll('a')).map((link) => link.getAttribute('href')),
+    ).toEqual(['#/A', '#/A/:id2', '#/A/:id2/:idé']);
+  });
+
+  it('should preserve params with nullish values', () => {
+    const { container } = render(
+      <Breadcrumb
+        params={{ nullValue: null, undefinedValue: undefined, zero: 0, bool: false, empty: '' }}
+        items={[
+          {
+            path: ':nullValue/:undefinedValue/:zero/:bool/:empty',
+            title: ':nullValue/:undefinedValue/:zero/:bool/:empty',
+          },
+        ]}
+      />,
+    );
+
+    expect(container.querySelector('a')?.getAttribute('href')).toBe(
+      '#/:nullValue/:undefinedValue/0/false/',
+    );
+    expect(container.querySelector('a')).toHaveTextContent(':nullValue/:undefinedValue/0/false/');
+  });
+
   it('support classNames and styles', async () => {
     const customClassNames: Required<GetProp<BreadcrumbProps, 'classNames', 'Return'>> = {
       root: 'custom-root',

--- a/components/breadcrumb/useItemRender.tsx
+++ b/components/breadcrumb/useItemRender.tsx
@@ -4,6 +4,7 @@ import { clsx } from 'clsx';
 
 import { isPlainObject } from '../_util/is';
 import type { BreadcrumbProps, InternalRouteType, ItemType } from './Breadcrumb';
+import { replaceParams } from './util';
 
 type AddParameters<TFunction extends (...args: any) => any, TParameters extends [...args: any]> = (
   ...args: [...Parameters<TFunction>, ...TParameters]
@@ -16,13 +17,7 @@ function getBreadcrumbName(route: InternalRouteType, params: any) {
   if (!isReactRenderable(route.title)) {
     return null;
   }
-  const paramsKeys = Object.keys(params).join('|');
-  return isPlainObject(route.title)
-    ? route.title
-    : String(route.title).replace(
-        new RegExp(`:(${paramsKeys})`, 'g'),
-        (replacement, key) => params[key] || replacement,
-      );
+  return isPlainObject(route.title) ? route.title : replaceParams(String(route.title), params);
 }
 
 export function renderItem(

--- a/components/breadcrumb/util.ts
+++ b/components/breadcrumb/util.ts
@@ -1,0 +1,32 @@
+import type { AnyObject } from '../_util/type';
+
+export const replaceParams = <T extends AnyObject = AnyObject>(text: string, params: T) => {
+  // Collect parameter names and try longer names first to avoid prefix matches such as `:id` in `:id2`.
+  const keys = Object.keys(params).sort((a, b) => b.length - a.length);
+
+  // Avoid creating a regular expression when there are no parameters to replace.
+  if (!keys.length) {
+    return text;
+  }
+
+  // Escape parameter names before embedding them in the dynamically generated regular expression.
+  const escapedKeys = keys.map((key) => key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  // Match every occurrence of a known `:param` token so repeated parameters are all replaced.
+  const paramsRegExp = new RegExp(`:(${escapedKeys.join('|')})`, 'g');
+  // Treat letters, numbers, and underscores as part of a parameter name to prevent partial matches.
+  const paramNameCharRegExp = /[\p{L}\p{N}_]/u;
+
+  // Replace valid tokens while preserving unknown or incomplete tokens exactly as written.
+  return text.replace(paramsRegExp, (match, key, offset, source) => {
+    // Inspect the character after the match to distinguish a complete token from a parameter-name prefix.
+    const nextChar = source[offset + match.length];
+
+    if (nextChar && paramNameCharRegExp.test(nextChar)) {
+      return match;
+    }
+
+    // Keep placeholders whose values are intentionally missing instead of rendering `null` or `undefined`.
+    const value = params[key];
+    return value == null ? match : String(value);
+  });
+};


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] ✅ 测试用例

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Breadcrumb 的路径和标题参数替换存在以下问题：

- 参数名存在前缀关系时可能发生错误替换，例如 `:id` 与 `:id2`
- 同一参数重复出现时无法全部替换
- 参数值包含 `$&` 等特殊替换字符时结果不正确
- `null` / `undefined` 参数可能被渲染为字面量文本

本次改动抽取了统一的 `replaceParams` 方法，用于 Breadcrumb 路径和标题参数替换：

- 按参数名长度匹配，避免前缀误匹配
- 支持全局替换
- 对参数名进行正则转义
- 保留未匹配参数和 `null` / `undefined` 占位符
- 正确处理 `0`、`false` 和空字符串

同时补充了参数重叠、重复参数、特殊字符、未匹配参数及 nullish 参数的测试。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Breadcrumb parameter replacement for overlapping, repeated, and nullish route parameters. |
| 🇨🇳 中文 | 🐞 修复 Breadcrumb 路由参数重叠、重复及 nullish 值的替换问题。 |