### PR TITLE
fix(Radio): treat undefined group value as uncontrolled

### DIFF
--- a/components/radio/__tests__/group.test.tsx
+++ b/components/radio/__tests__/group.test.tsx
@@ -204,6 +204,41 @@ describe('Radio Group', () => {
       expect(container.querySelectorAll('.ant-radio-wrapper-checked').length).toBe(1);
     });
 
+    it('should update value when `value` is undefined', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Radio.Group defaultValue="A" value={undefined} onChange={onChange}>
+          <Radio value="A">A</Radio>
+          <Radio value="B">B</Radio>
+        </Radio.Group>,
+      );
+      const radios = container.querySelectorAll('input');
+
+      expect(radios[0]).toBeChecked();
+      fireEvent.click(radios[1]);
+      expect(radios[0]).not.toBeChecked();
+      expect(radios[1]).toBeChecked();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0].target.value).toBe('B');
+    });
+
+    it('should remain controlled when `value` is null', () => {
+      const onChange = jest.fn();
+      const { container } = render(
+        <Radio.Group value={null} onChange={onChange}>
+          <Radio value="A">A</Radio>
+          <Radio value="B">B</Radio>
+        </Radio.Group>,
+      );
+      const radios = container.querySelectorAll('input');
+
+      fireEvent.click(radios[1]);
+      expect(radios[0]).not.toBeChecked();
+      expect(radios[1]).not.toBeChecked();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0].target.value).toBe('B');
+    });
+
     [undefined, null].forEach((newValue) => {
       it(`should set value back when value change back to ${newValue}`, () => {
         const options = [{ label: 'Bamboo', value: 'bamboo' }];

--- a/components/radio/group.tsx
+++ b/components/radio/group.tsx
@@ -57,9 +57,7 @@ const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>((props, ref
     (event: RadioChangeEvent) => {
       const lastValue = value;
       const val = event.target.value;
-      if (!('value' in props)) {
-        setValue(val);
-      }
+      setValue(val);
       if (val !== lastValue) {
         onChange?.(event);
       }


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close https://github.com/ant-design/ant-design/issues/59161

- 相关：https://github.com/ant-design/ant-design/issues/22209
- 相关：https://github.com/ant-design/ant-design/pull/22245
- 参考：https://github.com/ant-design/ant-design/pull/59076

### 💡 需求背景和解决方案

`Radio.Group` 已使用 `useControlledState`，该 Hook 会在 `value` 为 `undefined` 时回退到内部状态。但事件处理此前通过 `'value' in props` 再次判断受控模式，导致显式传入 `value={undefined}` 时不调用状态更新函数，点击后选中项无法切换。

本 PR 在 change 事件中始终调用 `setValue`，由 `useControlledState` 统一管理受控与非受控状态。`value={undefined}` 会正常更新内部状态，`value={null}` 和其他显式值仍保持受控。

同时补充回归测试，覆盖 `undefined` 时更新选中值并触发一次 `onChange`，以及 `null` 时保持受控空值的行为。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Radio.Group not updating its selected value when `value` is `undefined`. |
| 🇨🇳 中文 | 🐞 修复 Radio.Group 在 `value` 为 `undefined` 时不更新选中值的问题。 |