### PR TITLE
docs: remove stale create-react-app guide references

### DIFF
--- a/docs/react/getting-started.en-US.md
+++ b/docs/react/getting-started.en-US.md
@@ -29,9 +29,11 @@ Visit https://u.ant.design/reproduce to create a CodeSandbox -- don't forget to 
 
 ### 2. Use and modify an antd component
 
-Replace the contents of `index.js` with the following code. As you can see, there is no difference between antd's components and typical React components.
+If you are working in a local React project, install `antd` first. The CodeSandbox created above already includes this dependency.
 
-If you have already set things up by following the [Use with create-react-app](/docs/react/use-with-create-react-app), replace the content of `/src/index.js` as follows:
+<InstallDependencies npm='$ npm install antd --save' yarn='$ yarn add antd' pnpm='$ pnpm install antd --save' bun='$ bun add antd'></InstallDependencies>
+
+Then replace the contents of your application's entry file (for example, `src/index.js`) with the following code. As you can see, there is no difference between antd's components and typical React components.
 
 ```jsx
 import React, { useState } from 'react';
@@ -97,8 +99,6 @@ During actual real-world project development, you will most likely need a develo
 - More scaffolds at [Scaffold Market](https://scaffold.ant.design/)
 
 ## Test with Jest
-
-If you use `create-react-app` follow the instructions [here](/docs/react/use-with-create-react-app) instead.
 
 Jest does not support `esm` modules, and Ant Design uses them. In order to test your Ant Design application with Jest you have to add the following to your Jest config :
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Related to #52791

### 💡 需求背景和解决方案

`use-with-create-react-app` 教程已在 #52791 中删除，但英文 Getting Started 文档仍有两处链接指向该教程。

<img width="405" height="229" alt="image" src="https://github.com/user-attachments/assets/a01e758a-25b9-4e33-91ab-adc644b99989" />

本次修改直接提供本地 React 项目安装 `antd` 的命令，并使用通用的应用入口文件说明，不再依赖特定脚手架。同时移除 Jest 章节中指向已删除教程的链接。

### 📝 更新日志

| 语言     | 更新描述       |
| -------- | -------------- |
| 🇺🇸 英文 | N/A            |
| 🇨🇳 中文 | 无需更新日志   |