### PR TITLE
fix: clear stale Transfer selection when key type changes

### DIFF
--- a/components/transfer/__tests__/index.test.tsx
+++ b/components/transfer/__tests__/index.test.tsx
@@ -1001,6 +1001,35 @@ describe('Transfer', () => {
     });
   });
 
+  it('should clear stale selection when dataSource key type changes', () => {
+    const App: React.FC = () => {
+      const [stringKey, setStringKey] = useState(false);
+
+      return (
+        <>
+          <Button onClick={() => setStringKey((prev) => !prev)}>Toggle key type</Button>
+          <Transfer
+            dataSource={[{ key: stringKey ? '1' : 1, title: 'item' }]}
+            render={(item) => item.title}
+          />
+        </>
+      );
+    };
+
+    const { container, getByRole } = render(<App />);
+    const getItemCheckbox = () =>
+      container.querySelector<HTMLInputElement>('.ant-transfer-list-content input');
+
+    fireEvent.click(getItemCheckbox()!);
+    expect(getItemCheckbox()).toBeChecked();
+
+    fireEvent.click(getByRole('button', { name: 'Toggle key type' }));
+    expect(getItemCheckbox()).not.toBeChecked();
+
+    fireEvent.click(getByRole('button', { name: 'Toggle key type' }));
+    expect(getItemCheckbox()).not.toBeChecked();
+  });
+
   it('showSearch with single object', () => {
     const emptyProps = { dataSource: [], selectedKeys: [], targetKeys: [] };
     const locale = { itemUnit: 'Person', notFoundContent: 'Nothing' };

--- a/components/transfer/hooks/useSelection.ts
+++ b/components/transfer/hooks/useSelection.ts
@@ -11,7 +11,7 @@ function filterKeys(keys: TransferKey[], dataKeys: Set<TransferKey>) {
 }
 
 function flattenKeys(keys: Set<TransferKey>) {
-  return Array.from(keys).join(';');
+  return JSON.stringify(Array.from(keys, (key) => [typeof key, String(key)]));
 }
 
 function useSelection<T extends { key: TransferKey }>(


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

None

### 💡 需求背景和解决方案

Transfer 使用数据源 key 集合的签名清理已不存在的非受控选中状态。原实现直接使用分隔符拼接 key，数字 `1` 与字符串 `'1'` 会得到相同签名，导致数据源在两种 key 之间切换后旧选中状态重新出现。

本次通过同时序列化 key 的类型和值来区分不同类型，并避免含分隔符的字符串产生签名碰撞；同时添加回归测试。不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Transfer restoring stale selections after data source key types change. |
| 🇨🇳 中文 | 🐞 修复 Transfer 在数据源 key 类型变化后恢复旧选中状态的问题。 |
