### PR TITLE
fix(Input.Search): preserve custom enterButton onMouseDown

### DIFF
--- a/components/input/Search.tsx
+++ b/components/input/Search.tsx
@@ -187,12 +187,15 @@ const Search = React.forwardRef<InputRef, SearchProps>((props, ref) => {
   if (isAntdButton || enterButtonAsElement.type === 'button') {
     const enterButtonProps = enterButtonAsElement.props as Pick<
       ButtonProps,
-      'className' | 'disabled' | 'loading'
+      'className' | 'disabled' | 'loading' | 'onMouseDown'
     >;
 
     button = cloneElement(enterButtonAsElement, {
       disabled: mergedDisabled || enterButtonProps.disabled || (!isAntdButton && loading),
-      onMouseDown,
+      onMouseDown: (e: React.MouseEvent<HTMLElement>) => {
+        enterButtonProps.onMouseDown?.(e);
+        onMouseDown(e);
+      },
       onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
         (
           enterButtonAsElement as React.ReactElement<{

--- a/components/input/__tests__/Search.test.tsx
+++ b/components/input/__tests__/Search.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { EditOutlined, UserOutlined } from '@ant-design/icons';
-import { fireEvent, render } from '@testing-library/react';
+import { createEvent, fireEvent, render } from '@testing-library/react';
 
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
@@ -196,6 +196,32 @@ describe('Input.Search', () => {
     expect(onSearch).toHaveBeenCalledTimes(1);
     expect(onSearch).toHaveBeenCalledWith('search text', expect.anything(), { source: 'input' });
     expect(onButtonClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should preserve custom button onMouseDown', () => {
+    let defaultPrevented: boolean | undefined;
+    const onMouseDown = jest.fn((event: React.MouseEvent<HTMLButtonElement>) => {
+      defaultPrevented = event.defaultPrevented;
+    });
+    const ref = React.createRef<InputRef>();
+    const { getByRole } = render(
+      <Search
+        ref={ref}
+        enterButton={
+          <button type="button" onMouseDown={onMouseDown}>
+            search
+          </button>
+        }
+      />,
+      { container: document.body },
+    );
+
+    ref.current?.focus();
+    const event = createEvent.mouseDown(getByRole('button'));
+    fireEvent(getByRole('button'), event);
+    expect(onMouseDown).toHaveBeenCalledTimes(1);
+    expect(defaultPrevented).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
   });
 
   it('should trigger onSearch when press enter', () => {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

fix #59179

### 💡 需求背景和解决方案

Input.Search 在克隆自定义 `enterButton` 时会覆盖元素原有的 `onMouseDown`，导致调用方配置的按压态、埋点或指针交互无法执行。

本次变更在执行 Search 内部防失焦逻辑前调用自定义 `onMouseDown`，既保留调用方收到的原始事件状态，也继续避免搜索按钮按下时输入框失焦。同时增加回归测试覆盖回调调用顺序和默认行为。

本次变更不新增或修改公开 API。

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | 🐞 Fix Input.Search ignoring the custom `enterButton` `onMouseDown` handler. |
| 🇨🇳 中文 | 🐞 修复 Input.Search 忽略自定义 `enterButton` 的 `onMouseDown` 回调。 |
