### PR TITLE
docs(blog): fix broken size-limit workflow links

### DIFF
--- a/docs/blog/github-actions-workflow.en-US.md
+++ b/docs/blog/github-actions-workflow.en-US.md
@@ -97,7 +97,7 @@ For every pull request created, GitHub Actions will trigger the build process to
 
 ### Other Reviews
 
-- The [size-limit.yml](https://github.com/ant-design/ant-design/blob/5dfce5443744271f778313c23eb8ec3a5af481f8/.github/workflows/size-limit.ym) job checks the size of the product resulting from the PR.
+- The [size-limit.yml](https://github.com/ant-design/ant-design/blob/5dfce5443744271f778313c23eb8ec3a5af481f8/.github/workflows/size-limit.yml) job checks the size of the product resulting from the PR.
 - Recently, the team has added ChatGPT to GitHub Actions to perform AI-based code review. The specific job can be found in the [chatgpt-cr.yml](https://github.com/ant-design/ant-design/blob/f7fd474cf8792ea01d03461d407c0edc11828a1c/.github/workflows/chatgpt-cr.yml) file.
 
 ## Unit Testing

--- a/docs/blog/github-actions-workflow.zh-CN.md
+++ b/docs/blog/github-actions-workflow.zh-CN.md
@@ -97,7 +97,7 @@ Ant Design 团队非常鼓励社区参与 Pull Request (PR)，可以先阅读 [�
 
 ### 其他审查
 
-- [size-limit.yml](https://github.com/ant-design/ant-design/blob/5dfce5443744271f778313c23eb8ec3a5af481f8/.github/workflows/size-limit.ym) Job 则是对 PR 的一个产物大小进行一个检查。
+- [size-limit.yml](https://github.com/ant-design/ant-design/blob/5dfce5443744271f778313c23eb8ec3a5af481f8/.github/workflows/size-limit.yml) Job 则是对 PR 的一个产物大小进行一个检查。
 - 最近比较火热的 chatGPT，团队也将它添加到 GitHub Action 中，用 AI 先对代码进行审查，具体 Job 可以参考 [chatgpt-cr.yml](https://github.com/ant-design/ant-design/blob/f7fd474cf8792ea01d03461d407c0edc11828a1c/.github/workflows/chatgpt-cr.yml) 文件。
 
 ## 单元测试


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

`size-limit.yml` 链接扩展名误写为 `.ym`，导致链接返回 404。

将中英文博客文章中的链接统一修正为实际存在的 `.github/workflows/size-limit.yml`。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A      |
| 🇨🇳 中文 | 无需更新日志 |