### PR TITLE
chore: remove obsolete nwsapi override

### DIFF
--- a/package.json
+++ b/package.json
@@ -348,8 +348,7 @@
     }
   ],
   "overrides": {
-    "jest-environment-node": "30.4.1",
-    "nwsapi": "2.2.24"
+    "jest-environment-node": "30.4.1"
   },
   "title": "Ant Design",
   "tnpm": {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] ⏩ 工作流程

### 🔗 相关 Issue

- ref #59155
- https://github.com/dperini/nwsapi/issues/168
- https://github.com/dperini/nwsapi/pull/169

### 💡 需求背景和解决方案

#59155 为规避 `nwsapi@2.2.25` 引入的 `:has()` 兄弟选择器回归，临时将依赖固定为 `2.2.24`。

上游已经修复该问题并发布 `nwsapi@2.2.27`，因此移除临时 override，恢复由 `jsdom` 的版本范围正常解析依赖。

验证结果：

- `nwsapi@2.2.27` 最小复现通过
- Tooltip 8 个测试套件全部通过，99 个测试通过
- `git diff --check` 通过

### 📝 更新日志

| 语言    | 更新描述              |
| ------- | --------------------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志          |
