### PR TITLE
🐛 fix: pin jest dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,11 +261,11 @@
     "immer": "^11.1.4",
     "is-ci": "^4.1.0",
     "isomorphic-fetch": "^3.0.0",
-    "jest": "^30.4.2",
+    "jest": "30.4.2",
     "jest-axe": "^11.0.0",
     "jest-canvas-mock": "2.5.8",
-    "jest-environment-jsdom": "^30.4.1",
-    "jest-environment-node": "^30.4.1",
+    "jest-environment-jsdom": "30.4.1",
+    "jest-environment-node": "30.4.1",
     "jest-image-snapshot": "^6.5.2",
     "jest-puppeteer": "^11.0.0",
     "jquery": "^4.0.0",
@@ -348,7 +348,7 @@
     }
   ],
   "overrides": {
-    "jest-environment-node": "^30.4.1",
+    "jest-environment-node": "30.4.1",
     "nwsapi": "2.2.24"
   },
   "title": "Ant Design",


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

N/A

### 💡 Background and Solution

Some dependency resolvers select the latest Jest release from the `^30.4.2` range. When a registry mirror has not synchronized the matching `@jest/core` release, installing antd can fail with a version resolution error. Pin Jest and its test environments to the known compatible versions to keep dependency resolution deterministic.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Jest dependency resolution when registry mirrors lag behind the latest release. |
| 🇨🇳 Chinese | 🐞 修复镜像源未同步 Jest 最新版本时的依赖解析失败问题。 |
