### PR TITLE
fix(Checkbox): allow group to override global disabled state

### DIFF
--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -123,7 +123,7 @@ const InternalCheckbox: React.ForwardRefRenderFunction<CheckboxRef, CheckboxProp
   const checkboxGroup = React.useContext(GroupContext);
   const { isFormItemInput } = React.useContext(FormItemInputContext);
   const contextDisabled = React.useContext(DisabledContext);
-  const mergedDisabled = (checkboxGroup?.disabled || disabled) ?? contextDisabled;
+  const mergedDisabled = disabled ?? checkboxGroup?.disabled ?? contextDisabled;
 
   // ============================= Warning ==============================
   if (process.env.NODE_ENV !== 'production') {

--- a/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -783,14 +783,13 @@ Array [
       </span>
     </label>
     <label
-      class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-checkbox-group-item label-3 css-var-test-id ant-checkbox-css-var"
+      class="ant-checkbox-wrapper ant-checkbox-group-item label-3 css-var-test-id ant-checkbox-css-var"
     >
       <span
-        class="ant-checkbox ant-wave-target ant-checkbox-disabled"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
-          disabled=""
           type="checkbox"
           value="Orange"
         />

--- a/components/checkbox/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.tsx.snap
@@ -738,14 +738,13 @@ Array [
       </span>
     </label>
     <label
-      class="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-checkbox-group-item label-3 css-var-test-id ant-checkbox-css-var"
+      class="ant-checkbox-wrapper ant-checkbox-group-item label-3 css-var-test-id ant-checkbox-css-var"
     >
       <span
-        class="ant-checkbox ant-wave-target ant-checkbox-disabled"
+        class="ant-checkbox ant-wave-target"
       >
         <input
           class="ant-checkbox-input"
-          disabled=""
           type="checkbox"
           value="Orange"
         />

--- a/components/checkbox/__tests__/group.test.tsx
+++ b/components/checkbox/__tests__/group.test.tsx
@@ -6,6 +6,7 @@ import mountTest from '../../../tests/shared/mountTest';
 import rtlTest from '../../../tests/shared/rtlTest';
 import { fireEvent, render } from '../../../tests/utils';
 import Collapse from '../../collapse';
+import ConfigProvider from '../../config-provider';
 import Input from '../../input';
 import Table from '../../table';
 
@@ -58,6 +59,18 @@ describe('CheckboxGroup', () => {
     expect(onChangeGroup).toHaveBeenCalledWith(['Apple']);
     fireEvent.click(container.querySelectorAll('.ant-checkbox-input')[1]);
     expect(onChangeGroup).toHaveBeenCalledWith(['Apple']);
+  });
+
+  it('should override context disabled status when CheckboxGroup is enabled', () => {
+    const { getByRole } = render(
+      <ConfigProvider componentDisabled>
+        <Checkbox.Group disabled={false}>
+          <Checkbox value="Apple" />
+        </Checkbox.Group>
+      </ConfigProvider>,
+    );
+
+    expect(getByRole('checkbox')).not.toBeDisabled();
   });
 
   it('all children should have a name property', () => {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #59108

### 💡 需求背景和解决方案

在 `ConfigProvider componentDisabled` 下，`Checkbox.Group disabled={false}` 无法在 JSX 子节点场景中覆盖全局禁用状态。

本次调整 Checkbox 的禁用状态合并顺序，使组件自身配置、Group 配置和全局配置的优先级与 Radio 保持一致，并增加对应的回归测试。不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Checkbox.Group `disabled={false}` not overriding the global disabled state for JSX children. |
| 🇨🇳 中文 | 🐞 修复 Checkbox.Group `disabled={false}` 在 JSX 子节点场景下无法覆盖全局禁用状态的问题。 |