### PR TITLE
docs(Tree): clarify useTree memo dependencies

### DIFF
--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -142,8 +142,12 @@ Before `3.4.0`: The number of treeNodes can be very large, but when `checkable=t
 
 Provides Tree data utilities. `getPath(key)` returns the node entities from the root to the target node, which can be used to update `expandedKeys` in controlled mode.
 
+`getPath` has a stable function identity and reads the latest `treeData` when called. If you memoize a value derived from `getPath`, include `treeData` and the lookup key in the dependency list because dependency tracking cannot observe the data captured inside `getPath`.
+
 ```tsx
 const { getPath } = Tree.useTree(treeData, {});
+
+const path = useMemo(() => getPath(selectedKey), [getPath, selectedKey, treeData]);
 ```
 
 ## Semantic DOM

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -144,8 +144,12 @@ demo:
 
 提供 Tree 数据工具。`getPath(key)` 返回从根节点到目标节点的实体路径，可用于在受控模式下更新 `expandedKeys`。
 
+`getPath` 的函数引用保持稳定，并在调用时读取最新的 `treeData`。如果对 `getPath` 的派生结果进行 memo，请将 `treeData` 和查询 key 加入依赖项，因为依赖追踪无法感知 `getPath` 内部捕获的数据。
+
 ```tsx
 const { getPath } = Tree.useTree(treeData, {});
+
+const path = useMemo(() => getPath(selectedKey), [getPath, selectedKey, treeData]);
 ```
 
 ## Semantic DOM


### PR DESCRIPTION
## Summary

- document that `Tree.useTree().getPath` intentionally keeps a stable function identity
- explain that memoized values derived from `getPath` must also depend on `treeData` and the lookup key
- add matching English and Chinese examples

## Context

In #59069, a derived path could remain stale when its memoization depended only on `getPath`. The maintainer clarified that the stable identity is intentional: `getPath` reads the latest data when invoked, but dependency tracking cannot observe that internal data change.

This keeps the runtime contract unchanged and documents the required dependency boundary at the API definition, where users discover `useTree`.

## Verification

- targeted Remark/Markdown lint: passed
- Prettier for both changed files: passed
- `git diff --check`: passed
- checked every current open Ant Design PR: no target-file overlap

I also attempted the full documentation site build. Its preprocessing completed, but Utoopack rejected the shared `node_modules` symlink because it resolved outside the worktree and then reported missing site-only dependencies such as `mermaid` and `swr` across unrelated pages. I am not treating that environment failure as a successful build.

Related to #59069.

AI assistance disclosure: Codex assisted with issue/source tracing, duplicate and target-file screening, wording, validation, and this description. I verified the final bilingual diff and public issue context.
