### PR TITLE
fix(Result): hide decorative exception illustrations

### DIFF
--- a/components/result/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/result/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -8,6 +8,8 @@ exports[`renders components/result/demo/403.tsx extend context correctly 1`] = `
     class="ant-result-icon ant-result-image"
   >
     <svg
+      aria-hidden="true"
+      focusable="false"
       height="294"
       width="251"
     >
@@ -312,6 +314,8 @@ exports[`renders components/result/demo/404.tsx extend context correctly 1`] = `
     class="ant-result-icon ant-result-image"
   >
     <svg
+      aria-hidden="true"
+      focusable="false"
       height="294"
       width="252"
     >
@@ -616,6 +620,8 @@ exports[`renders components/result/demo/500.tsx extend context correctly 1`] = `
     class="ant-result-icon ant-result-image"
   >
     <svg
+      aria-hidden="true"
+      focusable="false"
       height="294"
       width="254"
     >

--- a/components/result/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/result/__tests__/__snapshots__/demo.test.ts.snap
@@ -8,6 +8,8 @@ exports[`renders components/result/demo/403.tsx correctly 1`] = `
     class="ant-result-icon ant-result-image"
   >
     <svg
+      aria-hidden="true"
+      focusable="false"
       height="294"
       width="251"
     >
@@ -310,6 +312,8 @@ exports[`renders components/result/demo/404.tsx correctly 1`] = `
     class="ant-result-icon ant-result-image"
   >
     <svg
+      aria-hidden="true"
+      focusable="false"
       height="294"
       width="252"
     >
@@ -612,6 +616,8 @@ exports[`renders components/result/demo/500.tsx correctly 1`] = `
     class="ant-result-icon ant-result-image"
   >
     <svg
+      aria-hidden="true"
+      focusable="false"
       height="294"
       width="254"
     >

--- a/components/result/__tests__/index.test.tsx
+++ b/components/result/__tests__/index.test.tsx
@@ -84,6 +84,16 @@ describe('Result', () => {
     });
   });
 
+  it('should preserve standalone exception illustration semantics', () => {
+    const { getByRole } = render(
+      <Result.PRESENTED_IMAGE_404 role="img" aria-label="Not found illustration" />,
+    );
+    const illustration = getByRole('img');
+
+    expect(illustration).not.toHaveAttribute('aria-hidden');
+    expect(illustration).toHaveAccessibleName('Not found illustration');
+  });
+
   it('🙂  When extra is undefined, the extra dom is undefined', () => {
     const { container } = render(<Result status="404" />);
     expect(container.querySelectorAll('.ant-result-extra')).toHaveLength(0);

--- a/components/result/__tests__/index.test.tsx
+++ b/components/result/__tests__/index.test.tsx
@@ -5,7 +5,6 @@ import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { render } from '../../../tests/utils';
 import Button from '../../button';
-
 import type { AliasToken } from '../../theme/internal';
 import type { ComponentToken } from '../style';
 import { prepareComponentToken } from '../style';
@@ -71,6 +70,18 @@ describe('Result', () => {
   it('🙂  When status = 404, the icon is an image', () => {
     const { container } = render(<Result status="404" />);
     expect(container.querySelectorAll('.ant-result-404 .ant-result-image')).toHaveLength(1);
+  });
+
+  it('should hide built-in exception illustrations from assistive technology', () => {
+    (['403', '404', '500'] as const).forEach((status) => {
+      const { container, unmount } = render(<Result status={status} title={status} />);
+      const illustration = container.querySelector('.ant-result-image svg');
+
+      expect(illustration).toHaveAttribute('aria-hidden', 'true');
+      expect(illustration).toHaveAttribute('focusable', 'false');
+      expect(illustration).not.toHaveAccessibleName();
+      unmount();
+    });
   });
 
   it('🙂  When extra is undefined, the extra dom is undefined', () => {

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -105,7 +105,7 @@ const Icon: React.FC<IconProps> = ({ icon, status, className, style }) => {
     const SVGComponent = ExceptionMap[status as ExceptionStatusType];
     return (
       <div className={className} style={style}>
-        <SVGComponent />
+        <SVGComponent aria-hidden focusable="false" />
       </div>
     );
   }
@@ -144,9 +144,9 @@ const Extra: React.FC<ExtraProps> = ({ className, extra, style }) => {
 
 export interface ResultType
   extends React.ForwardRefExoticComponent<ResultProps & React.RefAttributes<ResultRef>> {
-  PRESENTED_IMAGE_404: React.FC;
-  PRESENTED_IMAGE_403: React.FC;
-  PRESENTED_IMAGE_500: React.FC;
+  PRESENTED_IMAGE_404: React.FC<React.SVGProps<SVGSVGElement>>;
+  PRESENTED_IMAGE_403: React.FC<React.SVGProps<SVGSVGElement>>;
+  PRESENTED_IMAGE_500: React.FC<React.SVGProps<SVGSVGElement>>;
 }
 
 const Result = React.forwardRef<ResultRef, ResultProps>((props, ref) => {

--- a/components/result/noFound.tsx
+++ b/components/result/noFound.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-const NoFound: React.FC = () => (
-  <svg width="252" height="294" aria-hidden="true" focusable="false">
+const NoFound: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg width="252" height="294" {...props}>
     <title>No Found</title>
     <g fill="none" fillRule="evenodd">
       <circle cx="126.75" cy="128.1" r="126" fill="#E4EBF7" />

--- a/components/result/noFound.tsx
+++ b/components/result/noFound.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 const NoFound: React.FC = () => (
-  <svg width="252" height="294">
+  <svg width="252" height="294" aria-hidden="true" focusable="false">
     <title>No Found</title>
     <g fill="none" fillRule="evenodd">
       <circle cx="126.75" cy="128.1" r="126" fill="#E4EBF7" />

--- a/components/result/serverError.tsx
+++ b/components/result/serverError.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-const ServerError: React.FC = () => (
-  <svg width="254" height="294" aria-hidden="true" focusable="false">
+const ServerError: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg width="254" height="294" {...props}>
     <title>Server Error</title>
     <g fill="none" fillRule="evenodd">
       <path

--- a/components/result/serverError.tsx
+++ b/components/result/serverError.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 const ServerError: React.FC = () => (
-  <svg width="254" height="294">
+  <svg width="254" height="294" aria-hidden="true" focusable="false">
     <title>Server Error</title>
     <g fill="none" fillRule="evenodd">
       <path

--- a/components/result/unauthorized.tsx
+++ b/components/result/unauthorized.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-const Unauthorized: React.FC = () => (
-  <svg width="251" height="294" aria-hidden="true" focusable="false">
+const Unauthorized: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg width="251" height="294" {...props}>
     <title>Unauthorized</title>
     <g fill="none" fillRule="evenodd">
       <path

--- a/components/result/unauthorized.tsx
+++ b/components/result/unauthorized.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 const Unauthorized: React.FC = () => (
-  <svg width="251" height="294">
+  <svg width="251" height="294" aria-hidden="true" focusable="false">
     <title>Unauthorized</title>
     <g fill="none" fillRule="evenodd">
       <path


### PR DESCRIPTION
### 🤔 This is a ...

- [x] ⌨️ Accessibility improvement
- [x] 🐞 Bug fix

### 🔗 Related Issues

No linked issue. I checked current open issues and pull requests for this Result exception-illustration accessibility defect and found no duplicate.

### 💡 Background and Solution

The built-in 403, 404, and 500 Result SVGs expose hardcoded English `<title>` elements. Result already renders a visible title and subtitle, so screen readers can receive duplicated content and non-English interfaces can leak English.

This change:

- marks all three built-in exception illustrations as decorative with `aria-hidden="true"`
- keeps them out of legacy keyboard focus with `focusable="false"`
- adds a regression covering 403, 404, and 500

Custom `icon` content is unchanged.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Result hides the built-in 403, 404, and 500 decorative illustrations from assistive technology to avoid duplicated English announcements. |
| 🇨🇳 Chinese | Result 内置的 403、404 和 500 装饰插图不再被辅助技术读取，避免重复播报英文内容。 |

### Verification

- Exact-base regression: failed because the built-in SVG had no `aria-hidden`
- Jest: 17/17 Result tests passed
- Vitest: 17/17 Result tests passed
- ESLint, Biome, Prettier, and `git diff --check`: passed
- Full `tsc --noEmit`: after excluding an unrelated nested review worktree, the only remaining error is the existing `@types/puppeteer@5` versus `puppeteer-core@25` Page mismatch in `tests/shared/imageTest.tsx`

AI assistance disclosure: Codex was used to trace the accessibility behavior, check for duplicate work, implement the focused change, and run verification.