### PR TITLE
fix(Notification): upgrade non-submitting close controls

### DIFF
--- a/components/notification/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/notification/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -556,6 +556,7 @@ exports[`renders components/notification/demo/render-panel.tsx extend context co
     <button
       aria-label="Close"
       class="ant-notification-notice-close"
+      type="button"
     >
       <span
         aria-label="Close"

--- a/components/notification/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/notification/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`renders components/notification/demo/_semantic.tsx correctly 1`] = `
             <button
               aria-label="Close"
               class="ant-notification-notice-close semantic-mark-close"
+              type="button"
             >
               <span
                 aria-label="close"
@@ -154,6 +155,7 @@ exports[`renders components/notification/demo/_semantic.tsx correctly 1`] = `
             <button
               aria-label="Close"
               class="ant-notification-notice-close semantic-mark-close"
+              type="button"
             >
               <span
                 aria-label="close"

--- a/components/notification/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/notification/__tests__/__snapshots__/demo.test.ts.snap
@@ -542,6 +542,7 @@ exports[`renders components/notification/demo/render-panel.tsx correctly 1`] = `
     <button
       aria-label="Close"
       class="ant-notification-notice-close"
+      type="button"
     >
       <span
         aria-label="Close"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@rc-component/menu": "~1.5.0",
     "@rc-component/motion": "^1.3.3",
     "@rc-component/mutate-observer": "^2.0.1",
-    "@rc-component/notification": "~2.0.7",
+    "@rc-component/notification": "~2.0.8",
     "@rc-component/pagination": "~1.4.0",
     "@rc-component/picker": "~1.12.0",
     "@rc-component/progress": "~1.0.2",


### PR DESCRIPTION
## Summary

- upgrade `@rc-component/notification` to 2.0.8 so Notification close controls use the upstream non-submitting button fix from react-component/notification#408
- synchronize the regular, extended-context, and semantic demo snapshots with the new `type="button"` contract
- restore the Ant Design test matrix after the patch release made fresh installs diverge from the committed snapshots

## Reproduction evidence

The dependency was published at 2026-08-27 08:54 UTC. On exact Ant Design master `dc4490a` with rc-notification 2.0.8:

- the regular and extended demo files passed their runtime assertions but failed 2 snapshots because the close button gained `type="button"`
- after updating those two snapshots, the complete Notification scope exposed the same stale expectation twice in the semantic demo snapshot
- the same regular/extended snapshot mismatch caused the React 18, React latest, ES, and dist-min failures in PR #59125; it is unrelated to that PR

## Validation

- complete Notification scope: 10 suites, 95 tests, and 43 snapshots passed
- focused regular/extended demos: 29 tests and 42 snapshots passed
- Prettier and `git diff --check` passed
- the signed commit is verified by GitHub

## Duplicate check

No current open PR changes any of the three affected Notification snapshot files.

AI assistance disclosure: Codex was used to trace the cross-repository release, inspect the failing CI logs, audit open PR file overlap, update the generated snapshots, and run validation. All stated failures and passing results were reproduced locally with the published dependency.