### PR TITLE
fix: restore jest-puppeteer global types

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,7 +205,6 @@
     "@types/isomorphic-fetch": "^0.0.39",
     "@types/jest": "^30.0.0",
     "@types/jest-axe": "^3.5.9",
-    "@types/jest-environment-puppeteer": "^5.0.6",
     "@types/jest-image-snapshot": "^6.4.1",
     "@types/jquery": "^4.0.0",
     "@types/jsdom": "^30.0.0",

--- a/typings/jest.d.ts
+++ b/typings/jest.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="jest-environment-puppeteer" />
 import type * as React from 'react';
+import 'jest-puppeteer';
 
 declare global {
   namespace jest {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🤖 TypeScript 定义更新

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

`jest-puppeteer` 已升级到 v11，新版本自带 TypeScript 类型定义，并要求通过 `import 'jest-puppeteer'` 暴露 `page`、`jestPuppeteer` 等全局 API。移除旧版 `@types/jest-environment-puppeteer`，改用[官方推荐](https://github.com/argos-ci/jest-puppeteer/blob/main/packages/jest-environment-puppeteer/README.md#typescript-setup)的类型入口，修复 `npm run tsc` 中的全局变量类型错误。

无组件 API、UI 或交互变化。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 无需更新日志 |
| 🇨🇳 中文 | 无需更新日志 |