### PR TITLE
fix(Typography): avoid nested edit button semantics

### DIFF
--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -462,7 +462,7 @@ const Base = React.forwardRef<HTMLElement, BlockProps>((props, ref) => {
           aria-label={ariaLabel}
           tabIndex={tabIndex}
         >
-          {icon || <EditOutlined role="button" />}
+          {icon || <EditOutlined />}
         </button>
       </Tooltip>
     ) : null;

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -848,7 +848,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -904,7 +904,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -1078,7 +1078,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -1243,7 +1243,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -1296,7 +1296,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -1352,7 +1352,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -1408,7 +1408,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -1464,7 +1464,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -1520,7 +1520,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -1576,7 +1576,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"

--- a/components/typography/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`renders components/typography/demo/_semantic.tsx correctly 1`] = `
               <span
                 aria-label="edit"
                 class="anticon anticon-edit"
-                role="button"
+                role="img"
               >
                 <svg
                   aria-hidden="true"

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -698,7 +698,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -734,7 +734,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -868,7 +868,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -970,7 +970,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -1004,7 +1004,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -1039,7 +1039,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -1074,7 +1074,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -1109,7 +1109,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -1144,7 +1144,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"
@@ -1179,7 +1179,7 @@ Array [
         <span
           aria-label="edit"
           class="anticon anticon-edit"
-          role="button"
+          role="img"
         >
           <svg
             aria-hidden="true"

--- a/components/typography/__tests__/editable.test.tsx
+++ b/components/typography/__tests__/editable.test.tsx
@@ -91,6 +91,16 @@ describe('Typography.Editable', () => {
     expect(container.querySelector('.ant-typography-edit')).toBeTruthy();
   });
 
+  it('does not expose the default edit icon as a second button', () => {
+    const { getAllByRole } = render(
+      <Base component="p" editable>
+        test
+      </Base>,
+    );
+
+    expect(getAllByRole('button')).toHaveLength(1);
+  });
+
   it('tabIndex of edit button', () => {
     const { container, rerender } = render(<Base component="p">test</Base>);
     expect(container.querySelector('.ant-typography-edit')).toBeFalsy();


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] ⌨️ Accessibility improvement
- [x] ✅ Test Case

### 🔗 Related Issues

No existing issue or open PR was found for this exact Typography behavior.

### 💡 Background and Solution

Editable Typography already renders its edit action as a native `<button>` with a localized `aria-label`, but the default `EditOutlined` child was also forced to `role="button"`. Accessibility queries therefore exposed one visual edit action as two nested buttons.

This removes the redundant role from the default icon so it returns to its normal image semantics while the parent remains the only interactive control. A regression test renders the default editable Typography and requires exactly one accessible button.

Before the fix, the new assertion received two button roles. After the fix:

- complete Typography Jest scope: 10 suites, 163 tests
- 47 snapshots
- focused ESLint and Biome lint
- snapshot formatting and `git diff --check`

I also audited every currently open Ant Design PR changed-file list and found no overlap with the two source/test files.

AI assistance disclosure: Codex was used to trace the rendered roles, write and run the failing regression, audit open-PR file overlap, and draft this description. I verified the failure, fix, exact head, and validation results locally.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Typography's default edit icon exposing a duplicate nested button role. |
| 🇨🇳 Chinese | 修复 Typography 默认编辑图标暴露重复嵌套按钮语义的问题。 |
