### PR TITLE
chore: pin nwsapi to fix CI failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -349,7 +349,8 @@
     }
   ],
   "overrides": {
-    "jest-environment-node": "^30.4.1"
+    "jest-environment-node": "^30.4.1",
+    "nwsapi": "2.2.24"
   },
   "title": "Ant Design",
   "tnpm": {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] ⏩ 工作流程

### 🔗 相关 Issue

- https://github.com/dperini/nwsapi/issues/168
- https://github.com/dperini/nwsapi/pull/169
- ant-design/ant-design#59150
- ant-design/ant-design#59151

### 💡 需求背景和解决方案

`nwsapi` 2.2.25 引入了 `:has()` 兄弟选择器在根节点匹配时的回归，最新的 2.2.26 仍未修复，导致多个无关 PR 的 Tooltip 测试出现相同的 `Cannot read properties of null (reading 'children')` 错误。

临时通过 npm `overrides` 将 `nwsapi` 固定为 2.2.24。待上游修复合并并发布后，可以移除该版本限制。

验证结果：

- `nwsapi@2.2.26`：Tooltip 测试出现 6 个失败
- `nwsapi@2.2.24`：8 个测试套件全部通过，99 个测试通过
- `ut` 安装确认解析为 `nwsapi@2.2.24 overridden`
- `git diff --check` 通过

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |
