### PR TITLE
fix(Alert, Empty): render numeric zero for content nodes

### DIFF
--- a/components/alert/Alert.tsx
+++ b/components/alert/Alert.tsx
@@ -11,7 +11,7 @@ import { clsx } from 'clsx';
 import type { ClosableType } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isNonNullable, isPlainObject } from '../_util/is';
+import { isNonNullable, isPlainObject, isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import useStyle from './style';
@@ -293,7 +293,7 @@ const Alert = React.forwardRef<AlertRef, AlertProps>((props, ref) => {
     `${prefixCls}-${type}`,
     `${prefixCls}-${mergedVariant}`,
     {
-      [`${prefixCls}-with-description`]: !!description,
+      [`${prefixCls}-with-description`]: isReactRenderable(description),
       [`${prefixCls}-no-icon`]: !isShowIcon,
       [`${prefixCls}-banner`]: !!banner,
       [`${prefixCls}-rtl`]: direction === 'rtl',
@@ -375,7 +375,7 @@ const Alert = React.forwardRef<AlertRef, AlertProps>((props, ref) => {
             className={clsx(`${prefixCls}-section`, mergedClassNames.section)}
             style={mergedStyles.section}
           >
-            {mergedTitle ? (
+            {isReactRenderable(mergedTitle) ? (
               <div
                 className={clsx(`${prefixCls}-title`, mergedClassNames.title)}
                 style={mergedStyles.title}
@@ -383,7 +383,7 @@ const Alert = React.forwardRef<AlertRef, AlertProps>((props, ref) => {
                 {mergedTitle}
               </div>
             ) : null}
-            {description ? (
+            {isReactRenderable(description) ? (
               <div
                 className={clsx(`${prefixCls}-description`, mergedClassNames.description)}
                 style={mergedStyles.description}
@@ -392,7 +392,7 @@ const Alert = React.forwardRef<AlertRef, AlertProps>((props, ref) => {
               </div>
             ) : null}
           </div>
-          {action ? (
+          {isReactRenderable(action) ? (
             <div
               className={clsx(`${prefixCls}-actions`, mergedClassNames.actions)}
               style={mergedStyles.actions}

--- a/components/alert/__tests__/index.test.tsx
+++ b/components/alert/__tests__/index.test.tsx
@@ -169,6 +169,14 @@ describe('Alert', () => {
     expect(!!container.querySelector('.ant-alert-title')).toBe(false);
   });
 
+  it('should render numeric 0 for title, description and action', () => {
+    const { container } = render(<Alert title={0} description={0} action={0} />);
+    expect(container.querySelector('.ant-alert-title')?.textContent).toBe('0');
+    expect(container.querySelector('.ant-alert-description')?.textContent).toBe('0');
+    expect(container.querySelector('.ant-alert-actions')?.textContent).toBe('0');
+    expect(container.querySelector('.ant-alert-with-description')).toBeTruthy();
+  });
+
   it('close button should be hidden when closeIcon setting to null or false', () => {
     const { container, rerender } = render(<Alert closeIcon={null} />);
     expect(container.querySelector('.ant-alert-close-icon')).toBeFalsy();

--- a/components/empty/__tests__/index.test.tsx
+++ b/components/empty/__tests__/index.test.tsx
@@ -198,4 +198,10 @@ describe('Empty', () => {
       'https://example.com/foobar.jpg',
     );
   });
+
+  it('should render numeric 0 for description and children', () => {
+    const { container } = render(<Empty description={0}>{0}</Empty>);
+    expect(container.querySelector('.ant-empty-description')?.textContent).toBe('0');
+    expect(container.querySelector('.ant-empty-footer')?.textContent).toBe('0');
+  });
 });

--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -3,6 +3,7 @@ import { clsx } from 'clsx';
 
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
+import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import { useLocale } from '../locale';
@@ -153,7 +154,7 @@ const Empty = React.forwardRef<EmptyRef, EmptyProps>((props, ref) => {
       >
         {imageNode}
       </div>
-      {des && (
+      {isReactRenderable(des) && (
         <div
           className={clsx(`${prefixCls}-description`, mergedClassNames.description)}
           style={mergedStyles.description}
@@ -161,7 +162,7 @@ const Empty = React.forwardRef<EmptyRef, EmptyProps>((props, ref) => {
           {des}
         </div>
       )}
-      {children && (
+      {isReactRenderable(children) && (
         <div
           className={clsx(`${prefixCls}-footer`, mergedClassNames.footer)}
           style={mergedStyles.footer}


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [ ] 🆕 New feature
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other

### 🔗 Related Issues

<!-- None / internal discovery -->

### 💡 Background and Solution

- **Problem**: When passing numeric `0` to renderable props (such as `Alert`'s `title`, `description`, `action` and `Empty`'s `description`, `children`), JavaScript truthy checks evaluated `0` as falsy, causing the content to be suppressed or rendered outside their semantic container divs.
- **Solution**: Replaced truthy conditions with `isReactRenderable` to ensure numeric `0` and other valid renderable nodes display properly without unintended omissions.
- Added comprehensive unit tests for both `Alert` and `Empty` components.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix `Alert` and `Empty` not rendering when passing numeric `0` to content props (`title`, `description`, `action`, `children`). |
| 🇨🇳 Chinese | 🐞 修复 `Alert` 与 `Empty` 组件在内容属性（`title`、`description`、`action`、`children`）传入数字 `0` 时无法正常渲染的问题。 |
