### PR TITLE
fix(Tag): ignore repeated key activation

### DIFF
--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -60,7 +60,7 @@ const CheckableTag = React.forwardRef<HTMLSpanElement, CheckableTagProps>((props
       return;
     }
 
-    if (e.key === ' ') {
+    if (e.key === ' ' && !e.repeat) {
       e.preventDefault();
       onChange?.(!checked);
     }

--- a/components/tag/CheckableTag.tsx
+++ b/components/tag/CheckableTag.tsx
@@ -60,9 +60,11 @@ const CheckableTag = React.forwardRef<HTMLSpanElement, CheckableTagProps>((props
       return;
     }
 
-    if (e.key === ' ' && !e.repeat) {
+    if (e.key === ' ') {
       e.preventDefault();
-      onChange?.(!checked);
+      if (!e.repeat) {
+        onChange?.(!checked);
+      }
     }
   };
 

--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -223,6 +223,13 @@ describe('Tag', () => {
       expect(onChange).toHaveBeenCalledWith(true);
     });
 
+    it('should ignore repeated Space key activation', () => {
+      const onChange = jest.fn();
+      const { container } = render(<Tag.CheckableTag checked={false} onChange={onChange} />);
+      fireEvent.keyDown(container.querySelector('.ant-tag')!, { key: ' ', repeat: true });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
     it('should not trigger onChange when key event is prevented', () => {
       const onChange = jest.fn();
       const onKeyDown = jest.fn((e: React.KeyboardEvent<HTMLSpanElement>) => {
@@ -340,6 +347,16 @@ describe('Tag', () => {
     expect(onClose).toHaveBeenCalled();
     expect(onClose.mock.calls[0][0].type).toBe('click');
     expect(container.querySelectorAll('.ant-tag:not(.ant-tag-hidden)').length).toBe(0);
+  });
+
+  it.each(['Enter', ' '])('should ignore repeated %s key activation on close controls', (key) => {
+    const onClose = jest.fn();
+    const { container } = render(<Tag closable onClose={onClose} />);
+
+    fireEvent.keyDown(container.querySelector('.ant-tag-close-icon')!, { key, repeat: true });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(container.querySelectorAll('.ant-tag:not(.ant-tag-hidden)').length).toBe(1);
   });
   it('should not close when closeIcon key event is prevented', () => {
     const onClose = jest.fn();

--- a/components/tag/__tests__/index.test.tsx
+++ b/components/tag/__tests__/index.test.tsx
@@ -226,8 +226,13 @@ describe('Tag', () => {
     it('should ignore repeated Space key activation', () => {
       const onChange = jest.fn();
       const { container } = render(<Tag.CheckableTag checked={false} onChange={onChange} />);
-      fireEvent.keyDown(container.querySelector('.ant-tag')!, { key: ' ', repeat: true });
+      const tag = container.querySelector('.ant-tag')!;
+      const keyDownEvent = createEvent.keyDown(tag, { key: ' ', repeat: true });
+
+      fireEvent(tag, keyDownEvent);
+
       expect(onChange).not.toHaveBeenCalled();
+      expect(keyDownEvent.defaultPrevented).toBe(true);
     });
 
     it('should not trigger onChange when key event is prevented', () => {
@@ -352,11 +357,14 @@ describe('Tag', () => {
   it.each(['Enter', ' '])('should ignore repeated %s key activation on close controls', (key) => {
     const onClose = jest.fn();
     const { container } = render(<Tag closable onClose={onClose} />);
+    const closeIcon = container.querySelector('.ant-tag-close-icon')!;
+    const keyDownEvent = createEvent.keyDown(closeIcon, { key, repeat: true });
 
-    fireEvent.keyDown(container.querySelector('.ant-tag-close-icon')!, { key, repeat: true });
+    fireEvent(closeIcon, keyDownEvent);
 
     expect(onClose).not.toHaveBeenCalled();
     expect(container.querySelectorAll('.ant-tag:not(.ant-tag-hidden)').length).toBe(1);
+    expect(keyDownEvent.defaultPrevented).toBe(true);
   });
   it('should not close when closeIcon key event is prevented', () => {
     const onClose = jest.fn();

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -186,9 +186,11 @@ const InternalTag = React.forwardRef<HTMLSpanElement | HTMLAnchorElement, TagPro
     };
 
     const handleCloseKeyDown: React.KeyboardEventHandler<HTMLElement> = (e) => {
-      if (!e.repeat && (e.key === 'Enter' || e.key === ' ')) {
+      if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
-        e.currentTarget.click();
+        if (!e.repeat) {
+          e.currentTarget.click();
+        }
       }
     };
 

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -186,7 +186,7 @@ const InternalTag = React.forwardRef<HTMLSpanElement | HTMLAnchorElement, TagPro
     };
 
     const handleCloseKeyDown: React.KeyboardEventHandler<HTMLElement> = (e) => {
-      if (e.key === 'Enter' || e.key === ' ') {
+      if (!e.repeat && (e.key === 'Enter' || e.key === ' ')) {
         e.preventDefault();
         e.currentTarget.click();
       }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Follow-up audit after the repeat-key boundary identified during review of #59130. No public API changes.

### 💡 Background and Solution

Tag implements two keyboard-operable controls with span elements:

- CheckableTag handles Space to toggle its checked state.
- A closable Tag handles Enter and Space to activate its close control.

Both handlers currently accept repeated keydown events. Holding a key can therefore invoke `onChange` repeatedly or close a tag from an auto-repeated event, unlike native one-action keyboard controls.

Ignore `event.repeat` only for the built-in activation step. Consumer `onKeyDown` handlers still receive every event and can prevent ordinary activation as before.

Regression proof against exact master `d58fe298`:

- Repeated Space invokes CheckableTag `onChange` before the fix.
- Repeated Enter and Space both invoke Tag `onClose` before the fix.
- All three cases are ignored after the fix while ordinary activation remains covered.

Validation:

- 6 Tag test suites passed.
- 100 tests passed, 3 skipped.
- 35 snapshots passed.
- Focused ESLint, Biome, Prettier, and `git diff` checks passed.

AI assistance disclosure: Codex was used to audit repeat-key handlers, add the regressions, implement the guards, and run validation. The diff and results were verified locally.

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Prevent repeated keyboard events from activating CheckableTag and Tag close controls multiple times. |
| 🇨🇳 Chinese | 防止重复键盘事件多次触发 CheckableTag 和 Tag 关闭控件。 |