### PR TITLE
fix(Upload): avoid leaving canvas after GIF preview

### DIFF
--- a/components/upload/__tests__/uploadlist.test.tsx
+++ b/components/upload/__tests__/uploadlist.test.tsx
@@ -1158,6 +1158,17 @@ describe('Upload List', () => {
     unmount();
   });
 
+  it('should not leave a canvas after generating a GIF preview', async () => {
+    const mockFile = new File([''], 'foo.gif', {
+      type: 'image/gif',
+    });
+    const canvasCount = document.body.querySelectorAll('canvas').length;
+
+    await previewImage(mockFile);
+
+    expect(document.body.querySelectorAll('canvas')).toHaveLength(canvasCount);
+  });
+
   it("upload non image file shouldn't be converted to the base64", async () => {
     const mockFile = new File([''], 'foo.7z', {
       type: 'application/x-7z-compressed',

--- a/components/upload/utils.ts
+++ b/components/upload/utils.ts
@@ -96,6 +96,18 @@ export function previewImage(file: File | Blob): Promise<string> {
       resolve('');
       return;
     }
+
+    if (file.type.startsWith('image/gif')) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (reader.result) {
+          resolve(reader.result as string);
+        }
+      };
+      reader.readAsDataURL(file);
+      return;
+    }
+
     const canvas = document.createElement('canvas');
     canvas.width = MEASURE_SIZE;
     canvas.height = MEASURE_SIZE;
@@ -131,14 +143,6 @@ export function previewImage(file: File | Blob): Promise<string> {
       reader.onload = () => {
         if (reader.result && typeof reader.result === 'string') {
           img.src = reader.result;
-        }
-      };
-      reader.readAsDataURL(file);
-    } else if (file.type.startsWith('image/gif')) {
-      const reader = new FileReader();
-      reader.onload = () => {
-        if (reader.result) {
-          resolve(reader.result as string);
         }
       };
       reader.readAsDataURL(file);


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] ✅ 测试用例

### 🔗 相关 Issue

None

### 💡 需求背景和解决方案

Upload 生成 GIF 预览时，会在判断文件类型前创建 canvas 并添加到文档中。由于 GIF 使用 FileReader 直接生成 Base64，后续不会进入 canvas 清理流程，导致页面中遗留隐藏 canvas。

这有演示GIF，请耐心等待 👇
<img width="1415" height="1191" alt="upload-gif-canvas" src="https://github.com/user-attachments/assets/a1350d94-8a6d-484d-b8ca-9981dced5893" />

本次调整在创建 canvas 前处理 GIF 文件，新增回归测试。不涉及公开 API、视觉或交互变更。

### 📝 更新日志

| 语言    | 更新描述                                                              |
| ------- | --------------------------------------------------------------------- |
| 🇺🇸 英文 | Fix Upload leaving a hidden canvas after generating a GIF preview.    |
| 🇨🇳 中文 | 修复 Upload 生成 GIF 预览后遗留隐藏 canvas 的问题。                   |