### PR TITLE
fix(Steps): hide decorative panel arrows

### DIFF
--- a/components/steps/PanelArrow.tsx
+++ b/components/steps/PanelArrow.tsx
@@ -7,13 +7,14 @@ export interface PanelArrowProps {
 const PanelArrow: React.FC<PanelArrowProps> = (props) => {
   const { prefixCls } = props;
   return (
+    // biome-ignore lint/a11y/noSvgWithoutTitle: decorative separator hidden from assistive technology
     <svg
+      aria-hidden
       className={`${prefixCls}-panel-arrow`}
       viewBox="0 0 100 100"
       xmlns="http://www.w3.org/2000/svg"
       preserveAspectRatio="none"
     >
-      <title>Arrow</title>
       <path d="M 0 0 L 100 50 L 0 100" />
     </svg>
   );

--- a/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4152,14 +4152,12 @@ exports[`renders components/steps/demo/panel.tsx extend context correctly 1`] = 
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />
@@ -4220,14 +4218,12 @@ exports[`renders components/steps/demo/panel.tsx extend context correctly 1`] = 
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />
@@ -4270,14 +4266,12 @@ exports[`renders components/steps/demo/panel.tsx extend context correctly 1`] = 
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />
@@ -4334,14 +4328,12 @@ exports[`renders components/steps/demo/panel.tsx extend context correctly 1`] = 
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />
@@ -4402,14 +4394,12 @@ exports[`renders components/steps/demo/panel.tsx extend context correctly 1`] = 
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />
@@ -4452,14 +4442,12 @@ exports[`renders components/steps/demo/panel.tsx extend context correctly 1`] = 
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />

--- a/components/steps/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/steps/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -224,14 +224,12 @@ exports[`renders components/steps/demo/_semantic.tsx correctly 1`] = `
               </div>
             </div>
             <svg
+              aria-hidden="true"
               class="ant-steps-panel-arrow"
               preserveAspectRatio="none"
               viewBox="0 0 100 100"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <title>
-                Arrow
-              </title>
               <path
                 d="M 0 0 L 100 50 L 0 100"
               />
@@ -281,14 +279,12 @@ exports[`renders components/steps/demo/_semantic.tsx correctly 1`] = `
               </div>
             </div>
             <svg
+              aria-hidden="true"
               class="ant-steps-panel-arrow"
               preserveAspectRatio="none"
               viewBox="0 0 100 100"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <title>
-                Arrow
-              </title>
               <path
                 d="M 0 0 L 100 50 L 0 100"
               />
@@ -335,14 +331,12 @@ exports[`renders components/steps/demo/_semantic.tsx correctly 1`] = `
               </div>
             </div>
             <svg
+              aria-hidden="true"
               class="ant-steps-panel-arrow"
               preserveAspectRatio="none"
               viewBox="0 0 100 100"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <title>
-                Arrow
-              </title>
               <path
                 d="M 0 0 L 100 50 L 0 100"
               />
@@ -1517,14 +1511,12 @@ exports[`renders components/steps/demo/_semantic_items.tsx correctly 1`] = `
               </div>
             </div>
             <svg
+              aria-hidden="true"
               class="ant-steps-panel-arrow"
               preserveAspectRatio="none"
               viewBox="0 0 100 100"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <title>
-                Arrow
-              </title>
               <path
                 d="M 0 0 L 100 50 L 0 100"
               />
@@ -1574,14 +1566,12 @@ exports[`renders components/steps/demo/_semantic_items.tsx correctly 1`] = `
               </div>
             </div>
             <svg
+              aria-hidden="true"
               class="ant-steps-panel-arrow"
               preserveAspectRatio="none"
               viewBox="0 0 100 100"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <title>
-                Arrow
-              </title>
               <path
                 d="M 0 0 L 100 50 L 0 100"
               />
@@ -1628,14 +1618,12 @@ exports[`renders components/steps/demo/_semantic_items.tsx correctly 1`] = `
               </div>
             </div>
             <svg
+              aria-hidden="true"
               class="ant-steps-panel-arrow"
               preserveAspectRatio="none"
               viewBox="0 0 100 100"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <title>
-                Arrow
-              </title>
               <path
                 d="M 0 0 L 100 50 L 0 100"
               />

--- a/components/steps/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo.test.ts.snap
@@ -3493,14 +3493,12 @@ exports[`renders components/steps/demo/panel.tsx correctly 1`] = `
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />
@@ -3561,14 +3559,12 @@ exports[`renders components/steps/demo/panel.tsx correctly 1`] = `
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />
@@ -3611,14 +3607,12 @@ exports[`renders components/steps/demo/panel.tsx correctly 1`] = `
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />
@@ -3675,14 +3669,12 @@ exports[`renders components/steps/demo/panel.tsx correctly 1`] = `
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />
@@ -3743,14 +3735,12 @@ exports[`renders components/steps/demo/panel.tsx correctly 1`] = `
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />
@@ -3793,14 +3783,12 @@ exports[`renders components/steps/demo/panel.tsx correctly 1`] = `
         </div>
       </div>
       <svg
+        aria-hidden="true"
         class="ant-steps-panel-arrow"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title>
-          Arrow
-        </title>
         <path
           d="M 0 0 L 100 50 L 0 100"
         />

--- a/components/steps/__tests__/index.test.tsx
+++ b/components/steps/__tests__/index.test.tsx
@@ -23,6 +23,22 @@ describe('Steps', () => {
     jest.useRealTimers();
   });
 
+  it('should hide decorative panel arrows from assistive technology', () => {
+    const { container } = render(
+      <Steps
+        type="panel"
+        items={[{ title: 'Account' }, { title: 'Verification' }, { title: 'Done' }]}
+      />,
+    );
+    const arrows = container.querySelectorAll('.ant-steps-panel-arrow');
+
+    expect(arrows).toHaveLength(3);
+    arrows.forEach((arrow) => {
+      expect(arrow).not.toHaveAccessibleName();
+      expect(arrow).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
   const description = 'This is a description.';
   it('should render correct', () => {
     const { container } = render(


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] ✅ Test Case
- [x] ⌨️ Accessibility improvement

### 🔗 Related Issues

No linked issue. I reproduced this directly on current `master` and found no open issue or PR targeting `components/steps/PanelArrow.tsx`.

### 💡 Background and Solution

Panel-style Steps renders a chevron SVG after each item as a purely visual separator. The SVG currently contains `<title>Arrow</title>`, which gives every separator the computed accessible name `Arrow`. This exposes repeated, non-interactive, English-only names to assistive technology even though the arrows convey no state or action.

This change marks each separator `aria-hidden` and removes its title. A regression test verifies that all rendered panel arrows remain present visually while exposing neither an accessible name nor accessibility-tree content.

Exact-base reproduction before the fix:

- three panel-arrow SVGs rendered for three items;
- each had the computed accessible name `Arrow`;
- the new assertion failed with `Received: Arrow`.

Verification after the fix:

- `npx jest components/steps --config .jest.js --runInBand --no-cache`: 7 suites, 83 tests, and 64 snapshots passed;
- focused Jest and Vitest regression runs passed;
- `npx vitest run components/steps/__tests__/index.test.tsx`: 9 tests passed;
- ESLint, Biome, Prettier, and `git diff --check` passed.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Hide decorative Steps panel arrows from assistive technology. |
| 🇨🇳 Chinese | 对辅助技术隐藏 Steps 面板中仅用于装饰的箭头。 |

AI assistance disclosure: Codex was used to trace the rendering path, audit duplicates, reproduce the accessible-name behavior, draft the focused regression, and run the verification listed above. The final diff and test results were reviewed locally before submission.
