### PR TITLE
refactor: reuse type guards from @rc-component/util

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ ant-design/
 
 ## 通用编码规范
 
-- 判断数据类型时，优先使用 `components/_util/is.ts` 中已有的方法，例如 `isNumber`、`isString`、`isPlainObject`、`isFunction`、`isThenable`、`isPrimitive`、`isNonNullable`。
+- 判断数据类型时，优先使用 `@rc-component/util` 中的 `isNonNullable`、`isReactRenderable`，或 `components/_util/is.ts` 中已有的方法，例如 `isNumber`、`isString`、`isPlainObject`、`isFunction`、`isThenable`、`isPrimitive`。
 - 仅当 `components/_util/is.ts` 中没有合适方法，或当前场景需要更严格、更特殊的判断逻辑时，再使用内联 `typeof`、`instanceof` 等判断方式。
 
 ## 样式优先级规范
@@ -199,10 +199,10 @@ ant-design/
 | 🇺🇸🇨🇳🇬🇧 | 国际化改动             |
 | 📖 📝  | 文档或网站改进         |
 | ✅     | 新增或更新测试用例     |
-| 🛎     | 更新警告/提示信息      |
+| 🛎      | 更新警告/提示信息      |
 | ⌨️ ♿  | 可访问性增强           |
-| 🗑     | 废弃或移除             |
-| 🛠     | 重构或工具链优化       |
+| 🗑      | 废弃或移除             |
+| 🛠      | 重构或工具链优化       |
 | ⚡️     | 性能提升               |
 
 每条 Changelog 仅选择一个 Emoji，不要在同一条目中叠加多个 Emoji。

--- a/components/_util/ContextIsolator.tsx
+++ b/components/_util/ContextIsolator.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import { isReactRenderable } from '@rc-component/util';
 
 import { NoFormStyle } from '../form/context';
 import { NoCompactStyle } from '../space/Compact';
-import { isReactRenderable } from './is';
 
 const ContextIsolator: React.FC<
   Readonly<React.PropsWithChildren<Partial<Record<'space' | 'form', boolean>>>>

--- a/components/_util/convertToTooltipProps.ts
+++ b/components/_util/convertToTooltipProps.ts
@@ -1,8 +1,9 @@
 import type { ReactNode } from 'react';
 import { isValidElement } from 'react';
+import { isReactRenderable } from '@rc-component/util';
 
 import type { TooltipProps } from '../tooltip';
-import { isPlainObject, isReactRenderable } from './is';
+import { isPlainObject } from './is';
 
 const convertToTooltipProps = <P extends TooltipProps>(tooltip: P | ReactNode, context?: P) => {
   if (!isReactRenderable(tooltip)) {

--- a/components/_util/getRenderPropValue.ts
+++ b/components/_util/getRenderPropValue.ts
@@ -1,6 +1,7 @@
 import type * as React from 'react';
+import { isReactRenderable } from '@rc-component/util';
 
-import { isFunction, isReactRenderable } from './is';
+import { isFunction } from './is';
 
 export type RenderFunction = () => React.ReactNode;
 

--- a/components/_util/hooks/useClosable.tsx
+++ b/components/_util/hooks/useClosable.tsx
@@ -2,12 +2,12 @@ import type { ReactNode } from 'react';
 import React from 'react';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import type { DialogProps } from '@rc-component/dialog';
-import { mergeProps, pickAttrs } from '@rc-component/util';
+import { isNonNullable, mergeProps, pickAttrs } from '@rc-component/util';
 
 import { useLocale } from '../../locale';
 import defaultLocale from '../../locale/en_US';
 import type { HTMLAriaDataAttributes } from '../aria-data-attrs';
-import { isNonNullable, isPlainObject } from '../is';
+import { isPlainObject } from '../is';
 
 export type ClosableType = DialogProps['closable'] | null;
 export type BaseContextClosable = { closable?: ClosableType; closeIcon?: ReactNode };

--- a/components/_util/is.ts
+++ b/components/_util/is.ts
@@ -1,10 +1,4 @@
-export const isNonNullable = <T>(val: T): val is NonNullable<T> => {
-  return val !== undefined && val !== null;
-};
-
-export const isReactRenderable = <T>(val: T): val is Exclude<NonNullable<T>, false | ''> => {
-  return isNonNullable(val) && val !== false && val !== '';
-};
+import { isNonNullable } from '@rc-component/util';
 
 export const isNumber = (val: any): val is number => {
   return typeof val === 'number' && !Number.isNaN(val);

--- a/components/_util/toList.ts
+++ b/components/_util/toList.ts
@@ -1,4 +1,4 @@
-import { isNonNullable } from './is';
+import { isNonNullable } from '@rc-component/util';
 
 interface Config {
   skipEmpty?: boolean;

--- a/components/alert/Alert.tsx
+++ b/components/alert/Alert.tsx
@@ -5,13 +5,13 @@ import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
 import InfoCircleFilled from '@ant-design/icons/InfoCircleFilled';
 import CSSMotion from '@rc-component/motion';
-import { composeRef, pickAttrs } from '@rc-component/util';
+import { composeRef, isNonNullable, isReactRenderable, pickAttrs } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { ClosableType } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isNonNullable, isPlainObject, isReactRenderable } from '../_util/is';
+import { isPlainObject } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import useStyle from './style';

--- a/components/alert/ErrorBoundary.tsx
+++ b/components/alert/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { isNonNullable } from '@rc-component/util';
 
-import { isNonNullable } from '../_util/is';
 import Alert from './Alert';
 
 export interface ErrorBoundaryProps {

--- a/components/badge/Badge.tsx
+++ b/components/badge/Badge.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { useMemo, useRef } from 'react';
 import CSSMotion from '@rc-component/motion';
+import { isNonNullable, isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { PresetStatusColorType } from '../_util/colors';
 import { isPresetColor } from '../_util/colors';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isNonNullable, isNumber, isPlainObject, isReactRenderable, isString } from '../_util/is';
+import { isNumber, isPlainObject, isString } from '../_util/is';
 import { cloneElement } from '../_util/reactNode';
 import type { LiteralUnion } from '../_util/type';
 import { devUseWarning } from '../_util/warning';

--- a/components/border-beam/BorderBeam.tsx
+++ b/components/border-beam/BorderBeam.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from 'react';
 import { unit } from '@ant-design/cssinjs';
+import { isNonNullable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { isNonNullable, isNumber, isString } from '../_util/is';
+import { isNumber, isString } from '../_util/is';
 import { useComponentConfig } from '../config-provider/context';
 import { genCssVar } from '../theme/util/genStyleUtils';
 import BorderBeamEffect from './BorderBeamEffect';

--- a/components/breadcrumb/BreadcrumbItem.tsx
+++ b/components/breadcrumb/BreadcrumbItem.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
+import { isNonNullable, isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { isNonNullable, isReactRenderable } from '../_util/is';
 import { ConfigContext } from '../config-provider';
 import type { DropdownProps } from '../dropdown/dropdown';
 import Dropdown from '../dropdown/dropdown';

--- a/components/breadcrumb/useItemRender.tsx
+++ b/components/breadcrumb/useItemRender.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { pickAttrs } from '@rc-component/util';
+import { isReactRenderable, pickAttrs } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { isPlainObject, isReactRenderable } from '../_util/is';
+import { isPlainObject } from '../_util/is';
 import type { BreadcrumbProps, InternalRouteType, ItemType } from './Breadcrumb';
 
 type AddParameters<TFunction extends (...args: any) => any, TParameters extends [...args: any]> = (

--- a/components/button/Button.tsx
+++ b/components/button/Button.tsx
@@ -1,10 +1,17 @@
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { omit, toArray, useComposeRef, useDelayState, useLayoutEffect } from '@rc-component/util';
+import {
+  isReactRenderable,
+  omit,
+  toArray,
+  useComposeRef,
+  useDelayState,
+  useLayoutEffect,
+} from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isNumber, isPlainObject, isReactRenderable } from '../_util/is';
+import { isNumber, isPlainObject } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import Wave from '../_util/wave';
 import { useComponentConfig } from '../config-provider/context';

--- a/components/button/buttonHelpers.tsx
+++ b/components/button/buttonHelpers.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { isNumber, isReactRenderable, isString } from '../_util/is';
+import { isNumber, isString } from '../_util/is';
 import { cloneElement, isFragment } from '../_util/reactNode';
 import { PresetColors } from '../theme/interface';
 import type { BaseButtonProps, LegacyButtonType } from './Button';

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import type { Tab, TabBarExtraContent } from '@rc-component/tabs';
-import { omit, toArray } from '@rc-component/util';
+import { isReactRenderable, omit, toArray } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import useSize from '../config-provider/hooks/useSize';

--- a/components/card/CardMeta.tsx
+++ b/components/card/CardMeta.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
+import { isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isReactRenderable } from '../_util/is';
 import { useComponentConfig } from '../config-provider/context';
 
 export type CardMetaSemanticType = {

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import type { CheckboxRef } from '@rc-component/checkbox';
 import RcCheckbox from '@rc-component/checkbox';
-import { useComposeRef, useControlledState, useEvent } from '@rc-component/util';
+import { isReactRenderable, useComposeRef, useControlledState, useEvent } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import Wave from '../_util/wave';
 import { TARGET_CLS } from '../_util/wave/interface';

--- a/components/checkbox/Group.tsx
+++ b/components/checkbox/Group.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { omit } from '@rc-component/util';
+import { isNonNullable, omit } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { HTMLAriaDataAttributes } from '../_util/aria-data-attrs';
-import { isNonNullable, isNumber, isString } from '../_util/is';
+import { isNumber, isString } from '../_util/is';
 import { ConfigContext } from '../config-provider';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import type { CheckboxChangeEvent } from './Checkbox';

--- a/components/date-picker/generatePicker/generateRangePicker.tsx
+++ b/components/date-picker/generatePicker/generateRangePicker.tsx
@@ -4,12 +4,11 @@ import SwapRightOutlined from '@ant-design/icons/SwapRightOutlined';
 import { RangePicker as RCRangePicker } from '@rc-component/picker';
 import type { PickerRef } from '@rc-component/picker';
 import type { GenerateConfig } from '@rc-component/picker/generate/index';
-import { merge } from '@rc-component/util';
+import { isNonNullable, merge } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import ContextIsolator from '../../_util/ContextIsolator';
 import { useAllowClear, useZIndex } from '../../_util/hooks';
-import { isNonNullable } from '../../_util/is';
 import { getMergedStatus, getStatusClassNames } from '../../_util/statusUtils';
 import type { AnyObject } from '../../_util/type';
 import { devUseWarning } from '../../_util/warning';

--- a/components/date-picker/util.ts
+++ b/components/date-picker/util.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { PickerMode } from '@rc-component/picker/interface';
+import { isNonNullable } from '@rc-component/util';
 
-import { isNonNullable } from '../_util/is';
 import useSelectIcons from '../select/useIcons';
 import type { PickerLocale, PickerProps } from './generatePicker';
 

--- a/components/descriptions/Cell.tsx
+++ b/components/descriptions/Cell.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import { isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
-import { isReactRenderable } from '../_util/is';
 import type { CellSemanticType } from './DescriptionsContext';
 import DescriptionsContext from './DescriptionsContext';
 

--- a/components/drawer/Drawer.tsx
+++ b/components/drawer/Drawer.tsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 import type { Placement, DrawerProps as RcDrawerProps } from '@rc-component/drawer';
 import RcDrawer from '@rc-component/drawer';
 import type { CSSMotionProps } from '@rc-component/motion';
-import { composeRef, useId } from '@rc-component/util';
+import { composeRef, isReactRenderable, useId } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import ContextIsolator from '../_util/ContextIsolator';
 import { useMergedMask, useZIndex } from '../_util/hooks';
 import type { MaskType } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
-import { isNumber, isReactRenderable } from '../_util/is';
+import { isNumber } from '../_util/is';
 import { getTransitionName } from '../_util/motion';
 import { devUseWarning } from '../_util/warning';
 import zIndexContext from '../_util/zindexContext';

--- a/components/drawer/DrawerPanel.tsx
+++ b/components/drawer/DrawerPanel.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { DrawerProps as RCDrawerProps } from '@rc-component/drawer';
+import { isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { DrawerProps } from '.';
@@ -7,7 +8,7 @@ import { pickClosable, useClosable } from '../_util/hooks';
 import type { ClosableType } from '../_util/hooks';
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isPlainObject, isReactRenderable } from '../_util/is';
+import { isPlainObject } from '../_util/is';
 import { cloneElement } from '../_util/reactNode';
 import { useComponentConfig } from '../config-provider/context';
 import Skeleton from '../skeleton';

--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
+import { isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import { useLocale } from '../locale';

--- a/components/flex/index.tsx
+++ b/components/flex/index.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { omit } from '@rc-component/util';
+import { isNonNullable, omit } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { isPresetSize } from '../_util/gapSize';
 import { useOrientation } from '../_util/hooks';
-import { isNonNullable } from '../_util/is';
 import { ConfigContext } from '../config-provider';
 import type { ConfigConsumerProps } from '../config-provider';
 import type { FlexProps } from './interface';

--- a/components/float-button/FloatButton.tsx
+++ b/components/float-button/FloatButton.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import FileTextOutlined from '@ant-design/icons/FileTextOutlined';
-import { omit } from '@rc-component/util';
+import { isReactRenderable, omit } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import convertToTooltipProps from '../_util/convertToTooltipProps';
 import { useZIndex } from '../_util/hooks';
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import Badge from '../badge';
 import type { BadgeProps } from '../badge';

--- a/components/form/ErrorList.tsx
+++ b/components/form/ErrorList.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import type { CSSMotionProps } from '@rc-component/motion';
 import CSSMotion, { CSSMotionList } from '@rc-component/motion';
+import { isNonNullable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { isNonNullable } from '../_util/is';
 import initCollapseMotion from '../_util/motion';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import { FormContext, FormItemPrefixContext } from './context';

--- a/components/form/FormItem/ItemHolder.tsx
+++ b/components/form/FormItem/ItemHolder.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import type { Meta } from '@rc-component/form';
-import { isVisible, omit, useLayoutEffect } from '@rc-component/util';
+import { isNonNullable, isVisible, omit, useLayoutEffect } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { FormItemProps } from '.';
-import { isNonNullable } from '../../_util/is';
 import { Row } from '../../grid';
 import type { ReportMetaChange } from '../context';
 import { FormContext, NoStyleItemContext } from '../context';

--- a/components/form/FormItem/index.tsx
+++ b/components/form/FormItem/index.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import type { JSX } from 'react';
 import { Field, FieldContext, ListContext } from '@rc-component/form';
 import type { FieldProps, InternalNamePath, Meta, RuleObject } from '@rc-component/form';
-import { supportRef, useState } from '@rc-component/util';
+import { isNonNullable, supportRef, useState } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { isFunction, isNonNullable, isPlainObject } from '../../_util/is';
+import { isFunction, isPlainObject } from '../../_util/is';
 import { cloneElement } from '../../_util/reactNode';
 import { useDevWarning } from '../../_util/warning';
 import { ConfigContext } from '../../config-provider';
@@ -76,7 +76,9 @@ const MemoInput = React.memo<React.PropsWithChildren<MemoInputProps>>(
 );
 
 export interface FormItemProps<Values = any>
-  extends Omit<FormItemLabelProps, 'requiredMark'>, FormItemInputProps, RcFieldProps<Values> {
+  extends Omit<FormItemLabelProps, 'requiredMark'>,
+    FormItemInputProps,
+    RcFieldProps<Values> {
   prefixCls?: string;
   noStyle?: boolean;
   style?: React.CSSProperties;

--- a/components/form/FormItemLabel.tsx
+++ b/components/form/FormItemLabel.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import QuestionCircleOutlined from '@ant-design/icons/QuestionCircleOutlined';
+import { isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import convertToTooltipProps from '../_util/convertToTooltipProps';
-import { isFunction, isReactRenderable } from '../_util/is';
+import { isFunction } from '../_util/is';
 import type { ColProps } from '../grid/col';
 import Col from '../grid/col';
 import { useLocale } from '../locale';

--- a/components/grid/col.tsx
+++ b/components/grid/col.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { isNonNullable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { isNonNullable, isNumber, isPlainObject } from '../_util/is';
+import { isNumber, isPlainObject } from '../_util/is';
 import { responsiveArrayReversed } from '../_util/responsiveObserver';
 import type { Breakpoint } from '../_util/responsiveObserver';
 import type { LiteralUnion } from '../_util/type';

--- a/components/message/useMessage.tsx
+++ b/components/message/useMessage.tsx
@@ -8,6 +8,7 @@ import type {
   NotificationConfig as RcNotificationConfig,
   NotificationProps as RcNotificationProps,
 } from '@rc-component/notification';
+import { isNonNullable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import {
@@ -15,7 +16,7 @@ import {
   useMergeSemantic,
   useSemanticRootStyle,
 } from '../_util/hooks/useMergeSemantic';
-import { isFunction, isNonNullable, isPlainObject } from '../_util/is';
+import { isFunction, isPlainObject } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import { useComponentConfig } from '../config-provider/context';

--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -3,12 +3,12 @@ import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
 import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
 import InfoCircleFilled from '@ant-design/icons/InfoCircleFilled';
-import { omit } from '@rc-component/util';
+import { isReactRenderable, omit } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import fallbackProp from '../_util/fallbackProp';
 import { CONTAINER_MAX_OFFSET, normalizeMaskConfig } from '../_util/hooks';
-import { isFunction, isPlainObject, isReactRenderable } from '../_util/is';
+import { isFunction, isPlainObject } from '../_util/is';
 import { getTransitionName } from '../_util/motion';
 import { devUseWarning } from '../_util/warning';
 import type { ThemeConfig } from '../config-provider';

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
 import Dialog from '@rc-component/dialog';
 import type { DialogProps } from '@rc-component/dialog';
-import { composeRef, omit } from '@rc-component/util';
+import { composeRef, isNonNullable, omit } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import ContextIsolator from '../_util/ContextIsolator';
 import { pickClosable, useClosable, useMergedMask, useZIndex } from '../_util/hooks';
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
-import { isNonNullable, isNumber, isPlainObject } from '../_util/is';
+import { isNumber, isPlainObject } from '../_util/is';
 import { getTransitionName } from '../_util/motion';
 import type { Breakpoint } from '../_util/responsiveObserver';
 import { canUseDocElement } from '../_util/styleChecker';

--- a/components/notification/PurePanel.tsx
+++ b/components/notification/PurePanel.tsx
@@ -7,12 +7,13 @@ import InfoCircleFilled from '@ant-design/icons/InfoCircleFilled';
 import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 import { Notification as RcNotification } from '@rc-component/notification';
 import type { NotificationProps as RcNotificationProps } from '@rc-component/notification';
+import { isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { pickClosable, useClosable } from '../_util/hooks';
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isPlainObject, isReactRenderable } from '../_util/is';
+import { isPlainObject } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import { useComponentConfig } from '../config-provider/context';

--- a/components/notification/useNotification.tsx
+++ b/components/notification/useNotification.tsx
@@ -8,6 +8,7 @@ import type {
   NotificationAPI,
   NotificationConfig as RcNotificationConfig,
 } from '@rc-component/notification';
+import { isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { computeClosable, pickClosable } from '../_util/hooks';
@@ -16,7 +17,7 @@ import {
   useMergeSemantic,
   useSemanticRootStyle,
 } from '../_util/hooks/useMergeSemantic';
-import { isNumber, isPlainObject, isReactRenderable } from '../_util/is';
+import { isNumber, isPlainObject } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { ConfigContext } from '../config-provider';
 import { useComponentConfig } from '../config-provider/context';

--- a/components/notification/util.ts
+++ b/components/notification/util.ts
@@ -1,8 +1,8 @@
 import type * as React from 'react';
 import { unit } from '@ant-design/cssinjs';
 import type { CSSMotionProps } from '@rc-component/motion';
+import { isNonNullable } from '@rc-component/util';
 
-import { isNonNullable } from '../_util/is';
 import type { NotificationConfig as CPNotificationConfig } from '../config-provider/context';
 import type { NotificationConfig } from './interface';
 

--- a/components/popconfirm/PurePanel.tsx
+++ b/components/popconfirm/PurePanel.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
+import { isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import ActionButton from '../_util/ActionButton';
 import { getRenderPropValue } from '../_util/getRenderPropValue';
-import { isReactRenderable } from '../_util/is';
 import Button from '../button/Button';
 import { convertLegacyProps } from '../button/buttonHelpers';
 import { ConfigContext } from '../config-provider';

--- a/components/popover/PurePanel.tsx
+++ b/components/popover/PurePanel.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { Popup } from '@rc-component/tooltip';
+import { isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { PopoverProps, PopoverSemanticAllType } from '.';
 import { getRenderPropValue } from '../_util/getRenderPropValue';
 import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
-import { isReactRenderable } from '../_util/is';
 import { ConfigContext } from '../config-provider';
 import useStyle from './style';
 

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import { useControlledState } from '@rc-component/util';
+import { isReactRenderable, useControlledState } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { RenderFunction } from '../_util/getRenderPropValue';
 import { getRenderPropValue } from '../_util/getRenderPropValue';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isReactRenderable } from '../_util/is';
 import { getTransitionName } from '../_util/motion';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import RcCheckbox from '@rc-component/checkbox';
-import { composeRef } from '@rc-component/util';
+import { composeRef, isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
-import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import Wave from '../_util/wave';
 import { TARGET_CLS } from '../_util/wave/interface';

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -3,13 +3,12 @@ import CheckCircleFilled from '@ant-design/icons/CheckCircleFilled';
 import CloseCircleFilled from '@ant-design/icons/CloseCircleFilled';
 import ExclamationCircleFilled from '@ant-design/icons/ExclamationCircleFilled';
 import WarningFilled from '@ant-design/icons/WarningFilled';
-import { pickAttrs } from '@rc-component/util';
+import { isReactRenderable, pickAttrs } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { HTMLAriaDataAttributes } from '../_util/aria-data-attrs';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import noFound from './noFound';

--- a/components/segmented/index.tsx
+++ b/components/segmented/index.tsx
@@ -6,14 +6,14 @@ import type {
   SegmentedRawOption,
 } from '@rc-component/segmented';
 import RcSegmented from '@rc-component/segmented';
-import { useId } from '@rc-component/util';
+import { isReactRenderable, useId } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useOrientation } from '../_util/hooks';
 import type { Orientation } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isPlainObject, isReactRenderable } from '../_util/is';
+import { isPlainObject } from '../_util/is';
 import { useComponentConfig } from '../config-provider/context';
 import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';

--- a/components/space/Item.tsx
+++ b/components/space/Item.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
+import { isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { SpaceSemanticAllType } from '.';
-import { isReactRenderable } from '../_util/is';
 import { SpaceContext } from './context';
 import type { SpaceContextType } from './context';
 

--- a/components/space/index.tsx
+++ b/components/space/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { toArray } from '@rc-component/util';
+import { isReactRenderable, toArray } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { isPresetSize, isValidGapNumber } from '../_util/gapSize';
@@ -7,7 +7,6 @@ import { useOrientation } from '../_util/hooks';
 import type { Orientation } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isReactRenderable } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import type { SizeType } from '../config-provider/SizeContext';

--- a/components/splitter/hooks/useSizes.ts
+++ b/components/splitter/hooks/useSizes.ts
@@ -1,6 +1,6 @@
 import React from 'react';
+import { isNonNullable } from '@rc-component/util';
 
-import { isNonNullable } from '../../_util/is';
 import type { PanelProps } from '../interface';
 import { autoPtgSizes } from './sizeUtil';
 

--- a/components/statistic/Statistic.tsx
+++ b/components/statistic/Statistic.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { pickAttrs } from '@rc-component/util';
+import { isReactRenderable, pickAttrs } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { HTMLAriaDataAttributes } from '../_util/aria-data-attrs';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isFunction, isReactRenderable } from '../_util/is';
+import { isFunction } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';
 import Skeleton from '../skeleton';

--- a/components/table/demo/ajax.tsx
+++ b/components/table/demo/ajax.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { isNonNullable } from '@rc-component/util';
 import type { GetProp, TableProps } from 'antd';
 import { Table } from 'antd';
 import type { SorterResult } from 'antd/es/table/interface';
@@ -42,10 +43,6 @@ const columns: ColumnsType<DataType> = [
     dataIndex: 'email',
   },
 ];
-
-const isNonNullable = <T,>(val: T): val is NonNullable<T> => {
-  return val !== undefined && val !== null;
-};
 
 const toURLSearchParams = <T extends Record<PropertyKey, any>>(record: T) => {
   const params = new URLSearchParams();

--- a/components/table/hooks/useColumnTitleProps.ts
+++ b/components/table/hooks/useColumnTitleProps.ts
@@ -1,6 +1,6 @@
 import React from 'react';
+import { isNonNullable } from '@rc-component/util';
 
-import { isNonNullable } from '../../_util/is';
 import type { AnyObject } from '../../_util/type';
 import type { ColumnTitleProps, FilterValue } from '../interface';
 

--- a/components/table/util.ts
+++ b/components/table/util.ts
@@ -1,4 +1,5 @@
-import { isFunction, isNonNullable, isPlainObject } from '../_util/is';
+import { isNonNullable } from '@rc-component/util';
+import { isFunction, isPlainObject } from '../_util/is';
 import type { AnyObject } from '../_util/type';
 import type { SizeType } from '../config-provider/SizeContext';
 import type {

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { omit } from '@rc-component/util';
+import { isReactRenderable, omit } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import type { PresetColorType, PresetStatusColorType } from '../_util/colors';
@@ -7,7 +7,7 @@ import { pickClosable, useClosable } from '../_util/hooks';
 import type { ClosableType } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isFunction, isReactRenderable } from '../_util/is';
+import { isFunction } from '../_util/is';
 import { cloneElement, replaceElement } from '../_util/reactNode';
 import type { LiteralUnion } from '../_util/type';
 import { devUseWarning } from '../_util/warning';

--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { UnstableContext } from '@rc-component/steps';
+import { isNonNullable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isNonNullable, isNumber } from '../_util/is';
+import { isNumber } from '../_util/is';
 import type { GetProp, GetProps, LiteralUnion } from '../_util/type';
 import { devUseWarning } from '../_util/warning';
 import { useComponentConfig } from '../config-provider/context';

--- a/components/tour/panelRender.tsx
+++ b/components/tour/panelRender.tsx
@@ -1,10 +1,9 @@
 import type { ReactNode } from 'react';
 import React from 'react';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
-import { pickAttrs } from '@rc-component/util';
+import { isReactRenderable, pickAttrs } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { isReactRenderable } from '../_util/is';
 import type { ButtonProps } from '../button/Button';
 import Button from '../button/Button';
 import { useLocale } from '../locale';

--- a/components/transfer/Section.tsx
+++ b/components/transfer/Section.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo, useRef, useState } from 'react';
 import DownOutlined from '@ant-design/icons/DownOutlined';
-import { omit } from '@rc-component/util';
+import { isNonNullable, omit } from '@rc-component/util';
 import { clsx } from 'clsx';
 
-import { isFunction, isNonNullable, isNumber, isPlainObject, isString } from '../_util/is';
+import { isFunction, isNumber, isPlainObject, isString } from '../_util/is';
 import { groupKeysMap } from '../_util/transKeys';
 import Checkbox from '../checkbox';
 import Dropdown from '../dropdown';

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -1,13 +1,13 @@
 import type { ChangeEvent, CSSProperties } from 'react';
 import React, { useCallback, useContext } from 'react';
-import { pickAttrs } from '@rc-component/util';
+import { isNonNullable, pickAttrs } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useMultipleSelect } from '../_util/hooks';
 import type { PrevSelectedIndex } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isFunction, isNonNullable } from '../_util/is';
+import { isFunction } from '../_util/is';
 import type { InputStatus } from '../_util/statusUtils';
 import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';
 import { groupDisabledKeysMap, groupKeysMap } from '../_util/transKeys';

--- a/components/tree/utils/dictUtil.ts
+++ b/components/tree/utils/dictUtil.ts
@@ -1,8 +1,8 @@
 import type React from 'react';
 import { fillFieldNames } from '@rc-component/tree';
 import type { DataNode } from '@rc-component/tree';
+import { isNonNullable } from '@rc-component/util';
 
-import { isNonNullable } from '../../_util/is';
 import type { TreeProps } from '../Tree';
 
 const RECORD_NONE = 0;

--- a/components/typography/Base/index.tsx
+++ b/components/typography/Base/index.tsx
@@ -5,6 +5,7 @@ import type { AutoSizeType } from '@rc-component/input';
 import ResizeObserver from '@rc-component/resize-observer';
 import {
   composeRef,
+  isReactRenderable,
   omit,
   toArray,
   useControlledState,
@@ -14,7 +15,7 @@ import {
 import { clsx } from 'clsx';
 
 import type { GenerateSemantic } from '../../_util/hooks/useMergeSemantic/semanticType';
-import { isFunction, isReactRenderable } from '../../_util/is';
+import { isFunction } from '../../_util/is';
 import { isStyleSupport } from '../../_util/styleChecker';
 import type { DirectionType } from '../../config-provider';
 import useLocale from '../../locale/useLocale';
@@ -111,9 +112,8 @@ export interface EllipsisConfig {
   tooltip?: React.ReactNode | TooltipProps;
 }
 
-export interface BlockProps<
-  C extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements,
-> extends TypographyProps<C> {
+export interface BlockProps<C extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements>
+  extends TypographyProps<C> {
   /**
    * @since 6.4.0
    */

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "@rc-component/tree-select": "~1.16.1",
     "@rc-component/trigger": "^3.10.1",
     "@rc-component/upload": "~1.1.1",
-    "@rc-component/util": "^1.12.0",
+    "@rc-component/util": "^1.13.0",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.11",
     "scroll-into-view-if-needed": "^3.1.0",


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [x] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无。

### 💡 需求背景和解决方案

`@rc-component/util@1.13.0` 已提供 `isNonNullable` 和 `isReactRenderable`，无需在 antd 内部重复维护相同实现。

本 PR 升级 `@rc-component/util`，删除 antd 本地实现，并将组件源码及 demo 中的相关引用迁移到 `@rc-component/util`。同时更新 `AGENTS.md` 中的工具函数使用规范。

本次调整不涉及公开 API 或组件行为变化。TypeScript、ESLint、Biome 以及相关单元测试均已通过。

### 📝 更新日志

| 语言    | 更新描述              |
| ------- | --------------------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志          |