### PR TITLE
fix(Table): make filter triggers keyboard accessible

### DIFF
--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -25330,9 +25330,10 @@ exports[`ConfigProvider components Table configProvider 1`] = `
                         </div>
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="config-dropdown-trigger config-table-filter-trigger config-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -25637,9 +25638,10 @@ exports[`ConfigProvider components Table configProvider componentDisabled 1`] = 
                         </div>
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="config-dropdown-trigger config-table-filter-trigger config-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -25946,9 +25948,10 @@ exports[`ConfigProvider components Table configProvider componentSize large 1`] 
                         </div>
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="config-dropdown-trigger config-table-filter-trigger config-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -26253,9 +26256,10 @@ exports[`ConfigProvider components Table configProvider componentSize medium 1`]
                         </div>
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="config-dropdown-trigger config-table-filter-trigger config-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -26560,9 +26564,10 @@ exports[`ConfigProvider components Table configProvider componentSize small 1`] 
                         </div>
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="config-dropdown-trigger config-table-filter-trigger config-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -26867,9 +26872,10 @@ exports[`ConfigProvider components Table normal 1`] = `
                         </div>
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger ant-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -27174,9 +27180,10 @@ exports[`ConfigProvider components Table prefixCls 1`] = `
                         </div>
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger prefix-Table-filter-trigger ant-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"

--- a/components/locale/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/index.test.tsx.snap
@@ -6973,9 +6973,10 @@ exports[`Locale Provider should display the text as ar 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -12208,9 +12209,10 @@ exports[`Locale Provider should display the text as az 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -17443,9 +17445,10 @@ exports[`Locale Provider should display the text as bg 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -22678,9 +22681,10 @@ exports[`Locale Provider should display the text as bn-bd 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -27913,9 +27917,10 @@ exports[`Locale Provider should display the text as by 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -33148,9 +33153,10 @@ exports[`Locale Provider should display the text as ca 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -38383,9 +38389,10 @@ exports[`Locale Provider should display the text as cs 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -43618,9 +43625,10 @@ exports[`Locale Provider should display the text as da 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -48853,9 +48861,10 @@ exports[`Locale Provider should display the text as de 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -54088,9 +54097,10 @@ exports[`Locale Provider should display the text as el 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -59323,9 +59333,10 @@ exports[`Locale Provider should display the text as en 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -64558,9 +64569,10 @@ exports[`Locale Provider should display the text as en-gb 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -69793,9 +69805,10 @@ exports[`Locale Provider should display the text as es 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -75028,9 +75041,10 @@ exports[`Locale Provider should display the text as es-us 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -80263,9 +80277,10 @@ exports[`Locale Provider should display the text as et 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -85498,9 +85513,10 @@ exports[`Locale Provider should display the text as eu 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -90733,9 +90749,10 @@ exports[`Locale Provider should display the text as fa 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -95968,9 +95985,10 @@ exports[`Locale Provider should display the text as fi 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -101203,9 +101221,10 @@ exports[`Locale Provider should display the text as fr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -106438,9 +106457,10 @@ exports[`Locale Provider should display the text as fr 2`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -111673,9 +111693,10 @@ exports[`Locale Provider should display the text as fr 3`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -116908,9 +116929,10 @@ exports[`Locale Provider should display the text as ga 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -122143,9 +122165,10 @@ exports[`Locale Provider should display the text as gl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -127378,9 +127401,10 @@ exports[`Locale Provider should display the text as he 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -132613,9 +132637,10 @@ exports[`Locale Provider should display the text as hi 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -137848,9 +137873,10 @@ exports[`Locale Provider should display the text as hr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -143083,9 +143109,10 @@ exports[`Locale Provider should display the text as hu 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -148318,9 +148345,10 @@ exports[`Locale Provider should display the text as hy-am 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -153553,9 +153581,10 @@ exports[`Locale Provider should display the text as id 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -158788,9 +158817,10 @@ exports[`Locale Provider should display the text as is 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -164023,9 +164053,10 @@ exports[`Locale Provider should display the text as it 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -169258,9 +169289,10 @@ exports[`Locale Provider should display the text as ja 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -174493,9 +174525,10 @@ exports[`Locale Provider should display the text as ka 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -179728,9 +179761,10 @@ exports[`Locale Provider should display the text as kk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -184961,9 +184995,10 @@ exports[`Locale Provider should display the text as km 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -190196,9 +190231,10 @@ exports[`Locale Provider should display the text as kn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -195431,9 +195467,10 @@ exports[`Locale Provider should display the text as ko 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -200666,9 +200703,10 @@ exports[`Locale Provider should display the text as ku 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -205901,9 +205939,10 @@ exports[`Locale Provider should display the text as ku-iq 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -211136,9 +211175,10 @@ exports[`Locale Provider should display the text as lt 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -216371,9 +216411,10 @@ exports[`Locale Provider should display the text as lv 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -221606,9 +221647,10 @@ exports[`Locale Provider should display the text as mk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -226841,9 +226883,10 @@ exports[`Locale Provider should display the text as ml 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -232076,9 +232119,10 @@ exports[`Locale Provider should display the text as mn-mn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -237311,9 +237355,10 @@ exports[`Locale Provider should display the text as mr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -242546,9 +242591,10 @@ exports[`Locale Provider should display the text as ms-my 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -247781,9 +247827,10 @@ exports[`Locale Provider should display the text as my 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -253016,9 +253063,10 @@ exports[`Locale Provider should display the text as nb 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -258251,9 +258299,10 @@ exports[`Locale Provider should display the text as ne-np 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -263486,9 +263535,10 @@ exports[`Locale Provider should display the text as nl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -268721,9 +268771,10 @@ exports[`Locale Provider should display the text as nl-be 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -273956,9 +274007,10 @@ exports[`Locale Provider should display the text as pl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -279191,9 +279243,10 @@ exports[`Locale Provider should display the text as pt 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -284426,9 +284479,10 @@ exports[`Locale Provider should display the text as pt-br 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -289661,9 +289715,10 @@ exports[`Locale Provider should display the text as ro 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -294896,9 +294951,10 @@ exports[`Locale Provider should display the text as ru 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -300131,9 +300187,10 @@ exports[`Locale Provider should display the text as si 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -305366,9 +305423,10 @@ exports[`Locale Provider should display the text as sk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -310601,9 +310659,10 @@ exports[`Locale Provider should display the text as sl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -315836,9 +315895,10 @@ exports[`Locale Provider should display the text as sq 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -321071,9 +321131,10 @@ exports[`Locale Provider should display the text as sr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -326306,9 +326367,10 @@ exports[`Locale Provider should display the text as sv 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -331541,9 +331603,10 @@ exports[`Locale Provider should display the text as ta 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -336776,9 +336839,10 @@ exports[`Locale Provider should display the text as th 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -342011,9 +342075,10 @@ exports[`Locale Provider should display the text as tk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -347246,9 +347311,10 @@ exports[`Locale Provider should display the text as tr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -352481,9 +352547,10 @@ exports[`Locale Provider should display the text as uk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -357716,9 +357783,10 @@ exports[`Locale Provider should display the text as ur 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -362951,9 +363019,10 @@ exports[`Locale Provider should display the text as uz-latn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -368186,9 +368255,10 @@ exports[`Locale Provider should display the text as vi 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -373421,9 +373491,10 @@ exports[`Locale Provider should display the text as zh-cn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -378656,9 +378727,10 @@ exports[`Locale Provider should display the text as zh-hk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -383891,9 +383963,10 @@ exports[`Locale Provider should display the text as zh-tw 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"

--- a/components/locale/__tests__/__snapshots__/vitest/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/vitest/index.test.tsx.snap
@@ -1962,9 +1962,10 @@ exports[`Locale Provider > should display the text as ar 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -3911,9 +3912,10 @@ exports[`Locale Provider > should display the text as az 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -5860,9 +5862,10 @@ exports[`Locale Provider > should display the text as bg 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -7809,9 +7812,10 @@ exports[`Locale Provider > should display the text as bn-bd 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -9758,9 +9762,10 @@ exports[`Locale Provider > should display the text as by 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -11707,9 +11712,10 @@ exports[`Locale Provider > should display the text as ca 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -13656,9 +13662,10 @@ exports[`Locale Provider > should display the text as cs 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -15605,9 +15612,10 @@ exports[`Locale Provider > should display the text as da 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -17554,9 +17562,10 @@ exports[`Locale Provider > should display the text as de 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -19503,9 +19512,10 @@ exports[`Locale Provider > should display the text as el 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -21452,9 +21462,10 @@ exports[`Locale Provider > should display the text as en 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -23401,9 +23412,10 @@ exports[`Locale Provider > should display the text as en-gb 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -25350,9 +25362,10 @@ exports[`Locale Provider > should display the text as es 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -27299,9 +27312,10 @@ exports[`Locale Provider > should display the text as es-us 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -29248,9 +29262,10 @@ exports[`Locale Provider > should display the text as et 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -31197,9 +31212,10 @@ exports[`Locale Provider > should display the text as eu 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -33146,9 +33162,10 @@ exports[`Locale Provider > should display the text as fa 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -35095,9 +35112,10 @@ exports[`Locale Provider > should display the text as fi 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -37044,9 +37062,10 @@ exports[`Locale Provider > should display the text as fr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -38993,9 +39012,10 @@ exports[`Locale Provider > should display the text as fr 2`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -40942,9 +40962,10 @@ exports[`Locale Provider > should display the text as fr 3`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -42891,9 +42912,10 @@ exports[`Locale Provider > should display the text as ga 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -44840,9 +44862,10 @@ exports[`Locale Provider > should display the text as gl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -46789,9 +46812,10 @@ exports[`Locale Provider > should display the text as he 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -48738,9 +48762,10 @@ exports[`Locale Provider > should display the text as hi 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -50687,9 +50712,10 @@ exports[`Locale Provider > should display the text as hr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -52636,9 +52662,10 @@ exports[`Locale Provider > should display the text as hu 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -54585,9 +54612,10 @@ exports[`Locale Provider > should display the text as hy-am 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -56534,9 +56562,10 @@ exports[`Locale Provider > should display the text as id 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -58483,9 +58512,10 @@ exports[`Locale Provider > should display the text as is 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -60432,9 +60462,10 @@ exports[`Locale Provider > should display the text as it 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -62381,9 +62412,10 @@ exports[`Locale Provider > should display the text as ja 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -64330,9 +64362,10 @@ exports[`Locale Provider > should display the text as ka 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -66279,9 +66312,10 @@ exports[`Locale Provider > should display the text as kk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -68226,9 +68260,10 @@ exports[`Locale Provider > should display the text as km 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -70175,9 +70210,10 @@ exports[`Locale Provider > should display the text as kn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -72124,9 +72160,10 @@ exports[`Locale Provider > should display the text as ko 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -74073,9 +74110,10 @@ exports[`Locale Provider > should display the text as ku 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -76022,9 +76060,10 @@ exports[`Locale Provider > should display the text as ku-iq 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -77971,9 +78010,10 @@ exports[`Locale Provider > should display the text as lt 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -79920,9 +79960,10 @@ exports[`Locale Provider > should display the text as lv 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -81869,9 +81910,10 @@ exports[`Locale Provider > should display the text as mk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -83818,9 +83860,10 @@ exports[`Locale Provider > should display the text as ml 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -85767,9 +85810,10 @@ exports[`Locale Provider > should display the text as mn-mn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -87716,9 +87760,10 @@ exports[`Locale Provider > should display the text as mr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -89665,9 +89710,10 @@ exports[`Locale Provider > should display the text as ms-my 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -91614,9 +91660,10 @@ exports[`Locale Provider > should display the text as my 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -93563,9 +93610,10 @@ exports[`Locale Provider > should display the text as nb 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -95512,9 +95560,10 @@ exports[`Locale Provider > should display the text as ne-np 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -97461,9 +97510,10 @@ exports[`Locale Provider > should display the text as nl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -99410,9 +99460,10 @@ exports[`Locale Provider > should display the text as nl-be 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -101359,9 +101410,10 @@ exports[`Locale Provider > should display the text as pl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -103308,9 +103360,10 @@ exports[`Locale Provider > should display the text as pt 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -105257,9 +105310,10 @@ exports[`Locale Provider > should display the text as pt-br 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -107206,9 +107260,10 @@ exports[`Locale Provider > should display the text as ro 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -109155,9 +109210,10 @@ exports[`Locale Provider > should display the text as ru 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -111104,9 +111160,10 @@ exports[`Locale Provider > should display the text as si 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -113053,9 +113110,10 @@ exports[`Locale Provider > should display the text as sk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -115002,9 +115060,10 @@ exports[`Locale Provider > should display the text as sl 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -116951,9 +117010,10 @@ exports[`Locale Provider > should display the text as sq 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -118900,9 +118960,10 @@ exports[`Locale Provider > should display the text as sr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -120849,9 +120910,10 @@ exports[`Locale Provider > should display the text as sv 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -122798,9 +122860,10 @@ exports[`Locale Provider > should display the text as ta 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -124747,9 +124810,10 @@ exports[`Locale Provider > should display the text as th 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -126696,9 +126760,10 @@ exports[`Locale Provider > should display the text as tk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -128645,9 +128710,10 @@ exports[`Locale Provider > should display the text as tr 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -130594,9 +130660,10 @@ exports[`Locale Provider > should display the text as uk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -132543,9 +132610,10 @@ exports[`Locale Provider > should display the text as ur 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -134492,9 +134560,10 @@ exports[`Locale Provider > should display the text as uz-latn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -136441,9 +136510,10 @@ exports[`Locale Provider > should display the text as vi 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -138390,9 +138460,10 @@ exports[`Locale Provider > should display the text as zh-cn 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -140339,9 +140410,10 @@ exports[`Locale Provider > should display the text as zh-hk 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -142288,9 +142360,10 @@ exports[`Locale Provider > should display the text as zh-tw 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"

--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -122,6 +122,25 @@ describe('Table.filter', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
+  it('provides a localized accessible name for the filter trigger', () => {
+    const { container } = render(createTable({ locale: { filterTitle: '篩選器' } }));
+    const trigger = container.querySelector('.ant-table-filter-trigger');
+
+    expect(trigger).toHaveAttribute('aria-label', '篩選器');
+    expect(trigger).toHaveAttribute('tabindex', '0');
+  });
+
+  it.each(['Enter', ' '])('opens the filter dropdown with %s', async (key) => {
+    const { container } = render(createTable());
+    const trigger = container.querySelector<HTMLElement>('.ant-table-filter-trigger')!;
+
+    fireEvent.keyDown(trigger, { key });
+
+    await waitFor(() => {
+      expect(container.querySelector('.ant-table-filter-dropdown')).toBeTruthy();
+    });
+  });
+
   // async await 解决 Warning: An update to Item ran an effect, but was not wrapped in act(...).
   it('renders menu correctly', async () => {
     const { container } = render(createTable());

--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -141,6 +141,15 @@ describe('Table.filter', () => {
     });
   });
 
+  it.each(['Enter', ' '])('ignores repeated %s activation', (key) => {
+    const { container } = render(createTable());
+    const trigger = container.querySelector<HTMLElement>('.ant-table-filter-trigger')!;
+
+    fireEvent.keyDown(trigger, { key, repeat: true });
+
+    expect(container.querySelector('.ant-table-filter-dropdown')).toBeFalsy();
+  });
+
   // async await 解决 Warning: An update to Item ran an effect, but was not wrapped in act(...).
   it('renders menu correctly', async () => {
     const { container } = render(createTable());

--- a/components/table/__tests__/__snapshots__/Table.filter.test.tsx.snap
+++ b/components/table/__tests__/__snapshots__/Table.filter.test.tsx.snap
@@ -138,9 +138,10 @@ exports[`Table.filter renders custom filter icon as ReactNode 1`] = `
                         Name
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           class="customize-icon"
@@ -244,9 +245,10 @@ exports[`Table.filter renders custom filter icon as string correctly 1`] = `
                         Name
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         string
                       </span>
@@ -356,9 +358,10 @@ exports[`Table.filter renders custom filter icon with right Tooltip title 1`] = 
                         Name
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-describedby="test-id"
@@ -485,9 +488,10 @@ exports[`Table.filter renders filter correctly 1`] = `
                         Name
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2166,9 +2166,10 @@ Array [
                           Address
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -3570,9 +3571,10 @@ Array [
                           Age
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -3980,9 +3982,10 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                         Name
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -4117,9 +4120,10 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                         Age
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -4333,9 +4337,10 @@ exports[`renders components/table/demo/custom-filter-panel.tsx extend context co
                         </div>
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -6711,9 +6716,10 @@ Array [
                           Address
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -10730,9 +10736,10 @@ exports[`renders components/table/demo/filter-in-tree.tsx extend context correct
                         Name
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -11289,9 +11296,10 @@ exports[`renders components/table/demo/filter-in-tree.tsx extend context correct
                         Address
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -11711,9 +11719,10 @@ exports[`renders components/table/demo/filter-search.tsx extend context correctl
                         Name
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -12068,9 +12077,10 @@ exports[`renders components/table/demo/filter-search.tsx extend context correctl
                         Address
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -13875,9 +13885,10 @@ exports[`renders components/table/demo/grouping-columns.tsx extend context corre
                         Name
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -14252,6 +14263,7 @@ exports[`renders components/table/demo/grouping-columns.tsx extend context corre
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-table-filter-trigger"
                           role="button"
                           tabindex="-1"
@@ -15347,9 +15359,10 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
                         </div>
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -15749,9 +15762,10 @@ exports[`renders components/table/demo/head.tsx extend context correctly 1`] = `
                         Address
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -16935,9 +16949,10 @@ exports[`renders components/table/demo/measure-row-render.tsx extend context cor
                         Name
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger ant-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -17072,9 +17087,10 @@ exports[`renders components/table/demo/measure-row-render.tsx extend context cor
                         Age
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger ant-dropdown-open"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -17367,9 +17383,10 @@ exports[`renders components/table/demo/measure-row-render.tsx extend context cor
                         </div>
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -17532,6 +17549,7 @@ exports[`renders components/table/demo/measure-row-render.tsx extend context cor
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-table-filter-trigger"
                           role="button"
                           tabindex="-1"
@@ -17574,6 +17592,7 @@ exports[`renders components/table/demo/measure-row-render.tsx extend context cor
                           Age
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-table-filter-trigger"
                           role="button"
                           tabindex="-1"
@@ -17692,6 +17711,7 @@ exports[`renders components/table/demo/measure-row-render.tsx extend context cor
                           </div>
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-table-filter-trigger"
                           role="button"
                           tabindex="-1"
@@ -23535,9 +23555,10 @@ Array [
                           </div>
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -23872,9 +23893,10 @@ Array [
                           </div>
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"

--- a/components/table/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.ts.snap
@@ -2143,9 +2143,10 @@ Array [
                           Address
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -3392,9 +3393,10 @@ Array [
                           Age
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -3668,9 +3670,10 @@ exports[`renders components/table/demo/custom-filter-panel.tsx correctly 1`] = `
                         Name
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -3707,9 +3710,10 @@ exports[`renders components/table/demo/custom-filter-panel.tsx correctly 1`] = `
                         Age
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -3804,9 +3808,10 @@ exports[`renders components/table/demo/custom-filter-panel.tsx correctly 1`] = `
                         </div>
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="search"
@@ -6008,9 +6013,10 @@ Array [
                           Address
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -9320,9 +9326,10 @@ exports[`renders components/table/demo/filter-in-tree.tsx correctly 1`] = `
                         Name
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -9423,9 +9430,10 @@ exports[`renders components/table/demo/filter-in-tree.tsx correctly 1`] = `
                         Address
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -9673,9 +9681,10 @@ exports[`renders components/table/demo/filter-search.tsx correctly 1`] = `
                         Name
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -9776,9 +9785,10 @@ exports[`renders components/table/demo/filter-search.tsx correctly 1`] = `
                         Address
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -14827,9 +14837,10 @@ exports[`renders components/table/demo/grouping-columns.tsx correctly 1`] = `
                         Name
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -15051,6 +15062,7 @@ exports[`renders components/table/demo/grouping-columns.tsx correctly 1`] = `
                           Name
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-table-filter-trigger"
                           role="button"
                           tabindex="-1"
@@ -15996,9 +16008,10 @@ exports[`renders components/table/demo/head.tsx correctly 1`] = `
                         </div>
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -16100,9 +16113,10 @@ exports[`renders components/table/demo/head.tsx correctly 1`] = `
                         Address
                       </span>
                       <span
+                        aria-label="Filter menu"
                         class="ant-dropdown-trigger ant-table-filter-trigger"
                         role="button"
-                        tabindex="-1"
+                        tabindex="0"
                       >
                         <span
                           aria-label="filter"
@@ -21826,9 +21840,10 @@ Array [
                           </div>
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"
@@ -21989,9 +22004,10 @@ Array [
                           </div>
                         </span>
                         <span
+                          aria-label="Filter menu"
                           class="ant-dropdown-trigger ant-table-filter-trigger"
                           role="button"
-                          tabindex="-1"
+                          tabindex="0"
                         >
                           <span
                             aria-label="filter"

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -552,10 +552,17 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
     return (
       <span
         role="button"
-        tabIndex={-1}
+        aria-label={locale.filterTitle}
+        tabIndex={inMeasureRow ? -1 : 0}
         className={clsx(`${prefixCls}-trigger`, { active: filtered })}
         onClick={(e) => {
           e.stopPropagation();
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            e.currentTarget.click();
+          }
         }}
       >
         {filterIcon}

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -561,7 +561,9 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            e.currentTarget.click();
+            if (!e.repeat) {
+              e.currentTarget.click();
+            }
           }
         }}
       >


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [x] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

Table filter triggers expose `role="button"`, but the visible trigger is currently removed from the Tab order with `tabIndex={-1}` and has no keyboard activation handler. It also does not use the existing localized `Table.filterTitle`, so the generated icon name remains English in non-English locales.

This change:

- names the trigger with the existing `locale.filterTitle` contract
- keeps the visible trigger in the Tab order while leaving the aria-hidden measure-row trigger at `tabIndex={-1}`
- routes non-repeated Enter and Space through the existing click path, preserving Dropdown behavior and preventing both Space scrolling and long-press toggle loops

On exact base `d58fe298deafb588f83a90dd02db505614078f22`, three focused regressions failed: the zh-TW accessible name was absent, and neither Enter nor Space opened the filter dropdown. The review follow-up adds a two-key repeat matrix that fails twice on the previous implementation because each repeated keydown opens the dropdown.

### 📝 Changelog

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Make Table filter triggers keyboard accessible and use their localized accessible name. |
| 🇨🇳 Chinese | 使表格筛选触发器支持键盘操作并使用本地化无障碍名称。 |

### ✅ Validation

- complete Table filter suite: 97 tests and 10 snapshots
- repeat regression: fails twice without the guard and passes twice on exact head `c28481a13a804c9e7844fb93f7fc9f6c87c030f9`
- focused ESLint for implementation and regression file
- focused Biome for the implementation and signed commit-hook validation for both changed files
- `git diff --check`
- direct TypeScript adds no diagnostic; the current environment reports only the existing Puppeteer `Page` type mismatch

I checked all current open PR changed files and searched open issues/PRs for the same Table filter-trigger keyboard and localization work immediately before submission; no overlap was found.

AI assistance disclosure: Codex was used to trace the runtime and locale paths, audit current overlap, implement the scoped change, and run validation. The original regressions and the repeated-key follow-up were reproduced against the implementation immediately before each fix.
