### PR TITLE
docs(react): capitalize JavaScript in introduce.en-US.md

### DIFF
--- a/docs/react/introduce.en-US.md
+++ b/docs/react/introduce.en-US.md
@@ -48,7 +48,7 @@ You can subscribe to this feed for new version notifications: https://github.com
 
 ### Using npm or yarn or pnpm or bun
 
-**We recommend using [npm](https://www.npmjs.com/) or [yarn](https://github.com/yarnpkg/yarn/) or [pnpm](https://pnpm.io/) or [bun](https://bun.sh/) to install**, it not only makes development easier, but also allow you to take advantage of the rich ecosystem of Javascript packages and tooling.
+**We recommend using [npm](https://www.npmjs.com/) or [yarn](https://github.com/yarnpkg/yarn/) or [pnpm](https://pnpm.io/) or [bun](https://bun.sh/) to install**, it not only makes development easier, but also allow you to take advantage of the rich ecosystem of JavaScript packages and tooling.
 
 <InstallDependencies npm='$ npm install antd --save' yarn='$ yarn add antd' pnpm='$ pnpm install antd --save' bun='$ bun add antd'></InstallDependencies>
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

文档中将标准术语 `JavaScript` 错写为 `Javascript`。本次修正该拼写，以保持技术名词大小写规范。无 API 或 UI 变更。

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |