### PR TITLE
fix(Alert): restrict global closable configuration type

### DIFF
--- a/components/alert/index.en-US.md
+++ b/components/alert/index.en-US.md
@@ -46,7 +46,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | banner | Whether to show as banner | boolean | false |  | × |
 | variant | Variant of Alert style | `outlined` \| `filled` | `outlined` | 6.4.0 | 6.4.0 |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
-| closable | The config of closable | boolean \| [ClosableType](#closabletype) & React.AriaAttributes | `false` |  | 5.15.0 |
+| closable | The config of closable | boolean \| [ClosableType](#closabletype) & React.AriaAttributes | `false` |  | `closable.closeIcon`, `closable.aria-*`: 5.15.0 |
 | closeIcon | (Only supports global configuration) Custom close icon | ReactNode | - | × | 5.14.0 |
 | description | Additional content of Alert | ReactNode | - |  | × |
 | errorIcon | (Only supports global configuration) Custom error icon in Alert icon | ReactNode | - | × | 6.2.0 |

--- a/components/alert/index.zh-CN.md
+++ b/components/alert/index.zh-CN.md
@@ -47,7 +47,7 @@ group:
 | banner | 是否用作顶部公告 | boolean | false |  | × |
 | variant | 警告提示样式变体 | `outlined` \| `filled` | `outlined` | 6.4.0 | 6.4.0 |
 | classNames | 自定义组件内部各语义化结构的类名。支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props }) => Record<[SemanticDOM](#semantic-dom), string> | - |  | 6.0.0 |
-| closable | 可关闭配置 | boolean \| [ClosableType](#closabletype) & React.AriaAttributes | `false` |  | 5.15.0 |
+| closable | 可关闭配置 | boolean \| [ClosableType](#closabletype) & React.AriaAttributes | `false` |  | `closable.closeIcon`、`closable.aria-*`：5.15.0 |
 | closeIcon | （仅支持全局配置）自定义关闭图标 | ReactNode | - | × | 5.14.0 |
 | description | 警告提示的辅助性文字介绍 | ReactNode | - |  | × |
 | errorIcon | （仅支持全局配置）自定义错误图标 | ReactNode | - | × | 6.2.0 |

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -238,7 +238,11 @@ export type TabsConfig = ComponentStyleConfig &
 export type AnchorStyleConfig = ComponentStyleConfig & Pick<AnchorProps, 'classNames' | 'styles'>;
 
 export type AlertConfig = ComponentStyleConfig &
-  Pick<AlertProps, 'variant' | 'closable' | 'closeIcon' | 'classNames' | 'styles'> & {
+  Pick<AlertProps, 'variant' | 'closeIcon' | 'classNames' | 'styles'> & {
+    closable?:
+      | boolean
+      | (Pick<Exclude<NonNullable<AlertProps['closable']>, boolean>, 'closeIcon'> &
+          React.AriaAttributes);
     successIcon?: React.ReactNode;
     infoIcon?: React.ReactNode;
     warningIcon?: React.ReactNode;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [x] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无对应 Issue；[在线最小复现](https://codesandbox.io/p/sandbox/configprovider-de-alert-closable-lei-xing-bao-han-bu-shou-zhi-chi-de-hui-diao-gvhdz3?file=%2Findex.tsx)。

### 💡 需求背景和解决方案

`ConfigProvider` 的 `alert.closable` 复用了 Alert 组件级的完整类型，导致 `onClose`、`afterClose` 等不会被全局配置消费的字段仍能通过 TypeScript 检查。

本次将全局 `closable` 类型收窄为实际支持的 `closeIcon` 和 ARIA 属性，并同步更新中英文 API 文档的全局配置标注。运行时行为不变。

已通过 TypeScript、ESLint、Markdown lint 和相关 ConfigProvider 用例检查。

### 📝 更新日志

| 语言    | 更新描述                                                           |
| ------- | ------------------------------------------------------------------ |
| 🇺🇸 英文 | Fix Alert global `closable` type to exclude unsupported callbacks. |
| 🇨🇳 中文 | 修复 Alert 全局 `closable` 类型错误暴露不支持回调的问题。          |
