### PR TITLE
fix(ColorPicker): make default trigger keyboard accessible

### DIFF
--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -317,6 +317,7 @@ const ColorPicker: CompoundedComponent = (props) => {
         <ColorTrigger
           activeIndex={popupOpen ? activeIndex : -1}
           open={popupOpen}
+          onOpenChange={triggerOpenChange}
           className={mergedCls}
           classNames={mergedClassNames}
           styles={mergedStyles}

--- a/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4,7 +4,11 @@ exports[`renders components/color-picker/demo/allowClear.tsx extend context corr
 Array [
   <div
     aria-describedby="test-id"
+    aria-expanded="false"
+    aria-label="rgb(22,119,255)"
     class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+    role="button"
+    tabindex="0"
   >
     <div
       class="ant-color-picker-color-block"
@@ -386,7 +390,11 @@ exports[`renders components/color-picker/demo/base.tsx extend context correctly 
 Array [
   <div
     aria-describedby="test-id"
+    aria-expanded="false"
+    aria-label="rgb(22,119,255)"
     class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+    role="button"
+    tabindex="0"
   >
     <div
       class="ant-color-picker-color-block"
@@ -763,7 +771,11 @@ exports[`renders components/color-picker/demo/controlled.tsx extend context corr
   >
     <div
       aria-describedby="test-id"
+      aria-expanded="false"
+      aria-label="rgb(22,119,255)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+      role="button"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -1132,7 +1144,11 @@ exports[`renders components/color-picker/demo/controlled.tsx extend context corr
   >
     <div
       aria-describedby="test-id"
+      aria-expanded="false"
+      aria-label="rgb(22,119,255)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+      role="button"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -1505,7 +1521,12 @@ exports[`renders components/color-picker/demo/disabled.tsx extend context correc
 Array [
   <div
     aria-describedby="test-id"
+    aria-disabled="true"
+    aria-expanded="false"
+    aria-label="rgb(22,119,255)"
     class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var ant-color-picker-trigger-disabled"
+    role="button"
+    tabindex="-1"
   >
     <div
       class="ant-color-picker-color-block"
@@ -1882,7 +1903,11 @@ exports[`renders components/color-picker/demo/disabled-alpha.tsx extend context 
 Array [
   <div
     aria-describedby="test-id"
+    aria-expanded="false"
+    aria-label="rgb(22,119,255)"
     class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+    role="button"
+    tabindex="0"
   >
     <div
       class="ant-color-picker-color-block"
@@ -2172,7 +2197,11 @@ exports[`renders components/color-picker/demo/format.tsx extend context correctl
       >
         <div
           aria-describedby="test-id"
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -2556,7 +2585,11 @@ exports[`renders components/color-picker/demo/format.tsx extend context correctl
       >
         <div
           aria-describedby="test-id"
+          aria-expanded="false"
+          aria-label="rgb(23,120,255)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -3146,7 +3179,11 @@ exports[`renders components/color-picker/demo/format.tsx extend context correctl
       >
         <div
           aria-describedby="test-id"
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -3739,7 +3776,11 @@ exports[`renders components/color-picker/demo/line-gradient.tsx extend context c
   >
     <div
       aria-describedby="test-id"
+      aria-expanded="false"
+      aria-label="linear-gradient(90deg, rgb(16,142,233) 0%, rgb(135,208,104) 100%)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+      role="button"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -4208,7 +4249,11 @@ exports[`renders components/color-picker/demo/line-gradient.tsx extend context c
   >
     <div
       aria-describedby="test-id"
+      aria-expanded="false"
+      aria-label="linear-gradient(90deg, rgb(16,142,233) 0%, rgb(135,208,104) 100%)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+      role="button"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -4656,7 +4701,11 @@ exports[`renders components/color-picker/demo/panel-render.tsx extend context co
       >
         <div
           aria-describedby="test-id"
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -5049,7 +5098,11 @@ exports[`renders components/color-picker/demo/panel-render.tsx extend context co
       >
         <div
           aria-describedby="test-id"
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -5999,7 +6052,11 @@ exports[`renders components/color-picker/demo/presets.tsx extend context correct
 Array [
   <div
     aria-describedby="test-id"
+    aria-expanded="false"
+    aria-label="rgb(22,119,255)"
     class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+    role="button"
+    tabindex="0"
   >
     <div
       class="ant-color-picker-color-block"
@@ -6802,8 +6859,12 @@ exports[`renders components/color-picker/demo/pure-panel.tsx extend context corr
   >
     <div
       aria-describedby="test-id"
+      aria-expanded="true"
+      aria-label="rgb(22,119,255)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var ant-popover-open ant-color-picker-trigger-active"
+      role="button"
       style="margin: 0px;"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -7187,7 +7248,11 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
       >
         <div
           aria-describedby="test-id"
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger ant-color-picker-sm css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -7556,7 +7621,11 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
       >
         <div
           aria-describedby="test-id"
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -7925,7 +7994,11 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
       >
         <div
           aria-describedby="test-id"
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger ant-color-picker-lg css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -8302,7 +8375,11 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
       >
         <div
           aria-describedby="test-id"
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger ant-color-picker-sm css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -8676,7 +8753,11 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
       >
         <div
           aria-describedby="test-id"
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -9050,7 +9131,11 @@ exports[`renders components/color-picker/demo/size.tsx extend context correctly 
       >
         <div
           aria-describedby="test-id"
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger ant-color-picker-lg css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -9439,7 +9524,11 @@ exports[`renders components/color-picker/demo/style-class.tsx extend context cor
     >
       <div
         aria-describedby="test-id"
+        aria-expanded="false"
+        aria-label="rgb(22,119,255)"
         class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var acss-pbemrr"
+        role="button"
+        tabindex="0"
       >
         <div
           class="ant-color-picker-color-block"
@@ -9804,7 +9893,11 @@ exports[`renders components/color-picker/demo/style-class.tsx extend context cor
     >
       <div
         aria-describedby="test-id"
+        aria-expanded="false"
+        aria-label="rgb(114,46,209)"
         class="ant-color-picker-trigger ant-color-picker-lg css-var-test-id ant-color-picker-css-var acss-pbemrr"
+        role="button"
+        tabindex="0"
       >
         <div
           class="ant-color-picker-color-block"
@@ -10175,7 +10268,11 @@ exports[`renders components/color-picker/demo/text-render.tsx extend context cor
   >
     <div
       aria-describedby="test-id"
+      aria-expanded="false"
+      aria-label="rgb(22,119,255)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+      role="button"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -10559,7 +10656,11 @@ exports[`renders components/color-picker/demo/text-render.tsx extend context cor
   >
     <div
       aria-describedby="test-id"
+      aria-expanded="false"
+      aria-label="rgb(22,119,255)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+      role="button"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -10935,7 +11036,11 @@ exports[`renders components/color-picker/demo/text-render.tsx extend context cor
   >
     <div
       aria-describedby="test-id"
+      aria-expanded="false"
+      aria-label="rgb(22,119,255)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+      role="button"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -11701,7 +11806,11 @@ exports[`renders components/color-picker/demo/trigger-event.tsx extend context c
 Array [
   <div
     aria-describedby="test-id"
+    aria-expanded="false"
+    aria-label="rgb(22,119,255)"
     class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+    role="button"
+    tabindex="0"
   >
     <div
       class="ant-color-picker-color-block"

--- a/components/color-picker/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -16,7 +16,11 @@ exports[`renders components/color-picker/demo/_semantic.tsx correctly 1`] = `
       >
         <div
           aria-describedby="test-id"
+          aria-expanded="true"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var ant-popover-open semantic-mark-root ant-color-picker-trigger-active"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block semantic-mark-body"
@@ -288,13 +292,14 @@ exports[`renders components/color-picker/demo/_semantic.tsx correctly 1`] = `
           </div>
         </div>
         <div
+          aria-expanded="false"
+          aria-label="rgba(0,0,0,0)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var semantic-mark-root"
+          role="button"
+          tabindex="0"
         >
           <div
-            aria-label="Clear color"
             class="ant-color-picker-clear semantic-mark-body"
-            role="button"
-            tabindex="0"
           />
         </div>
       </div>

--- a/components/color-picker/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/color-picker/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`renders components/color-picker/demo/allowClear.tsx correctly 1`] = `
 <div
+  aria-expanded="false"
+  aria-label="rgb(22,119,255)"
   class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+  role="button"
+  tabindex="0"
 >
   <div
     class="ant-color-picker-color-block"
@@ -17,7 +21,11 @@ exports[`renders components/color-picker/demo/allowClear.tsx correctly 1`] = `
 
 exports[`renders components/color-picker/demo/base.tsx correctly 1`] = `
 <div
+  aria-expanded="false"
+  aria-label="rgb(22,119,255)"
   class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+  role="button"
+  tabindex="0"
 >
   <div
     class="ant-color-picker-color-block"
@@ -38,7 +46,11 @@ exports[`renders components/color-picker/demo/controlled.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-expanded="false"
+      aria-label="rgb(22,119,255)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+      role="button"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -54,7 +66,11 @@ exports[`renders components/color-picker/demo/controlled.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-expanded="false"
+      aria-label="rgb(22,119,255)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+      role="button"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -71,7 +87,12 @@ exports[`renders components/color-picker/demo/controlled.tsx correctly 1`] = `
 
 exports[`renders components/color-picker/demo/disabled.tsx correctly 1`] = `
 <div
+  aria-disabled="true"
+  aria-expanded="false"
+  aria-label="rgb(22,119,255)"
   class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var ant-color-picker-trigger-disabled"
+  role="button"
+  tabindex="-1"
 >
   <div
     class="ant-color-picker-color-block"
@@ -91,7 +112,11 @@ exports[`renders components/color-picker/demo/disabled.tsx correctly 1`] = `
 
 exports[`renders components/color-picker/demo/disabled-alpha.tsx correctly 1`] = `
 <div
+  aria-expanded="false"
+  aria-label="rgb(22,119,255)"
   class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+  role="button"
+  tabindex="0"
 >
   <div
     class="ant-color-picker-color-block"
@@ -119,7 +144,11 @@ exports[`renders components/color-picker/demo/format.tsx correctly 1`] = `
         class="ant-space-item"
       >
         <div
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -152,7 +181,11 @@ exports[`renders components/color-picker/demo/format.tsx correctly 1`] = `
         class="ant-space-item"
       >
         <div
+          aria-expanded="false"
+          aria-label="rgb(23,120,255)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -185,7 +218,11 @@ exports[`renders components/color-picker/demo/format.tsx correctly 1`] = `
         class="ant-space-item"
       >
         <div
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -219,7 +256,11 @@ exports[`renders components/color-picker/demo/line-gradient.tsx correctly 1`] = 
     class="ant-space-item"
   >
     <div
+      aria-expanded="false"
+      aria-label="linear-gradient(90deg, rgb(16,142,233) 0%, rgb(135,208,104) 100%)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+      role="button"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -259,7 +300,11 @@ exports[`renders components/color-picker/demo/line-gradient.tsx correctly 1`] = 
     class="ant-space-item"
   >
     <div
+      aria-expanded="false"
+      aria-label="linear-gradient(90deg, rgb(16,142,233) 0%, rgb(135,208,104) 100%)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+      role="button"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -319,7 +364,11 @@ exports[`renders components/color-picker/demo/panel-render.tsx correctly 1`] = `
         class="ant-space-item"
       >
         <div
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -350,7 +399,11 @@ exports[`renders components/color-picker/demo/panel-render.tsx correctly 1`] = `
         class="ant-space-item"
       >
         <div
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -369,7 +422,11 @@ exports[`renders components/color-picker/demo/panel-render.tsx correctly 1`] = `
 
 exports[`renders components/color-picker/demo/presets.tsx correctly 1`] = `
 <div
+  aria-expanded="false"
+  aria-label="rgb(22,119,255)"
   class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+  role="button"
+  tabindex="0"
 >
   <div
     class="ant-color-picker-color-block"
@@ -390,8 +447,12 @@ exports[`renders components/color-picker/demo/pure-panel.tsx correctly 1`] = `
     style="padding-bottom:0;position:relative;min-width:0"
   >
     <div
+      aria-expanded="false"
+      aria-label="rgb(22,119,255)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+      role="button"
       style="margin:0"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -420,7 +481,11 @@ exports[`renders components/color-picker/demo/size.tsx correctly 1`] = `
         class="ant-space-item"
       >
         <div
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger ant-color-picker-sm css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -436,7 +501,11 @@ exports[`renders components/color-picker/demo/size.tsx correctly 1`] = `
         class="ant-space-item"
       >
         <div
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -452,7 +521,11 @@ exports[`renders components/color-picker/demo/size.tsx correctly 1`] = `
         class="ant-space-item"
       >
         <div
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger ant-color-picker-lg css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -476,7 +549,11 @@ exports[`renders components/color-picker/demo/size.tsx correctly 1`] = `
         class="ant-space-item"
       >
         <div
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger ant-color-picker-sm css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -497,7 +574,11 @@ exports[`renders components/color-picker/demo/size.tsx correctly 1`] = `
         class="ant-space-item"
       >
         <div
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -518,7 +599,11 @@ exports[`renders components/color-picker/demo/size.tsx correctly 1`] = `
         class="ant-space-item"
       >
         <div
+          aria-expanded="false"
+          aria-label="rgb(22,119,255)"
           class="ant-color-picker-trigger ant-color-picker-lg css-var-test-id ant-color-picker-css-var"
+          role="button"
+          tabindex="0"
         >
           <div
             class="ant-color-picker-color-block"
@@ -552,7 +637,11 @@ exports[`renders components/color-picker/demo/style-class.tsx correctly 1`] = `
       class="ant-flex css-var-test-id ant-flex-gap-small"
     >
       <div
+        aria-expanded="false"
+        aria-label="rgb(22,119,255)"
         class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var acss-pbemrr"
+        role="button"
+        tabindex="0"
       >
         <div
           class="ant-color-picker-color-block"
@@ -572,7 +661,11 @@ exports[`renders components/color-picker/demo/style-class.tsx correctly 1`] = `
       class="ant-flex css-var-test-id ant-flex-gap-small"
     >
       <div
+        aria-expanded="false"
+        aria-label="rgb(114,46,209)"
         class="ant-color-picker-trigger ant-color-picker-lg css-var-test-id ant-color-picker-css-var acss-pbemrr"
+        role="button"
+        tabindex="0"
       >
         <div
           class="ant-color-picker-color-block"
@@ -596,7 +689,11 @@ exports[`renders components/color-picker/demo/text-render.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-expanded="false"
+      aria-label="rgb(22,119,255)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+      role="button"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -617,7 +714,11 @@ exports[`renders components/color-picker/demo/text-render.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-expanded="false"
+      aria-label="rgb(22,119,255)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+      role="button"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -644,7 +745,11 @@ exports[`renders components/color-picker/demo/text-render.tsx correctly 1`] = `
     class="ant-space-item"
   >
     <div
+      aria-expanded="false"
+      aria-label="rgb(22,119,255)"
       class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+      role="button"
+      tabindex="0"
     >
       <div
         class="ant-color-picker-color-block"
@@ -697,7 +802,11 @@ exports[`renders components/color-picker/demo/trigger.tsx correctly 1`] = `
 
 exports[`renders components/color-picker/demo/trigger-event.tsx correctly 1`] = `
 <div
+  aria-expanded="false"
+  aria-label="rgb(22,119,255)"
   class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
+  role="button"
+  tabindex="0"
 >
   <div
     class="ant-color-picker-color-block"

--- a/components/color-picker/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/color-picker/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,13 +3,15 @@
 exports[`ColorPicker Should disabled work 1`] = `
 <div>
   <div
+    aria-disabled="true"
+    aria-expanded="false"
+    aria-label="rgba(0,0,0,0)"
     class="ant-color-picker-trigger css-var-root ant-color-picker-css-var ant-color-picker-trigger-disabled"
+    role="button"
+    tabindex="-1"
   >
     <div
-      aria-label="Clear color"
       class="ant-color-picker-clear"
-      role="button"
-      tabindex="0"
     />
   </div>
 </div>
@@ -19,13 +21,14 @@ exports[`ColorPicker Should panelRender work 1`] = `
 <div>
   <div
     aria-describedby="test-id"
+    aria-expanded="true"
+    aria-label="rgba(0,0,0,0)"
     class="ant-color-picker-trigger css-var-root ant-color-picker-css-var ant-popover-open ant-color-picker-trigger-active"
+    role="button"
+    tabindex="0"
   >
     <div
-      aria-label="Clear color"
       class="ant-color-picker-clear"
-      role="button"
-      tabindex="0"
     />
   </div>
   <div
@@ -294,13 +297,14 @@ exports[`ColorPicker Should panelRender work 2`] = `
 <div>
   <div
     aria-describedby="test-id"
+    aria-expanded="true"
+    aria-label="rgba(0,0,0,0)"
     class="ant-color-picker-trigger css-var-root ant-color-picker-css-var ant-popover-open ant-color-picker-trigger-active"
+    role="button"
+    tabindex="0"
   >
     <div
-      aria-label="Clear color"
       class="ant-color-picker-clear"
-      role="button"
-      tabindex="0"
     />
   </div>
   <div
@@ -571,13 +575,14 @@ exports[`ColorPicker Should render trigger work 1`] = `
 
 exports[`ColorPicker rtl render component should be rendered correctly in RTL direction 1`] = `
 <div
+  aria-expanded="false"
+  aria-label="rgba(0,0,0,0)"
   class="ant-color-picker-trigger css-var-root ant-color-picker-css-var ant-color-picker-rtl"
+  role="button"
+  tabindex="0"
 >
   <div
-    aria-label="Clear color"
     class="ant-color-picker-clear"
-    role="button"
-    tabindex="0"
   />
 </div>
 `;

--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -70,6 +70,39 @@ describe('ColorPicker', () => {
     expect(container.querySelector('.ant-color-picker-trigger')).toBeTruthy();
   });
 
+  it('Should make the default trigger keyboard accessible', async () => {
+    const { container } = render(<ColorPicker />);
+    const trigger = container.querySelector('.ant-color-picker-trigger')!;
+
+    expect(trigger).toHaveAttribute('role', 'button');
+    expect(trigger).toHaveAttribute('tabindex', '0');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveAccessibleName('rgba(0,0,0,0)');
+
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    await waitFakeTimer();
+    expect(container.querySelector('.ant-color-picker')).toBeTruthy();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.keyDown(trigger, { key: ' ' });
+    await waitFakeTimer();
+    expect(container.querySelector('.ant-color-picker')).toHaveClass('ant-popover-hidden');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('Should keep the disabled default trigger out of keyboard navigation', async () => {
+    const { container } = render(<ColorPicker disabled />);
+    const trigger = container.querySelector('.ant-color-picker-trigger')!;
+
+    expect(trigger).toHaveAttribute('role', 'button');
+    expect(trigger).toHaveAttribute('aria-disabled', 'true');
+    expect(trigger).toHaveAttribute('tabindex', '-1');
+
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    await waitFakeTimer();
+    expect(container.querySelector('.ant-color-picker')).toBeFalsy();
+  });
+
   it('Should component defaultValue work', () => {
     const { container } = render(<ColorPicker defaultValue="#000000" />);
     expect(
@@ -145,6 +178,12 @@ describe('ColorPicker', () => {
     expect(
       container.querySelector('.ant-color-picker-trigger .ant-color-picker-clear'),
     ).toBeTruthy();
+    expect(
+      container.querySelector('.ant-color-picker-trigger .ant-color-picker-clear'),
+    ).not.toHaveAttribute('role');
+    expect(
+      container.querySelector('.ant-color-picker-trigger .ant-color-picker-clear'),
+    ).not.toHaveAttribute('tabindex');
 
     fireEvent.change(container.querySelector('.ant-color-picker-hex-input input')!, {
       target: { value: '#273B57' },

--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -79,6 +79,11 @@ describe('ColorPicker', () => {
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     expect(trigger).toHaveAccessibleName('rgba(0,0,0,0)');
 
+    fireEvent.keyDown(trigger, { key: 'Enter', repeat: true });
+    await waitFakeTimer();
+    expect(container.querySelector('.ant-color-picker')).toBeFalsy();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
     fireEvent.keyDown(trigger, { key: 'Enter' });
     await waitFakeTimer();
     expect(container.querySelector('.ant-color-picker')).toBeTruthy();
@@ -202,6 +207,9 @@ describe('ColorPicker', () => {
 
       fireEvent.click(container.querySelector('.ant-color-picker-trigger')!);
       await waitFakeTimer();
+      fireEvent.keyDown(container.querySelector('.ant-color-picker-clear')!, { key, repeat: true });
+      expect(onClear).not.toHaveBeenCalled();
+
       fireEvent.keyDown(container.querySelector('.ant-color-picker-clear')!, { key });
       expect(onClear).toHaveBeenCalledTimes(1);
 

--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -108,6 +108,21 @@ describe('ColorPicker', () => {
     expect(container.querySelector('.ant-color-picker')).toBeFalsy();
   });
 
+  it('Should operate a hover trigger with the keyboard', async () => {
+    const { container } = render(<ColorPicker trigger="hover" />);
+    const trigger = container.querySelector('.ant-color-picker-trigger')!;
+
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    await waitFakeTimer();
+    expect(container.querySelector('.ant-color-picker')).toBeTruthy();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.keyDown(trigger, { key: ' ' });
+    await waitFakeTimer();
+    expect(container.querySelector('.ant-color-picker')).toHaveClass('ant-popover-hidden');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
   it('Should component defaultValue work', () => {
     const { container } = render(<ColorPicker defaultValue="#000000" />);
     expect(

--- a/components/color-picker/components/ColorClear.tsx
+++ b/components/color-picker/components/ColorClear.tsx
@@ -28,7 +28,7 @@ const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, onChange, className
   };
 
   const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (event) => {
-    if (canClear && (event.key === 'Enter' || event.key === ' ')) {
+    if (canClear && !event.repeat && (event.key === 'Enter' || event.key === ' ')) {
       event.preventDefault();
       onClick();
     }

--- a/components/color-picker/components/ColorClear.tsx
+++ b/components/color-picker/components/ColorClear.tsx
@@ -14,8 +14,10 @@ interface ColorClearProps {
 }
 
 const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, onChange, className, style }) => {
+  const canClear = !!onChange && !!value && !value.cleared;
+
   const onClick = () => {
-    if (onChange && value && !value.cleared) {
+    if (canClear) {
       const hsba = value.toHsb();
       hsba.a = 0;
       const genColor = generateColor(hsba);
@@ -26,7 +28,7 @@ const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, onChange, className
   };
 
   const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (event) => {
-    if (event.key === 'Enter' || event.key === ' ') {
+    if (canClear && (event.key === 'Enter' || event.key === ' ')) {
       event.preventDefault();
       onClick();
     }
@@ -34,9 +36,9 @@ const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, onChange, className
 
   return (
     <div
-      role="button"
-      aria-label="Clear color"
-      tabIndex={0}
+      role={canClear ? 'button' : undefined}
+      aria-label={canClear ? 'Clear color' : undefined}
+      tabIndex={canClear ? 0 : undefined}
       className={clsx(`${prefixCls}-clear`, className)}
       style={style}
       onClick={onClick}

--- a/components/color-picker/components/ColorTrigger.tsx
+++ b/components/color-picker/components/ColorTrigger.tsx
@@ -27,6 +27,7 @@ export interface ColorTriggerProps {
   onMouseEnter?: MouseEventHandler<HTMLDivElement>;
   onMouseLeave?: MouseEventHandler<HTMLDivElement>;
   onKeyDown?: KeyboardEventHandler<HTMLDivElement>;
+  onOpenChange?: (open: boolean) => void;
   activeIndex: number;
 }
 
@@ -44,6 +45,7 @@ const ColorTrigger = forwardRef<HTMLDivElement, ColorTriggerProps>((props, ref) 
     showText,
     activeIndex,
     onKeyDown,
+    onOpenChange,
     ...rest
   } = props;
 
@@ -63,7 +65,7 @@ const ColorTrigger = forwardRef<HTMLDivElement, ColorTriggerProps>((props, ref) 
       (event.key === 'Enter' || event.key === ' ')
     ) {
       event.preventDefault();
-      event.currentTarget.click();
+      onOpenChange?.(!open);
     }
   };
 

--- a/components/color-picker/components/ColorTrigger.tsx
+++ b/components/color-picker/components/ColorTrigger.tsx
@@ -56,7 +56,12 @@ const ColorTrigger = forwardRef<HTMLDivElement, ColorTriggerProps>((props, ref) 
   const onInternalKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
     onKeyDown?.(event);
 
-    if (!event.defaultPrevented && !disabled && (event.key === 'Enter' || event.key === ' ')) {
+    if (
+      !event.defaultPrevented &&
+      !event.repeat &&
+      !disabled &&
+      (event.key === 'Enter' || event.key === ' ')
+    ) {
       event.preventDefault();
       event.currentTarget.click();
     }

--- a/components/color-picker/components/ColorTrigger.tsx
+++ b/components/color-picker/components/ColorTrigger.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-array-index-key */
-import type { CSSProperties, MouseEventHandler } from 'react';
+import type { CSSProperties, KeyboardEventHandler, MouseEventHandler } from 'react';
 import React, { forwardRef, useMemo } from 'react';
 import { ColorBlock } from '@rc-component/color-picker';
 import { pickAttrs } from '@rc-component/util';
@@ -26,6 +26,7 @@ export interface ColorTriggerProps {
   onClick?: MouseEventHandler<HTMLDivElement>;
   onMouseEnter?: MouseEventHandler<HTMLDivElement>;
   onMouseLeave?: MouseEventHandler<HTMLDivElement>;
+  onKeyDown?: KeyboardEventHandler<HTMLDivElement>;
   activeIndex: number;
 }
 
@@ -42,6 +43,7 @@ const ColorTrigger = forwardRef<HTMLDivElement, ColorTriggerProps>((props, ref) 
     styles,
     showText,
     activeIndex,
+    onKeyDown,
     ...rest
   } = props;
 
@@ -50,6 +52,15 @@ const ColorTrigger = forwardRef<HTMLDivElement, ColorTriggerProps>((props, ref) 
   const colorTextCellPrefixCls = `${colorTextPrefixCls}-cell`;
 
   const [locale] = useLocale('ColorPicker');
+
+  const onInternalKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
+    onKeyDown?.(event);
+
+    if (!event.defaultPrevented && !disabled && (event.key === 'Enter' || event.key === ' ')) {
+      event.preventDefault();
+      event.currentTarget.click();
+    }
+  };
 
   // ============================== Text ==============================
   const desc: React.ReactNode = React.useMemo(() => {
@@ -117,6 +128,11 @@ const ColorTrigger = forwardRef<HTMLDivElement, ColorTriggerProps>((props, ref) 
   return (
     <div
       ref={ref}
+      role="button"
+      aria-disabled={disabled || undefined}
+      aria-expanded={open}
+      aria-label={color.toCssString()}
+      tabIndex={disabled ? -1 : 0}
       className={clsx(colorTriggerPrefixCls, className, classNames.root, {
         [`${colorTriggerPrefixCls}-active`]: open,
         [`${colorTriggerPrefixCls}-disabled`]: disabled,
@@ -126,6 +142,7 @@ const ColorTrigger = forwardRef<HTMLDivElement, ColorTriggerProps>((props, ref) 
         ...style,
       }}
       {...pickAttrs(rest)}
+      onKeyDown={onInternalKeyDown}
     >
       {containerNode}
       {showText && (

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -12062,91 +12062,99 @@ exports[`ConfigProvider components Collapse prefixCls 1`] = `
 
 exports[`ConfigProvider components ColorPicker configProvider 1`] = `
 <div
+  aria-expanded="false"
+  aria-label="rgba(0,0,0,0)"
   class="config-color-picker-trigger css-var-root config-color-picker-css-var"
+  role="button"
+  tabindex="0"
 >
   <div
-    aria-label="Clear color"
     class="config-color-picker-clear"
-    role="button"
-    tabindex="0"
   />
 </div>
 `;
 
 exports[`ConfigProvider components ColorPicker configProvider componentDisabled 1`] = `
 <div
+  aria-disabled="true"
+  aria-expanded="false"
+  aria-label="rgba(0,0,0,0)"
   class="config-color-picker-trigger css-var-root config-color-picker-css-var config-color-picker-trigger-disabled"
+  role="button"
+  tabindex="-1"
 >
   <div
-    aria-label="Clear color"
     class="config-color-picker-clear"
-    role="button"
-    tabindex="0"
   />
 </div>
 `;
 
 exports[`ConfigProvider components ColorPicker configProvider componentSize large 1`] = `
 <div
+  aria-expanded="false"
+  aria-label="rgba(0,0,0,0)"
   class="config-color-picker-trigger config-color-picker-lg css-var-root config-color-picker-css-var"
+  role="button"
+  tabindex="0"
 >
   <div
-    aria-label="Clear color"
     class="config-color-picker-clear"
-    role="button"
-    tabindex="0"
   />
 </div>
 `;
 
 exports[`ConfigProvider components ColorPicker configProvider componentSize medium 1`] = `
 <div
+  aria-expanded="false"
+  aria-label="rgba(0,0,0,0)"
   class="config-color-picker-trigger css-var-root config-color-picker-css-var"
+  role="button"
+  tabindex="0"
 >
   <div
-    aria-label="Clear color"
     class="config-color-picker-clear"
-    role="button"
-    tabindex="0"
   />
 </div>
 `;
 
 exports[`ConfigProvider components ColorPicker configProvider componentSize small 1`] = `
 <div
+  aria-expanded="false"
+  aria-label="rgba(0,0,0,0)"
   class="config-color-picker-trigger config-color-picker-sm css-var-root config-color-picker-css-var"
+  role="button"
+  tabindex="0"
 >
   <div
-    aria-label="Clear color"
     class="config-color-picker-clear"
-    role="button"
-    tabindex="0"
   />
 </div>
 `;
 
 exports[`ConfigProvider components ColorPicker normal 1`] = `
 <div
+  aria-expanded="false"
+  aria-label="rgba(0,0,0,0)"
   class="ant-color-picker-trigger css-var-root ant-color-picker-css-var"
+  role="button"
+  tabindex="0"
 >
   <div
-    aria-label="Clear color"
     class="ant-color-picker-clear"
-    role="button"
-    tabindex="0"
   />
 </div>
 `;
 
 exports[`ConfigProvider components ColorPicker prefixCls 1`] = `
 <div
+  aria-expanded="false"
+  aria-label="rgba(0,0,0,0)"
   class="prefix-ColorPicker-trigger css-var-root prefix-ColorPicker-css-var"
+  role="button"
+  tabindex="0"
 >
   <div
-    aria-label="Clear color"
     class="prefix-ColorPicker-clear"
-    role="button"
-    tabindex="0"
   />
 </div>
 `;

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5176,13 +5176,15 @@ Array [
             >
               <div
                 aria-describedby="test-id"
+                aria-disabled="true"
+                aria-expanded="false"
+                aria-label="rgba(0,0,0,0)"
                 class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var ant-color-picker-trigger-disabled"
+                role="button"
+                tabindex="-1"
               >
                 <div
-                  aria-label="Clear color"
                   class="ant-color-picker-clear"
-                  role="button"
-                  tabindex="0"
                 />
               </div>
               <div
@@ -24496,15 +24498,16 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
           >
             <div
               aria-describedby="test-id"
+              aria-expanded="false"
+              aria-label="rgba(0,0,0,0)"
               aria-required="true"
               class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
               id="validate_other_color-picker"
+              role="button"
+              tabindex="0"
             >
               <div
-                aria-label="Clear color"
                 class="ant-color-picker-clear"
-                role="button"
-                tabindex="0"
               />
             </div>
             <div

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2681,13 +2681,15 @@ Array [
               class="ant-form-item-control-input-content"
             >
               <div
+                aria-disabled="true"
+                aria-expanded="false"
+                aria-label="rgba(0,0,0,0)"
                 class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var ant-color-picker-trigger-disabled"
+                role="button"
+                tabindex="-1"
               >
                 <div
-                  aria-label="Clear color"
                   class="ant-color-picker-clear"
-                  role="button"
-                  tabindex="0"
                 />
               </div>
             </div>
@@ -11818,15 +11820,16 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
             class="ant-form-item-control-input-content"
           >
             <div
+              aria-expanded="false"
+              aria-label="rgba(0,0,0,0)"
               aria-required="true"
               class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
               id="validate_other_color-picker"
+              role="button"
+              tabindex="0"
             >
               <div
-                aria-label="Clear color"
                 class="ant-color-picker-clear"
-                role="button"
-                tabindex="0"
               />
             </div>
           </div>

--- a/components/form/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/index.test.tsx.snap
@@ -978,13 +978,15 @@ exports[`Form form should support disabled 1`] = `
             class="ant-form-item-control-input-content"
           >
             <div
+              aria-disabled="true"
+              aria-expanded="false"
+              aria-label="rgba(0,0,0,0)"
               class="ant-color-picker-trigger css-var-root ant-color-picker-css-var ant-color-picker-trigger-disabled"
+              role="button"
+              tabindex="-1"
             >
               <div
-                aria-label="Clear color"
                 class="ant-color-picker-clear"
-                role="button"
-                tabindex="0"
               />
             </div>
           </div>

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -8780,13 +8780,14 @@ exports[`renders components/space/demo/compact.tsx extend context correctly 1`] 
       />
       <div
         aria-describedby="test-id"
+        aria-expanded="false"
+        aria-label="rgba(0,0,0,0)"
         class="ant-color-picker-trigger ant-color-picker-compact-item ant-color-picker-compact-last-item css-var-test-id ant-color-picker-css-var"
+        role="button"
+        tabindex="0"
       >
         <div
-          aria-label="Clear color"
           class="ant-color-picker-clear"
-          role="button"
-          tabindex="0"
         />
       </div>
       <div

--- a/components/space/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1809,13 +1809,14 @@ exports[`renders components/space/demo/compact.tsx correctly 1`] = `
         value=""
       />
       <div
+        aria-expanded="false"
+        aria-label="rgba(0,0,0,0)"
         class="ant-color-picker-trigger ant-color-picker-compact-item ant-color-picker-compact-last-item css-var-test-id ant-color-picker-css-var"
+        role="button"
+        tabindex="0"
       >
         <div
-          aria-label="Clear color"
           class="ant-color-picker-clear"
-          role="button"
-          tabindex="0"
         />
       </div>
     </div>

--- a/components/watermark/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/watermark/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -123,8 +123,12 @@ exports[`renders components/watermark/demo/custom.tsx extend context correctly 1
             >
               <div
                 aria-describedby="test-id"
+                aria-expanded="false"
+                aria-label="rgba(0,0,0,0.15)"
                 class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
                 id="color"
+                role="button"
+                tabindex="0"
               >
                 <div
                   class="ant-color-picker-color-block"

--- a/components/watermark/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/watermark/__tests__/__snapshots__/demo.test.ts.snap
@@ -114,8 +114,12 @@ exports[`renders components/watermark/demo/custom.tsx correctly 1`] = `
               class="ant-form-item-control-input-content"
             >
               <div
+                aria-expanded="false"
+                aria-label="rgba(0,0,0,0.15)"
                 class="ant-color-picker-trigger css-var-test-id ant-color-picker-css-var"
                 id="color"
+                role="button"
+                tabindex="0"
               >
                 <div
                   class="ant-color-picker-color-block"


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [ ] 🆕 New feature
- [ ] 📝 Site / documentation update
- [ ] 📽️ Demo update
- [ ] 💄 Component style update
- [ ] 🤖 TypeScript definition update
- [ ] 🛠️ Workflow / CI update
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other

### 🔗 Related issue link

Addresses the default-trigger keyboard gap in #57935 (item 1). The remaining picker-handle, focus-transfer, focus-style, and localized panel-label items are outside this PR.

### 💡 Background and solution

The default ColorPicker trigger is a clickable `div` with no role, tab stop, accessible name, or keyboard activation path.

This PR:

- gives the default trigger button semantics, a current-color accessible name, `aria-expanded`, and a tab stop
- activates it with Enter and Space while composing any existing `onKeyDown` handler
- ignores repeated activation keys and preserves keyboard opening when `trigger="hover"`
- keeps a disabled trigger out of sequential keyboard navigation and exposes `aria-disabled`
- removes button semantics from the trigger-only `ColorClear` marker, which has no `onChange` action; the actionable panel clear control remains a keyboard-operable button
- leaves custom ColorPicker triggers consumer-controlled

### Prior art and scope

This is a focused current-master extraction of the default-trigger portion of draft #58235 by @Pareder. That earlier PR established the broader accessibility direction and should receive credit for identifying and designing the trigger work.

#58235 remains a large, currently conflicting draft that also changes panel focus management, presets, inputs, sliders, styles, locales, and depends on react-component/color-picker#286. This PR intentionally addresses only item 1 of #57935 with a small independently mergeable diff and newer Enter/Space repeat plus hover-trigger regressions. It does not replace or claim the remaining work in #58235.

### 📝 Changelog

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Make the default ColorPicker trigger keyboard accessible. |
| 🇨🇳 Chinese | 使 ColorPicker 默认触发器支持键盘操作。 |

### ✅ Validation

Merged current master `4a39f54842eade4e565ab336ef6097cd7e723cdd` and resolved the requested conflicts at signed/GitHub-Verified head `2400bb68354d87092d984c590d0c37a1abbbfb92`.

The resolution preserves upstream disabled styling and behavior for the actionable clear control. The trigger-only color marker keeps that styling but has no button role or tab stop. Its two upstream assertions were updated to match this distinction; the panel clear-control disabled test still passes.

Validation:

- 51 distinct affected test suites pass across ColorPicker, Form, ConfigProvider, Space and Watermark; one additional suite is skipped. The initial broad run passed 38 suites and exposed only two marker assertions in ColorPicker's index file. After correction, the entire index file plus Space/Watermark passed 13 suites / 206 tests / 84 snapshots. The broader run passed 577 snapshots.
- Full repository TypeScript passes after standard version generation and dumi setup.
- Focused ESLint, Biome, Prettier and diff checks pass.
- The final PR remains 16 files: ColorPicker source/tests plus its dependent snapshots. Remote changed-file blobs match the local branch, and the merge commit signature is verified.

New-head upstream CI is pending; this does not claim visual approval or a merge.

AI assistance disclosure: Codex was used to trace the default trigger, compare the prior draft, implement the focused fix, run exact-head validation, and draft this report. The overlap, behavior, and cited results were directly verified.