### PR TITLE
fix(Slider): correct tooltip alignment near viewport boundaries

### DIFF
--- a/components/_util/placements.ts
+++ b/components/_util/placements.ts
@@ -6,6 +6,8 @@ import { isPlainObject } from './is';
 export interface AdjustOverflow {
   adjustX?: 0 | 1;
   adjustY?: 0 | 1;
+  shiftX?: boolean | number;
+  shiftY?: boolean | number;
 }
 
 export interface PlacementsConfig {
@@ -19,6 +21,8 @@ export interface PlacementsConfig {
 
 export function getOverflowOptions(
   placement: string,
+  arrowOffset: ReturnType<typeof getArrowOffsetToken>,
+  arrowWidth: number,
   autoAdjustOverflow?: boolean | AdjustOverflow,
 ) {
   if (autoAdjustOverflow === false) {
@@ -35,14 +39,14 @@ export function getOverflowOptions(
   switch (placement) {
     case 'top':
     case 'bottom':
-      baseOverflow.shiftX = true;
+      baseOverflow.shiftX = arrowOffset.arrowOffsetHorizontal * 2 + arrowWidth;
       baseOverflow.shiftY = true;
       baseOverflow.adjustY = true;
       break;
 
     case 'left':
     case 'right':
-      baseOverflow.shiftY = true;
+      baseOverflow.shiftY = arrowOffset.arrowOffsetVertical * 2 + arrowWidth;
       baseOverflow.shiftX = true;
       baseOverflow.adjustX = true;
       break;
@@ -224,7 +228,7 @@ export default function getPlacements(config: PlacementsConfig) {
     }
 
     // Overflow
-    placementInfo.overflow = getOverflowOptions(key, autoAdjustOverflow);
+    placementInfo.overflow = getOverflowOptions(key, arrowOffset, arrowWidth, autoAdjustOverflow);
 
     // VisibleFirst
     if (visibleFirst) {

--- a/components/_util/placements.ts
+++ b/components/_util/placements.ts
@@ -19,8 +19,6 @@ export interface PlacementsConfig {
 
 export function getOverflowOptions(
   placement: string,
-  arrowOffset: ReturnType<typeof getArrowOffsetToken>,
-  arrowWidth: number,
   autoAdjustOverflow?: boolean | AdjustOverflow,
 ) {
   if (autoAdjustOverflow === false) {
@@ -37,14 +35,14 @@ export function getOverflowOptions(
   switch (placement) {
     case 'top':
     case 'bottom':
-      baseOverflow.shiftX = arrowOffset.arrowOffsetHorizontal * 2 + arrowWidth;
+      baseOverflow.shiftX = true;
       baseOverflow.shiftY = true;
       baseOverflow.adjustY = true;
       break;
 
     case 'left':
     case 'right':
-      baseOverflow.shiftY = arrowOffset.arrowOffsetVertical * 2 + arrowWidth;
+      baseOverflow.shiftY = true;
       baseOverflow.shiftX = true;
       baseOverflow.adjustX = true;
       break;
@@ -226,7 +224,7 @@ export default function getPlacements(config: PlacementsConfig) {
     }
 
     // Overflow
-    placementInfo.overflow = getOverflowOptions(key, arrowOffset, arrowWidth, autoAdjustOverflow);
+    placementInfo.overflow = getOverflowOptions(key, autoAdjustOverflow);
 
     // VisibleFirst
     if (visibleFirst) {

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -24115,7 +24115,7 @@ exports[`ConfigProvider components Slider configProvider 1`] = `
   >
     <div
       class="config-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
+      style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
     >
       <span
         class="config-tooltip-arrow-content"
@@ -24163,7 +24163,7 @@ exports[`ConfigProvider components Slider configProvider componentDisabled 1`] =
   >
     <div
       class="config-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
+      style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
     >
       <span
         class="config-tooltip-arrow-content"
@@ -24212,7 +24212,7 @@ exports[`ConfigProvider components Slider configProvider componentSize large 1`]
   >
     <div
       class="config-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
+      style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
     >
       <span
         class="config-tooltip-arrow-content"
@@ -24261,7 +24261,7 @@ exports[`ConfigProvider components Slider configProvider componentSize medium 1`
   >
     <div
       class="config-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
+      style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
     >
       <span
         class="config-tooltip-arrow-content"
@@ -24310,7 +24310,7 @@ exports[`ConfigProvider components Slider configProvider componentSize small 1`]
   >
     <div
       class="config-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
+      style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
     >
       <span
         class="config-tooltip-arrow-content"
@@ -24359,7 +24359,7 @@ exports[`ConfigProvider components Slider normal 1`] = `
   >
     <div
       class="ant-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
+      style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
     >
       <span
         class="ant-tooltip-arrow-content"
@@ -24408,7 +24408,7 @@ exports[`ConfigProvider components Slider prefixCls 1`] = `
   >
     <div
       class="prefix-Slider-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
+      style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
     >
       <span
         class="prefix-Slider-tooltip-arrow-content"

--- a/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -10654,7 +10654,7 @@ exports[`renders components/date-picker/demo/components.tsx extend context corre
                   >
                     <div
                       class="ant-tooltip-arrow"
-                      style="position: absolute; bottom: 0px; left: 0px;"
+                      style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
                     >
                       <span
                         class="ant-tooltip-arrow-content"

--- a/components/float-button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/float-button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -409,7 +409,7 @@ Array [
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5129,7 +5129,7 @@ Array [
                 >
                   <div
                     class="ant-tooltip-arrow"
-                    style="position: absolute; bottom: 0px; left: 0px;"
+                    style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
                   >
                     <span
                       class="ant-tooltip-arrow-content"
@@ -23524,7 +23524,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
               >
                 <div
                   class="ant-tooltip-arrow"
-                  style="position: absolute; bottom: 0px; left: 0px;"
+                  style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
                 >
                   <span
                     class="ant-tooltip-arrow-content"

--- a/components/grid/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/grid/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1104,7 +1104,7 @@ Array [
       >
         <div
           class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
+          style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
         >
           <span
             class="ant-tooltip-arrow-content"
@@ -1222,7 +1222,7 @@ Array [
       >
         <div
           class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
+          style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
         >
           <span
             class="ant-tooltip-arrow-content"
@@ -1340,7 +1340,7 @@ Array [
       >
         <div
           class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
+          style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
         >
           <span
             class="ant-tooltip-arrow-content"

--- a/components/progress/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/progress/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -537,7 +537,7 @@ Array [
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -588,7 +588,7 @@ Array [
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"

--- a/components/slider/SliderTooltip.tsx
+++ b/components/slider/SliderTooltip.tsx
@@ -3,7 +3,7 @@ import { useRef } from 'react';
 import type { SliderRef } from '@rc-component/slider';
 import { composeRef, raf } from '@rc-component/util';
 
-import type { TooltipProps } from '../tooltip';
+import type { AdjustOverflow, TooltipProps } from '../tooltip';
 import Tooltip from '../tooltip';
 
 export type SliderTooltipProps = TooltipProps & {
@@ -11,8 +11,15 @@ export type SliderTooltipProps = TooltipProps & {
   value?: number;
 };
 
+const sliderAutoAdjustOverflow: AdjustOverflow = {
+  adjustX: 1,
+  adjustY: 1,
+  shiftX: true,
+  shiftY: true,
+};
+
 const SliderTooltip = React.forwardRef<SliderRef, SliderTooltipProps>((props, ref) => {
-  const { open, draggingDelete, value } = props;
+  const { open, draggingDelete, value, autoAdjustOverflow } = props;
   const innerRef = useRef<any>(null);
 
   const mergedOpen = open && !draggingDelete;
@@ -41,7 +48,14 @@ const SliderTooltip = React.forwardRef<SliderRef, SliderTooltipProps>((props, re
     return cancelKeepAlign;
   }, [mergedOpen, props.title, value]);
 
-  return <Tooltip ref={composeRef(innerRef, ref)} {...props} open={mergedOpen} />;
+  return (
+    <Tooltip
+      ref={composeRef(innerRef, ref)}
+      {...props}
+      autoAdjustOverflow={autoAdjustOverflow === false ? false : sliderAutoAdjustOverflow}
+      open={mergedOpen}
+    />
+  );
 });
 
 if (process.env.NODE_ENV !== 'production') {

--- a/components/slider/__tests__/SliderTooltip.test.tsx
+++ b/components/slider/__tests__/SliderTooltip.test.tsx
@@ -1,23 +1,23 @@
 import React from 'react';
 
 import { render } from '../../../tests/utils';
-import type { TooltipRef } from '../../tooltip';
+import type { TooltipProps, TooltipRef } from '../../tooltip';
 import SliderTooltip from '../SliderTooltip';
 
 let mockForceAlign: jest.Mock;
+let mockTooltipProps: TooltipProps;
 
 jest.mock('../../tooltip', () => {
   const ReactReal: typeof React = jest.requireActual('react');
   return {
     __esModule: true,
-    default: ReactReal.forwardRef<Partial<TooltipRef>, React.HTMLAttributes<HTMLDivElement>>(
-      (props, ref) => {
-        ReactReal.useImperativeHandle(ref, () => ({
-          forceAlign: mockForceAlign,
-        }));
-        return <div {...props} />;
-      },
-    ),
+    default: ReactReal.forwardRef<Partial<TooltipRef>, TooltipProps>((props, ref) => {
+      mockTooltipProps = props;
+      ReactReal.useImperativeHandle(ref, () => ({
+        forceAlign: mockForceAlign,
+      }));
+      return <div />;
+    }),
   };
 });
 
@@ -56,5 +56,22 @@ describe('SliderTooltip', () => {
     rerender(<SliderTooltip open draggingDelete value={3} />);
     jest.runAllTimers();
     expect(mockForceAlign).not.toHaveBeenCalled();
+  });
+
+  it('uses viewport-priority overflow adjustment by default', () => {
+    render(<SliderTooltip open />);
+
+    expect(mockTooltipProps.autoAdjustOverflow).toEqual({
+      adjustX: 1,
+      adjustY: 1,
+      shiftX: true,
+      shiftY: true,
+    });
+  });
+
+  it('preserves disabled overflow adjustment', () => {
+    render(<SliderTooltip open autoAdjustOverflow={false} />);
+
+    expect(mockTooltipProps.autoAdjustOverflow).toBe(false);
   });
 });

--- a/components/slider/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/slider/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -33,7 +33,7 @@ Array [
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -142,7 +142,7 @@ Array [
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -227,7 +227,7 @@ Array [
       >
         <div
           class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
+          style="position: absolute; top: clamp(8px, var(--arrow-y), calc(100% - 8px)); left: 0px;"
         >
           <span
             class="ant-tooltip-arrow-content"
@@ -604,7 +604,7 @@ Array [
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -714,7 +714,7 @@ exports[`renders components/slider/demo/icon-slider.tsx extend context correctly
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -798,7 +798,7 @@ exports[`renders components/slider/demo/input-number.tsx extend context correctl
           >
             <div
               class="ant-tooltip-arrow"
-              style="position: absolute; bottom: 0px; left: 0px;"
+              style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
             >
               <span
                 class="ant-tooltip-arrow-content"
@@ -933,7 +933,7 @@ exports[`renders components/slider/demo/input-number.tsx extend context correctl
           >
             <div
               class="ant-tooltip-arrow"
-              style="position: absolute; bottom: 0px; left: 0px;"
+              style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
             >
               <span
                 class="ant-tooltip-arrow-content"
@@ -1089,7 +1089,7 @@ Array [
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -1268,7 +1268,7 @@ Array [
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -1367,7 +1367,7 @@ Array [
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -1466,7 +1466,7 @@ Array [
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -1609,7 +1609,7 @@ Array [
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -1718,7 +1718,7 @@ exports[`renders components/slider/demo/show-tooltip.tsx extend context correctl
   >
     <div
       class="ant-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
+      style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
     >
       <span
         class="ant-tooltip-arrow-content"
@@ -1772,7 +1772,7 @@ exports[`renders components/slider/demo/style-class.tsx extend context correctly
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -1819,7 +1819,7 @@ exports[`renders components/slider/demo/style-class.tsx extend context correctly
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; top: 0px; left: 0px;"
+        style="position: absolute; top: clamp(8px, var(--arrow-y), calc(100% - 8px)); left: 0px;"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -1872,7 +1872,7 @@ Array [
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -1918,7 +1918,7 @@ Array [
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -1972,7 +1972,7 @@ Array [
       >
         <div
           class="ant-tooltip-arrow"
-          style="position: absolute; top: 0px; left: 0px;"
+          style="position: absolute; top: clamp(8px, var(--arrow-y), calc(100% - 8px)); left: 0px;"
         >
           <span
             class="ant-tooltip-arrow-content"

--- a/components/slider/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/slider/__tests__/__snapshots__/index.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`Slider should render in RTL direction 1`] = `
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -86,7 +86,7 @@ exports[`Slider should show tooltip when hovering slider handler 1`] = `
 >
   <div
     class="ant-tooltip-arrow"
-    style="position: absolute; bottom: 0px; left: 0px;"
+    style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
   >
     <span
       class="ant-tooltip-arrow-content"
@@ -109,7 +109,7 @@ exports[`Slider should show tooltip when hovering slider handler 2`] = `
 >
   <div
     class="ant-tooltip-arrow"
-    style="position: absolute; bottom: 0px; left: 0px;"
+    style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
   >
     <span
       class="ant-tooltip-arrow-content"

--- a/components/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
+++ b/components/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`Tooltip support arrow props by default 1`] = `
   >
     <div
       class="ant-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
+      style="position: absolute; bottom: 0px; left: 0px;"
     >
       <span
         class="ant-tooltip-arrow-content"

--- a/components/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
+++ b/components/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`Tooltip support arrow props by default 1`] = `
   >
     <div
       class="ant-tooltip-arrow"
-      style="position: absolute; bottom: 0px; left: 0px;"
+      style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
     >
       <span
         class="ant-tooltip-arrow-content"

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -291,6 +291,20 @@ describe('Tooltip', () => {
     }).not.toThrow();
   });
 
+  it('uses unrestricted cross-axis shift for cardinal placements', () => {
+    const placements = getPlacements({
+      arrowWidth: 16,
+      borderRadius: 6,
+      offset: 4,
+      autoAdjustOverflow: true,
+    });
+
+    expect(placements.top.overflow?.shiftX).toBe(true);
+    expect(placements.bottom.overflow?.shiftX).toBe(true);
+    expect(placements.left.overflow?.shiftY).toBe(true);
+    expect(placements.right.overflow?.shiftY).toBe(true);
+  });
+
   describe('support other placement when mouse enter', () => {
     const placementList = [
       'top',

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -307,7 +307,7 @@ describe('Tooltip', () => {
 
   it('keeps cardinal placement arrows within the popup edge', () => {
     const { rerender } = render(
-      <Tooltip title={0} open placement="bottom">
+      <Tooltip title={0} open placement="bottom" autoAdjustOverflow={{ shiftX: true }}>
         <span />
       </Tooltip>,
     );
@@ -317,7 +317,7 @@ describe('Tooltip', () => {
     });
 
     rerender(
-      <Tooltip title={0} open placement="right">
+      <Tooltip title={0} open placement="right" autoAdjustOverflow={{ shiftY: true }}>
         <span />
       </Tooltip>,
     );
@@ -325,6 +325,16 @@ describe('Tooltip', () => {
     expect(document.querySelector('.ant-tooltip-arrow')).toHaveStyle({
       top: 'clamp(8px, var(--arrow-y), calc(100% - 8px))',
     });
+  });
+
+  it('keeps default cardinal arrow positioning unchanged', () => {
+    render(
+      <Tooltip title={0} open placement="bottom">
+        <span />
+      </Tooltip>,
+    );
+
+    expect(document.querySelector('.ant-tooltip-arrow')).toHaveStyle({ left: '0px' });
   });
 
   describe('support other placement when mouse enter', () => {

--- a/components/tooltip/__tests__/tooltip.test.tsx
+++ b/components/tooltip/__tests__/tooltip.test.tsx
@@ -291,7 +291,7 @@ describe('Tooltip', () => {
     }).not.toThrow();
   });
 
-  it('uses unrestricted cross-axis shift for cardinal placements', () => {
+  it('keeps numeric shift thresholds for cardinal placements', () => {
     const placements = getPlacements({
       arrowWidth: 16,
       borderRadius: 6,
@@ -299,10 +299,32 @@ describe('Tooltip', () => {
       autoAdjustOverflow: true,
     });
 
-    expect(placements.top.overflow?.shiftX).toBe(true);
-    expect(placements.bottom.overflow?.shiftX).toBe(true);
-    expect(placements.left.overflow?.shiftY).toBe(true);
-    expect(placements.right.overflow?.shiftY).toBe(true);
+    expect(placements.top.overflow?.shiftX).toBe(40);
+    expect(placements.bottom.overflow?.shiftX).toBe(40);
+    expect(placements.left.overflow?.shiftY).toBe(32);
+    expect(placements.right.overflow?.shiftY).toBe(32);
+  });
+
+  it('keeps cardinal placement arrows within the popup edge', () => {
+    const { rerender } = render(
+      <Tooltip title={0} open placement="bottom">
+        <span />
+      </Tooltip>,
+    );
+
+    expect(document.querySelector('.ant-tooltip-arrow')).toHaveStyle({
+      left: 'clamp(12px, var(--arrow-x), calc(100% - 12px))',
+    });
+
+    rerender(
+      <Tooltip title={0} open placement="right">
+        <span />
+      </Tooltip>,
+    );
+
+    expect(document.querySelector('.ant-tooltip-arrow')).toHaveStyle({
+      top: 'clamp(8px, var(--arrow-y), calc(100% - 8px))',
+    });
   });
 
   describe('support other placement when mouse enter', () => {

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -10,7 +10,7 @@ import type { RenderFunction } from '../_util/getRenderPropValue';
 import { useZIndex } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isFunction } from '../_util/is';
+import { isFunction, isPlainObject } from '../_util/is';
 import { getTransitionName } from '../_util/motion';
 import type { AdjustOverflow, PlacementsConfig } from '../_util/placements';
 import getPlacements from '../_util/placements';
@@ -366,11 +366,14 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
     contentRadius: token.borderRadius,
     limitVerticalRadius: true,
   });
+  const overflow = isPlainObject<AdjustOverflow>(autoAdjustOverflow)
+    ? autoAdjustOverflow
+    : undefined;
   const arrowEdgeStyle: React.CSSProperties = {};
 
-  if (placement === 'top' || placement === 'bottom') {
+  if ((placement === 'top' || placement === 'bottom') && overflow?.shiftX === true) {
     arrowEdgeStyle.left = `clamp(${arrowOffsetHorizontal}px, var(--arrow-x), calc(100% - ${arrowOffsetHorizontal}px))`;
-  } else if (placement === 'left' || placement === 'right') {
+  } else if ((placement === 'left' || placement === 'right') && overflow?.shiftY === true) {
     arrowEdgeStyle.top = `clamp(${arrowOffsetVertical}px, var(--arrow-y), calc(100% - ${arrowOffsetVertical}px))`;
   }
 

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -20,6 +20,7 @@ import { devUseWarning } from '../_util/warning';
 import ZIndexContext from '../_util/zindexContext';
 import { useComponentConfig } from '../config-provider/context';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
+import { getArrowOffsetToken } from '../style/placementArrow';
 import TableMeasureRowContext from '../table/TableMeasureRowContext';
 import { useToken } from '../theme/internal';
 import useMergedArrow from './hook/useMergedArrow';
@@ -361,6 +362,18 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
     ...colorInfo.overlayStyle,
   };
 
+  const { arrowOffsetHorizontal, arrowOffsetVertical } = getArrowOffsetToken({
+    contentRadius: token.borderRadius,
+    limitVerticalRadius: true,
+  });
+  const arrowEdgeStyle: React.CSSProperties = {};
+
+  if (placement === 'top' || placement === 'bottom') {
+    arrowEdgeStyle.left = `clamp(${arrowOffsetHorizontal}px, var(--arrow-x), calc(100% - ${arrowOffsetHorizontal}px))`;
+  } else if (placement === 'left' || placement === 'right') {
+    arrowEdgeStyle.top = `clamp(${arrowOffsetVertical}px, var(--arrow-y), calc(100% - ${arrowOffsetVertical}px))`;
+  }
+
   const content = (
     <RcTooltip
       unique
@@ -384,7 +397,10 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
         },
         container: containerStyle,
         uniqueContainer: containerStyle,
-        arrow: mergedStyles.arrow,
+        arrow: {
+          ...arrowEdgeStyle,
+          ...mergedStyles.arrow,
+        },
       }}
       ref={tooltipRef}
       overlay={memoOverlayWrapper}

--- a/components/tour/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tour/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -410,7 +410,7 @@ exports[`renders components/tour/demo/gap.tsx extend context correctly 1`] = `
             >
               <div
                 class="ant-tooltip-arrow"
-                style="position: absolute; bottom: 0px; left: 0px;"
+                style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
               >
                 <span
                   class="ant-tooltip-arrow-content"
@@ -477,7 +477,7 @@ exports[`renders components/tour/demo/gap.tsx extend context correctly 1`] = `
             >
               <div
                 class="ant-tooltip-arrow"
-                style="position: absolute; bottom: 0px; left: 0px;"
+                style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
               >
                 <span
                   class="ant-tooltip-arrow-content"
@@ -544,7 +544,7 @@ exports[`renders components/tour/demo/gap.tsx extend context correctly 1`] = `
             >
               <div
                 class="ant-tooltip-arrow"
-                style="position: absolute; bottom: 0px; left: 0px;"
+                style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
               >
                 <span
                   class="ant-tooltip-arrow-content"
@@ -611,7 +611,7 @@ exports[`renders components/tour/demo/gap.tsx extend context correctly 1`] = `
             >
               <div
                 class="ant-tooltip-arrow"
-                style="position: absolute; bottom: 0px; left: 0px;"
+                style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
               >
                 <span
                   class="ant-tooltip-arrow-content"

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1735,7 +1735,7 @@ exports[`renders components/typography/demo/ellipsis-controlled.tsx extend conte
       >
         <div
           class="ant-tooltip-arrow"
-          style="position: absolute; bottom: 0px; left: 0px;"
+          style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
         >
           <span
             class="ant-tooltip-arrow-content"
@@ -1928,7 +1928,7 @@ Array [
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"
@@ -2667,7 +2667,7 @@ Array [
     >
       <div
         class="ant-tooltip-arrow"
-        style="position: absolute; bottom: 0px; left: 0px;"
+        style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
       >
         <span
           class="ant-tooltip-arrow-content"

--- a/components/watermark/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/watermark/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -550,7 +550,7 @@ exports[`renders components/watermark/demo/custom.tsx extend context correctly 1
                 >
                   <div
                     class="ant-tooltip-arrow"
-                    style="position: absolute; bottom: 0px; left: 0px;"
+                    style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
                   >
                     <span
                       class="ant-tooltip-arrow-content"
@@ -628,7 +628,7 @@ exports[`renders components/watermark/demo/custom.tsx extend context correctly 1
                 >
                   <div
                     class="ant-tooltip-arrow"
-                    style="position: absolute; bottom: 0px; left: 0px;"
+                    style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
                   >
                     <span
                       class="ant-tooltip-arrow-content"
@@ -706,7 +706,7 @@ exports[`renders components/watermark/demo/custom.tsx extend context correctly 1
                 >
                   <div
                     class="ant-tooltip-arrow"
-                    style="position: absolute; bottom: 0px; left: 0px;"
+                    style="position: absolute; bottom: 0px; left: clamp(12px, var(--arrow-x), calc(100% - 12px));"
                   >
                     <span
                       class="ant-tooltip-arrow-content"


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #56632

### 💡 需求背景和解决方案

Slider 靠近视口边缘时，Tooltip 可能被裁切，箭头也可能越出浮层边缘。Tooltip 原有的数值型 shift 阈值用于让已远离视口的目标与浮层一起离屏，不能全局取消。

本次保留 Tooltip 原有的数值型 shift 行为，仅为 Slider 默认启用不受限的视口内偏移；同时将正向 placement 的箭头限制在浮层安全边距内，并保留 autoAdjustOverflow=false 的原有语义。新增回归测试覆盖历史 shift 阈值、Slider 的覆盖配置及横纵向箭头边界。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Slider tooltip and arrow alignment near viewport boundaries. |
| 🇨🇳 中文 | 修复 Slider 靠近视口边缘时提示浮层及箭头的对齐问题。 |