### PR TITLE
docs: fix i18n contribution guide link

### DIFF
--- a/docs/react/i18n.zh-CN.md
+++ b/docs/react/i18n.zh-CN.md
@@ -131,7 +131,7 @@ return (
    npm run test -- components/locale -u
    ```
 
-8. 更新 [docs/react/i18n.zh-CN.md](https://github.com/ant-design/ant-design/blob/master/docs/react/i18n.zh-CN.md) 和 [docs/react/i18n.zh-CN.md](https://github.com/ant-design/ant-design/blob/master/docs/react/i18n.zh-CN.md)，将对应语言添加到文档列表。
+8. 更新 [docs/react/i18n.en-US.md](https://github.com/ant-design/ant-design/blob/master/docs/react/i18n.en-US.md) 和 [docs/react/i18n.zh-CN.md](https://github.com/ant-design/ant-design/blob/master/docs/react/i18n.zh-CN.md)，将对应语言添加到文档列表。
 9. 观察 CI 是否通过，若未通过，根据日志进行修改直至通过。
 10. 万事俱备等待 review 。
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

N/A — this fixes an incorrect navigation target in the current contribution guide.

### 💡 Background and Solution

The Chinese i18n contribution guide tells contributors to update both locale lists, but both links in step 8 point to `docs/react/i18n.zh-CN.md`. Contributors following the Chinese guide can therefore miss the English locale list.

Update the first label and target to `docs/react/i18n.en-US.md`, matching the English guide and the established locale contribution workflow.

Validation:

- Ran the repository-pinned Remark lint plugins against `docs/react/i18n.zh-CN.md` with zero messages.
- Confirmed both destination URLs return HTTP 200.
- Ran `git diff --check`.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the Chinese i18n contribution guide to link both the English and Chinese locale lists. |
| 🇨🇳 Chinese | 修复中文国际化贡献指南中的重复链接，使其分别指向中英文语言列表。 |
