### PR TITLE
fix(Image): use RTL icons in PreviewGroup

### DIFF
--- a/components/image/PreviewGroup.tsx
+++ b/components/image/PreviewGroup.tsx
@@ -105,7 +105,7 @@ const InternalPreviewGroup: React.FC<PreviewGroupProps> = ({
     prefixCls,
     mergedRootClassName,
     getContextPopupContainer,
-    icons,
+    memoizedIcons,
   );
 
   const { mask: mergedMask, blurClassName } = mergedPreview ?? {};


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

在 `ConfigProvider direction="rtl"` 下，`Image.PreviewGroup` 的预览切换按钮仍使用 LTR 方向图标，导致按钮位置与箭头方向表达不一致。
<img width="2560" height="1271" alt="image-preview-rtl-icon-before" src="https://github.com/user-attachments/assets/32d9b13a-e40d-4a4e-809f-9ed035a942e4" />


修复预览配置，使其使用根据当前 `direction` 计算得到的 RTL 图标，确保预览配置与组件实际传入的图标保持一致。
<img width="2560" height="1271" alt="image-preview-rtl-icon-after" src="https://github.com/user-attachments/assets/1b2d44fa-32ef-4737-aafe-a10baa45f94a" />

（实测 X 平台使用 RTL 语言，查看多张图片时，左边按钮是←箭头，功能是“下一张”，右边按钮是右箭头，功能是“上一张”）。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Image PreviewGroup switch icons in RTL direction. |
| 🇨🇳 中文 | 修复 Image PreviewGroup 在 RTL 方向下切换按钮图标错误的问题。 |