### PR TITLE
fix(List): preserve numeric zero row keys

### DIFF
--- a/components/list/__tests__/Item.test.tsx
+++ b/components/list/__tests__/Item.test.tsx
@@ -232,6 +232,36 @@ describe('List Item Layout', () => {
     expect(loadId).toEqual([1, 3, 5]);
   });
 
+  it('should preserve an item with numeric zero rowKey when data is reordered', () => {
+    const mountedIds: number[] = [];
+
+    const Demo = ({ id }: { id: number }) => {
+      useEffect(() => {
+        mountedIds.push(id);
+      }, []);
+
+      return <div>{id}</div>;
+    };
+
+    const getDom = (dataSource: Array<{ id: number }>) => (
+      <List
+        dataSource={dataSource}
+        rowKey={(item) => item.id}
+        renderItem={(item) => (
+          <List.Item>
+            <Demo id={item.id} />
+          </List.Item>
+        )}
+      />
+    );
+
+    const { rerender } = pureRender(getDom([{ id: 0 }, { id: 1 }]));
+    expect(mountedIds).toEqual([0, 1]);
+
+    rerender(getDom([{ id: 1 }, { id: 0 }]));
+    expect(mountedIds).toEqual([0, 1]);
+  });
+
   it('List.Item.Meta title should have no default margin', () => {
     render(
       <List

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -153,9 +153,7 @@ const InternalList = <T,>(props: ListProps<T>, ref: React.ForwardedRef<HTMLDivEl
       key = (item as any).key;
     }
 
-    if (!key) {
-      key = `list-item-${index}`;
-    }
+    key ??= `list-item-${index}`;
 
     return <React.Fragment key={key}>{renderItem(item, index)}</React.Fragment>;
   };


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

No linked issue. I searched the current open issues and PRs for List row-key handling before submitting. PR #58604 also touches `components/list/index.tsx`, but only changes the pagination callback path and does not overlap this fix.

### 💡 Background and Solution

`List` currently treats every falsy resolved row key as missing. Therefore a valid numeric `0` returned by `rowKey` is replaced with the index-based fallback. When the data order changes, that item receives a different key and React remounts it, which can discard local state or focus.

Use nullish assignment so only `null` and `undefined` receive the fallback. The regression test renders rows keyed `0` and `1`, reverses them, and verifies neither child remounts.

Verification:

- On the exact base, the regression test fails with mount history `[0, 1, 0]`.
- With this change, the focused test file passes: 15 tests and 4 snapshots.
- The complete List test scope passes: 15 suites, 110 tests, and 68 snapshots (10 tests skipped).
- ESLint, Biome, and `git diff --check` pass for the changed files.

AI assistance disclosure: Codex was used to trace the key resolution path, audit open overlap, run the regression checks, and draft this report. The failure and fix were directly verified locally.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix List remounting items whose `rowKey` resolves to numeric zero. |
| 🇨🇳 Chinese | 修复 List 将数值零 `rowKey` 视为缺失而导致项目重新挂载的问题。 |
