### PR TITLE
feat: support external file drops in DirectoryTree

### DIFF
--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -8,15 +8,25 @@ import type { BasicDataNode, DataNode, EventDataNode } from '@rc-component/tree'
 import { useControlledState } from '@rc-component/util';
 import { clsx } from 'clsx';
 
+import { isHTMLElement } from '../_util/is';
 import { ConfigContext } from '../config-provider';
+import { useToken } from '../theme/internal';
 import type { AntdTreeNodeAttribute, TreeProps } from './Tree';
 import Tree from './Tree';
 import { calcRangeKeys, convertDirectoryKeysToNodes } from './utils/dictUtil';
 
 export type ExpandAction = false | 'click' | 'doubleClick';
 
+export interface DirectoryTreeFileDropInfo<T extends BasicDataNode = DataNode> {
+  event: React.DragEvent<HTMLDivElement>;
+  node: T;
+  files: FileList;
+}
+
 export interface DirectoryTreeProps<T extends BasicDataNode = DataNode> extends TreeProps<T> {
+  allowFileDrop?: boolean;
   expandAction?: ExpandAction;
+  onFileDrop?: (info: DirectoryTreeFileDropInfo<T>) => void;
 }
 
 type DirectoryTreeCompoundedComponent = (<T extends BasicDataNode | DataNode = DataNode>(
@@ -77,6 +87,10 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
     getInitExpandedKeys,
     props.expandedKeys,
   );
+
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const fileDropNodesRef = React.useRef(new WeakMap<HTMLElement, DataNode>());
+  const [fileDropNode, setFileDropNode] = React.useState<DataNode | null>(null);
 
   const onExpand = (
     keys: React.Key[],
@@ -152,12 +166,16 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
     setSelectedKeys(newSelectedKeys);
   };
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
+  const [, token] = useToken();
 
   const {
+    allowFileDrop = false,
     prefixCls: customizePrefixCls,
     className,
     showIcon = true,
     expandAction = 'click',
+    onFileDrop: onFileDropCallback,
+    titleRender,
     ...restProps
   } = props;
 
@@ -171,12 +189,82 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
     className,
   );
 
-  return (
+  const getFileDropNode = (target: EventTarget | null) => {
+    let element = isHTMLElement(target) ? target : null;
+
+    while (element && element !== rootRef.current) {
+      const node = fileDropNodesRef.current.get(element);
+      if (node) {
+        return node;
+      }
+      element = element.parentElement;
+    }
+
+    return null;
+  };
+
+  const isFileDrag = (event: React.DragEvent<HTMLDivElement>) =>
+    Array.from(event.dataTransfer.types).includes('Files') || event.dataTransfer.files.length > 0;
+
+  const onFileDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!isFileDrag(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = 'copy';
+    setFileDropNode(getFileDropNode(event.target));
+  };
+
+  const onFileDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+      setFileDropNode(null);
+    }
+  };
+
+  const onFileDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!isFileDrag(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const node = getFileDropNode(event.target);
+    setFileDropNode(null);
+
+    if (node && event.dataTransfer.files.length > 0) {
+      onFileDropCallback?.({ event, node, files: event.dataTransfer.files });
+    }
+  };
+
+  const renderFileDropTitle = (node: DataNode) => (
+    <span
+      className={`${prefixCls}-file-drop-target`}
+      ref={(element) => {
+        if (element) {
+          fileDropNodesRef.current.set(element, node);
+        }
+      }}
+      style={{
+        borderRadius: token.borderRadius,
+        padding: `${token.paddingXXS}px ${token.paddingXS}px`,
+        background: fileDropNode === node ? token.controlItemBgHover : undefined,
+        transition: `background ${token.motionDurationSlow}`,
+      }}
+    >
+      {titleRender ? titleRender(node) : (node.title as React.ReactNode)}
+    </span>
+  );
+
+  const treeNode = (
     <Tree
       icon={getIcon}
       ref={ref}
       blockNode
       {...restProps}
+      draggable={allowFileDrop ? false : restProps.draggable}
       showIcon={showIcon}
       expandAction={expandAction}
       prefixCls={prefixCls}
@@ -186,8 +274,25 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
       selectedKeys={selectedKeys}
       onSelect={onSelect}
       onExpand={onExpand}
+      titleRender={allowFileDrop ? renderFileDropTitle : titleRender}
     />
   );
+
+  if (allowFileDrop) {
+    return (
+      <div
+        ref={rootRef}
+        className={`${prefixCls}-directory-file-drop`}
+        onDragOver={onFileDragOver}
+        onDragLeave={onFileDragLeave}
+        onDrop={onFileDrop}
+      >
+        {treeNode}
+      </div>
+    );
+  }
+
+  return treeNode;
 }) as DirectoryTreeCompoundedComponent;
 
 if (process.env.NODE_ENV !== 'production') {

--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -10,7 +10,6 @@ import { clsx } from 'clsx';
 
 import { isHTMLElement } from '../_util/is';
 import { ConfigContext } from '../config-provider';
-import { useToken } from '../theme/internal';
 import type { AntdTreeNodeAttribute, TreeProps } from './Tree';
 import Tree from './Tree';
 import { calcRangeKeys, convertDirectoryKeysToNodes } from './utils/dictUtil';
@@ -166,7 +165,6 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
     setSelectedKeys(newSelectedKeys);
   };
   const { getPrefixCls, direction } = React.useContext(ConfigContext);
-  const [, token] = useToken();
 
   const {
     allowFileDrop = false,
@@ -180,6 +178,7 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
   } = props;
 
   const prefixCls = getPrefixCls('tree', customizePrefixCls);
+  const titleField = props.fieldNames?.title ?? 'title';
 
   const connectClassName = clsx(
     `${prefixCls}-directory`,
@@ -241,20 +240,16 @@ const DirectoryTree = React.forwardRef<RcTree, DirectoryTreeProps>((oriProps, re
 
   const renderFileDropTitle = (node: DataNode) => (
     <span
-      className={`${prefixCls}-file-drop-target`}
+      className={clsx(`${prefixCls}-file-drop-target`, {
+        [`${prefixCls}-file-drop-target-active`]: fileDropNode === node,
+      })}
       ref={(element) => {
         if (element) {
           fileDropNodesRef.current.set(element, node);
         }
       }}
-      style={{
-        borderRadius: token.borderRadius,
-        padding: `${token.paddingXXS}px ${token.paddingXS}px`,
-        background: fileDropNode === node ? token.controlItemBgHover : undefined,
-        transition: `background ${token.motionDurationSlow}`,
-      }}
     >
-      {titleRender ? titleRender(node) : (node.title as React.ReactNode)}
+      {titleRender ? titleRender(node) : (Reflect.get(node, titleField) as React.ReactNode)}
     </span>
   );
 

--- a/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3679,7 +3679,6 @@ exports[`renders components/tree/demo/external-file-drop.tsx extend context corr
                   >
                     <span
                       class="ant-tree-file-drop-target"
-                      style="border-radius: 6px; padding: 4px 8px; transition: background 0.3s;"
                     >
                       Documents
                     </span>
@@ -3737,7 +3736,6 @@ exports[`renders components/tree/demo/external-file-drop.tsx extend context corr
                   >
                     <span
                       class="ant-tree-file-drop-target"
-                      style="border-radius: 6px; padding: 4px 8px; transition: background 0.3s;"
                     >
                       Invoices
                     </span>
@@ -3795,7 +3793,6 @@ exports[`renders components/tree/demo/external-file-drop.tsx extend context corr
                   >
                     <span
                       class="ant-tree-file-drop-target"
-                      style="border-radius: 6px; padding: 4px 8px; transition: background 0.3s;"
                     >
                       Reports
                     </span>

--- a/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3574,6 +3574,245 @@ exports[`renders components/tree/demo/dynamic.tsx extend context correctly 1`] =
 
 exports[`renders components/tree/demo/dynamic.tsx extend context correctly 2`] = `[]`;
 
+exports[`renders components/tree/demo/external-file-drop.tsx extend context correctly 1`] = `
+<div
+  class="ant-app css-var-test-id"
+>
+  <div
+    class="ant-tree-directory-file-drop"
+  >
+    <div
+      class="ant-tree ant-tree-block-node ant-tree-directory css-var-test-id"
+    >
+      <div
+        aria-hidden="true"
+        class="ant-tree-treenode"
+        style="position: absolute; pointer-events: none; visibility: hidden; height: 0px; overflow: hidden; border: 0px; padding: 0px;"
+      >
+        <div
+          class="ant-tree-indent"
+        >
+          <div
+            class="ant-tree-indent-unit"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-tree-list"
+        role="tree"
+        style="position: relative;"
+        tabindex="0"
+      >
+        <div
+          class="ant-tree-list-holder"
+        >
+          <div>
+            <div
+              class="ant-tree-list-holder-inner"
+              style="display: flex; flex-direction: column;"
+            >
+              <div
+                aria-disabled="false"
+                aria-expanded="true"
+                aria-selected="false"
+                class="ant-tree-treenode ant-tree-treenode-switcher-open ant-tree-treenode-leaf-last"
+                draggable="false"
+                id="test-id-documents"
+                role="treeitem"
+              >
+                <span
+                  aria-hidden="true"
+                  class="ant-tree-indent"
+                />
+                <span
+                  class="ant-tree-switcher ant-tree-switcher_open"
+                >
+                  <span
+                    aria-label="caret-down"
+                    class="anticon anticon-caret-down ant-tree-switcher-icon"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="caret-down"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="0 0 1024 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+                <span
+                  class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+                  title="Documents"
+                >
+                  <span
+                    class="ant-tree-iconEle ant-tree-icon__customize"
+                  >
+                    <span
+                      aria-label="folder-open"
+                      class="anticon anticon-folder-open"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="folder-open"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M928 444H820V330.4c0-17.7-14.3-32-32-32H473L355.7 186.2a8.15 8.15 0 00-5.5-2.2H96c-17.7 0-32 14.3-32 32v592c0 17.7 14.3 32 32 32h698c13 0 24.8-7.9 29.7-20l134-332c1.5-3.8 2.3-7.9 2.3-12 0-17.7-14.3-32-32-32zM136 256h188.5l119.6 114.4H748V444H238c-13 0-24.8 7.9-29.7 20L136 643.2V256zm635.3 512H159l103.3-256h612.4L771.3 768z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <span
+                    class="ant-tree-title"
+                  >
+                    <span
+                      class="ant-tree-file-drop-target"
+                      style="border-radius: 6px; padding: 4px 8px; transition: background 0.3s;"
+                    >
+                      Documents
+                    </span>
+                  </span>
+                </span>
+              </div>
+              <div
+                aria-disabled="false"
+                aria-selected="false"
+                class="ant-tree-treenode ant-tree-treenode-leaf"
+                draggable="false"
+                id="test-id-invoices"
+                role="treeitem"
+              >
+                <span
+                  aria-hidden="true"
+                  class="ant-tree-indent"
+                >
+                  <span
+                    class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
+                  />
+                </span>
+                <span
+                  class="ant-tree-switcher ant-tree-switcher-noop"
+                />
+                <span
+                  class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+                  title="Invoices"
+                >
+                  <span
+                    class="ant-tree-iconEle ant-tree-icon__customize"
+                  >
+                    <span
+                      aria-label="file"
+                      class="anticon anticon-file"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="file"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0042 42h216v494z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <span
+                    class="ant-tree-title"
+                  >
+                    <span
+                      class="ant-tree-file-drop-target"
+                      style="border-radius: 6px; padding: 4px 8px; transition: background 0.3s;"
+                    >
+                      Invoices
+                    </span>
+                  </span>
+                </span>
+              </div>
+              <div
+                aria-disabled="false"
+                aria-selected="false"
+                class="ant-tree-treenode ant-tree-treenode-leaf-last ant-tree-treenode-leaf"
+                draggable="false"
+                id="test-id-reports"
+                role="treeitem"
+              >
+                <span
+                  aria-hidden="true"
+                  class="ant-tree-indent"
+                >
+                  <span
+                    class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
+                  />
+                </span>
+                <span
+                  class="ant-tree-switcher ant-tree-switcher-noop"
+                />
+                <span
+                  class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+                  title="Reports"
+                >
+                  <span
+                    class="ant-tree-iconEle ant-tree-icon__customize"
+                  >
+                    <span
+                      aria-label="file"
+                      class="anticon anticon-file"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="file"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0042 42h216v494z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <span
+                    class="ant-tree-title"
+                  >
+                    <span
+                      class="ant-tree-file-drop-target"
+                      style="border-radius: 6px; padding: 4px 8px; transition: background 0.3s;"
+                    >
+                      Reports
+                    </span>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/tree/demo/external-file-drop.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/tree/demo/line.tsx extend context correctly 1`] = `
 <div>
   <div

--- a/components/tree/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo.test.ts.snap
@@ -3558,6 +3558,243 @@ exports[`renders components/tree/demo/dynamic.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/tree/demo/external-file-drop.tsx correctly 1`] = `
+<div
+  class="ant-app css-var-test-id"
+>
+  <div
+    class="ant-tree-directory-file-drop"
+  >
+    <div
+      class="ant-tree ant-tree-block-node ant-tree-directory css-var-test-id"
+    >
+      <div
+        aria-hidden="true"
+        class="ant-tree-treenode"
+        style="position:absolute;pointer-events:none;visibility:hidden;height:0;overflow:hidden;border:0;padding:0"
+      >
+        <div
+          class="ant-tree-indent"
+        >
+          <div
+            class="ant-tree-indent-unit"
+          />
+        </div>
+      </div>
+      <div
+        class="ant-tree-list"
+        role="tree"
+        style="position:relative"
+        tabindex="0"
+      >
+        <div
+          class="ant-tree-list-holder"
+        >
+          <div>
+            <div
+              class="ant-tree-list-holder-inner"
+              style="display:flex;flex-direction:column"
+            >
+              <div
+                aria-disabled="false"
+                aria-expanded="true"
+                aria-selected="false"
+                class="ant-tree-treenode ant-tree-treenode-switcher-open ant-tree-treenode-leaf-last"
+                draggable="false"
+                id="test-id-documents"
+                role="treeitem"
+              >
+                <span
+                  aria-hidden="true"
+                  class="ant-tree-indent"
+                />
+                <span
+                  class="ant-tree-switcher ant-tree-switcher_open"
+                >
+                  <span
+                    aria-label="caret-down"
+                    class="anticon anticon-caret-down ant-tree-switcher-icon"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="caret-down"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="0 0 1024 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+                <span
+                  class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+                  title="Documents"
+                >
+                  <span
+                    class="ant-tree-iconEle ant-tree-icon__customize"
+                  >
+                    <span
+                      aria-label="folder-open"
+                      class="anticon anticon-folder-open"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="folder-open"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M928 444H820V330.4c0-17.7-14.3-32-32-32H473L355.7 186.2a8.15 8.15 0 00-5.5-2.2H96c-17.7 0-32 14.3-32 32v592c0 17.7 14.3 32 32 32h698c13 0 24.8-7.9 29.7-20l134-332c1.5-3.8 2.3-7.9 2.3-12 0-17.7-14.3-32-32-32zM136 256h188.5l119.6 114.4H748V444H238c-13 0-24.8 7.9-29.7 20L136 643.2V256zm635.3 512H159l103.3-256h612.4L771.3 768z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <span
+                    class="ant-tree-title"
+                  >
+                    <span
+                      class="ant-tree-file-drop-target"
+                      style="border-radius:6px;padding:4px 8px;transition:background 0.3s"
+                    >
+                      Documents
+                    </span>
+                  </span>
+                </span>
+              </div>
+              <div
+                aria-disabled="false"
+                aria-selected="false"
+                class="ant-tree-treenode ant-tree-treenode-leaf"
+                draggable="false"
+                id="test-id-invoices"
+                role="treeitem"
+              >
+                <span
+                  aria-hidden="true"
+                  class="ant-tree-indent"
+                >
+                  <span
+                    class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
+                  />
+                </span>
+                <span
+                  class="ant-tree-switcher ant-tree-switcher-noop"
+                />
+                <span
+                  class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+                  title="Invoices"
+                >
+                  <span
+                    class="ant-tree-iconEle ant-tree-icon__customize"
+                  >
+                    <span
+                      aria-label="file"
+                      class="anticon anticon-file"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="file"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0042 42h216v494z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <span
+                    class="ant-tree-title"
+                  >
+                    <span
+                      class="ant-tree-file-drop-target"
+                      style="border-radius:6px;padding:4px 8px;transition:background 0.3s"
+                    >
+                      Invoices
+                    </span>
+                  </span>
+                </span>
+              </div>
+              <div
+                aria-disabled="false"
+                aria-selected="false"
+                class="ant-tree-treenode ant-tree-treenode-leaf-last ant-tree-treenode-leaf"
+                draggable="false"
+                id="test-id-reports"
+                role="treeitem"
+              >
+                <span
+                  aria-hidden="true"
+                  class="ant-tree-indent"
+                >
+                  <span
+                    class="ant-tree-indent-unit ant-tree-indent-unit-start ant-tree-indent-unit-end"
+                  />
+                </span>
+                <span
+                  class="ant-tree-switcher ant-tree-switcher-noop"
+                />
+                <span
+                  class="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
+                  title="Reports"
+                >
+                  <span
+                    class="ant-tree-iconEle ant-tree-icon__customize"
+                  >
+                    <span
+                      aria-label="file"
+                      class="anticon anticon-file"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="file"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0042 42h216v494z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                  <span
+                    class="ant-tree-title"
+                  >
+                    <span
+                      class="ant-tree-file-drop-target"
+                      style="border-radius:6px;padding:4px 8px;transition:background 0.3s"
+                    >
+                      Reports
+                    </span>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/tree/demo/line.tsx correctly 1`] = `
 <div>
   <div

--- a/components/tree/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tree/__tests__/__snapshots__/demo.test.ts.snap
@@ -3663,7 +3663,6 @@ exports[`renders components/tree/demo/external-file-drop.tsx correctly 1`] = `
                   >
                     <span
                       class="ant-tree-file-drop-target"
-                      style="border-radius:6px;padding:4px 8px;transition:background 0.3s"
                     >
                       Documents
                     </span>
@@ -3721,7 +3720,6 @@ exports[`renders components/tree/demo/external-file-drop.tsx correctly 1`] = `
                   >
                     <span
                       class="ant-tree-file-drop-target"
-                      style="border-radius:6px;padding:4px 8px;transition:background 0.3s"
                     >
                       Invoices
                     </span>
@@ -3779,7 +3777,6 @@ exports[`renders components/tree/demo/external-file-drop.tsx correctly 1`] = `
                   >
                     <span
                       class="ant-tree-file-drop-target"
-                      style="border-radius:6px;padding:4px 8px;transition:background 0.3s"
                     >
                       Reports
                     </span>

--- a/components/tree/__tests__/directory.test.tsx
+++ b/components/tree/__tests__/directory.test.tsx
@@ -228,15 +228,15 @@ describe('Directory Tree', () => {
     fireEvent.dragOver(target.querySelector('strong')!, {
       dataTransfer: { dropEffect: 'none', files: [], types: ['Files'] },
     });
-    expect(target.style.background).not.toBe('');
+    expect(target).toHaveClass('ant-tree-file-drop-target-active');
 
     const innerDragLeave = new Event('dragleave', { bubbles: true });
     Object.defineProperty(innerDragLeave, 'relatedTarget', { value: target });
     target.dispatchEvent(innerDragLeave);
-    expect(target.style.background).not.toBe('');
+    expect(target).toHaveClass('ant-tree-file-drop-target-active');
 
     fireEvent.dragLeave(wrapper, { relatedTarget: document.body });
-    expect(target.style.background).toBe('');
+    expect(target).not.toHaveClass('ant-tree-file-drop-target-active');
 
     fireEvent.drop(wrapper, {
       dataTransfer: { files: [file], types: ['Files'] },
@@ -247,7 +247,32 @@ describe('Directory Tree', () => {
       dataTransfer: { files: [file], types: ['Files'] },
     });
     expect(onFileDrop).toHaveBeenCalledTimes(1);
-    expect(target.style.background).toBe('');
+    expect(target).not.toHaveClass('ant-tree-file-drop-target-active');
+  });
+
+  it('preserves custom title fields when external files are dropped', () => {
+    const onFileDrop = jest.fn();
+    const file = new File(['content'], 'example.txt', { type: 'text/plain' });
+    const treeData = [{ id: 0, label: 'Custom title' }];
+    const { container } = render(
+      <DirectoryTree
+        allowFileDrop
+        // @ts-ignore custom field names are supported at runtime
+        treeData={treeData}
+        fieldNames={{ key: 'id', title: 'label' }}
+        onFileDrop={onFileDrop}
+      />,
+    );
+    const target = container.querySelector<HTMLElement>('.ant-tree-file-drop-target')!;
+
+    expect(target).toHaveTextContent('Custom title');
+
+    fireEvent.drop(target, {
+      dataTransfer: { files: [file], types: ['Files'] },
+    });
+    expect(onFileDrop).toHaveBeenCalledWith(
+      expect.objectContaining({ node: treeData[0], files: [file] }),
+    );
   });
 
   it('DirectoryTree should expend all when use treeData and defaultExpandAll is true', () => {

--- a/components/tree/__tests__/directory.test.tsx
+++ b/components/tree/__tests__/directory.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type RcTree from '@rc-component/tree';
+import type { BasicDataNode } from '@rc-component/tree';
 import debounce from 'lodash/debounce';
 
 import type { TreeProps } from '..';
@@ -9,6 +10,11 @@ import rtlTest from '../../../tests/shared/rtlTest';
 import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 
 const { DirectoryTree, TreeNode } = Tree;
+
+interface FileDropTreeNode extends BasicDataNode {
+  id: number;
+  label: string;
+}
 
 jest.mock('lodash/debounce');
 
@@ -253,11 +259,10 @@ describe('Directory Tree', () => {
   it('preserves custom title fields when external files are dropped', () => {
     const onFileDrop = jest.fn();
     const file = new File(['content'], 'example.txt', { type: 'text/plain' });
-    const treeData = [{ id: 0, label: 'Custom title' }];
+    const treeData: FileDropTreeNode[] = [{ id: 0, label: 'Custom title' }];
     const { container } = render(
-      <DirectoryTree
+      <DirectoryTree<FileDropTreeNode>
         allowFileDrop
-        // @ts-ignore custom field names are supported at runtime
         treeData={treeData}
         fieldNames={{ key: 'id', title: 'label' }}
         onFileDrop={onFileDrop}

--- a/components/tree/__tests__/directory.test.tsx
+++ b/components/tree/__tests__/directory.test.tsx
@@ -168,6 +168,88 @@ describe('Directory Tree', () => {
     );
   });
 
+  it('preserves numeric node keys when files are dropped from outside the browser', () => {
+    const onFileDrop = jest.fn();
+    const file = new File(['content'], 'example.txt', { type: 'text/plain' });
+    const { container } = render(
+      <DirectoryTree
+        allowFileDrop
+        treeData={[{ key: 0, title: 'Zero' }]}
+        onFileDrop={onFileDrop}
+      />,
+    );
+
+    const targets = container.querySelectorAll('.ant-tree-file-drop-target');
+    expect(targets[0]).toHaveTextContent('Zero');
+
+    fireEvent.drop(targets[0], {
+      dataTransfer: { files: [file], types: ['Files'] },
+    });
+
+    expect(onFileDrop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        files: [file],
+        node: expect.objectContaining({ key: 0 }),
+      }),
+    );
+  });
+
+  it('only handles external file drags and preserves custom titles', () => {
+    const onFileDrop = jest.fn();
+    const file = new File(['content'], 'example.txt', { type: 'text/plain' });
+    const { container } = render(
+      <DirectoryTree
+        allowFileDrop
+        treeData={[{ key: 'custom', title: 'Custom' }]}
+        titleRender={(node) => <strong>{node.title}</strong>}
+        onFileDrop={onFileDrop}
+      />,
+    );
+    const target = container.querySelector<HTMLElement>('.ant-tree-file-drop-target')!;
+    const wrapper = container.querySelector<HTMLElement>('.ant-tree-directory-file-drop')!;
+
+    expect(target.querySelector('strong')).toHaveTextContent('Custom');
+
+    const textDrop = new Event('drop', { bubbles: true, cancelable: true });
+    Object.defineProperty(textDrop, 'dataTransfer', {
+      value: { files: [], types: ['text/plain'] },
+    });
+    target.dispatchEvent(textDrop);
+    expect(textDrop.defaultPrevented).toBe(false);
+    expect(onFileDrop).not.toHaveBeenCalled();
+
+    const textDragOver = new Event('dragover', { bubbles: true, cancelable: true });
+    Object.defineProperty(textDragOver, 'dataTransfer', {
+      value: { files: [], types: ['text/plain'] },
+    });
+    target.dispatchEvent(textDragOver);
+    expect(textDragOver.defaultPrevented).toBe(false);
+
+    fireEvent.dragOver(target.querySelector('strong')!, {
+      dataTransfer: { dropEffect: 'none', files: [], types: ['Files'] },
+    });
+    expect(target.style.background).not.toBe('');
+
+    const innerDragLeave = new Event('dragleave', { bubbles: true });
+    Object.defineProperty(innerDragLeave, 'relatedTarget', { value: target });
+    target.dispatchEvent(innerDragLeave);
+    expect(target.style.background).not.toBe('');
+
+    fireEvent.dragLeave(wrapper, { relatedTarget: document.body });
+    expect(target.style.background).toBe('');
+
+    fireEvent.drop(wrapper, {
+      dataTransfer: { files: [file], types: ['Files'] },
+    });
+    expect(onFileDrop).not.toHaveBeenCalled();
+
+    fireEvent.drop(target, {
+      dataTransfer: { files: [file], types: ['Files'] },
+    });
+    expect(onFileDrop).toHaveBeenCalledTimes(1);
+    expect(target.style.background).toBe('');
+  });
+
   it('DirectoryTree should expend all when use treeData and defaultExpandAll is true', () => {
     const treeData = [
       {

--- a/components/tree/__tests__/type.test.tsx
+++ b/components/tree/__tests__/type.test.tsx
@@ -68,6 +68,7 @@ describe('Tree.TypeScript', () => {
 
     const { container } = render(
       <DirectoryTree<MyDataNode>
+        allowFileDrop
         treeData={[
           {
             bamboo: 'good',
@@ -78,6 +79,9 @@ describe('Tree.TypeScript', () => {
             ],
           },
         ]}
+        onFileDrop={(info) => {
+          expect(info.node.bamboo).toBe('good');
+        }}
       />,
     );
 

--- a/components/tree/demo/external-file-drop.md
+++ b/components/tree/demo/external-file-drop.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+从操作系统的文件管理器将文件拖放到目录节点。外部文件拖放模式不会同时启用树节点内部拖拽。
+
+## en-US
+
+Drop files from the operating system file manager onto a directory node. External file drop mode does not enable internal tree-node dragging at the same time.

--- a/components/tree/demo/external-file-drop.tsx
+++ b/components/tree/demo/external-file-drop.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { App, Tree } from 'antd';
+import type { GetProps, TreeDataNode } from 'antd';
+
+type DirectoryTreeProps = GetProps<typeof Tree.DirectoryTree>;
+
+const treeData: TreeDataNode[] = [
+  {
+    title: 'Documents',
+    key: 'documents',
+    children: [
+      { title: 'Invoices', key: 'invoices', isLeaf: true },
+      { title: 'Reports', key: 'reports', isLeaf: true },
+    ],
+  },
+];
+
+const Demo: React.FC = () => {
+  const { message } = App.useApp();
+
+  const onFileDrop: DirectoryTreeProps['onFileDrop'] = ({ files }) => {
+    message.success(`Dropped ${files.length} file(s)`);
+  };
+
+  return (
+    <Tree.DirectoryTree
+      allowFileDrop
+      defaultExpandAll
+      treeData={treeData}
+      onFileDrop={onFileDrop}
+    />
+  );
+};
+
+const AppDemo: React.FC = () => (
+  <App>
+    <Demo />
+  </App>
+);
+
+export default AppDemo;

--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -108,7 +108,9 @@ Common props ref：[Common props](/docs/react/common-props)
 
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
+| allowFileDrop | Whether to accept files dragged from outside the browser. Internal tree dragging is disabled when enabled | boolean | false |
 | expandAction | Directory opening logic, options: false \| `click` \| `doubleClick` | string \| boolean | `click` |
+| onFileDrop | Callback when files are dropped on a directory node | function({ event, node, files }) | - |
 
 ## Note
 

--- a/components/tree/index.tsx
+++ b/components/tree/index.tsx
@@ -14,6 +14,7 @@ import TreePure from './Tree';
 
 export type {
   ExpandAction as DirectoryTreeExpandAction,
+  DirectoryTreeFileDropInfo,
   DirectoryTreeProps,
 } from './DirectoryTree';
 

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -110,7 +110,9 @@ demo:
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
+| allowFileDrop | 是否接收从浏览器外拖入的文件。启用后会关闭树节点内部拖拽 | boolean | false |
 | expandAction | 目录展开逻辑，可选：false \| `click` \| `doubleClick` | string \| boolean | `click` |
+| onFileDrop | 文件拖放到目录节点时的回调 | function({ event, node, files }) | - |
 
 ## 注意 {#note}
 

--- a/components/tree/style/directory.ts
+++ b/components/tree/style/directory.ts
@@ -8,9 +8,22 @@ export const genDirectoryStyle = ({
   directoryNodeSelectedBg,
   directoryNodeSelectedColor,
   motionDurationMid,
+  motionDurationSlow,
   borderRadius,
   controlItemBgHover,
+  paddingXXS,
+  paddingXS,
 }: TreeToken): CSSObject => ({
+  [`${treeCls}-file-drop-target`]: {
+    padding: `${paddingXXS}px ${paddingXS}px`,
+    borderRadius,
+    transition: `background ${motionDurationSlow}`,
+
+    '&-active': {
+      background: controlItemBgHover,
+    },
+  },
+
   [`${treeCls}${treeCls}-directory ${treeNodeCls}`]: {
     // >>> Title
     [`${treeCls}-node-content-wrapper`]: {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [x] 📽️ Demo improvement
- [x] 🤖 TypeScript definition improvement
- [x] ✅ Test Case

### 🔗 Related Issues

Closes #53043.

This supersedes #55884 and incorporates the maintainer feedback that numeric or otherwise typed Tree keys must not be coerced to strings. Thank you @caronchen for the earlier implementation and demo work.

### 💡 Background and Solution

`DirectoryTree` currently only exposes drag callbacks for nodes dragged from the same Tree. Files dragged from the operating-system file manager therefore cannot be associated with a target directory node.

This adds an opt-in external file-drop mode:

- `allowFileDrop` enables file drag-over and drop handling and disables internal tree-node dragging to avoid conflicting event lifecycles.
- `onFileDrop({ event, node, files })` returns the original typed data node and browser `FileList`.
- Target nodes are associated through a `WeakMap<HTMLElement, DataNode>` instead of serializing keys into DOM attributes. Numeric keys and custom `fieldNames` data therefore keep their original values and types.
- Non-file drag operations are left untouched.
- The hovered title receives token-based visual feedback, including custom `titleRender` output.

Regression coverage verifies numeric key preservation, nested custom titles, non-file event behavior, hover cleanup, drops outside a node, and generic callback typing. After rebasing the unchanged Tree patch onto `master`, GitHub-verified signed head `2afabaf3273b2cf5993750efd026722c672eeef9` is one commit and changes only 10 Tree files.

Exact-head local validation:

- DirectoryTree scope: 27 tests and 12 snapshots passed
- Tree type + extended-demo scope: 20 tests passed, 5 existing skips, and 30 snapshots passed
- Tree demo scope: 17 tests passed, 5 existing skips, and 15 snapshots passed
- full `npm run compile`: passed
- focused ESLint and Biome: passed
- `git diff --check`: passed

AI assistance disclosure: Codex was used to trace the prior implementation and maintainer feedback, develop the type-preserving approach, diagnose the original base-branch mismatch, and run validation. The behavior and exact diff were manually verified.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🆕 Add DirectoryTree support for dropping files from outside the browser onto typed target nodes. |
| 🇨🇳 Chinese | 🆕 新增 DirectoryTree 支持将浏览器外部文件拖放到保留类型的目标节点。 |
