### PR TITLE
fix(locale): correct Traditional Chinese picker terms

### DIFF
--- a/components/date-picker/locale/zh_TW.ts
+++ b/components/date-picker/locale/zh_TW.ts
@@ -23,7 +23,7 @@ const locale: PickerLocale = {
   },
 };
 
-locale.lang.ok = '確 定';
+locale.lang.ok = '確定';
 
 // All settings at:
 // https://github.com/ant-design/ant-design/blob/master/components/date-picker/locale/example.json

--- a/components/locale/__tests__/index.test.tsx
+++ b/components/locale/__tests__/index.test.tsx
@@ -292,6 +292,11 @@ describe('Locale Provider', () => {
     MockDate.reset();
   });
 
+  it('uses Taiwan terminology for picker controls', () => {
+    expect(zhTW.DatePicker?.lang.ok).toBe('確定');
+    expect(zhTW.ColorPicker?.gradientColor).toBe('漸層色');
+  });
+
   locales.forEach((locale) => {
     it(`should display the text as ${locale.locale}`, () => {
       const { container } = render(

--- a/components/locale/zh_TW.ts
+++ b/components/locale/zh_TW.ts
@@ -145,7 +145,7 @@ const localeValues: Locale = {
     presetEmpty: '暫無',
     transparent: '透明',
     singleColor: '單色',
-    gradientColor: '漸變色',
+    gradientColor: '漸層色',
   },
 };
 


### PR DESCRIPTION
## Summary

- remove the unintended space from the zh-TW DatePicker confirmation label (`確 定` → `確定`)
- use the established Taiwan UI term for gradient color (`漸變色` → `漸層色`)
- add a focused locale-contract regression for both strings

## Why

The DatePicker label currently renders a visible space inside a two-character action whose other Ant Design zh-TW confirmation labels consistently use `確定`. `漸變色` is the Mainland/Hong Kong wording; Taiwan software interfaces use `漸層色` for gradient color.

This keeps the changes together as one zh-TW terminology correction rather than splitting individual strings into separate pull requests.

## Verification

- exact-base focused regression failed with `Expected: 確定`, `Received: 確 定`
- fixed full locale-provider file: 77/77 tests passed
- focused ESLint passed
- focused Biome passed
- focused Prettier check passed
- `git diff --check` passed
- audited current open PR titles and bodies; no zh-TW locale overlap found

AI assistance disclosure: Codex was used to audit Taiwan terminology, check open-PR overlap, add the regression, and run validation. I verified both translations, the test output, diff, and signed commit.
