### PR TITLE
docs(Statistic): correct milliseconds terminology

### DIFF
--- a/components/statistic/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/statistic/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -618,7 +618,7 @@ exports[`renders components/statistic/demo/timer.tsx extend context correctly 1`
         <div
           class="ant-statistic-title"
         >
-          Million Seconds
+          Milliseconds
         </div>
       </div>
       <div

--- a/components/statistic/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/statistic/__tests__/__snapshots__/demo.test.ts.snap
@@ -606,7 +606,7 @@ exports[`renders components/statistic/demo/timer.tsx correctly 1`] = `
         <div
           class="ant-statistic-title"
         >
-          Million Seconds
+          Milliseconds
         </div>
       </div>
       <div

--- a/components/statistic/demo/timer.tsx
+++ b/components/statistic/demo/timer.tsx
@@ -43,7 +43,7 @@ const Demo: React.FC = () => {
         <Timer
           classNames={{ content: styles.content }}
           type="countdown"
-          title="Million Seconds"
+          title="Milliseconds"
           value={deadline}
           format="HH:mm:ss:SSS"
         />

--- a/components/statistic/utils.ts
+++ b/components/statistic/utils.ts
@@ -29,7 +29,7 @@ const timeUnits: [string, number][] = [
   ['H', 1000 * 60 * 60], // hours
   ['m', 1000 * 60], // minutes
   ['s', 1000], // seconds
-  ['S', 1], // million seconds
+  ['S', 1], // milliseconds
 ];
 
 export function formatTimeStr(duration: number, format: string) {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📽️ 演示代码改进

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Statistic Timer 示例将毫秒误写为 “Million Seconds”，`S` 时间单位的代码注释中也存在相同错误。

本 PR 将示例标题修正为 “Milliseconds”，将 `S` 单位注释修正为 “milliseconds”，并同步更新相关 demo snapshots。

该改动不影响组件 API 或运行时行为。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A      |
| 🇨🇳 中文 | 无需更新日志 |