### PR TITLE
fix(Statistic): preserve semantic nodes for zero values

### DIFF
--- a/components/statistic/Statistic.tsx
+++ b/components/statistic/Statistic.tsx
@@ -5,7 +5,7 @@ import { clsx } from 'clsx';
 import type { HTMLAriaDataAttributes } from '../_util/aria-data-attrs';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isFunction } from '../_util/is';
+import { isFunction, isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import Skeleton from '../skeleton';
@@ -182,7 +182,7 @@ const Statistic = React.forwardRef<StatisticRef, StatisticProps>((props, ref) =>
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      {title && (
+      {isReactRenderable(title) && (
         <div className={headerClassNames} style={mergedStyles.header}>
           <div className={titleClassNames} style={mergedStyles.title}>
             {title}
@@ -191,13 +191,13 @@ const Statistic = React.forwardRef<StatisticRef, StatisticProps>((props, ref) =>
       )}
       <Skeleton paragraph={false} loading={loading} className={`${prefixCls}-skeleton`} active>
         <div className={contentClassNames} style={{ ...valueStyle, ...mergedStyles.content }}>
-          {prefix && (
+          {isReactRenderable(prefix) && (
             <span className={prefixClassNames} style={mergedStyles.prefix}>
               {prefix}
             </span>
           )}
           {isFunction(valueRender) ? valueRender(valueNode) : valueNode}
-          {suffix && (
+          {isReactRenderable(suffix) && (
             <span className={suffixClassNames} style={mergedStyles.suffix}>
               {suffix}
             </span>

--- a/components/statistic/__tests__/index.test.tsx
+++ b/components/statistic/__tests__/index.test.tsx
@@ -30,6 +30,14 @@ describe('Statistic', () => {
     expect(container.querySelector('.ant-statistic-content')!.textContent).toBe('-');
   });
 
+  it('renders semantic nodes for zero title, prefix, and suffix', () => {
+    const { container } = render(<Statistic title={0} prefix={0} suffix={0} />);
+
+    expect(container.querySelector('.ant-statistic-title')).toHaveTextContent('0');
+    expect(container.querySelector('.ant-statistic-content-prefix')).toHaveTextContent('0');
+    expect(container.querySelector('.ant-statistic-content-suffix')).toHaveTextContent('0');
+  });
+
   it('customize formatter', () => {
     const formatter = jest.fn(() => 93);
     const { container } = render(<Statistic value={1128} formatter={formatter} />);


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] ✅ 测试用例

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Statistic 使用 truthy 判断决定是否渲染 `title`、`prefix` 和 `suffix` 的语义节点，导致值为 `0` 时丢失对应的语义结构与样式。
<img width="1751" height="513" alt="image" src="https://github.com/user-attachments/assets/29604446-09c3-450f-bd3c-3e4406e4075b" />

本次改用 `isReactRenderable` 判断可渲染内容，使数值 `0` 能够正常显示，同时继续忽略 `null`、`undefined`、`false` 和空字符串，并补充相应测试覆盖。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Statistic missing semantic nodes when `title`, `prefix`, or `suffix` is `0`. |
| 🇨🇳 中文 | 🐞 修复 Statistic 的 `title`、`prefix` 或 `suffix` 为 `0` 时缺少语义节点的问题。 |