### PR TITLE
feat(Radio): support sizes for default radio groups

### DIFF
--- a/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2100,253 +2100,409 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx extend context c
 
 exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
 <div
-  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-large"
 >
   <div
-    class="ant-radio-group ant-radio-group-outline ant-radio-group-large css-var-test-id ant-radio-css-var"
-    role="radiogroup"
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
+    style="flex: 1 1 280px;"
   >
-    <label
-      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
+    <span
+      class="ant-typography css-var-test-id"
     >
-      <span
-        class="ant-radio-button ant-radio-button-checked"
-      >
-        <input
-          checked=""
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="a"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Hangzhou
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      <strong>
+        Radio
+      </strong>
+    </span>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-large css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="b"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
       >
-        Shanghai
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="c"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
       >
-        Beijing
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-small css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="d"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
       >
-        Chengdu
-      </span>
-    </label>
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
   </div>
   <div
-    class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
-    role="radiogroup"
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
+    style="flex: 1 1 280px;"
   >
-    <label
-      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
+    <span
+      class="ant-typography css-var-test-id"
     >
-      <span
-        class="ant-radio-button ant-radio-button-checked"
-      >
-        <input
-          checked=""
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="a"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Hangzhou
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      <strong>
+        Radio.Button
+      </strong>
+    </span>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-large css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="b"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        Shanghai
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="c"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        Beijing
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-small css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="d"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        Chengdu
-      </span>
-    </label>
-  </div>
-  <div
-    class="ant-radio-group ant-radio-group-outline ant-radio-group-small css-var-test-id ant-radio-css-var"
-    role="radiogroup"
-  >
-    <label
-      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button ant-radio-button-checked"
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        <input
-          checked=""
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="a"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Hangzhou
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button"
-      >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="b"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Shanghai
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button"
-      >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="c"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Beijing
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button"
-      >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="d"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Chengdu
-      </span>
-    </label>
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
   </div>
 </div>
 `;

--- a/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2074,253 +2074,409 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx correctly 1`] = 
 
 exports[`renders components/radio/demo/size.tsx correctly 1`] = `
 <div
-  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-large"
 >
   <div
-    class="ant-radio-group ant-radio-group-outline ant-radio-group-large css-var-test-id ant-radio-css-var"
-    role="radiogroup"
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
+    style="flex:1 1 280px"
   >
-    <label
-      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
+    <span
+      class="ant-typography css-var-test-id"
     >
-      <span
-        class="ant-radio-button ant-radio-button-checked"
-      >
-        <input
-          checked=""
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="a"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Hangzhou
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      <strong>
+        Radio
+      </strong>
+    </span>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-large css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="b"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
       >
-        Shanghai
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="c"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
       >
-        Beijing
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-small css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="d"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
       >
-        Chengdu
-      </span>
-    </label>
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
   </div>
   <div
-    class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
-    role="radiogroup"
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
+    style="flex:1 1 280px"
   >
-    <label
-      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
+    <span
+      class="ant-typography css-var-test-id"
     >
-      <span
-        class="ant-radio-button ant-radio-button-checked"
-      >
-        <input
-          checked=""
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="a"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Hangzhou
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      <strong>
+        Radio.Button
+      </strong>
+    </span>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-large css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="b"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        Shanghai
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="c"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        Beijing
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-small css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="d"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        Chengdu
-      </span>
-    </label>
-  </div>
-  <div
-    class="ant-radio-group ant-radio-group-outline ant-radio-group-small css-var-test-id ant-radio-css-var"
-    role="radiogroup"
-  >
-    <label
-      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button ant-radio-button-checked"
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        <input
-          checked=""
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="a"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Hangzhou
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button"
-      >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="b"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Shanghai
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button"
-      >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="c"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Beijing
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button"
-      >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="d"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Chengdu
-      </span>
-    </label>
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
   </div>
 </div>
 `;

--- a/components/radio/__tests__/group.test.tsx
+++ b/components/radio/__tests__/group.test.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
+import { renderToString } from 'react-dom/server';
 
 import type { RadioGroupProps } from '..';
 import Radio from '..';
 import { fireEvent, render, screen } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
 import Form from '../../form';
 
 describe('Radio Group', () => {
@@ -130,6 +133,58 @@ describe('Radio Group', () => {
     const radios = container.querySelectorAll('input');
 
     expect(radios.length).toBe(3);
+  });
+
+  it('should support size for default radio groups', () => {
+    const { container } = render(
+      <>
+        <Radio.Group size="large" options={['A']} />
+        <Radio.Group options={['B']} />
+        <Radio.Group size="small">
+          <Radio value="C">C</Radio>
+        </Radio.Group>
+      </>,
+    );
+    const [largeGroup, defaultGroup, smallGroup] = container.querySelectorAll('.ant-radio-group');
+    const getRadioStyle = (group: Element) => {
+      const radio = group.querySelector<HTMLElement>('.ant-radio')!;
+      return {
+        radioSize: getComputedStyle(radio).width,
+        labelFontSize: getComputedStyle(radio.parentElement!).fontSize,
+      };
+    };
+    const largeRadioStyle = getRadioStyle(largeGroup);
+    const defaultRadioStyle = getRadioStyle(defaultGroup);
+    const smallRadioStyle = getRadioStyle(smallGroup);
+
+    expect(largeRadioStyle).not.toEqual(defaultRadioStyle);
+    expect(defaultRadioStyle).not.toEqual(smallRadioStyle);
+
+    const getRadioGroupStyle = (wireframe: boolean) => {
+      const cache = createCache();
+      renderToString(
+        <ConfigProvider theme={wireframe ? { token: { wireframe } } : undefined}>
+          <StyleProvider cache={cache}>
+            <Radio.Group size="large" options={['A']} />
+            <Radio.Group size="small" options={['B']} />
+          </StyleProvider>
+        </ConfigProvider>,
+      );
+      return extractStyle(cache);
+    };
+    const getRadioDotSize = (style: string, size: 'large' | 'small') =>
+      style.match(
+        new RegExp(`\\.ant-radio-group-${size}[^}]*\\.ant-radio:after\\{width:([^;]+);`),
+      )?.[1];
+
+    [false, true].forEach((wireframe) => {
+      const style = getRadioGroupStyle(wireframe);
+
+      expect(style).not.toContain('NaN');
+      expect(getRadioDotSize(style, 'large')).toBeDefined();
+      expect(getRadioDotSize(style, 'small')).toBeDefined();
+      expect(getRadioDotSize(style, 'large')).not.toEqual(getRadioDotSize(style, 'small'));
+    });
   });
 
   it('all children should have a name property', () => {

--- a/components/radio/demo/size.tsx
+++ b/components/radio/demo/size.tsx
@@ -1,26 +1,26 @@
 import React from 'react';
-import { Flex, Radio } from 'antd';
+import { Flex, Radio, Typography } from 'antd';
+
+const options = [
+  { label: 'Hangzhou', value: 'a' },
+  { label: 'Shanghai', value: 'b' },
+  { label: 'Beijing', value: 'c' },
+];
 
 const App: React.FC = () => (
-  <Flex vertical gap="medium">
-    <Radio.Group defaultValue="a" size="large">
-      <Radio.Button value="a">Hangzhou</Radio.Button>
-      <Radio.Button value="b">Shanghai</Radio.Button>
-      <Radio.Button value="c">Beijing</Radio.Button>
-      <Radio.Button value="d">Chengdu</Radio.Button>
-    </Radio.Group>
-    <Radio.Group defaultValue="a">
-      <Radio.Button value="a">Hangzhou</Radio.Button>
-      <Radio.Button value="b">Shanghai</Radio.Button>
-      <Radio.Button value="c">Beijing</Radio.Button>
-      <Radio.Button value="d">Chengdu</Radio.Button>
-    </Radio.Group>
-    <Radio.Group defaultValue="a" size="small">
-      <Radio.Button value="a">Hangzhou</Radio.Button>
-      <Radio.Button value="b">Shanghai</Radio.Button>
-      <Radio.Button value="c">Beijing</Radio.Button>
-      <Radio.Button value="d">Chengdu</Radio.Button>
-    </Radio.Group>
+  <Flex gap="large" wrap>
+    <Flex vertical gap="medium" style={{ flex: '1 1 280px' }}>
+      <Typography.Text strong>Radio</Typography.Text>
+      <Radio.Group defaultValue="a" size="large" options={options} />
+      <Radio.Group defaultValue="a" options={options} />
+      <Radio.Group defaultValue="a" size="small" options={options} />
+    </Flex>
+    <Flex vertical gap="medium" style={{ flex: '1 1 280px' }}>
+      <Typography.Text strong>Radio.Button</Typography.Text>
+      <Radio.Group defaultValue="a" size="large" options={options} optionType="button" />
+      <Radio.Group defaultValue="a" options={options} optionType="button" />
+      <Radio.Group defaultValue="a" size="small" options={options} optionType="button" />
+    </Flex>
   </Flex>
 );
 

--- a/components/radio/index.en-US.md
+++ b/components/radio/index.en-US.md
@@ -88,7 +88,7 @@ Radio group can wrap a group of `Radio`.
 | options | Set children optional | string\[] \| number\[] \| Array&lt;[CheckboxOptionType](#checkboxoptiontype)> | - |  |
 | optionType | Set Radio optionType | `default` \| `button` | `default` | 4.4.0 |
 | orientation | Orientation | `horizontal` \| `vertical` | `horizontal` |  |
-| size | The size of radio button style | `large` \| `medium` \| `small` | - |  |
+| size | The size of the Radio | `large` \| `medium` \| `small` | - |  |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-group), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-group), CSSProperties> | - | 6.7.0 |
 | value | Used for setting the currently selected value | any | - |  |
 | vertical | If true, the Radio group will be vertical. Simultaneously existing with `orientation`, `orientation` takes priority | boolean | false |  |

--- a/components/radio/index.zh-CN.md
+++ b/components/radio/index.zh-CN.md
@@ -91,7 +91,7 @@ return (
 | options | 以配置形式设置子元素 | string\[] \| number\[] \| Array&lt;[CheckboxOptionType](#checkboxoptiontype)> | - |  |
 | optionType | 用于设置 Radio `options` 类型 | `default` \| `button` | `default` | 4.4.0 |
 | orientation | 排列方向 | `horizontal` \| `vertical` | `horizontal` |  |
-| size | 大小，只对按钮样式生效 | `large` \| `medium` \| `small` | - |  |
+| size | Radio 的大小 | `large` \| `medium` \| `small` | - |  |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-group), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-group), CSSProperties> | - | 6.7.0 |
 | value | 用于设置当前选中的值 | any | - |  |
 | vertical | 值为 true，Radio Group 为垂直方向。与 `orientation` 同时存在，以 `orientation` 优先 | boolean | false |  |

--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -5,6 +5,8 @@ import { genFocusOutline, resetComponent } from '../../style';
 import type { FullToken, GenerateStyle, GetDefaultToken } from '../../theme/internal';
 import { genStyleHooks, mergeToken } from '../../theme/internal';
 
+const radioDotPadding = 4;
+
 // ============================== Tokens ==============================
 export interface ComponentToken {
   // Radio
@@ -225,7 +227,34 @@ const getRadioBasicStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
     lineType,
     radioColor,
     radioBgColor,
+    fontSize,
+    fontSizeLG,
+    fontSizeSM,
+    fontSizeXL,
+    wireframe,
+    calc,
   } = token;
+
+  const genRadioSizeStyle = (size: number, labelFontSize: number): CSSObject => {
+    const radioDotSize = wireframe
+      ? calc(size)
+          .sub(radioDotPadding * 2)
+          .equal()
+      : calc(size).sub(calc(radioDotPadding).add(lineWidth).mul(2)).equal();
+
+    return {
+      fontSize: labelFontSize,
+      [componentCls]: {
+        width: unit(size),
+        height: unit(size),
+
+        '&:after': {
+          width: radioDotSize,
+          height: radioDotSize,
+        },
+      },
+    };
+  };
 
   return {
     [`${componentCls}-wrapper`]: {
@@ -261,6 +290,10 @@ const getRadioBasicStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
         flex: 1,
         justifyContent: 'center',
       },
+
+      [`${componentCls}-group-large &`]: genRadioSizeStyle(fontSizeXL, fontSizeLG),
+
+      [`${componentCls}-group-small &`]: genRadioSizeStyle(fontSize, fontSizeSM),
 
       // ===================== Radio =====================
       [componentCls]: {
@@ -656,11 +689,10 @@ export const prepareComponentToken: GetDefaultToken<'Radio'> = (token) => {
     colorWhite,
   } = token;
 
-  const dotPadding = 4; // Fixed value
   const radioSize = fontSizeLG;
   const radioDotSize = wireframe
-    ? radioSize - dotPadding * 2
-    : radioSize - (dotPadding + lineWidth) * 2;
+    ? radioSize - radioDotPadding * 2
+    : radioSize - (radioDotPadding + lineWidth) * 2;
 
   return {
     // Radio


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [x] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [x] ✅ 测试用例

### 🔗 相关 Issue

close #54558

### 💡 需求背景和解决方案

`Radio.Group` 的 `size` 此前只对 `Radio.Button` 生效。现在普通 Radio 也会随 `large` 和 `small` 调整外圈、标签与中心圆点尺寸，并兼容 CSS Variable 主题。

尺寸 demo 分栏展示普通 Radio 与 Radio.Button 的三种尺寸。
<img width="998" height="391" alt="image" src="https://github.com/user-attachments/assets/de22521e-a09e-42df-9f35-2ba5b0b76589" />


### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🆕 Support Radio.Group `size` for default Radio options. |
| 🇨🇳 中文 | 🆕 支持 Radio.Group `size` 调整默认 Radio 的尺寸。 |