### PR TITLE
fix: render numeric zero content nodes

### DIFF
--- a/components/divider/__tests__/index.test.tsx
+++ b/components/divider/__tests__/index.test.tsx
@@ -26,6 +26,11 @@ describe('Divider', () => {
     errSpy.mockRestore();
   });
 
+  it('should render numeric zero children', () => {
+    const { container } = render(<Divider>{0}</Divider>);
+    expect(container.querySelector('.ant-divider-inner-text')).toHaveTextContent('0');
+  });
+
   it('support string orientationMargin', () => {
     const { container } = render(
       <Divider titlePlacement="end" orientationMargin="10">

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -5,7 +5,7 @@ import { useOrientation } from '../_util/hooks';
 import type { Orientation } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isNumber } from '../_util/is';
+import { isNumber, isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import useSize from '../config-provider/hooks/useSize';
@@ -102,7 +102,7 @@ const Divider = React.forwardRef<DividerRef, DividerProps>((props, ref) => {
 
   const sizeFullName = useSize(customSize);
 
-  const hasChildren = !!children;
+  const hasChildren = isReactRenderable(children);
 
   const validTitlePlacement = titlePlacementList.includes(orientation || '');
 
@@ -159,8 +159,8 @@ const Divider = React.forwardRef<DividerRef, DividerProps>((props, ref) => {
       [`${prefixCls}-no-default-orientation-margin-end`]: hasMarginEnd,
       [`${prefixCls}-md`]: sizeFullName === 'medium' || sizeFullName === 'middle',
       [`${prefixCls}-sm`]: sizeFullName === 'small',
-      [railCls]: !children,
-      [mergedClassNames.rail as string]: mergedClassNames.rail && !children,
+      [railCls]: !hasChildren,
+      [mergedClassNames.rail as string]: mergedClassNames.rail && !hasChildren,
     },
     className,
     rootClassName,
@@ -192,7 +192,7 @@ const Divider = React.forwardRef<DividerRef, DividerProps>((props, ref) => {
   if (process.env.NODE_ENV !== 'production') {
     const warning = devUseWarning('Divider');
 
-    warning(!children || !mergedVertical, 'usage', '`children` not working in `vertical` mode.');
+    warning(!hasChildren || !mergedVertical, 'usage', '`children` not working in `vertical` mode.');
     warning(
       !validTitlePlacement,
       'usage',
@@ -212,13 +212,13 @@ const Divider = React.forwardRef<DividerRef, DividerProps>((props, ref) => {
       className={classString}
       style={{
         ...mergedStyles.root,
-        ...(children ? {} : mergedStyles.rail),
+        ...(hasChildren ? {} : mergedStyles.rail),
         ...style,
       }}
       {...restProps}
       role="separator"
     >
-      {children && !mergedVertical && (
+      {hasChildren && !mergedVertical && (
         <>
           <div
             className={clsx(railCls, `${railCls}-start`, mergedClassNames.rail)}

--- a/components/divider/index.tsx
+++ b/components/divider/index.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
+import { isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useOrientation } from '../_util/hooks';
 import type { Orientation } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isNumber, isReactRenderable } from '../_util/is';
+import { isNumber } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import useSize from '../config-provider/hooks/useSize';

--- a/components/popconfirm/PurePanel.tsx
+++ b/components/popconfirm/PurePanel.tsx
@@ -71,7 +71,7 @@ export const Overlay: React.FC<OverlayProps> = (props) => {
   return (
     <div className={`${prefixCls}-inner-content`} onClick={onPopupClick}>
       <div className={`${prefixCls}-message`}>
-        {icon && (
+        {isReactRenderable(icon) && (
           <span
             className={clsx(`${prefixCls}-message-icon`, classNames?.icon)}
             style={styles?.icon}

--- a/components/popconfirm/__tests__/index.test.tsx
+++ b/components/popconfirm/__tests__/index.test.tsx
@@ -151,6 +151,17 @@ describe('Popconfirm', () => {
     expect(titleNode?.textContent).toContain('0');
   });
 
+  it('should render icon when it is the number 0', () => {
+    const { container } = render(
+      <Popconfirm title="code" icon={0} open>
+        <span>show me your code</span>
+      </Popconfirm>,
+    );
+    const iconNode = container.querySelector('.ant-popconfirm-message-icon');
+    expect(iconNode).not.toBe(null);
+    expect(iconNode).toHaveTextContent('0');
+  });
+
   it('should trigger onConfirm and onCancel', async () => {
     const confirm = jest.fn();
     const cancel = jest.fn();

--- a/components/spin/__tests__/index.test.tsx
+++ b/components/spin/__tests__/index.test.tsx
@@ -79,6 +79,11 @@ describe('Spin', () => {
     expect(container.querySelector('.ant-spin-container')?.textContent).toBe('0');
   });
 
+  it('should render numeric zero descriptions', () => {
+    const { container } = render(<Spin description={0} />);
+    expect(container.querySelector('.ant-spin-description')).toHaveTextContent('0');
+  });
+
   it('right style when fullscreen', () => {
     const { container } = render(<Spin fullscreen spinning />);
     const element = container.querySelector<HTMLDivElement>('.ant-spin-fullscreen');

--- a/components/spin/index.tsx
+++ b/components/spin/index.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
+import { isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 import { debounce } from 'throttle-debounce';
 
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import useSize from '../config-provider/hooks/useSize';

--- a/components/spin/index.tsx
+++ b/components/spin/index.tsx
@@ -4,6 +4,7 @@ import { debounce } from 'throttle-debounce';
 
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
+import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import useSize from '../config-provider/hooks/useSize';
@@ -210,7 +211,7 @@ const Spin = React.forwardRef<SpinRef, SpinProps>((props, ref) => {
         indicator={mergedIndicator}
         percent={mergedPercent}
       />
-      {mergedDescription && (
+      {isReactRenderable(mergedDescription) && (
         <div
           className={clsx(
             `${prefixCls}-description`,


### PR DESCRIPTION
### 🤔 This is a ...\n\n- [ ] 🆕 New feature\n- [x] 🐞 Bug fix\n- [ ] 📝 Site / documentation improvement\n- [ ] 📽️ Demo improvement\n- [ ] 💄 Component style improvement\n- [ ] 🤖 TypeScript definition improvement\n- [ ] 📦 Bundle size optimization\n- [ ] ⚡️ Performance optimization\n- [ ] ⭐️ Feature enhancement\n- [ ] 🌐 Internationalization\n- [ ] 🛠 Refactoring\n- [ ] 🎨 Code style optimization\n- [x] ✅ Test Case\n- [ ] 🔀 Branch merge\n- [ ] ⏩ Workflow\n- [ ] ⌨️ Accessibility improvement\n- [ ] ❓ Other (about what?)\n\n### 🔗 Related Issues\n\nFollow-up consistency audit after #59117. No public API changes.\n\n### 💡 Background and Solution\n\nReact renders the number zero as visible content, but three remaining content-node paths used boolean truthiness and silently discarded it:\n\n- Spin description={0}\n- Divider children={0}\n- Popconfirm icon={0}\n\nUse the existing isReactRenderable utility for all three paths. Divider also derives its text classes, rail classes and styles, vertical-mode warning, and rendered content from one hasChildren value so the DOM and styling decisions cannot diverge.\n\nRegression proof against exact master d58fe298:\n\n- all three new assertions fail before the source change because their expected nodes are absent\n- the same assertions pass after the source change\n\nValidation:\n\n- 20 component test suites passed\n- 174 tests passed, 2 skipped\n- 97 snapshots passed\n- focused ESLint, Biome, and git diff checks passed\n- the repository-wide TypeScript command reports six existing FullToken.antCls errors in Table demos; an untouched worktree at the exact base commit reports the identical six errors\n\nAI assistance disclosure: Codex was used to audit ReactNode truthiness paths, add the regressions, implement the shared renderability checks, and run validation. The diff and results were verified locally.\n\n### 📝 Change Log\n\n| Language   | Changelog |\n| ---------- | --------- |\n| 🇺🇸 English | Fix Spin, Divider, and Popconfirm to render numeric zero content nodes. |\n| 🇨🇳 Chinese | 修复 Spin、Divider 和 Popconfirm 无法渲染数字零内容节点的问题。 |