### PR TITLE
demo(Form): disable upload button in disabled demo

### DIFF
--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -4995,6 +4995,7 @@ Array [
                         type="file"
                       />
                       <button
+                        disabled=""
                         style="color: inherit; cursor: inherit; border: 0px; background: none;"
                         type="button"
                       >

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2522,6 +2522,7 @@ Array [
                         type="file"
                       />
                       <button
+                        disabled=""
                         style="color:inherit;cursor:inherit;border:0;background:none"
                         type="button"
                       >

--- a/components/form/demo/disabled.tsx
+++ b/components/form/demo/disabled.tsx
@@ -107,6 +107,7 @@ const FormDisabledDemo: React.FC = () => {
             <button
               style={{ color: 'inherit', cursor: 'inherit', border: 0, background: 'none' }}
               type="button"
+              disabled={componentDisabled}
             >
               <PlusOutlined />
               <div style={{ marginTop: 8 }}>Upload</div>


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📽️ 演示代码改进

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

<img width="2554" height="731" alt="form-demo-upload-disabled" src="https://github.com/user-attachments/assets/e66eaf04-c6f7-4ecd-8d7b-48ea7be94eb7" />


在 Form disabled demo 中，Upload 已禁用，但自定义上传按钮仍可通过 tab 按键聚焦。

根据 Upload 组件 api [说明](https://ant-design.antgroup.com/components/upload-cn#api:~:text=%E5%AF%B9%E4%BA%8E%E8%87%AA%E5%AE%9A%E4%B9%89%20Upload%20children%20%E6%97%B6%EF%BC%8C%E8%AF%B7%E5%90%8C%E6%97%B6%E5%B0%86%20disabled%20%E5%B1%9E%E6%80%A7%E4%BC%A0%E7%BB%99%20child%20node%EF%BC%8C%E4%BB%A5%E7%A1%AE%E4%BF%9D%E7%A6%81%E7%94%A8%E7%8A%B6%E6%80%81%E7%9A%84%E6%B8%B2%E6%9F%93%E6%95%88%E6%9E%9C%E4%BF%9D%E6%8C%81%E4%B8%80%E8%87%B4)，为自定义上传按钮添加 `disabled={componentDisabled}`，使其与表单禁用状态保持一致，并同步更新相关快照。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |