### PR TITLE
fix(Skeleton): hide decorative image placeholder

### DIFF
--- a/components/skeleton/Image.tsx
+++ b/components/skeleton/Image.tsx
@@ -17,6 +17,8 @@ const SkeletonImage: React.FC<SkeletonImageProps> = (props) => {
         viewBox="0 0 1098 1024"
         xmlns="http://www.w3.org/2000/svg"
         className={`${prefixCls}-image-svg`}
+        aria-hidden="true"
+        focusable="false"
       >
         <title>Image placeholder</title>
         <path

--- a/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -212,7 +212,9 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
           class="ant-skeleton-image"
         >
           <svg
+            aria-hidden="true"
             class="ant-skeleton-image-svg"
+            focusable="false"
             viewBox="0 0 1098 1024"
             xmlns="http://www.w3.org/2000/svg"
           >

--- a/components/skeleton/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo.test.tsx.snap
@@ -202,7 +202,9 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
           class="ant-skeleton-image"
         >
           <svg
+            aria-hidden="true"
             class="ant-skeleton-image-svg"
+            focusable="false"
             viewBox="0 0 1098 1024"
             xmlns="http://www.w3.org/2000/svg"
           >

--- a/components/skeleton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/skeleton/__tests__/__snapshots__/index.test.tsx.snap
@@ -352,7 +352,9 @@ exports[`Skeleton image element should render normal 1`] = `
     class="ant-skeleton-image"
   >
     <svg
+      aria-hidden="true"
       class="ant-skeleton-image-svg"
+      focusable="false"
       viewBox="0 0 1098 1024"
       xmlns="http://www.w3.org/2000/svg"
     >

--- a/components/skeleton/__tests__/__snapshots__/vitest/index.test.tsx.snap
+++ b/components/skeleton/__tests__/__snapshots__/vitest/index.test.tsx.snap
@@ -352,7 +352,9 @@ exports[`Skeleton > image element > should render normal 1`] = `
     class="ant-skeleton-image"
   >
     <svg
+      aria-hidden="true"
       class="ant-skeleton-image-svg"
+      focusable="false"
       viewBox="0 0 1098 1024"
       xmlns="http://www.w3.org/2000/svg"
     >

--- a/components/skeleton/__tests__/index.test.tsx
+++ b/components/skeleton/__tests__/index.test.tsx
@@ -232,6 +232,15 @@ describe('Skeleton', () => {
       const { asFragment } = genSkeletonImage({});
       expect(asFragment().firstChild).toMatchSnapshot();
     });
+
+    it('should hide the placeholder illustration from assistive technology', () => {
+      const { container } = genSkeletonImage({});
+      const illustration = container.querySelector('.ant-skeleton-image-svg');
+
+      expect(illustration).toHaveAttribute('aria-hidden', 'true');
+      expect(illustration).toHaveAttribute('focusable', 'false');
+      expect(illustration).not.toHaveAccessibleName();
+    });
   });
 
   describe('custom node element', () => {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] ⌨️ Accessibility improvement
- [x] 🐞 Bug fix

### 🔗 Related Issues

No linked issue. I checked current issues, pull requests, and open changed files for this Skeleton.Image placeholder accessibility defect and found no duplicate.

### 💡 Background and Solution

`Skeleton.Image` is a visual loading placeholder, but its built-in SVG exposes the hardcoded English accessible name `Image placeholder`. That announcement neither identifies loaded content nor reports loading state, and it leaks English into non-English interfaces.

This change marks only the built-in placeholder SVG as decorative with `aria-hidden="true"` and keeps it out of legacy keyboard focus with `focusable="false"`. `Skeleton.Node` and caller-provided content are unchanged.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Skeleton.Image no longer exposes its decorative placeholder graphic to assistive technology. |
| 🇨🇳 Chinese | Skeleton.Image 不再向辅助技术暴露装饰性的占位图形。 |

### Verification

- Exact-base regression: failed because the placeholder SVG had no `aria-hidden`
- Jest: 32/32 assertions and 38/38 Skeleton snapshots passed; the local Jest process separately reports repository-wide Vitest snapshot files as obsolete
- Vitest: 32/32 Skeleton tests passed
- ESLint, Biome, and `git diff --check`: passed
- Full TypeScript remains blocked by the existing `@types/puppeteer@5` versus `puppeteer-core@25` Page mismatch in `tests/shared/imageTest.tsx`

AI assistance disclosure: Codex was used to audit the built-in SVG semantics, check for duplicate work, implement the focused change, and run verification.