### PR TITLE
fix(Input.Password): ignore repeated key activation

### DIFF
--- a/components/input/Password.tsx
+++ b/components/input/Password.tsx
@@ -153,7 +153,9 @@ const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            onVisibleChange();
+            if (!e.repeat) {
+              onVisibleChange();
+            }
           }
         }}
         {...{ [iconTrigger]: onVisibleChange }}

--- a/components/input/__tests__/Password.test.tsx
+++ b/components/input/__tests__/Password.test.tsx
@@ -80,6 +80,19 @@ describe('Input.Password', () => {
     expect(getByDisplayValue('111')).toBeInTheDocument();
   });
 
+  it.each(['Enter', ' '])('should ignore repeated %s key activation', (key) => {
+    const onVisibleChange = jest.fn();
+    const { container } = render(<Input.Password visibilityToggle={{ onVisibleChange }} />);
+
+    fireEvent.keyDown(container.querySelector('.ant-input-password-icon')!, {
+      key,
+      repeat: true,
+    });
+
+    expect(onVisibleChange).not.toHaveBeenCalled();
+    expect(container.querySelector('input')).toHaveAttribute('type', 'password');
+  });
+
   it('should keep focus state', () => {
     const { container, unmount } = render(<Input.Password defaultValue="111" autoFocus />, {
       container: document.body,


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [x] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Follow-up audit of keyboard repeat handling in custom button controls. No public API changes.

### 💡 Background and Solution

`Input.Password` renders its visibility toggle as a keyboard-operable `span` with `role="button"`. Its keydown handler currently accepts auto-repeated Enter and Space events, so holding either key repeatedly toggles password visibility and repeatedly invokes `visibilityToggle.onVisibleChange`.

Keep suppressing the native default for handled Enter and Space events, but gate the semantic visibility change on `!event.repeat`. This preserves ordinary keyboard activation and prevents long key presses from toggling the password repeatedly.

Regression proof against exact master `d58fe298`:

- repeated Enter invokes `onVisibleChange(true)` before the fix
- repeated Space invokes `onVisibleChange(true)` before the fix
- both cases leave the input as `type="password"` and emit no callback after the fix

Validation:

- 22 Input test suites passed
- 378 tests passed, 4 skipped
- 195 snapshots passed
- focused ESLint, Biome, Prettier, and `git diff --check` passed

AI assistance disclosure: Codex was used to audit the repeat-key boundary, add the failing regressions, implement the guard, and run validation. The diff and results were verified locally.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Prevent repeated keyboard events from toggling Input.Password visibility multiple times. |
| 🇨🇳 Chinese | 防止重复键盘事件多次切换 Input.Password 的密码可见状态。 |
