### PR TITLE
fix(Input.Password): respect controlled visibility state

### DIFF
--- a/components/input/Password.tsx
+++ b/components/input/Password.tsx
@@ -118,7 +118,9 @@ const Password = React.forwardRef<InputRef, PasswordProps>((props, ref) => {
     }
 
     const nextVisible = !visible;
-    setVisible(nextVisible);
+    if (!visibilityControlled) {
+      setVisible(nextVisible);
+    }
 
     if (isPlainObject(visibilityToggle)) {
       visibilityToggle.onVisibleChange?.(nextVisible);

--- a/components/input/__tests__/Password.test.tsx
+++ b/components/input/__tests__/Password.test.tsx
@@ -165,6 +165,18 @@ describe('Input.Password', () => {
     expect(container.querySelectorAll('.anticon-eye-invisible').length).toBe(1);
   });
 
+  it('should not change password visibility in controlled mode', () => {
+    const onVisibleChange = jest.fn();
+    const { container } = render(
+      <Input.Password visibilityToggle={{ visible: false, onVisibleChange }} />,
+    );
+
+    fireEvent.click(container.querySelector('.ant-input-password-icon')!);
+
+    expect(container.querySelector('input')).toHaveAttribute('type', 'password');
+    expect(onVisibleChange).toHaveBeenCalledWith(true);
+  });
+
   it('should call onPasswordVisibleChange when visible is changed', () => {
     const handlePasswordVisibleChange = jest.fn();
     const { container, rerender } = render(


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #59167

### 💡 需求背景和解决方案

Input.Password 使用 `visibilityToggle.visible` 受控显隐状态时，点击显隐图标仍会更新组件内部状态，导致密码在受控值保持 `false` 时也被显示。

受控模式下不再更新内部显隐状态，仅触发 `onVisibleChange` 通知外部更新；非受控模式保持原有行为。同时补充回归测试，确保点击图标不会绕过受控值。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Input.Password ignoring the controlled visibility state when clicking the visibility toggle. |
| 🇨🇳 中文 | 🐞 修复 Input.Password 点击显隐按钮时未遵循受控显隐状态的问题。 |
