### PR TITLE
fix(Table): support empty string values in tree filters

### DIFF
--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -2462,6 +2462,47 @@ describe('Table.filter', () => {
     expect(container.querySelectorAll('.ant-tree-checkbox-checked').length).toBe(0);
   });
 
+  it('filterMultiple is false - supports an empty string value in tree mode', () => {
+    const { container } = render(
+      createTable({
+        columns: [
+          {
+            title: 'Status',
+            dataIndex: 'status',
+            filterMode: 'tree',
+            filterMultiple: false,
+            filters: [
+              { text: 'Empty', value: '' },
+              { text: 'Filled', value: 'filled' },
+            ],
+            onFilter: (value, record) => record.status === value,
+          },
+        ],
+        dataSource: [
+          { key: 'empty', status: '' },
+          { key: 'filled', status: 'filled' },
+        ],
+      }),
+    );
+
+    fireEvent.click(container.querySelector('span.ant-dropdown-trigger')!, nativeEvent);
+    act(() => {
+      jest.runAllTimers();
+    });
+    fireEvent.click(container.querySelectorAll('.ant-tree-checkbox')[0]);
+
+    expect(container.querySelectorAll('.ant-tree-checkbox')[0]).toHaveClass(
+      'ant-tree-checkbox-checked',
+    );
+
+    fireEvent.click(
+      container.querySelector(
+        '.ant-table-filter-dropdown-btns .ant-btn-color-primary.ant-btn-variant-solid',
+      )!,
+    );
+    expect(renderedNames(container)).toEqual(['']);
+  });
+
   it('filterMultiple is false - select item', () => {
     jest.spyOn(console, 'error').mockImplementation(() => undefined);
     const { container } = render(

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -6,7 +6,7 @@ import { clsx } from 'clsx';
 
 import type { FilterState } from '.';
 import { useSyncState } from '../../../_util/hooks';
-import { isFunction, isNumber } from '../../../_util/is';
+import { isFunction, isNonNullable, isNumber } from '../../../_util/is';
 import type { AnyObject } from '../../../_util/type';
 import { devUseWarning } from '../../../_util/warning';
 import Button from '../../../button/Button';
@@ -234,7 +234,7 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
     { node, checked }: { node: EventDataNode<FilterTreeDataNode>; checked: boolean },
   ) => {
     if (!filterMultiple) {
-      onSelectKeys({ selectedKeys: checked && node.key ? [node.key] : [] });
+      onSelectKeys({ selectedKeys: checked && isNonNullable(node.key) ? [node.key] : [] });
     } else {
       onSelectKeys({ selectedKeys: keys });
     }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Fixes #59140

### 💡 Background and Solution

In tree filter mode with `filterMultiple={false}`, the selection handler used the truthiness of `node.key` to decide whether to retain the selected key. An empty string is a supported filter value but is falsy, so it could never become selected or filter the table.

Use the repository's `isNonNullable` guard instead. This keeps valid falsy values such as the empty string while still rejecting `null` and `undefined`. The regression test opens the tree filter, selects the empty-string option, confirms it, and verifies that only the matching row remains.

Validation:

- `npm test -- components/table/__tests__/Table.filter.test.tsx --runInBand` (93 tests, 10 snapshots)
- focused ESLint on both changed files
- `git diff --check`

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Table tree-mode single filters not accepting an empty string value. |
| 🇨🇳 Chinese | 🐞 修复 Table 树形单选筛选无法选择空字符串值的问题。 |

AI assistance disclosure: Codex was used to reproduce the reported behavior, implement the minimal fix, and run the focused validation. The failing-before/passing-after regression and final diff were verified locally.