### PR TITLE
fix(Collapse): localize interactive icon labels

### DIFF
--- a/components/collapse/Collapse.tsx
+++ b/components/collapse/Collapse.tsx
@@ -15,6 +15,7 @@ import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';
+import useLocale from '../locale/useLocale';
 import type { CollapsibleType } from './CollapsePanel';
 import CollapsePanel from './CollapsePanel';
 import useStyle from './style';
@@ -115,6 +116,7 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
   } = props;
 
   const mergedSize = useSize((ctx) => customizeSize ?? ctx ?? 'middle');
+  const [textLocale] = useLocale('Text');
   const prefixCls = getPrefixCls('collapse', customizePrefixCls);
   const rootPrefixCls = getPrefixCls();
   const [hashId, cssVarCls] = useStyle(prefixCls);
@@ -161,7 +163,7 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
         <RightOutlined
           rotate={panelProps.isActive ? (direction === 'rtl' ? -90 : 90) : undefined}
           {...(iconIsInteractive
-            ? { 'aria-label': panelProps.isActive ? 'expanded' : 'collapsed' }
+            ? { 'aria-label': panelProps.isActive ? textLocale.collapse : textLocale.expand }
             : { 'aria-hidden': true })}
         />
       );
@@ -169,7 +171,7 @@ const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>((props, ref) =>
         className: clsx(oriProps.className, `${prefixCls}-arrow`),
       }));
     },
-    [mergedExpandIcon, prefixCls, direction],
+    [mergedExpandIcon, prefixCls, direction, textLocale],
   );
 
   const collapseClassName = clsx(

--- a/components/collapse/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/collapse/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -449,7 +449,7 @@ exports[`renders components/collapse/demo/collapsible.tsx extend context correct
             tabindex="0"
           >
             <span
-              aria-label="expanded"
+              aria-label="Collapse"
               class="anticon anticon-right ant-collapse-arrow"
               role="img"
             >
@@ -515,7 +515,7 @@ exports[`renders components/collapse/demo/collapsible.tsx extend context correct
             tabindex="0"
           >
             <span
-              aria-label="expanded"
+              aria-label="Collapse"
               class="anticon anticon-right ant-collapse-arrow"
               role="img"
             >

--- a/components/collapse/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/collapse/__tests__/__snapshots__/demo.test.ts.snap
@@ -443,7 +443,7 @@ exports[`renders components/collapse/demo/collapsible.tsx correctly 1`] = `
             tabindex="0"
           >
             <span
-              aria-label="expanded"
+              aria-label="Collapse"
               class="anticon anticon-right ant-collapse-arrow"
               role="img"
             >
@@ -509,7 +509,7 @@ exports[`renders components/collapse/demo/collapsible.tsx correctly 1`] = `
             tabindex="0"
           >
             <span
-              aria-label="expanded"
+              aria-label="Collapse"
               class="anticon anticon-right ant-collapse-arrow"
               role="img"
             >

--- a/components/collapse/__tests__/accessibility.test.tsx
+++ b/components/collapse/__tests__/accessibility.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
+import ConfigProvider from '../../config-provider';
+import zhTW from '../../locale/zh_TW';
 import Collapse from '..';
 
 describe('Collapse accessibility', () => {
@@ -41,15 +43,38 @@ describe('Collapse accessibility', () => {
       const iconControl = container.querySelector('.ant-collapse-expand-icon');
       const icon = container.querySelector('.ant-collapse-arrow');
 
-      expect(iconControl).toHaveAccessibleName('expanded');
-      expect(icon).toHaveAttribute('aria-label', 'expanded');
+      expect(iconControl).toHaveAccessibleName('Collapse');
+      expect(icon).toHaveAttribute('aria-label', 'Collapse');
       expect(icon).not.toHaveAttribute('aria-hidden');
 
       rerender(<Collapse collapsible={collapsible} items={items} />);
 
-      expect(iconControl).toHaveAccessibleName('collapsed');
-      expect(icon).toHaveAttribute('aria-label', 'collapsed');
+      expect(iconControl).toHaveAccessibleName('Expand');
+      expect(icon).toHaveAttribute('aria-label', 'Expand');
       expect(icon).not.toHaveAttribute('aria-hidden');
+    },
+  );
+
+  it.each(['header', 'icon'] as const)(
+    'localizes the interactive default icon for collapsible="%s"',
+    (collapsible) => {
+      const items = [{ key: '1', label: 'Header' }];
+      const { container, rerender } = render(
+        <ConfigProvider locale={zhTW}>
+          <Collapse activeKey="1" collapsible={collapsible} items={items} />
+        </ConfigProvider>,
+      );
+      const iconControl = container.querySelector('.ant-collapse-expand-icon');
+
+      expect(iconControl).toHaveAccessibleName('收合');
+
+      rerender(
+        <ConfigProvider locale={zhTW}>
+          <Collapse collapsible={collapsible} items={items} />
+        </ConfigProvider>,
+      );
+
+      expect(iconControl).toHaveAccessibleName('展開');
     },
   );
 });


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] 🌐 Internationalization
- [x] ✅ Test Case
- [x] ⌨️ Accessibility improvement

### 🔗 Related Issues

No existing issue found. This affects the interactive icon controls in the official [collapsible Collapse demo](https://ant.design/components/collapse#components-collapse-demo-collapsible).

### 💡 Background and Solution

When `collapsible="header"` or `collapsible="icon"` makes the default expand icon interactive, the icon supplies the control's accessible name. That name was hardcoded as `expanded` or `collapsed`, so screen readers announced English even under a non-English `ConfigProvider` locale.

This change uses the existing `Text.collapse` and `Text.expand` locale strings for the control's action name. The surrounding header continues to expose the current state through `aria-expanded`. No locale contract or public API is added.

Regression coverage verifies both interactive modes with the default English locale and `zh_TW`. Before the implementation, the new zh-TW assertions failed because the controls were named `expanded`; after the change:

- all 7 Collapse test suites pass;
- 72 tests pass;
- all 47 snapshots pass;
- Biome passes for the changed source and test files.

AI assistance disclosure: Codex was used to trace the accessible-name source, check open issue/PR overlap, implement the localized labels, and run the focused regression suite. The behavior and test results were verified locally.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Localize the accessible names of interactive Collapse icons. |
| 🇨🇳 Chinese | 本地化 Collapse 互動圖示的無障礙名稱。 |
