### PR TITLE
fix(Transfer): disable select all for disabled search results

### DIFF
--- a/components/transfer/Section.tsx
+++ b/components/transfer/Section.tsx
@@ -304,7 +304,7 @@ const TransferSection = <RecordType extends KeyWiseTransferItem>(
 
   const checkBox = (
     <Checkbox
-      disabled={!dataSource.some((d) => !d.disabled) || disabled}
+      disabled={!filteredItems.some((d) => !d.disabled) || disabled}
       checked={checkStatus === 'all'}
       indeterminate={checkStatus === 'part'}
       className={`${listPrefixCls}-checkbox`}

--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -466,6 +466,29 @@ describe('Transfer', () => {
     expect(handleSelectChange).toHaveBeenCalledWith(['1'], []);
   });
 
+  it('should disable check all when filtered items are all disabled', () => {
+    const { container } = render(
+      <Transfer
+        dataSource={[
+          { key: 'enabled', title: 'Enabled item' },
+          { key: 'disabled', title: 'Only disabled item', disabled: true },
+        ]}
+        showSearch
+        render={(item) => item.title}
+      />,
+    );
+
+    const sourceSection = container.querySelectorAll('.ant-transfer-section').item(0);
+
+    fireEvent.change(sourceSection.querySelector('input[type="text"]')!, {
+      target: { value: 'Only disabled item' },
+    });
+
+    expect(
+      sourceSection.querySelector('.ant-transfer-list-header input[type="checkbox"]'),
+    ).toBeDisabled();
+  });
+
   it('should transfer just the filtered item after search by input', () => {
     const filterOption: TransferProps<any>['filterOption'] = (inputValue, option) =>
       option.description.includes(inputValue);


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #59120

### 💡 需求背景和解决方案

Transfer 搜索后的结果全部为禁用项时，列表标题处的“全选”复选框仍可操作。

本次改为根据过滤后的列表判断是否存在可选项。当搜索结果为空或全部为禁用项时，“全选”复选框将被禁用，并补充对应回归测试。不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Transfer select-all checkbox remaining enabled when all search results are disabled. |
| 🇨🇳 中文 | 🐞 修复 Transfer 搜索结果全部为禁用项时“全选”复选框仍可用的问题。 |
