### PR TITLE
fix(Table): allow empty string values in single-select tree filters

### DIFF
--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -2462,6 +2462,46 @@ describe('Table.filter', () => {
     expect(container.querySelectorAll('.ant-tree-checkbox-checked').length).toBe(0);
   });
 
+  it('filterMultiple is false - supports empty string value in tree mode', () => {
+    const { container } = render(
+      createTable({
+        dataSource: [
+          { key: 'blank', status: '', name: 'Blank row' },
+          { key: 'filled', status: 'filled', name: 'Filled row' },
+        ],
+        columns: [
+          { title: 'Name', dataIndex: 'name' },
+          {
+            title: 'Status',
+            dataIndex: 'status',
+            filterMode: 'tree',
+            filterMultiple: false,
+            filters: [
+              { text: 'Empty value', value: '' },
+              { text: 'Filled value', value: 'filled' },
+            ],
+            onFilter: (value, record) => record.status === value,
+          },
+        ],
+      }),
+    );
+
+    fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
+    act(() => {
+      jest.runAllTimers();
+    });
+    fireEvent.click(container.querySelectorAll('.ant-tree-checkbox')[0]);
+
+    expect(container.querySelectorAll('.ant-tree-checkbox-checked')).toHaveLength(1);
+
+    fireEvent.click(
+      container.querySelector(
+        '.ant-table-filter-dropdown-btns .ant-btn-color-primary.ant-btn-variant-solid',
+      )!,
+    );
+    expect(renderedNames(container)).toEqual(['Blank row']);
+  });
+
   it('filterMultiple is false - select item', () => {
     jest.spyOn(console, 'error').mockImplementation(() => undefined);
     const { container } = render(

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -234,7 +234,7 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
     { node, checked }: { node: EventDataNode<FilterTreeDataNode>; checked: boolean },
   ) => {
     if (!filterMultiple) {
-      onSelectKeys({ selectedKeys: checked && node.key ? [node.key] : [] });
+      onSelectKeys({ selectedKeys: checked ? [node.key] : [] });
     } else {
       onSelectKeys({ selectedKeys: keys });
     }


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #59140

### 💡 需求背景和解决方案

Table 树形筛选在 `filterMultiple={false}` 时，根据节点 key 的真假值决定是否记录选项，导致 `value: ''` 无法被选中。

本 PR 改为仅依据节点的 checked 状态维护选中 key，并新增覆盖选中状态和最终过滤结果的回归测试。不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Table single-select tree filters not selecting empty string values |
| 🇨🇳 中文 | 修复 Table 树形单选筛选无法选择空字符串值的问题 |
