### PR TITLE
fix(Select): exclude unsupported onPopupVisibleChange prop

### DIFF
--- a/components/auto-complete/AutoComplete.tsx
+++ b/components/auto-complete/AutoComplete.tsx
@@ -58,7 +58,15 @@ export interface AutoCompleteProps<
   OptionType extends BaseOptionType | DefaultOptionType = DefaultOptionType,
 > extends Omit<
     InternalSelectProps<ValueType, OptionType>,
-    'loading' | 'mode' | 'optionLabelProp' | 'labelInValue' | 'styles' | 'classNames' | 'showSearch' | 'optionFilterProp' | 'filterSort'
+    | 'loading'
+    | 'mode'
+    | 'optionLabelProp'
+    | 'labelInValue'
+    | 'styles'
+    | 'classNames'
+    | 'showSearch'
+    | 'optionFilterProp'
+    | 'filterSort'
   > {
   /** @deprecated Please use `options` instead */
   dataSource?: DataSourceItemType[];
@@ -80,7 +88,12 @@ export interface AutoCompleteProps<
   /** @deprecated Please use `onOpenChange` instead */
   onDropdownVisibleChange?: (visible: boolean) => void;
   onOpenChange?: (visible: boolean) => void;
-  showSearch?: boolean | Pick<SearchConfig<OptionType> & { searchIcon?: React.ReactNode }, 'filterOption' | 'onSearch' | 'searchIcon'>;
+  showSearch?:
+    | boolean
+    | Pick<
+        SearchConfig<OptionType> & { searchIcon?: React.ReactNode },
+        'filterOption' | 'onSearch' | 'searchIcon'
+      >;
 }
 
 function isSelectOptionOrSelectOptGroup(child: any): boolean {
@@ -251,13 +264,19 @@ const AutoComplete: React.ForwardRefRenderFunction<RefSelectProps, AutoCompleteP
     <Select
       ref={ref}
       suffixIcon={null}
-      {...omit(props, ['dataSource', 'dropdownClassName', 'popupClassName'])}
+      {...omit(props, [
+        'dataSource',
+        'dropdownClassName',
+        'popupClassName',
+        'onDropdownVisibleChange',
+        'onOpenChange',
+      ])}
       prefixCls={prefixCls}
       classNames={finalClassNames}
       styles={finalStyles}
       mode={Select.SECRET_COMBOBOX_MODE_DO_NOT_USE as SelectProps['mode']}
       popupRender={mergedPopupRender}
-      onPopupVisibleChange={mergedOnOpenChange}
+      onOpenChange={mergedOnOpenChange}
       popupMatchSelectWidth={mergedPopupMatchSelectWidth}
       {...{
         // Internal api

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -100,7 +100,10 @@ export type SelectValue = RawValue | RawValue[] | LabeledValue | LabeledValue[] 
 export interface InternalSelectProps<
   ValueType = any,
   OptionType extends BaseOptionType | DefaultOptionType = DefaultOptionType,
-> extends Omit<RcSelectProps<ValueType, OptionType>, 'mode' | 'styles' | 'classNames'> {
+> extends Omit<
+    RcSelectProps<ValueType, OptionType>,
+    'mode' | 'styles' | 'classNames' | 'onPopupVisibleChange'
+  > {
   rootClassName?: string;
   prefix?: React.ReactNode;
   suffixIcon?: React.ReactNode;
@@ -150,7 +153,7 @@ export interface SelectProps<
   /** @deprecated Please use `popupRender` instead */
   dropdownRender?: SelectProps['popupRender'];
   /** @deprecated Please use `onOpenChange` instead */
-  onDropdownVisibleChange?: SelectProps['onPopupVisibleChange'];
+  onDropdownVisibleChange?: RcSelectProps<ValueType, OptionType>['onPopupVisibleChange'];
   /** @deprecated Please use `popupMatchSelectWidth` instead */
   dropdownMatchSelectWidth?: boolean | number;
   popupMatchSelectWidth?: boolean | number;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [x] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Select 继承底层 `@rc-component/select` 类型时，意外暴露了内部使用的 `onPopupVisibleChange`。该属性虽然能够通过 TypeScript 检查，但不会在 Select 和 AutoComplete 中生效。

本次改动从 Select 公共类型中排除 `onPopupVisibleChange`，保留并复用底层类型定义描述兼容 API `onDropdownVisibleChange`。AutoComplete 在自身层级合并 `onOpenChange` 与 `onDropdownVisibleChange`，仅向 Select 传递标准化后的 `onOpenChange`，避免废弃 API 继续向下层透传。

已通过 TypeScript 检查、Select 和 AutoComplete 相关测试及代码检查。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Select and AutoComplete TypeScript definitions incorrectly exposing unsupported `onPopupVisibleChange`. |
| 🇨🇳 中文 | 🐞 修复 Select 和 AutoComplete 类型错误暴露不支持的 `onPopupVisibleChange` 属性。 |
