### PR TITLE
fix(Layout): handle undefined collapsed as uncontrolled

### DIFF
--- a/components/layout/Sider.tsx
+++ b/components/layout/Sider.tsx
@@ -3,7 +3,7 @@ import { useContext, useEffect, useRef, useState } from 'react';
 import BarsOutlined from '@ant-design/icons/BarsOutlined';
 import LeftOutlined from '@ant-design/icons/LeftOutlined';
 import RightOutlined from '@ant-design/icons/RightOutlined';
-import { omit } from '@rc-component/util';
+import { omit, useControlledState } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
@@ -104,21 +104,11 @@ const Sider = React.forwardRef<HTMLDivElement, SiderProps>((props, ref) => {
   } = props;
   const { siderHook } = useContext(LayoutContext);
 
-  const [collapsed, setCollapsed] = useState(
-    'collapsed' in props ? props.collapsed : defaultCollapsed,
-  );
+  const [collapsed, setCollapsed] = useControlledState(defaultCollapsed, props.collapsed);
   const [below, setBelow] = useState(false);
 
-  useEffect(() => {
-    if ('collapsed' in props) {
-      setCollapsed(props.collapsed);
-    }
-  }, [props.collapsed]);
-
   const handleSetCollapsed = (value: boolean, type: CollapseType) => {
-    if (!('collapsed' in props)) {
-      setCollapsed(value);
-    }
+    setCollapsed(value);
     onCollapse?.(value, type);
   };
 

--- a/components/layout/__tests__/index.test.tsx
+++ b/components/layout/__tests__/index.test.tsx
@@ -152,6 +152,22 @@ describe('Layout', () => {
         expect(onCollapse).toHaveBeenCalledTimes(1);
       });
 
+      it('treats undefined collapsed as uncontrolled', () => {
+        const onCollapse = jest.fn();
+        const { container } = render(
+          <Sider collapsible collapsed={undefined} onCollapse={onCollapse}>
+            Sider
+          </Sider>,
+        );
+
+        fireEvent.click(container.querySelector('.ant-layout-sider-trigger')!);
+
+        expect(container.querySelector('.ant-layout-sider')).toHaveClass(
+          'ant-layout-sider-collapsed',
+        );
+        expect(onCollapse).toHaveBeenCalledWith(true, 'clickTrigger');
+      });
+
       it('controlled', () => {
         const Demo: React.FC = () => {
           const [collapsed, setCollapsed] = React.useState(true);


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

当 `Layout.Sider` 使用 `collapsed={undefined}` 时，组件错误地将其识别为受控模式，点击 trigger 后虽然触发 `onCollapse`，但内部折叠状态不会更新。

本次改动使用 `useControlledState` 统一处理受控与非受控状态。

新增回归测试，验证点击 trigger 后正确添加 `ant-layout-sider-collapsed` 类名并触发回调。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Layout.Sider not collapsing when `collapsed={undefined}`. |
| 🇨🇳 中文 | 🐞 修复 Layout.Sider 在 `collapsed={undefined}` 时无法通过 trigger 收起的问题。 |