### PR TITLE
feat(Input.Search): support enter button props

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -4,7 +4,13 @@ import { composeRef, omit, pickAttrs } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import fallbackProp from '../_util/fallbackProp';
-import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
+import {
+  mergeClassNames,
+  mergeStyles,
+  resolveStyleOrClass,
+  useMergeSemantic,
+  useSemanticRootStyle,
+} from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { cloneElement } from '../_util/reactNode';
 import Button from '../button/Button';
@@ -219,13 +225,13 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
       loading: enterButtonLoading,
       onClick: enterButtonOnClick,
       onMouseDown: enterButtonOnMouseDown,
+      classNames: enterButtonClassNames,
+      styles: enterButtonStyles,
       ...restEnterButtonProps
     } = customizeEnterButtonProps || {};
 
     button = (
       <Button
-        classNames={mergedClassNames.button}
-        styles={mergedStyles.button}
         className={clsx(btnClassName, enterButtonClassName)}
         color={enterButton ? 'primary' : 'default'}
         size={size}
@@ -249,6 +255,16 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
               : undefined
         }
         {...restEnterButtonProps}
+        classNames={(info) =>
+          mergeClassNames(
+            {},
+            mergedClassNames.button,
+            resolveStyleOrClass(enterButtonClassNames, info),
+          )
+        }
+        styles={(info) =>
+          mergeStyles(mergedStyles.button, resolveStyleOrClass(enterButtonStyles, info))
+        }
       >
         {enterButton}
       </Button>

--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -55,6 +55,7 @@ export interface SearchProps extends InputProps {
   ) => void;
   searchIcon?: React.ReactNode;
   enterButton?: React.ReactNode;
+  enterButtonProps?: ButtonProps;
   loading?: boolean;
   onPressEnter?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   classNames?: InputSearchSemanticAllType['classNamesAndFn'];
@@ -69,6 +70,7 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
     size: customizeSize,
     style,
     enterButton = false,
+    enterButtonProps: customizeEnterButtonProps,
     searchIcon: customizeSearchIcon,
     addonAfter,
     loading,
@@ -211,18 +213,33 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
         : {}),
     });
   } else {
+    const {
+      className: enterButtonClassName,
+      disabled: enterButtonDisabled,
+      loading: enterButtonLoading,
+      onClick: enterButtonOnClick,
+      onMouseDown: enterButtonOnMouseDown,
+      ...restEnterButtonProps
+    } = customizeEnterButtonProps || {};
+
     button = (
       <Button
         classNames={mergedClassNames.button}
         styles={mergedStyles.button}
-        className={btnClassName}
+        className={clsx(btnClassName, enterButtonClassName)}
         color={enterButton ? 'primary' : 'default'}
         size={size}
-        disabled={disabled}
+        disabled={mergedDisabled || enterButtonDisabled}
         key="enterButton"
-        onMouseDown={onMouseDown}
-        onClick={onSearch}
-        loading={loading}
+        onMouseDown={(e) => {
+          onMouseDown(e);
+          enterButtonOnMouseDown?.(e);
+        }}
+        onClick={(e) => {
+          enterButtonOnClick?.(e);
+          onSearch(e);
+        }}
+        loading={loading || enterButtonLoading}
         icon={searchIcon}
         variant={
           variant === 'borderless' || variant === 'filled' || variant === 'underlined'
@@ -231,6 +248,7 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
               ? 'solid'
               : undefined
         }
+        {...restEnterButtonProps}
       >
         {enterButton}
       </Button>

--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -65,6 +65,29 @@ describe('Input.Search', () => {
     expect(onSearch).toHaveBeenCalledWith('search text', expect.anything(), { source: 'input' });
   });
 
+  it('should merge Search and enter button semantic styles', () => {
+    const { getByRole } = render(
+      <Search
+        enterButton
+        classNames={{ button: { root: 'search-button' } }}
+        styles={{ button: { root: { backgroundColor: 'red', color: 'blue' } } }}
+        enterButtonProps={{
+          classNames: ({ props }) => ({
+            root: props.color === 'primary' ? 'custom-button' : 'wrong-button',
+          }),
+          styles: ({ props }) => ({
+            root: { color: props.color === 'primary' ? 'green' : 'black' },
+          }),
+        }}
+      />,
+    );
+
+    const button = getByRole('button');
+    expect(button).toHaveClass('search-button', 'custom-button');
+    expect(button.style.backgroundColor).toBe('red');
+    expect(button.style.color).toBe('green');
+  });
+
   it('should support ReactNode suffix without error', () => {
     const { asFragment } = render(<Search suffix={<div>ok</div>} />);
     expect(asFragment().firstChild).toMatchSnapshot();

--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -41,6 +41,30 @@ describe('Input.Search', () => {
     }).not.toThrow();
   });
 
+  it('should support props for the generated enter button', () => {
+    const onButtonClick = jest.fn();
+    const onSearch = jest.fn();
+    const { getByRole } = render(
+      <Search
+        defaultValue="search text"
+        enterButton
+        enterButtonProps={{
+          'aria-label': 'Submit search',
+          className: 'custom-search-button',
+          onClick: onButtonClick,
+        }}
+        onSearch={onSearch}
+      />,
+    );
+
+    const button = getByRole('button', { name: 'Submit search' });
+    expect(button).toHaveClass('ant-input-search-btn', 'custom-search-button');
+
+    fireEvent.click(button);
+    expect(onButtonClick).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledWith('search text', expect.anything(), { source: 'input' });
+  });
+
   it('should support ReactNode suffix without error', () => {
     const { asFragment } = render(<Search suffix={<div>ok</div>} />);
     expect(asFragment().firstChild).toMatchSnapshot();

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -113,6 +113,7 @@ The rest of the props of `Input.TextArea` are the same as the original [textarea
 | --- | --- | --- | --- | --- | --- |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-search), string> \| (info: { props }) => Record<[SemanticDOM](#semantic-search), string> | - | 6.0.0 | 6.0.0 |
 | enterButton | false displays the default button color, true uses the primary color, or you can provide a custom button. Conflicts with addonAfter. | ReactNode | false |  | × |
+| enterButtonProps | Props for the generated search button. Configure a custom `enterButton` element directly. | [ButtonProps](/components/button#api) | - | 6.7.0 | × |
 | loading | Search box with loading | boolean | false |  | × |
 | onSearch | The callback function triggered when you click on the search-icon, the clear-icon or press the Enter key | function(value, event, { source: "input" \| "clear" }) | - |  | × |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-search), CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-search), CSSProperties> | - | 6.0.0 | 6.0.0 |

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -114,6 +114,7 @@ interface CountConfig {
 | --- | --- | --- | --- | --- | --- |
 | classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-search), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-search), string> | - | 6.0.0 | 6.0.0 |
 | enterButton | 是否有确认按钮，可设为按钮文字。该属性会与 `addonAfter` 冲突。 | ReactNode | false |  | × |
+| enterButtonProps | 自动生成的搜索按钮属性；自定义 `enterButton` 元素时请直接配置该元素。 | [ButtonProps](/components/button-cn#api) | - | 6.7.0 | × |
 | loading | 搜索 loading | boolean | false |  | × |
 | onSearch | 点击搜索图标、清除图标，或按下回车键时的回调 | function(value, event, { source: "input" \| "clear" }) | - |  | × |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-search) , CSSProperties> \| (info: { props }) => Record<[SemanticDOM](#semantic-search) , CSSProperties> | - | 6.0.0 | 6.0.0 |


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [x] 📝 Site / documentation improvement
- [x] 🤖 TypeScript definition improvement
- [x] ✅ Test Case
- [x] ⌨️ Accessibility improvement

### 🔗 Related Issues

Fixes #57175. Adapts the `enterButtonProps` API proposed in #57198 by @Arktomson; credit for the API direction belongs to that earlier work. That PR remains open, so maintainers should merge only one implementation.

### 💡 Background and Solution

Input.Search forwards input ARIA attributes to its searchbox, but its generated search button has no dedicated configuration path. Add `enterButtonProps?: ButtonProps` so applications can name or configure the generated button without replacing it.

The implementation composes class names, mouse/click handlers and function-capable semantic styles with Search behavior; preserves Search-level disabled/loading state while honoring button-level requests; and keeps custom `enterButton` elements configured directly. English and Chinese API tables document that scope.

This adaptation uses the current semantic contracts and includes coverage for icon-only, primary and text buttons, separate searchbox/button accessible names, focus preservation, disabled/loading precedence, custom-element isolation and semantic-style merging.

### Verification

Signed/GitHub-Verified head `9585bad58ecea2711a50a6d3c790be9d6d9be868` follows maintainer-updated head `4ced968cabd68a4fd23cb9432fc0b0f3f950cb18`. This follow-up changes only the custom-button isolation test, covering both Ant Design `Button` and native `<button>`. Production code is byte-identical to the preceding head.

- Complete Input scope (`components/input/`): 12 suites / 295 tests / 127 snapshots pass, with 2 skipped tests. This includes all 53 Search tests.
- Both custom-button cases preserve the custom accessible name and handler, ignore generated-button props, and invoke `onSearch` exactly once.
- Injecting generated props into only the native custom-button path makes the new native case fail while the Ant Design Button control passes; restoring the implementation passes both cases.
- Full repository `tsc --noEmit` passes after the standard fresh-checkout setup (`generate-version` and `dumi setup`). Focused ESLint, Biome, Prettier and diff checks pass.
- Earlier head `256c862` passed all 17 remote test-workflow jobs; its visual report used a stale fallback baseline and differed only in three Table images. Those results are historical. CI for this new head is pending verification, and visual approval is not claimed.
- Final PR diff remains four Input files; this follow-up adds no runtime, dependency, lockfile or workflow changes.

AI assistance: Codex helped address the native-button coverage request and verify the positive and mutation-control results.

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Input.Search supports configuring its generated search button through `enterButtonProps`. |
| 🇨🇳 Chinese | Input.Search 支持通过 `enterButtonProps` 配置自动生成的搜索按钮。 |
