### PR TITLE
fix(Empty): avoid duplicate accessible description

### DIFF
--- a/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/auto-complete/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -67,6 +67,7 @@ exports[`renders components/auto-complete/demo/AutoComplete-and-Select.tsx exten
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -211,6 +212,7 @@ exports[`renders components/auto-complete/demo/AutoComplete-and-Select.tsx exten
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -355,6 +357,7 @@ exports[`renders components/auto-complete/demo/AutoComplete-and-Select.tsx exten
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -1384,6 +1387,7 @@ exports[`renders components/auto-complete/demo/disabled-custom-debug.tsx extend 
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -1972,6 +1976,7 @@ exports[`renders components/auto-complete/demo/form-debug.tsx extend context cor
                     class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
                   >
                     <div
+                      aria-hidden="true"
                       class="ant-empty-image"
                     >
                       <svg
@@ -2112,6 +2117,7 @@ exports[`renders components/auto-complete/demo/form-debug.tsx extend context cor
                       class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
                     >
                       <div
+                        aria-hidden="true"
                         class="ant-empty-image"
                       >
                         <svg
@@ -2375,6 +2381,7 @@ exports[`renders components/auto-complete/demo/form-debug.tsx extend context cor
                       class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
                     >
                       <div
+                        aria-hidden="true"
                         class="ant-empty-image"
                       >
                         <svg
@@ -2574,6 +2581,7 @@ exports[`renders components/auto-complete/demo/form-debug.tsx extend context cor
                       class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
                     >
                       <div
+                        aria-hidden="true"
                         class="ant-empty-image"
                       >
                         <svg
@@ -2778,6 +2786,7 @@ exports[`renders components/auto-complete/demo/form-debug.tsx extend context cor
                       class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
                     >
                       <div
+                        aria-hidden="true"
                         class="ant-empty-image"
                       >
                         <svg

--- a/components/cascader/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/cascader/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2194,6 +2194,7 @@ exports[`renders components/cascader/demo/panel.tsx extend context correctly 1`]
       class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
     >
       <div
+        aria-hidden="true"
         class="ant-empty-image"
       >
         <svg
@@ -3653,6 +3654,7 @@ exports[`renders components/cascader/demo/status.tsx extend context correctly 1`
                   class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
                 >
                   <div
+                    aria-hidden="true"
                     class="ant-empty-image"
                   >
                     <svg
@@ -3791,6 +3793,7 @@ exports[`renders components/cascader/demo/status.tsx extend context correctly 1`
                   class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
                 >
                   <div
+                    aria-hidden="true"
                     class="ant-empty-image"
                   >
                     <svg
@@ -4885,6 +4888,7 @@ exports[`renders components/cascader/demo/variant.tsx extend context correctly 1
                 class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
               >
                 <div
+                  aria-hidden="true"
                   class="ant-empty-image"
                 >
                   <svg
@@ -5008,6 +5012,7 @@ exports[`renders components/cascader/demo/variant.tsx extend context correctly 1
                 class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
               >
                 <div
+                  aria-hidden="true"
                   class="ant-empty-image"
                 >
                   <svg
@@ -5131,6 +5136,7 @@ exports[`renders components/cascader/demo/variant.tsx extend context correctly 1
                 class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
               >
                 <div
+                  aria-hidden="true"
                   class="ant-empty-image"
                 >
                   <svg
@@ -5254,6 +5260,7 @@ exports[`renders components/cascader/demo/variant.tsx extend context correctly 1
                 class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
               >
                 <div
+                  aria-hidden="true"
                   class="ant-empty-image"
                 >
                   <svg

--- a/components/cascader/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/cascader/__tests__/__snapshots__/demo.test.tsx.snap
@@ -948,6 +948,7 @@ exports[`renders components/cascader/demo/panel.tsx correctly 1`] = `
       class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
     >
       <div
+        aria-hidden="true"
         class="ant-empty-image"
       >
         <svg

--- a/components/cascader/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/cascader/__tests__/__snapshots__/index.test.tsx.snap
@@ -1341,6 +1341,7 @@ exports[`Cascader should render not found content 1`] = `
               class="css-var-root ant-empty ant-empty-normal ant-empty-small"
             >
               <div
+                aria-hidden="true"
                 class="ant-empty-image"
               >
                 <svg
@@ -1419,6 +1420,7 @@ exports[`Cascader should show not found content when options.length is 0 1`] = `
               class="css-var-root ant-empty ant-empty-normal ant-empty-small"
             >
               <div
+                aria-hidden="true"
                 class="ant-empty-image"
               >
                 <svg

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -14473,6 +14473,7 @@ exports[`ConfigProvider components Empty configProvider 1`] = `
   class="css-var-root config-empty"
 >
   <div
+    aria-hidden="true"
     class="config-empty-image"
   >
     <svg
@@ -14545,6 +14546,7 @@ exports[`ConfigProvider components Empty configProvider componentDisabled 1`] = 
   class="css-var-root config-empty"
 >
   <div
+    aria-hidden="true"
     class="config-empty-image"
   >
     <svg
@@ -14617,6 +14619,7 @@ exports[`ConfigProvider components Empty configProvider componentSize large 1`] 
   class="css-var-root config-empty"
 >
   <div
+    aria-hidden="true"
     class="config-empty-image"
   >
     <svg
@@ -14689,6 +14692,7 @@ exports[`ConfigProvider components Empty configProvider componentSize medium 1`]
   class="css-var-root config-empty"
 >
   <div
+    aria-hidden="true"
     class="config-empty-image"
   >
     <svg
@@ -14761,6 +14765,7 @@ exports[`ConfigProvider components Empty configProvider componentSize small 1`] 
   class="css-var-root config-empty"
 >
   <div
+    aria-hidden="true"
     class="config-empty-image"
   >
     <svg
@@ -14833,6 +14838,7 @@ exports[`ConfigProvider components Empty normal 1`] = `
   class="css-var-root ant-empty"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -14905,6 +14911,7 @@ exports[`ConfigProvider components Empty prefixCls 1`] = `
   class="css-var-root prefix-Empty"
 >
   <div
+    aria-hidden="true"
     class="prefix-Empty-image"
   >
     <svg
@@ -25482,6 +25489,7 @@ exports[`ConfigProvider components Table configProvider 1`] = `
                       class="css-var-root config-empty config-empty-normal"
                     >
                       <div
+                        aria-hidden="true"
                         class="config-empty-image"
                       >
                         <svg
@@ -25791,6 +25799,7 @@ exports[`ConfigProvider components Table configProvider componentDisabled 1`] = 
                       class="css-var-root config-empty config-empty-normal"
                     >
                       <div
+                        aria-hidden="true"
                         class="config-empty-image"
                       >
                         <svg
@@ -26098,6 +26107,7 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
                       class="css-var-root config-empty config-empty-normal"
                     >
                       <div
+                        aria-hidden="true"
                         class="config-empty-image"
                       >
                         <svg
@@ -26405,6 +26415,7 @@ exports[`ConfigProvider components Table configProvider componentSize medium 1`]
                       class="css-var-root config-empty config-empty-normal"
                     >
                       <div
+                        aria-hidden="true"
                         class="config-empty-image"
                       >
                         <svg
@@ -26712,6 +26723,7 @@ exports[`ConfigProvider components Table configProvider componentSize small 1`] 
                       class="css-var-root config-empty config-empty-normal"
                     >
                       <div
+                        aria-hidden="true"
                         class="config-empty-image"
                       >
                         <svg
@@ -27019,6 +27031,7 @@ exports[`ConfigProvider components Table normal 1`] = `
                       class="css-var-root ant-empty ant-empty-normal"
                     >
                       <div
+                        aria-hidden="true"
                         class="ant-empty-image"
                       >
                         <svg
@@ -27326,6 +27339,7 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
                       class="css-var-root ant-empty ant-empty-normal"
                     >
                       <div
+                        aria-hidden="true"
                         class="ant-empty-image"
                       >
                         <svg
@@ -38056,6 +38070,7 @@ exports[`ConfigProvider components Transfer configProvider 1`] = `
           class="css-var-root config-empty config-empty-normal config-empty-small"
         >
           <div
+            aria-hidden="true"
             class="config-empty-image"
           >
             <svg
@@ -38223,6 +38238,7 @@ exports[`ConfigProvider components Transfer configProvider 1`] = `
           class="css-var-root config-empty config-empty-normal config-empty-small"
         >
           <div
+            aria-hidden="true"
             class="config-empty-image"
           >
             <svg
@@ -38336,6 +38352,7 @@ exports[`ConfigProvider components Transfer configProvider componentDisabled 1`]
           class="css-var-root config-empty config-empty-normal config-empty-small"
         >
           <div
+            aria-hidden="true"
             class="config-empty-image"
           >
             <svg
@@ -38504,6 +38521,7 @@ exports[`ConfigProvider components Transfer configProvider componentDisabled 1`]
           class="css-var-root config-empty config-empty-normal config-empty-small"
         >
           <div
+            aria-hidden="true"
             class="config-empty-image"
           >
             <svg
@@ -38616,6 +38634,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize large 1
           class="css-var-root config-empty config-empty-normal config-empty-small"
         >
           <div
+            aria-hidden="true"
             class="config-empty-image"
           >
             <svg
@@ -38783,6 +38802,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize large 1
           class="css-var-root config-empty config-empty-normal config-empty-small"
         >
           <div
+            aria-hidden="true"
             class="config-empty-image"
           >
             <svg
@@ -38895,6 +38915,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize medium 
           class="css-var-root config-empty config-empty-normal config-empty-small"
         >
           <div
+            aria-hidden="true"
             class="config-empty-image"
           >
             <svg
@@ -39062,6 +39083,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize medium 
           class="css-var-root config-empty config-empty-normal config-empty-small"
         >
           <div
+            aria-hidden="true"
             class="config-empty-image"
           >
             <svg
@@ -39174,6 +39196,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize small 1
           class="css-var-root config-empty config-empty-normal config-empty-small"
         >
           <div
+            aria-hidden="true"
             class="config-empty-image"
           >
             <svg
@@ -39341,6 +39364,7 @@ exports[`ConfigProvider components Transfer configProvider componentSize small 1
           class="css-var-root config-empty config-empty-normal config-empty-small"
         >
           <div
+            aria-hidden="true"
             class="config-empty-image"
           >
             <svg
@@ -39453,6 +39477,7 @@ exports[`ConfigProvider components Transfer normal 1`] = `
           class="css-var-root ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -39620,6 +39645,7 @@ exports[`ConfigProvider components Transfer normal 1`] = `
           class="css-var-root ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -39732,6 +39758,7 @@ exports[`ConfigProvider components Transfer prefixCls 1`] = `
           class="css-var-root ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -39899,6 +39926,7 @@ exports[`ConfigProvider components Transfer prefixCls 1`] = `
           class="css-var-root ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg

--- a/components/config-provider/__tests__/__snapshots__/renderEmpty.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/renderEmpty.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`renderEmpty should render Cascader empty 1`] = `
   class="css-var-root ant-empty ant-empty-normal ant-empty-small"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -56,6 +57,7 @@ exports[`renderEmpty should render List empty 1`] = `
   class="css-var-root ant-empty ant-empty-normal"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -107,6 +109,7 @@ exports[`renderEmpty should render Mentions empty 1`] = `
   class="css-var-root ant-empty ant-empty-normal ant-empty-small"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -158,6 +161,7 @@ exports[`renderEmpty should render Select empty 1`] = `
   class="css-var-root ant-empty ant-empty-normal ant-empty-small"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -209,6 +213,7 @@ exports[`renderEmpty should render Table empty 1`] = `
   class="css-var-root ant-empty ant-empty-normal"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -262,6 +267,7 @@ exports[`renderEmpty should render Transfer empty 1`] = `
   class="css-var-root ant-empty ant-empty-normal ant-empty-small"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -313,6 +319,7 @@ exports[`renderEmpty should render TreeSelect empty 1`] = `
   class="css-var-root ant-empty ant-empty-normal ant-empty-small"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -364,6 +371,7 @@ exports[`renderEmpty should return empty when componentName is not matched 1`] =
   class="css-var-root ant-empty"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg

--- a/components/config-provider/__tests__/__snapshots__/vitest/renderEmpty.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/vitest/renderEmpty.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`renderEmpty > should render Cascader empty 1`] = `
   class="css-var-root ant-empty ant-empty-normal ant-empty-small"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -56,6 +57,7 @@ exports[`renderEmpty > should render List empty 1`] = `
   class="css-var-root ant-empty ant-empty-normal"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -107,6 +109,7 @@ exports[`renderEmpty > should render Mentions empty 1`] = `
   class="css-var-root ant-empty ant-empty-normal ant-empty-small"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -158,6 +161,7 @@ exports[`renderEmpty > should render Select empty 1`] = `
   class="css-var-root ant-empty ant-empty-normal ant-empty-small"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -209,6 +213,7 @@ exports[`renderEmpty > should render Table empty 1`] = `
   class="css-var-root ant-empty ant-empty-normal"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -262,6 +267,7 @@ exports[`renderEmpty > should render Transfer empty 1`] = `
   class="css-var-root ant-empty ant-empty-normal ant-empty-small"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -313,6 +319,7 @@ exports[`renderEmpty > should render TreeSelect empty 1`] = `
   class="css-var-root ant-empty ant-empty-normal ant-empty-small"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -364,6 +371,7 @@ exports[`renderEmpty > should return empty when componentName is not matched 1`]
   class="css-var-root ant-empty"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg

--- a/components/empty/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/empty/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5,6 +5,7 @@ exports[`renders components/empty/demo/basic.tsx extend context correctly 1`] = 
   class="css-var-test-id ant-empty"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -1098,6 +1099,7 @@ exports[`renders components/empty/demo/simple.tsx extend context correctly 1`] =
   class="css-var-test-id ant-empty ant-empty-normal"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -1155,6 +1157,7 @@ exports[`renders components/empty/demo/style-class.tsx extend context correctly 
     style="background-color: rgb(245, 245, 245); border-radius: 8px;"
   >
     <div
+      aria-hidden="true"
       class="ant-empty-image"
       style="filter: grayscale(100%);"
     >
@@ -1219,6 +1222,7 @@ exports[`renders components/empty/demo/style-class.tsx extend context correctly 
     style="background-color: rgb(230, 247, 255); border: 1px solid rgb(145, 213, 255);"
   >
     <div
+      aria-hidden="true"
       class="ant-empty-image"
       style="filter: hue-rotate(180deg);"
     >

--- a/components/empty/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/empty/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`renders components/empty/demo/_semantic.tsx correctly 1`] = `
         class="css-var-test-id ant-empty ant-empty-normal semantic-mark-root"
       >
         <div
+          aria-hidden="true"
           class="ant-empty-image semantic-mark-image"
           style="height: 60px;"
         >

--- a/components/empty/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/empty/__tests__/__snapshots__/demo.test.ts.snap
@@ -5,6 +5,7 @@ exports[`renders components/empty/demo/basic.tsx correctly 1`] = `
   class="css-var-test-id ant-empty"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -803,6 +804,7 @@ exports[`renders components/empty/demo/simple.tsx correctly 1`] = `
   class="css-var-test-id ant-empty ant-empty-normal"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -858,6 +860,7 @@ exports[`renders components/empty/demo/style-class.tsx correctly 1`] = `
     style="background-color:#f5f5f5;border-radius:8px"
   >
     <div
+      aria-hidden="true"
       class="ant-empty-image"
       style="filter:grayscale(100%)"
     >
@@ -922,6 +925,7 @@ exports[`renders components/empty/demo/style-class.tsx correctly 1`] = `
     style="background-color:#e6f7ff;border:1px solid #91d5ff"
   >
     <div
+      aria-hidden="true"
       class="ant-empty-image"
       style="filter:hue-rotate(180deg)"
     >

--- a/components/empty/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/empty/__tests__/__snapshots__/index.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`Empty dark mode compatible 1`] = `
   class="css-var-test-id ant-empty"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -77,6 +78,7 @@ exports[`Empty rtl render component should be rendered correctly in RTL directio
   class="css-var-root ant-empty ant-empty-rtl"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -149,6 +151,7 @@ exports[`Empty should render in RTL direction 1`] = `
   class="css-var-root ant-empty ant-empty-rtl"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg

--- a/components/empty/__tests__/__snapshots__/vitest/index.test.tsx.snap
+++ b/components/empty/__tests__/__snapshots__/vitest/index.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`Empty > dark mode compatible 1`] = `
   class="css-var-test-id ant-empty"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -77,6 +78,7 @@ exports[`Empty > rtl render > component should be rendered correctly in RTL dire
   class="css-var-root ant-empty ant-empty-rtl"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg
@@ -149,6 +151,7 @@ exports[`Empty > should render in RTL direction 1`] = `
   class="css-var-root ant-empty ant-empty-rtl"
 >
   <div
+    aria-hidden="true"
     class="ant-empty-image"
   >
     <svg

--- a/components/empty/__tests__/index.test.tsx
+++ b/components/empty/__tests__/index.test.tsx
@@ -11,6 +11,23 @@ describe('Empty', () => {
   mountTest(Empty);
   rtlTest(Empty);
 
+  it('hides built-in illustrations when the description provides the accessible text', () => {
+    const { container, rerender } = render(<Empty description="Nothing here" />);
+
+    expect(container.querySelector('.ant-empty-image')).toHaveAttribute('aria-hidden', 'true');
+    expect(container.querySelector('.ant-empty-description')).toHaveTextContent('Nothing here');
+
+    rerender(<Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="Still empty" />);
+    expect(container.querySelector('.ant-empty-image')).toHaveAttribute('aria-hidden', 'true');
+
+    rerender(<Empty image={<svg data-testid="custom-image" />} description="Custom empty" />);
+    expect(container.querySelector('.ant-empty-image')).not.toHaveAttribute('aria-hidden');
+
+    rerender(<Empty description={false} />);
+    expect(container.querySelector('.ant-empty-image')).not.toHaveAttribute('aria-hidden');
+    expect(container.querySelector('.ant-empty-image title')).toHaveTextContent('No data');
+  });
+
   it('should support nativeElement ref', () => {
     const ref = React.createRef<React.ComponentRef<typeof Empty>>();
     const { container } = render(<Empty ref={ref} />);

--- a/components/empty/__tests__/index.test.tsx
+++ b/components/empty/__tests__/index.test.tsx
@@ -26,6 +26,10 @@ describe('Empty', () => {
     rerender(<Empty description={false} />);
     expect(container.querySelector('.ant-empty-image')).not.toHaveAttribute('aria-hidden');
     expect(container.querySelector('.ant-empty-image title')).toHaveTextContent('No data');
+
+    rerender(<Empty description={true} />);
+    expect(container.querySelector('.ant-empty-image')).not.toHaveAttribute('aria-hidden');
+    expect(container.querySelector('.ant-empty-description')).not.toBeInTheDocument();
   });
 
   it('should support nativeElement ref', () => {

--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -105,6 +105,7 @@ const Empty = React.forwardRef<EmptyRef, EmptyProps>((props, ref) => {
   const alt = typeof des === 'string' ? des : 'empty';
 
   const mergedImage = image ?? contextImage ?? defaultEmptyImg;
+  const isBuiltInImage = mergedImage === defaultEmptyImg || mergedImage === simpleEmptyImg;
 
   let imageNode: React.ReactNode = null;
 
@@ -149,6 +150,7 @@ const Empty = React.forwardRef<EmptyRef, EmptyProps>((props, ref) => {
       {...restProps}
     >
       <div
+        aria-hidden={isBuiltInImage && isReactRenderable(des) ? true : undefined}
         className={clsx(`${prefixCls}-image`, mergedClassNames.image)}
         style={{ ...imageStyle, ...mergedStyles.image }}
       >

--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -101,6 +101,7 @@ const Empty = React.forwardRef<EmptyRef, EmptyProps>((props, ref) => {
   const [locale] = useLocale('Empty');
 
   const des = typeof description !== 'undefined' ? description : locale?.description;
+  const hasDescription = isReactRenderable(des) && des !== true;
 
   const alt = typeof des === 'string' ? des : 'empty';
 
@@ -150,13 +151,13 @@ const Empty = React.forwardRef<EmptyRef, EmptyProps>((props, ref) => {
       {...restProps}
     >
       <div
-        aria-hidden={isBuiltInImage && isReactRenderable(des) ? true : undefined}
+        aria-hidden={isBuiltInImage && hasDescription ? true : undefined}
         className={clsx(`${prefixCls}-image`, mergedClassNames.image)}
         style={{ ...imageStyle, ...mergedStyles.image }}
       >
         {imageNode}
       </div>
-      {isReactRenderable(des) && (
+      {hasDescription && (
         <div
           className={clsx(`${prefixCls}-description`, mergedClassNames.description)}
           style={mergedStyles.description}

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -32629,6 +32629,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                     class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
                   >
                     <div
+                      aria-hidden="true"
                       class="ant-empty-image"
                     >
                       <svg
@@ -32779,6 +32780,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
                         >
                           <div
+                            aria-hidden="true"
                             class="ant-empty-image"
                           >
                             <svg
@@ -32920,6 +32922,7 @@ exports[`renders components/form/demo/variant.tsx extend context correctly 1`] =
                     class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
                   >
                     <div
+                      aria-hidden="true"
                       class="ant-empty-image"
                     >
                       <svg

--- a/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -648,6 +648,7 @@ exports[`renders components/input-number/demo/addon.tsx extend context correctly
                       class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
                     >
                       <div
+                        aria-hidden="true"
                         class="ant-empty-image"
                       >
                         <svg
@@ -1107,6 +1108,7 @@ exports[`renders components/input-number/demo/borderless-height-debug.tsx extend
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -1296,6 +1298,7 @@ exports[`renders components/input-number/demo/borderless-height-debug.tsx extend
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -1485,6 +1488,7 @@ exports[`renders components/input-number/demo/borderless-height-debug.tsx extend
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -497,6 +497,7 @@ exports[`renders components/input/demo/addon.tsx extend context correctly 1`] = 
                         class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -3462,6 +3463,7 @@ Array [
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg

--- a/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -829,6 +829,7 @@ Array [
             class="css-var-test-id ant-empty ant-empty-normal"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -2877,6 +2878,7 @@ exports[`renders components/list/demo/infinite-load.tsx extend context correctly
                 class="css-var-test-id ant-empty ant-empty-normal"
               >
                 <div
+                  aria-hidden="true"
                   class="ant-empty-image"
                 >
                   <svg

--- a/components/list/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.ts.snap
@@ -828,6 +828,7 @@ Array [
             class="css-var-test-id ant-empty ant-empty-normal"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -2815,6 +2816,7 @@ exports[`renders components/list/demo/infinite-load.tsx correctly 1`] = `
                 class="css-var-test-id ant-empty ant-empty-normal"
               >
                 <div
+                  aria-hidden="true"
                   class="ant-empty-image"
                 >
                   <svg

--- a/components/list/__tests__/__snapshots__/empty.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/empty.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`List renders empty list 1`] = `
           class="css-var-root ant-empty ant-empty-normal"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg

--- a/components/list/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/index.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`List rtl render component should be rendered correctly in RTL direction
           class="css-var-root ant-empty ant-empty-normal ant-empty-rtl"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg

--- a/components/list/__tests__/__snapshots__/vitest/empty.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/vitest/empty.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`List > renders empty list 1`] = `
           class="css-var-root ant-empty ant-empty-normal"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg

--- a/components/list/__tests__/__snapshots__/vitest/index.test.tsx.snap
+++ b/components/list/__tests__/__snapshots__/vitest/index.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`List > rtl render > component should be rendered correctly in RTL direc
           class="css-var-root ant-empty ant-empty-normal ant-empty-rtl"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg

--- a/components/locale/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/index.test.tsx.snap
@@ -5740,6 +5740,7 @@ exports[`Locale Provider should display the text as ar 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -5973,6 +5974,7 @@ exports[`Locale Provider should display the text as ar 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -7021,6 +7023,7 @@ exports[`Locale Provider should display the text as ar 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -10975,6 +10978,7 @@ exports[`Locale Provider should display the text as az 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -11208,6 +11212,7 @@ exports[`Locale Provider should display the text as az 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -12256,6 +12261,7 @@ exports[`Locale Provider should display the text as az 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -16210,6 +16216,7 @@ exports[`Locale Provider should display the text as bg 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -16443,6 +16450,7 @@ exports[`Locale Provider should display the text as bg 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -17491,6 +17499,7 @@ exports[`Locale Provider should display the text as bg 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -21445,6 +21454,7 @@ exports[`Locale Provider should display the text as bn-bd 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -21678,6 +21688,7 @@ exports[`Locale Provider should display the text as bn-bd 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -22726,6 +22737,7 @@ exports[`Locale Provider should display the text as bn-bd 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -26680,6 +26692,7 @@ exports[`Locale Provider should display the text as by 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -26913,6 +26926,7 @@ exports[`Locale Provider should display the text as by 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -27961,6 +27975,7 @@ exports[`Locale Provider should display the text as by 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -31915,6 +31930,7 @@ exports[`Locale Provider should display the text as ca 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -32148,6 +32164,7 @@ exports[`Locale Provider should display the text as ca 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -33196,6 +33213,7 @@ exports[`Locale Provider should display the text as ca 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -37150,6 +37168,7 @@ exports[`Locale Provider should display the text as cs 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -37383,6 +37402,7 @@ exports[`Locale Provider should display the text as cs 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -38431,6 +38451,7 @@ exports[`Locale Provider should display the text as cs 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -42385,6 +42406,7 @@ exports[`Locale Provider should display the text as da 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -42618,6 +42640,7 @@ exports[`Locale Provider should display the text as da 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -43666,6 +43689,7 @@ exports[`Locale Provider should display the text as da 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -47620,6 +47644,7 @@ exports[`Locale Provider should display the text as de 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -47853,6 +47878,7 @@ exports[`Locale Provider should display the text as de 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -48901,6 +48927,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -52855,6 +52882,7 @@ exports[`Locale Provider should display the text as el 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -53088,6 +53116,7 @@ exports[`Locale Provider should display the text as el 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -54136,6 +54165,7 @@ exports[`Locale Provider should display the text as el 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -58090,6 +58120,7 @@ exports[`Locale Provider should display the text as en 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -58323,6 +58354,7 @@ exports[`Locale Provider should display the text as en 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -59371,6 +59403,7 @@ exports[`Locale Provider should display the text as en 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -63325,6 +63358,7 @@ exports[`Locale Provider should display the text as en-gb 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -63558,6 +63592,7 @@ exports[`Locale Provider should display the text as en-gb 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -64606,6 +64641,7 @@ exports[`Locale Provider should display the text as en-gb 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -68560,6 +68596,7 @@ exports[`Locale Provider should display the text as es 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -68793,6 +68830,7 @@ exports[`Locale Provider should display the text as es 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -69841,6 +69879,7 @@ exports[`Locale Provider should display the text as es 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -73795,6 +73834,7 @@ exports[`Locale Provider should display the text as es-us 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -74028,6 +74068,7 @@ exports[`Locale Provider should display the text as es-us 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -75076,6 +75117,7 @@ exports[`Locale Provider should display the text as es-us 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -79030,6 +79072,7 @@ exports[`Locale Provider should display the text as et 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -79263,6 +79306,7 @@ exports[`Locale Provider should display the text as et 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -80311,6 +80355,7 @@ exports[`Locale Provider should display the text as et 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -84265,6 +84310,7 @@ exports[`Locale Provider should display the text as eu 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -84498,6 +84544,7 @@ exports[`Locale Provider should display the text as eu 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -85546,6 +85593,7 @@ exports[`Locale Provider should display the text as eu 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -89500,6 +89548,7 @@ exports[`Locale Provider should display the text as fa 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -89733,6 +89782,7 @@ exports[`Locale Provider should display the text as fa 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -90781,6 +90831,7 @@ exports[`Locale Provider should display the text as fa 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -94735,6 +94786,7 @@ exports[`Locale Provider should display the text as fi 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -94968,6 +95020,7 @@ exports[`Locale Provider should display the text as fi 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -96016,6 +96069,7 @@ exports[`Locale Provider should display the text as fi 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -99970,6 +100024,7 @@ exports[`Locale Provider should display the text as fr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -100203,6 +100258,7 @@ exports[`Locale Provider should display the text as fr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -101251,6 +101307,7 @@ exports[`Locale Provider should display the text as fr 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -105205,6 +105262,7 @@ exports[`Locale Provider should display the text as fr 2`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -105438,6 +105496,7 @@ exports[`Locale Provider should display the text as fr 2`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -106486,6 +106545,7 @@ exports[`Locale Provider should display the text as fr 2`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -110440,6 +110500,7 @@ exports[`Locale Provider should display the text as fr 3`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -110673,6 +110734,7 @@ exports[`Locale Provider should display the text as fr 3`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -111721,6 +111783,7 @@ exports[`Locale Provider should display the text as fr 3`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -115675,6 +115738,7 @@ exports[`Locale Provider should display the text as ga 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -115908,6 +115972,7 @@ exports[`Locale Provider should display the text as ga 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -116956,6 +117021,7 @@ exports[`Locale Provider should display the text as ga 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -120910,6 +120976,7 @@ exports[`Locale Provider should display the text as gl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -121143,6 +121210,7 @@ exports[`Locale Provider should display the text as gl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -122191,6 +122259,7 @@ exports[`Locale Provider should display the text as gl 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -126145,6 +126214,7 @@ exports[`Locale Provider should display the text as he 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -126378,6 +126448,7 @@ exports[`Locale Provider should display the text as he 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -127426,6 +127497,7 @@ exports[`Locale Provider should display the text as he 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -131380,6 +131452,7 @@ exports[`Locale Provider should display the text as hi 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -131613,6 +131686,7 @@ exports[`Locale Provider should display the text as hi 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -132661,6 +132735,7 @@ exports[`Locale Provider should display the text as hi 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -136615,6 +136690,7 @@ exports[`Locale Provider should display the text as hr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -136848,6 +136924,7 @@ exports[`Locale Provider should display the text as hr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -137896,6 +137973,7 @@ exports[`Locale Provider should display the text as hr 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -141850,6 +141928,7 @@ exports[`Locale Provider should display the text as hu 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -142083,6 +142162,7 @@ exports[`Locale Provider should display the text as hu 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -143131,6 +143211,7 @@ exports[`Locale Provider should display the text as hu 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -147085,6 +147166,7 @@ exports[`Locale Provider should display the text as hy-am 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -147318,6 +147400,7 @@ exports[`Locale Provider should display the text as hy-am 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -148366,6 +148449,7 @@ exports[`Locale Provider should display the text as hy-am 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -152320,6 +152404,7 @@ exports[`Locale Provider should display the text as id 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -152553,6 +152638,7 @@ exports[`Locale Provider should display the text as id 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -153601,6 +153687,7 @@ exports[`Locale Provider should display the text as id 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -157555,6 +157642,7 @@ exports[`Locale Provider should display the text as is 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -157788,6 +157876,7 @@ exports[`Locale Provider should display the text as is 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -158836,6 +158925,7 @@ exports[`Locale Provider should display the text as is 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -162790,6 +162880,7 @@ exports[`Locale Provider should display the text as it 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -163023,6 +163114,7 @@ exports[`Locale Provider should display the text as it 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -164071,6 +164163,7 @@ exports[`Locale Provider should display the text as it 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -168025,6 +168118,7 @@ exports[`Locale Provider should display the text as ja 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -168258,6 +168352,7 @@ exports[`Locale Provider should display the text as ja 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -169306,6 +169401,7 @@ exports[`Locale Provider should display the text as ja 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -173260,6 +173356,7 @@ exports[`Locale Provider should display the text as ka 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -173493,6 +173590,7 @@ exports[`Locale Provider should display the text as ka 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -174541,6 +174639,7 @@ exports[`Locale Provider should display the text as ka 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -178495,6 +178594,7 @@ exports[`Locale Provider should display the text as kk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -178728,6 +178828,7 @@ exports[`Locale Provider should display the text as kk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -179776,6 +179877,7 @@ exports[`Locale Provider should display the text as kk 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -183729,6 +183831,7 @@ exports[`Locale Provider should display the text as km 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -183961,6 +184064,7 @@ exports[`Locale Provider should display the text as km 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -185009,6 +185113,7 @@ exports[`Locale Provider should display the text as km 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -188963,6 +189068,7 @@ exports[`Locale Provider should display the text as kn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -189196,6 +189302,7 @@ exports[`Locale Provider should display the text as kn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -190244,6 +190351,7 @@ exports[`Locale Provider should display the text as kn 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -194198,6 +194306,7 @@ exports[`Locale Provider should display the text as ko 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -194431,6 +194540,7 @@ exports[`Locale Provider should display the text as ko 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -195479,6 +195589,7 @@ exports[`Locale Provider should display the text as ko 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -199433,6 +199544,7 @@ exports[`Locale Provider should display the text as ku 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -199666,6 +199778,7 @@ exports[`Locale Provider should display the text as ku 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -200714,6 +200827,7 @@ exports[`Locale Provider should display the text as ku 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -204668,6 +204782,7 @@ exports[`Locale Provider should display the text as ku-iq 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -204901,6 +205016,7 @@ exports[`Locale Provider should display the text as ku-iq 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -205949,6 +206065,7 @@ exports[`Locale Provider should display the text as ku-iq 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -209903,6 +210020,7 @@ exports[`Locale Provider should display the text as lt 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -210136,6 +210254,7 @@ exports[`Locale Provider should display the text as lt 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -211184,6 +211303,7 @@ exports[`Locale Provider should display the text as lt 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -215138,6 +215258,7 @@ exports[`Locale Provider should display the text as lv 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -215371,6 +215492,7 @@ exports[`Locale Provider should display the text as lv 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -216419,6 +216541,7 @@ exports[`Locale Provider should display the text as lv 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -220373,6 +220496,7 @@ exports[`Locale Provider should display the text as mk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -220606,6 +220730,7 @@ exports[`Locale Provider should display the text as mk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -221654,6 +221779,7 @@ exports[`Locale Provider should display the text as mk 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -225608,6 +225734,7 @@ exports[`Locale Provider should display the text as ml 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -225841,6 +225968,7 @@ exports[`Locale Provider should display the text as ml 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -226889,6 +227017,7 @@ exports[`Locale Provider should display the text as ml 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -230843,6 +230972,7 @@ exports[`Locale Provider should display the text as mn-mn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -231076,6 +231206,7 @@ exports[`Locale Provider should display the text as mn-mn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -232124,6 +232255,7 @@ exports[`Locale Provider should display the text as mn-mn 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -236078,6 +236210,7 @@ exports[`Locale Provider should display the text as mr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -236311,6 +236444,7 @@ exports[`Locale Provider should display the text as mr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -237359,6 +237493,7 @@ exports[`Locale Provider should display the text as mr 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -241313,6 +241448,7 @@ exports[`Locale Provider should display the text as ms-my 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -241546,6 +241682,7 @@ exports[`Locale Provider should display the text as ms-my 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -242594,6 +242731,7 @@ exports[`Locale Provider should display the text as ms-my 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -246548,6 +246686,7 @@ exports[`Locale Provider should display the text as my 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -246781,6 +246920,7 @@ exports[`Locale Provider should display the text as my 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -247829,6 +247969,7 @@ exports[`Locale Provider should display the text as my 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -251783,6 +251924,7 @@ exports[`Locale Provider should display the text as nb 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -252016,6 +252158,7 @@ exports[`Locale Provider should display the text as nb 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -253064,6 +253207,7 @@ exports[`Locale Provider should display the text as nb 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -257018,6 +257162,7 @@ exports[`Locale Provider should display the text as ne-np 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -257251,6 +257396,7 @@ exports[`Locale Provider should display the text as ne-np 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -258299,6 +258445,7 @@ exports[`Locale Provider should display the text as ne-np 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -262253,6 +262400,7 @@ exports[`Locale Provider should display the text as nl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -262486,6 +262634,7 @@ exports[`Locale Provider should display the text as nl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -263534,6 +263683,7 @@ exports[`Locale Provider should display the text as nl 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -267488,6 +267638,7 @@ exports[`Locale Provider should display the text as nl-be 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -267721,6 +267872,7 @@ exports[`Locale Provider should display the text as nl-be 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -268769,6 +268921,7 @@ exports[`Locale Provider should display the text as nl-be 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -272723,6 +272876,7 @@ exports[`Locale Provider should display the text as pl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -272956,6 +273110,7 @@ exports[`Locale Provider should display the text as pl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -274004,6 +274159,7 @@ exports[`Locale Provider should display the text as pl 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -277958,6 +278114,7 @@ exports[`Locale Provider should display the text as pt 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -278191,6 +278348,7 @@ exports[`Locale Provider should display the text as pt 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -279239,6 +279397,7 @@ exports[`Locale Provider should display the text as pt 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -283193,6 +283352,7 @@ exports[`Locale Provider should display the text as pt-br 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -283426,6 +283586,7 @@ exports[`Locale Provider should display the text as pt-br 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -284474,6 +284635,7 @@ exports[`Locale Provider should display the text as pt-br 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -288428,6 +288590,7 @@ exports[`Locale Provider should display the text as ro 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -288661,6 +288824,7 @@ exports[`Locale Provider should display the text as ro 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -289709,6 +289873,7 @@ exports[`Locale Provider should display the text as ro 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -293663,6 +293828,7 @@ exports[`Locale Provider should display the text as ru 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -293896,6 +294062,7 @@ exports[`Locale Provider should display the text as ru 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -294944,6 +295111,7 @@ exports[`Locale Provider should display the text as ru 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -298898,6 +299066,7 @@ exports[`Locale Provider should display the text as si 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -299131,6 +299300,7 @@ exports[`Locale Provider should display the text as si 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -300179,6 +300349,7 @@ exports[`Locale Provider should display the text as si 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -304133,6 +304304,7 @@ exports[`Locale Provider should display the text as sk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -304366,6 +304538,7 @@ exports[`Locale Provider should display the text as sk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -305414,6 +305587,7 @@ exports[`Locale Provider should display the text as sk 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -309368,6 +309542,7 @@ exports[`Locale Provider should display the text as sl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -309601,6 +309776,7 @@ exports[`Locale Provider should display the text as sl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -310649,6 +310825,7 @@ exports[`Locale Provider should display the text as sl 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -314603,6 +314780,7 @@ exports[`Locale Provider should display the text as sq 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -314836,6 +315014,7 @@ exports[`Locale Provider should display the text as sq 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -315884,6 +316063,7 @@ exports[`Locale Provider should display the text as sq 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -319838,6 +320018,7 @@ exports[`Locale Provider should display the text as sr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -320071,6 +320252,7 @@ exports[`Locale Provider should display the text as sr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -321119,6 +321301,7 @@ exports[`Locale Provider should display the text as sr 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -325073,6 +325256,7 @@ exports[`Locale Provider should display the text as sv 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -325306,6 +325490,7 @@ exports[`Locale Provider should display the text as sv 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -326354,6 +326539,7 @@ exports[`Locale Provider should display the text as sv 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -330308,6 +330494,7 @@ exports[`Locale Provider should display the text as ta 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -330541,6 +330728,7 @@ exports[`Locale Provider should display the text as ta 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -331589,6 +331777,7 @@ exports[`Locale Provider should display the text as ta 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -335543,6 +335732,7 @@ exports[`Locale Provider should display the text as th 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -335776,6 +335966,7 @@ exports[`Locale Provider should display the text as th 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -336824,6 +337015,7 @@ exports[`Locale Provider should display the text as th 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -340778,6 +340970,7 @@ exports[`Locale Provider should display the text as tk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -341011,6 +341204,7 @@ exports[`Locale Provider should display the text as tk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -342059,6 +342253,7 @@ exports[`Locale Provider should display the text as tk 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -346013,6 +346208,7 @@ exports[`Locale Provider should display the text as tr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -346246,6 +346442,7 @@ exports[`Locale Provider should display the text as tr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -347294,6 +347491,7 @@ exports[`Locale Provider should display the text as tr 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -351248,6 +351446,7 @@ exports[`Locale Provider should display the text as uk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -351481,6 +351680,7 @@ exports[`Locale Provider should display the text as uk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -352529,6 +352729,7 @@ exports[`Locale Provider should display the text as uk 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -356483,6 +356684,7 @@ exports[`Locale Provider should display the text as ur 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -356716,6 +356918,7 @@ exports[`Locale Provider should display the text as ur 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -357764,6 +357967,7 @@ exports[`Locale Provider should display the text as ur 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -361718,6 +361922,7 @@ exports[`Locale Provider should display the text as uz-latn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -361951,6 +362156,7 @@ exports[`Locale Provider should display the text as uz-latn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -362999,6 +363205,7 @@ exports[`Locale Provider should display the text as uz-latn 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -366953,6 +367160,7 @@ exports[`Locale Provider should display the text as vi 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -367186,6 +367394,7 @@ exports[`Locale Provider should display the text as vi 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -368234,6 +368443,7 @@ exports[`Locale Provider should display the text as vi 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -372188,6 +372398,7 @@ exports[`Locale Provider should display the text as zh-cn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -372421,6 +372632,7 @@ exports[`Locale Provider should display the text as zh-cn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -373469,6 +373681,7 @@ exports[`Locale Provider should display the text as zh-cn 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -377423,6 +377636,7 @@ exports[`Locale Provider should display the text as zh-hk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -377656,6 +377870,7 @@ exports[`Locale Provider should display the text as zh-hk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -378704,6 +378919,7 @@ exports[`Locale Provider should display the text as zh-hk 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -382658,6 +382874,7 @@ exports[`Locale Provider should display the text as zh-tw 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -382891,6 +383108,7 @@ exports[`Locale Provider should display the text as zh-tw 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -383939,6 +384157,7 @@ exports[`Locale Provider should display the text as zh-tw 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg

--- a/components/locale/__tests__/__snapshots__/vitest/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/vitest/index.test.tsx.snap
@@ -729,6 +729,7 @@ exports[`Locale Provider > should display the text as ar 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -962,6 +963,7 @@ exports[`Locale Provider > should display the text as ar 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -2010,6 +2012,7 @@ exports[`Locale Provider > should display the text as ar 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -2678,6 +2681,7 @@ exports[`Locale Provider > should display the text as az 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -2911,6 +2915,7 @@ exports[`Locale Provider > should display the text as az 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -3959,6 +3964,7 @@ exports[`Locale Provider > should display the text as az 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -4627,6 +4633,7 @@ exports[`Locale Provider > should display the text as bg 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -4860,6 +4867,7 @@ exports[`Locale Provider > should display the text as bg 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -5908,6 +5916,7 @@ exports[`Locale Provider > should display the text as bg 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -6576,6 +6585,7 @@ exports[`Locale Provider > should display the text as bn-bd 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -6809,6 +6819,7 @@ exports[`Locale Provider > should display the text as bn-bd 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -7857,6 +7868,7 @@ exports[`Locale Provider > should display the text as bn-bd 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -8525,6 +8537,7 @@ exports[`Locale Provider > should display the text as by 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -8758,6 +8771,7 @@ exports[`Locale Provider > should display the text as by 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -9806,6 +9820,7 @@ exports[`Locale Provider > should display the text as by 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -10474,6 +10489,7 @@ exports[`Locale Provider > should display the text as ca 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -10707,6 +10723,7 @@ exports[`Locale Provider > should display the text as ca 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -11755,6 +11772,7 @@ exports[`Locale Provider > should display the text as ca 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -12423,6 +12441,7 @@ exports[`Locale Provider > should display the text as cs 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -12656,6 +12675,7 @@ exports[`Locale Provider > should display the text as cs 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -13704,6 +13724,7 @@ exports[`Locale Provider > should display the text as cs 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -14372,6 +14393,7 @@ exports[`Locale Provider > should display the text as da 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -14605,6 +14627,7 @@ exports[`Locale Provider > should display the text as da 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -15653,6 +15676,7 @@ exports[`Locale Provider > should display the text as da 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -16321,6 +16345,7 @@ exports[`Locale Provider > should display the text as de 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -16554,6 +16579,7 @@ exports[`Locale Provider > should display the text as de 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -17602,6 +17628,7 @@ exports[`Locale Provider > should display the text as de 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -18270,6 +18297,7 @@ exports[`Locale Provider > should display the text as el 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -18503,6 +18531,7 @@ exports[`Locale Provider > should display the text as el 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -19551,6 +19580,7 @@ exports[`Locale Provider > should display the text as el 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -20219,6 +20249,7 @@ exports[`Locale Provider > should display the text as en 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -20452,6 +20483,7 @@ exports[`Locale Provider > should display the text as en 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -21500,6 +21532,7 @@ exports[`Locale Provider > should display the text as en 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -22168,6 +22201,7 @@ exports[`Locale Provider > should display the text as en-gb 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -22401,6 +22435,7 @@ exports[`Locale Provider > should display the text as en-gb 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -23449,6 +23484,7 @@ exports[`Locale Provider > should display the text as en-gb 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -24117,6 +24153,7 @@ exports[`Locale Provider > should display the text as es 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -24350,6 +24387,7 @@ exports[`Locale Provider > should display the text as es 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -25398,6 +25436,7 @@ exports[`Locale Provider > should display the text as es 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -26066,6 +26105,7 @@ exports[`Locale Provider > should display the text as es-us 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -26299,6 +26339,7 @@ exports[`Locale Provider > should display the text as es-us 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -27347,6 +27388,7 @@ exports[`Locale Provider > should display the text as es-us 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -28015,6 +28057,7 @@ exports[`Locale Provider > should display the text as et 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -28248,6 +28291,7 @@ exports[`Locale Provider > should display the text as et 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -29296,6 +29340,7 @@ exports[`Locale Provider > should display the text as et 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -29964,6 +30009,7 @@ exports[`Locale Provider > should display the text as eu 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -30197,6 +30243,7 @@ exports[`Locale Provider > should display the text as eu 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -31245,6 +31292,7 @@ exports[`Locale Provider > should display the text as eu 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -31913,6 +31961,7 @@ exports[`Locale Provider > should display the text as fa 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -32146,6 +32195,7 @@ exports[`Locale Provider > should display the text as fa 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -33194,6 +33244,7 @@ exports[`Locale Provider > should display the text as fa 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -33862,6 +33913,7 @@ exports[`Locale Provider > should display the text as fi 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -34095,6 +34147,7 @@ exports[`Locale Provider > should display the text as fi 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -35143,6 +35196,7 @@ exports[`Locale Provider > should display the text as fi 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -35811,6 +35865,7 @@ exports[`Locale Provider > should display the text as fr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -36044,6 +36099,7 @@ exports[`Locale Provider > should display the text as fr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -37092,6 +37148,7 @@ exports[`Locale Provider > should display the text as fr 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -37760,6 +37817,7 @@ exports[`Locale Provider > should display the text as fr 2`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -37993,6 +38051,7 @@ exports[`Locale Provider > should display the text as fr 2`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -39041,6 +39100,7 @@ exports[`Locale Provider > should display the text as fr 2`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -39709,6 +39769,7 @@ exports[`Locale Provider > should display the text as fr 3`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -39942,6 +40003,7 @@ exports[`Locale Provider > should display the text as fr 3`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -40990,6 +41052,7 @@ exports[`Locale Provider > should display the text as fr 3`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -41658,6 +41721,7 @@ exports[`Locale Provider > should display the text as ga 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -41891,6 +41955,7 @@ exports[`Locale Provider > should display the text as ga 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -42939,6 +43004,7 @@ exports[`Locale Provider > should display the text as ga 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -43607,6 +43673,7 @@ exports[`Locale Provider > should display the text as gl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -43840,6 +43907,7 @@ exports[`Locale Provider > should display the text as gl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -44888,6 +44956,7 @@ exports[`Locale Provider > should display the text as gl 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -45556,6 +45625,7 @@ exports[`Locale Provider > should display the text as he 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -45789,6 +45859,7 @@ exports[`Locale Provider > should display the text as he 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -46837,6 +46908,7 @@ exports[`Locale Provider > should display the text as he 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -47505,6 +47577,7 @@ exports[`Locale Provider > should display the text as hi 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -47738,6 +47811,7 @@ exports[`Locale Provider > should display the text as hi 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -48786,6 +48860,7 @@ exports[`Locale Provider > should display the text as hi 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -49454,6 +49529,7 @@ exports[`Locale Provider > should display the text as hr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -49687,6 +49763,7 @@ exports[`Locale Provider > should display the text as hr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -50735,6 +50812,7 @@ exports[`Locale Provider > should display the text as hr 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -51403,6 +51481,7 @@ exports[`Locale Provider > should display the text as hu 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -51636,6 +51715,7 @@ exports[`Locale Provider > should display the text as hu 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -52684,6 +52764,7 @@ exports[`Locale Provider > should display the text as hu 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -53352,6 +53433,7 @@ exports[`Locale Provider > should display the text as hy-am 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -53585,6 +53667,7 @@ exports[`Locale Provider > should display the text as hy-am 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -54633,6 +54716,7 @@ exports[`Locale Provider > should display the text as hy-am 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -55301,6 +55385,7 @@ exports[`Locale Provider > should display the text as id 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -55534,6 +55619,7 @@ exports[`Locale Provider > should display the text as id 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -56582,6 +56668,7 @@ exports[`Locale Provider > should display the text as id 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -57250,6 +57337,7 @@ exports[`Locale Provider > should display the text as is 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -57483,6 +57571,7 @@ exports[`Locale Provider > should display the text as is 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -58531,6 +58620,7 @@ exports[`Locale Provider > should display the text as is 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -59199,6 +59289,7 @@ exports[`Locale Provider > should display the text as it 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -59432,6 +59523,7 @@ exports[`Locale Provider > should display the text as it 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -60480,6 +60572,7 @@ exports[`Locale Provider > should display the text as it 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -61148,6 +61241,7 @@ exports[`Locale Provider > should display the text as ja 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -61381,6 +61475,7 @@ exports[`Locale Provider > should display the text as ja 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -62429,6 +62524,7 @@ exports[`Locale Provider > should display the text as ja 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -63097,6 +63193,7 @@ exports[`Locale Provider > should display the text as ka 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -63330,6 +63427,7 @@ exports[`Locale Provider > should display the text as ka 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -64378,6 +64476,7 @@ exports[`Locale Provider > should display the text as ka 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -65046,6 +65145,7 @@ exports[`Locale Provider > should display the text as kk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -65279,6 +65379,7 @@ exports[`Locale Provider > should display the text as kk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -66327,6 +66428,7 @@ exports[`Locale Provider > should display the text as kk 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -66994,6 +67096,7 @@ exports[`Locale Provider > should display the text as km 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -67226,6 +67329,7 @@ exports[`Locale Provider > should display the text as km 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -68274,6 +68378,7 @@ exports[`Locale Provider > should display the text as km 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -68942,6 +69047,7 @@ exports[`Locale Provider > should display the text as kn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -69175,6 +69281,7 @@ exports[`Locale Provider > should display the text as kn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -70223,6 +70330,7 @@ exports[`Locale Provider > should display the text as kn 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -70891,6 +70999,7 @@ exports[`Locale Provider > should display the text as ko 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -71124,6 +71233,7 @@ exports[`Locale Provider > should display the text as ko 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -72172,6 +72282,7 @@ exports[`Locale Provider > should display the text as ko 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -72840,6 +72951,7 @@ exports[`Locale Provider > should display the text as ku 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -73073,6 +73185,7 @@ exports[`Locale Provider > should display the text as ku 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -74121,6 +74234,7 @@ exports[`Locale Provider > should display the text as ku 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -74789,6 +74903,7 @@ exports[`Locale Provider > should display the text as ku-iq 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -75022,6 +75137,7 @@ exports[`Locale Provider > should display the text as ku-iq 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -76070,6 +76186,7 @@ exports[`Locale Provider > should display the text as ku-iq 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -76738,6 +76855,7 @@ exports[`Locale Provider > should display the text as lt 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -76971,6 +77089,7 @@ exports[`Locale Provider > should display the text as lt 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -78019,6 +78138,7 @@ exports[`Locale Provider > should display the text as lt 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -78687,6 +78807,7 @@ exports[`Locale Provider > should display the text as lv 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -78920,6 +79041,7 @@ exports[`Locale Provider > should display the text as lv 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -79968,6 +80090,7 @@ exports[`Locale Provider > should display the text as lv 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -80636,6 +80759,7 @@ exports[`Locale Provider > should display the text as mk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -80869,6 +80993,7 @@ exports[`Locale Provider > should display the text as mk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -81917,6 +82042,7 @@ exports[`Locale Provider > should display the text as mk 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -82585,6 +82711,7 @@ exports[`Locale Provider > should display the text as ml 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -82818,6 +82945,7 @@ exports[`Locale Provider > should display the text as ml 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -83866,6 +83994,7 @@ exports[`Locale Provider > should display the text as ml 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -84534,6 +84663,7 @@ exports[`Locale Provider > should display the text as mn-mn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -84767,6 +84897,7 @@ exports[`Locale Provider > should display the text as mn-mn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -85815,6 +85946,7 @@ exports[`Locale Provider > should display the text as mn-mn 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -86483,6 +86615,7 @@ exports[`Locale Provider > should display the text as mr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -86716,6 +86849,7 @@ exports[`Locale Provider > should display the text as mr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -87764,6 +87898,7 @@ exports[`Locale Provider > should display the text as mr 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -88432,6 +88567,7 @@ exports[`Locale Provider > should display the text as ms-my 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -88665,6 +88801,7 @@ exports[`Locale Provider > should display the text as ms-my 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -89713,6 +89850,7 @@ exports[`Locale Provider > should display the text as ms-my 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -90381,6 +90519,7 @@ exports[`Locale Provider > should display the text as my 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -90614,6 +90753,7 @@ exports[`Locale Provider > should display the text as my 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -91662,6 +91802,7 @@ exports[`Locale Provider > should display the text as my 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -92330,6 +92471,7 @@ exports[`Locale Provider > should display the text as nb 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -92563,6 +92705,7 @@ exports[`Locale Provider > should display the text as nb 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -93611,6 +93754,7 @@ exports[`Locale Provider > should display the text as nb 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -94279,6 +94423,7 @@ exports[`Locale Provider > should display the text as ne-np 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -94512,6 +94657,7 @@ exports[`Locale Provider > should display the text as ne-np 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -95560,6 +95706,7 @@ exports[`Locale Provider > should display the text as ne-np 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -96228,6 +96375,7 @@ exports[`Locale Provider > should display the text as nl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -96461,6 +96609,7 @@ exports[`Locale Provider > should display the text as nl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -97509,6 +97658,7 @@ exports[`Locale Provider > should display the text as nl 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -98177,6 +98327,7 @@ exports[`Locale Provider > should display the text as nl-be 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -98410,6 +98561,7 @@ exports[`Locale Provider > should display the text as nl-be 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -99458,6 +99610,7 @@ exports[`Locale Provider > should display the text as nl-be 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -100126,6 +100279,7 @@ exports[`Locale Provider > should display the text as pl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -100359,6 +100513,7 @@ exports[`Locale Provider > should display the text as pl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -101407,6 +101562,7 @@ exports[`Locale Provider > should display the text as pl 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -102075,6 +102231,7 @@ exports[`Locale Provider > should display the text as pt 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -102308,6 +102465,7 @@ exports[`Locale Provider > should display the text as pt 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -103356,6 +103514,7 @@ exports[`Locale Provider > should display the text as pt 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -104024,6 +104183,7 @@ exports[`Locale Provider > should display the text as pt-br 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -104257,6 +104417,7 @@ exports[`Locale Provider > should display the text as pt-br 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -105305,6 +105466,7 @@ exports[`Locale Provider > should display the text as pt-br 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -105973,6 +106135,7 @@ exports[`Locale Provider > should display the text as ro 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -106206,6 +106369,7 @@ exports[`Locale Provider > should display the text as ro 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -107254,6 +107418,7 @@ exports[`Locale Provider > should display the text as ro 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -107922,6 +108087,7 @@ exports[`Locale Provider > should display the text as ru 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -108155,6 +108321,7 @@ exports[`Locale Provider > should display the text as ru 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -109203,6 +109370,7 @@ exports[`Locale Provider > should display the text as ru 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -109871,6 +110039,7 @@ exports[`Locale Provider > should display the text as si 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -110104,6 +110273,7 @@ exports[`Locale Provider > should display the text as si 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -111152,6 +111322,7 @@ exports[`Locale Provider > should display the text as si 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -111820,6 +111991,7 @@ exports[`Locale Provider > should display the text as sk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -112053,6 +112225,7 @@ exports[`Locale Provider > should display the text as sk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -113101,6 +113274,7 @@ exports[`Locale Provider > should display the text as sk 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -113769,6 +113943,7 @@ exports[`Locale Provider > should display the text as sl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -114002,6 +114177,7 @@ exports[`Locale Provider > should display the text as sl 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -115050,6 +115226,7 @@ exports[`Locale Provider > should display the text as sl 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -115718,6 +115895,7 @@ exports[`Locale Provider > should display the text as sq 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -115951,6 +116129,7 @@ exports[`Locale Provider > should display the text as sq 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -116999,6 +117178,7 @@ exports[`Locale Provider > should display the text as sq 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -117667,6 +117847,7 @@ exports[`Locale Provider > should display the text as sr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -117900,6 +118081,7 @@ exports[`Locale Provider > should display the text as sr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -118948,6 +119130,7 @@ exports[`Locale Provider > should display the text as sr 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -119616,6 +119799,7 @@ exports[`Locale Provider > should display the text as sv 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -119849,6 +120033,7 @@ exports[`Locale Provider > should display the text as sv 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -120897,6 +121082,7 @@ exports[`Locale Provider > should display the text as sv 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -121565,6 +121751,7 @@ exports[`Locale Provider > should display the text as ta 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -121798,6 +121985,7 @@ exports[`Locale Provider > should display the text as ta 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -122846,6 +123034,7 @@ exports[`Locale Provider > should display the text as ta 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -123514,6 +123703,7 @@ exports[`Locale Provider > should display the text as th 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -123747,6 +123937,7 @@ exports[`Locale Provider > should display the text as th 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -124795,6 +124986,7 @@ exports[`Locale Provider > should display the text as th 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -125463,6 +125655,7 @@ exports[`Locale Provider > should display the text as tk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -125696,6 +125889,7 @@ exports[`Locale Provider > should display the text as tk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -126744,6 +126938,7 @@ exports[`Locale Provider > should display the text as tk 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -127412,6 +127607,7 @@ exports[`Locale Provider > should display the text as tr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -127645,6 +127841,7 @@ exports[`Locale Provider > should display the text as tr 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -128693,6 +128890,7 @@ exports[`Locale Provider > should display the text as tr 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -129361,6 +129559,7 @@ exports[`Locale Provider > should display the text as uk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -129594,6 +129793,7 @@ exports[`Locale Provider > should display the text as uk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -130642,6 +130842,7 @@ exports[`Locale Provider > should display the text as uk 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -131310,6 +131511,7 @@ exports[`Locale Provider > should display the text as ur 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -131543,6 +131745,7 @@ exports[`Locale Provider > should display the text as ur 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -132591,6 +132794,7 @@ exports[`Locale Provider > should display the text as ur 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -133259,6 +133463,7 @@ exports[`Locale Provider > should display the text as uz-latn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -133492,6 +133697,7 @@ exports[`Locale Provider > should display the text as uz-latn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -134540,6 +134746,7 @@ exports[`Locale Provider > should display the text as uz-latn 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -135208,6 +135415,7 @@ exports[`Locale Provider > should display the text as vi 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -135441,6 +135649,7 @@ exports[`Locale Provider > should display the text as vi 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -136489,6 +136698,7 @@ exports[`Locale Provider > should display the text as vi 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -137157,6 +137367,7 @@ exports[`Locale Provider > should display the text as zh-cn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -137390,6 +137601,7 @@ exports[`Locale Provider > should display the text as zh-cn 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -138438,6 +138650,7 @@ exports[`Locale Provider > should display the text as zh-cn 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -139106,6 +139319,7 @@ exports[`Locale Provider > should display the text as zh-hk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -139339,6 +139553,7 @@ exports[`Locale Provider > should display the text as zh-hk 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -140387,6 +140602,7 @@ exports[`Locale Provider > should display the text as zh-hk 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -141055,6 +141271,7 @@ exports[`Locale Provider > should display the text as zh-tw 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -141288,6 +141505,7 @@ exports[`Locale Provider > should display the text as zh-tw 1`] = `
             class="css-var-root ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -142336,6 +142554,7 @@ exports[`Locale Provider > should display the text as zh-tw 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg

--- a/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2191,6 +2191,7 @@ Array [
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -3096,6 +3097,7 @@ exports[`renders components/select/demo/debug.tsx extend context correctly 1`] =
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -16150,6 +16152,7 @@ exports[`renders components/select/demo/status.tsx extend context correctly 1`] 
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -16262,6 +16265,7 @@ exports[`renders components/select/demo/status.tsx extend context correctly 1`] 
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -11068,6 +11068,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
                         >
                           <div
+                            aria-hidden="true"
                             class="ant-empty-image"
                           >
                             <svg
@@ -12240,6 +12241,7 @@ exports[`renders components/space/demo/compact-debug.tsx extend context correctl
                     class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
                   >
                     <div
+                      aria-hidden="true"
                       class="ant-empty-image"
                     >
                       <svg

--- a/components/table/__tests__/__snapshots__/Table.pagination.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.pagination.test.tsx.snap
@@ -541,6 +541,7 @@ exports[`Table.pagination should not crash when trigger onChange in render 1`] =
                       class="css-var-root ant-empty ant-empty-normal"
                     >
                       <div
+                        aria-hidden="true"
                         class="ant-empty-image"
                       >
                         <svg

--- a/components/table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -157,6 +157,7 @@ exports[`Table rtl render component should be rendered correctly in RTL directio
                       class="css-var-root ant-empty ant-empty-normal ant-empty-rtl"
                     >
                       <div
+                        aria-hidden="true"
                         class="ant-empty-image"
                       >
                         <svg
@@ -594,6 +595,7 @@ exports[`Table should render title 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -700,6 +702,7 @@ exports[`Table support wireframe 1`] = `
                       class="css-var-test-id ant-empty ant-empty-normal"
                     >
                       <div
+                        aria-hidden="true"
                         class="ant-empty-image"
                       >
                         <svg

--- a/components/table/__tests__/__snapshots__/empty.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/empty.test.tsx.snap
@@ -92,6 +92,7 @@ exports[`Table renders empty table 1`] = `
                       class="css-var-root ant-empty ant-empty-normal"
                     >
                       <div
+                        aria-hidden="true"
                         class="ant-empty-image"
                       >
                         <svg
@@ -590,6 +591,7 @@ exports[`Table renders empty table with fixed columns should work 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -763,6 +765,7 @@ exports[`Table renders empty table without emptyText when loading 1`] = `
                       class="css-var-root ant-empty ant-empty-normal"
                     >
                       <div
+                        aria-hidden="true"
                         class="ant-empty-image"
                       >
                         <svg

--- a/components/table/__tests__/__snapshots__/vitest/empty.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/vitest/empty.test.tsx.snap
@@ -92,6 +92,7 @@ exports[`Table > renders empty table 1`] = `
                       class="css-var-root ant-empty ant-empty-normal"
                     >
                       <div
+                        aria-hidden="true"
                         class="ant-empty-image"
                       >
                         <svg
@@ -590,6 +591,7 @@ exports[`Table > renders empty table with fixed columns > should work 1`] = `
                         class="css-var-root ant-empty ant-empty-normal"
                       >
                         <div
+                          aria-hidden="true"
                           class="ant-empty-image"
                         >
                           <svg
@@ -763,6 +765,7 @@ exports[`Table > renders empty table without emptyText when loading 1`] = `
                       class="css-var-root ant-empty ant-empty-normal"
                     >
                       <div
+                        aria-hidden="true"
                         class="ant-empty-image"
                       >
                         <svg

--- a/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tooltip/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1625,6 +1625,7 @@ exports[`renders components/tooltip/demo/disabled-children.tsx extend context co
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg

--- a/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3428,6 +3428,7 @@ Array [
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -3672,6 +3673,7 @@ Array [
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -3924,6 +3926,7 @@ Array [
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -4234,6 +4237,7 @@ Array [
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -9963,6 +9967,7 @@ exports[`renders components/transfer/demo/status.tsx extend context correctly 1`
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -10207,6 +10212,7 @@ exports[`renders components/transfer/demo/status.tsx extend context correctly 1`
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -10459,6 +10465,7 @@ exports[`renders components/transfer/demo/status.tsx extend context correctly 1`
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -10769,6 +10776,7 @@ exports[`renders components/transfer/demo/status.tsx extend context correctly 1`
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -13585,6 +13593,7 @@ exports[`renders components/transfer/demo/table-transfer.tsx extend context corr
                                 class="css-var-test-id ant-empty ant-empty-normal"
                               >
                                 <div
+                                  aria-hidden="true"
                                   class="ant-empty-image"
                                 >
                                   <svg
@@ -14114,6 +14123,7 @@ exports[`renders components/transfer/demo/tree-transfer.tsx extend context corre
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg

--- a/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/transfer/__tests__/__snapshots__/demo.test.ts.snap
@@ -762,6 +762,7 @@ exports[`renders components/transfer/demo/advanced.tsx correctly 1`] = `
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -1017,6 +1018,7 @@ exports[`renders components/transfer/demo/advanced.tsx correctly 1`] = `
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -2405,6 +2407,7 @@ Array [
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -2574,6 +2577,7 @@ Array [
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -2751,6 +2755,7 @@ Array [
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -2986,6 +2991,7 @@ Array [
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -4330,6 +4336,7 @@ exports[`renders components/transfer/demo/custom-item.tsx correctly 1`] = `
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -4500,6 +4507,7 @@ exports[`renders components/transfer/demo/custom-item.tsx correctly 1`] = `
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -5001,6 +5009,7 @@ Array [
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -5157,6 +5166,7 @@ Array [
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -6063,6 +6073,7 @@ exports[`renders components/transfer/demo/search.tsx correctly 1`] = `
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -6298,6 +6309,7 @@ exports[`renders components/transfer/demo/search.tsx correctly 1`] = `
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -6415,6 +6427,7 @@ exports[`renders components/transfer/demo/status.tsx correctly 1`] = `
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -6584,6 +6597,7 @@ exports[`renders components/transfer/demo/status.tsx correctly 1`] = `
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -6761,6 +6775,7 @@ exports[`renders components/transfer/demo/status.tsx correctly 1`] = `
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -6996,6 +7011,7 @@ exports[`renders components/transfer/demo/status.tsx correctly 1`] = `
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -9296,6 +9312,7 @@ exports[`renders components/transfer/demo/table-transfer.tsx correctly 1`] = `
                                 class="css-var-test-id ant-empty ant-empty-normal"
                               >
                                 <div
+                                  aria-hidden="true"
                                   class="ant-empty-image"
                                 >
                                   <svg
@@ -9829,6 +9846,7 @@ exports[`renders components/transfer/demo/tree-transfer.tsx correctly 1`] = `
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg

--- a/components/transfer/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/transfer/__tests__/__snapshots__/index.test.tsx.snap
@@ -62,6 +62,7 @@ exports[`Transfer rtl render component should be rendered correctly in RTL direc
           class="css-var-root ant-empty ant-empty-normal ant-empty-rtl ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -229,6 +230,7 @@ exports[`Transfer rtl render component should be rendered correctly in RTL direc
           class="css-var-root ant-empty ant-empty-normal ant-empty-rtl ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -971,6 +973,7 @@ exports[`Transfer should support render value and label in item 1`] = `
           class="css-var-root ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -1221,6 +1224,7 @@ exports[`immutable data dataSource is frozen 1`] = `
           class="css-var-root ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg

--- a/components/tree-select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tree-select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2498,6 +2498,7 @@ exports[`renders components/tree-select/demo/status.tsx extend context correctly
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -2622,6 +2623,7 @@ exports[`renders components/tree-select/demo/status.tsx extend context correctly
             class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
           >
             <div
+              aria-hidden="true"
               class="ant-empty-image"
             >
               <svg
@@ -4205,6 +4207,7 @@ exports[`renders components/tree-select/demo/variant.tsx extend context correctl
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -4314,6 +4317,7 @@ exports[`renders components/tree-select/demo/variant.tsx extend context correctl
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -4423,6 +4427,7 @@ exports[`renders components/tree-select/demo/variant.tsx extend context correctl
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg
@@ -4532,6 +4537,7 @@ exports[`renders components/tree-select/demo/variant.tsx extend context correctl
           class="css-var-test-id ant-empty ant-empty-normal ant-empty-small"
         >
           <div
+            aria-hidden="true"
             class="ant-empty-image"
           >
             <svg


### PR DESCRIPTION
## Summary

- hide Ant Design built-in Empty illustrations from assistive technology when the component already renders a description
- preserve the built-in SVG title when `description={false}` so the illustration can still provide the fallback text
- leave custom image accessibility entirely under consumer control

## Why

The built-in default and simple illustrations contain a localized `<title>`, while `Empty` also renders the same localized description as visible text. Chromium therefore exposes both an image named `No data` and a `StaticText` node named `No data`, which can cause the empty-state message to be announced twice.

The image is decorative only when that visible description exists. Applying `aria-hidden` to the built-in image container removes the duplicate node without changing custom images or description-free usage.

## Regression proof

Chromium accessibility tree before:

```text
image: "No data"
StaticText: "No data"
```

With this change:

```text
StaticText: "No data"
```

The regression covers the default illustration, `PRESENTED_IMAGE_SIMPLE`, a custom SVG, and the `description={false}` fallback.

## Verification

- exact-base focused regression failed because the built-in image container had no `aria-hidden`
- fixed Empty scope: 2 files, 19 tests, 3 updated snapshots passed
- focused ESLint passed
- focused Prettier check passed
- `git diff --check` passed
- Chromium CDP accessibility-tree probe confirmed the duplicate image node is removed

AI assistance disclosure: Codex was used to audit the accessible tree, check open PR overlap, draft the focused regression, and run validation. I verified the DOM behavior, Chromium accessibility output, diff, and signed commit.
