### PR TITLE
fix(Card, Tag, Breadcrumb, Segmented, FloatButton): render numeric zero for content nodes

### DIFF
--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { clsx } from 'clsx';
 
-import { isNonNullable } from '../_util/is';
+import { isNonNullable, isReactRenderable } from '../_util/is';
 import { ConfigContext } from '../config-provider';
 import type { DropdownProps } from '../dropdown/dropdown';
 import Dropdown from '../dropdown/dropdown';
@@ -94,7 +94,7 @@ export const InternalBreadcrumbItem: React.FC<BreadcrumbItemProps> = (props) => 
         >
           {link}
         </li>
-        {separator && <BreadcrumbSeparator>{separator}</BreadcrumbSeparator>}
+        {isReactRenderable(separator) && <BreadcrumbSeparator>{separator}</BreadcrumbSeparator>}
       </>
     );
   }

--- a/components/breadcrumb/BreadcrumbSeparator.tsx
+++ b/components/breadcrumb/BreadcrumbSeparator.tsx
@@ -21,7 +21,7 @@ const BreadcrumbSeparator: CompoundedComponent = ({ children }) => {
       style={mergedStyles?.separator}
       aria-hidden="true"
     >
-      {children === '' ? children : children || '/'}
+      {children === '' ? children : children ?? '/'}
     </li>
   );
 };

--- a/components/breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/components/breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -452,4 +452,11 @@ describe('Breadcrumb', () => {
     );
     getByText('666');
   });
+
+  it('supports numeric 0 separator', () => {
+    const { container } = render(
+      <Breadcrumb separator={0} items={[{ title: 'foo' }, { title: 'bar' }]} />,
+    );
+    expect(container.querySelector('.ant-breadcrumb-separator')?.textContent).toBe('0');
+  });
 });

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -5,6 +5,7 @@ import { clsx } from 'clsx';
 
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
+import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import useSize from '../config-provider/hooks/useSize';
@@ -223,7 +224,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
       items={tabList.map(({ tab, ...item }) => ({ label: tab, ...item }))}
     />
   ) : null;
-  if (title || extra || tabs) {
+  if (isReactRenderable(title) || isReactRenderable(extra) || tabs) {
     const headClasses = clsx(`${prefixCls}-head`, mergedClassNames.header);
     const titleClasses = clsx(`${prefixCls}-head-title`, mergedClassNames.title);
     const extraClasses = clsx(`${prefixCls}-extra`, mergedClassNames.extra);
@@ -234,12 +235,12 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
     head = (
       <div className={headClasses} style={mergedHeadStyle}>
         <div className={`${prefixCls}-head-wrapper`}>
-          {title && (
+          {isReactRenderable(title) && (
             <div className={titleClasses} style={mergedStyles.title}>
               {title}
             </div>
           )}
-          {extra && (
+          {isReactRenderable(extra) && (
             <div className={extraClasses} style={mergedStyles.extra}>
               {extra}
             </div>
@@ -250,7 +251,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
     );
   }
   const coverClasses = clsx(`${prefixCls}-cover`, mergedClassNames.cover);
-  const coverDom = cover ? (
+  const coverDom = isReactRenderable(cover) ? (
     <div className={coverClasses} style={mergedStyles.cover}>
       {cover}
     </div>

--- a/components/card/CardMeta.tsx
+++ b/components/card/CardMeta.tsx
@@ -3,6 +3,7 @@ import { clsx } from 'clsx';
 
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
+import { isReactRenderable } from '../_util/is';
 import { useComponentConfig } from '../config-provider/context';
 
 export type CardMetaSemanticType = {
@@ -88,19 +89,19 @@ const CardMeta = React.forwardRef<CardMetaRef, CardMetaProps>((props, ref) => {
 
   const sectionClassNames = clsx(`${metaPrefixCls}-section`, mergedClassNames.section);
 
-  const avatarDom: React.ReactNode = avatar ? (
+  const avatarDom: React.ReactNode = isReactRenderable(avatar) ? (
     <div className={avatarClassNames} style={mergedStyles.avatar}>
       {avatar}
     </div>
   ) : null;
 
-  const titleDom: React.ReactNode = title ? (
+  const titleDom: React.ReactNode = isReactRenderable(title) ? (
     <div className={titleClassNames} style={mergedStyles.title}>
       {title}
     </div>
   ) : null;
 
-  const descriptionDom: React.ReactNode = description ? (
+  const descriptionDom: React.ReactNode = isReactRenderable(description) ? (
     <div className={descriptionClassNames} style={mergedStyles.description}>
       {description}
     </div>

--- a/components/card/__tests__/index.test.tsx
+++ b/components/card/__tests__/index.test.tsx
@@ -360,4 +360,19 @@ describe('Card', () => {
 
     expect(container).toMatchSnapshot();
   });
+
+  it('should render numeric 0 for title, extra, and Card.Meta', () => {
+    const { container } = render(
+      <Card title={0} extra={0} cover={0}>
+        <Card.Meta avatar={0} title={0} description={0} />
+      </Card>,
+    );
+
+    expect(container.querySelector('.ant-card-head-title')?.textContent).toBe('0');
+    expect(container.querySelector('.ant-card-extra')?.textContent).toBe('0');
+    expect(container.querySelector('.ant-card-cover')?.textContent).toBe('0');
+    expect(container.querySelector('.ant-card-meta-avatar')?.textContent).toBe('0');
+    expect(container.querySelector('.ant-card-meta-title')?.textContent).toBe('0');
+    expect(container.querySelector('.ant-card-meta-description')?.textContent).toBe('0');
+  });
 });

--- a/components/float-button/FloatButton.tsx
+++ b/components/float-button/FloatButton.tsx
@@ -7,6 +7,7 @@ import convertToTooltipProps from '../_util/convertToTooltipProps';
 import { useZIndex } from '../_util/hooks';
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
+import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import Badge from '../badge';
 import type { BadgeProps } from '../badge';
@@ -133,7 +134,7 @@ const InternalFloatButton = React.forwardRef<FloatButtonElement, FloatButtonProp
   );
 
   // ============================= Icon =============================
-  const mergedIcon = !mergedContent && !icon ? <FileTextOutlined /> : icon;
+  const mergedIcon = !isReactRenderable(mergedContent) && !icon ? <FileTextOutlined /> : icon;
 
   // ============================ zIndex ============================
 
@@ -162,7 +163,7 @@ const InternalFloatButton = React.forwardRef<FloatButtonElement, FloatButtonProp
     const warning = devUseWarning('FloatButton');
 
     warning(
-      !(mergedShape === 'circle' && mergedContent),
+      !(mergedShape === 'circle' && isReactRenderable(mergedContent)),
       'usage',
       'supported only when `shape` is `square`. Due to narrow space for text, short sentence is recommended.',
     );
@@ -188,7 +189,7 @@ const InternalFloatButton = React.forwardRef<FloatButtonElement, FloatButtonProp
         {
           [`${prefixCls}-rtl`]: direction === 'rtl',
           [`${prefixCls}-individual`]: mergedIndividual,
-          [`${prefixCls}-icon-only`]: !mergedContent,
+          [`${prefixCls}-icon-only`]: !isReactRenderable(mergedContent),
         },
       )}
       classNames={mergedClassNames}

--- a/components/float-button/__tests__/index.test.tsx
+++ b/components/float-button/__tests__/index.test.tsx
@@ -129,4 +129,10 @@ describe('FloatButton', () => {
     const element = container?.querySelector<HTMLButtonElement>('.ant-float-btn');
     expect(element?.type).toBe(type);
   });
+
+  it('should render numeric 0 content without fallback icon', () => {
+    const { container } = render(<FloatButton content={0} shape="square" />);
+    expect(container.querySelector('.ant-float-btn-icon-only')).toBeFalsy();
+    expect(container.querySelector('.ant-float-btn')?.textContent).toContain('0');
+  });
 });

--- a/components/segmented/__tests__/index.test.tsx
+++ b/components/segmented/__tests__/index.test.tsx
@@ -387,5 +387,19 @@ describe('Segmented', () => {
         expect(tooltipInnerList[1]?.textContent).toBe('hello Monthly');
       });
     });
+
+    it('should render numeric 0 label when icon is configured', () => {
+      const { container } = render(
+        <Segmented
+          options={[
+            { icon: <AppstoreOutlined />, label: 0, value: 'zero' },
+            { icon: <BarsOutlined />, label: 'bars', value: 'bars' },
+          ]}
+        />,
+      );
+      const firstItem = container.querySelector('.ant-segmented-item-label');
+      expect(firstItem?.textContent).toContain('0');
+      expect(firstItem?.lastElementChild?.textContent).toBe('0');
+    });
   });
 });

--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -13,7 +13,7 @@ import { useOrientation } from '../_util/hooks';
 import type { Orientation } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isPlainObject } from '../_util/is';
+import { isPlainObject, isReactRenderable } from '../_util/is';
 import { useComponentConfig } from '../config-provider/context';
 import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';
@@ -153,7 +153,7 @@ const InternalSegmented = React.forwardRef<HTMLDivElement, SegmentedProps>((prop
                 >
                   {icon}
                 </span>
-                {label && <span>{label}</span>}
+                {isReactRenderable(label) && <span>{label}</span>}
               </>
             ),
           };

--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -191,6 +191,12 @@ describe('Tag', () => {
       expect(onClose).not.toHaveBeenCalled();
       expect(onClick).not.toHaveBeenCalled();
     });
+
+    it('should render numeric 0 inside content span when icon is present', () => {
+      const { container } = render(<Tag icon={<span className="my-icon" />}>{0}</Tag>);
+      expect(container.querySelector('.ant-tag')?.textContent).toContain('0');
+      expect(container.querySelector('.ant-tag > span:not(.my-icon)')?.textContent).toBe('0');
+    });
   });
 
   describe('CheckableTag', () => {

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -7,7 +7,7 @@ import { pickClosable, useClosable } from '../_util/hooks';
 import type { ClosableType } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isFunction } from '../_util/is';
+import { isFunction, isReactRenderable } from '../_util/is';
 import { cloneElement, replaceElement } from '../_util/reactNode';
 import type { LiteralUnion } from '../_util/type';
 import { devUseWarning } from '../_util/warning';
@@ -249,7 +249,7 @@ const InternalTag = React.forwardRef<HTMLSpanElement | HTMLAnchorElement, TagPro
     const child: React.ReactNode = iconNode ? (
       <>
         {iconNode}
-        {children && (
+        {isReactRenderable(children) && (
           <span className={mergedClassNames.content} style={mergedStyles.content}>
             {children}
           </span>


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [ ] 🆕 New feature
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other

### 🔗 Related Issues

<!-- Related to previous merged fix in #59094 -->

### 💡 Background and Solution

- **Problem**: When passing numeric `0` to renderable props across several components, JavaScript truthy checks (`!!val` or `val ? ... : null` / `{val && ...}`) evaluated `0` as falsy, causing content to be hidden, stripped of semantic container styles, or overridden by default string fallbacks.
- **Solution**: Replaced truthy conditions with `isReactRenderable` across:
  1. **`Card` & `Card.Meta`**: Ensure numeric `0` in `title`, `extra`, `cover`, and `Card.Meta` (`avatar`, `title`, `description`) renders properly without collapsing the headers.
  2. **`Tag`**: Ensure numeric `0` inside a Tag with an icon is properly styled inside the content wrapper.
  3. **`Breadcrumb`**: Ensure `separator={0}` renders numeric `0` without falling back to `'/'`.
  4. **`Segmented`**: Ensure numeric `0` in option labels with icons is properly rendered in the label span.
  5. **`FloatButton`**: Ensure `content={0}` does not falsely trigger icon-only mode or inject fallback icons.
- Added comprehensive unit test cases for all 5 components (143/143 tests passing).

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix `Card`, `Tag`, `Breadcrumb`, `Segmented`, and `FloatButton` not rendering or displaying fallback icons when passing numeric `0` to content nodes. |
| 🇨🇳 Chinese | 🐞 修复 `Card`、`Tag`、`Breadcrumb`、`Segmented` 与 `FloatButton` 组件在内容属性传入数字 `0` 时无法正常渲染或显示错误图标的问题。 |
