### PR TITLE
docs: update getting started guides

### DIFF
--- a/docs/react/getting-started.en-US.md
+++ b/docs/react/getting-started.en-US.md
@@ -10,11 +10,11 @@ Ant Design React is dedicated to providing a **good development experience** for
 
 The official guide also assumes that you have intermediate knowledge about HTML, CSS, and JavaScript, and React. If you are just starting to learn front-end or React, it may not be the best idea to use the UI framework as your first step.
 
-Finally, if you are working in a local development environment, please refer to [Scaffolding Guide](https://u.ant.design/guide) to create a new project.
+Finally, if you are working in a local development environment, please refer to [Scaffolding Guide](/docs/react/use-with-vite) to create a new project.
 
 ---
 
-## Your First Example
+## Your First Example {#first-example}
 
 Here is a simple online CodeSandbox demo of an Ant Design component to show the usage of Ant Design React.
 
@@ -23,17 +23,17 @@ Here is a simple online CodeSandbox demo of an Ant Design component to show the 
 
 Follow the steps below to play around with Ant Design yourself:
 
-### 1. Create a CodeSandbox
+### 1. Create a CodeSandbox {#create-codesandbox}
 
 Visit https://u.ant.design/reproduce to create a CodeSandbox -- don't forget to press the save button as well to create a new instance.
 
-### 2. Use and modify an antd component
+### 2. Use and modify an antd component {#use-antd-component}
 
 If you are working in a local React project, install `antd` first. The CodeSandbox created above already includes this dependency.
 
 <InstallDependencies npm='$ npm install antd --save' yarn='$ yarn add antd' pnpm='$ pnpm install antd --save' bun='$ bun add antd'></InstallDependencies>
 
-Then replace the contents of your application's entry file (for example, `src/index.js`) with the following code. As you can see, there is no difference between antd's components and typical React components.
+Then replace the contents of your application's entry file (for example, `src/main.jsx`) with the following code. As you can see, there is no difference between antd's components and typical React components.
 
 ```jsx
 import React, { useState } from 'react';
@@ -63,22 +63,22 @@ const App = () => {
 createRoot(document.getElementById('root')).render(<App />);
 ```
 
-### 3. Explore more components
+### 3. Explore more components {#explore-components}
 
 You can view the list of components in the side menu of the Components page, such as the [Alert](/components/alert) component. Plenty of examples are also provided in the component pages and API documentation as well.
 
-Click the "Open in Editor" icon in the first example to open an editor with source code to use out-of-the-box. Now you can import the `Alert` component into the CodeSandbox:
+Click the "Show Code" icon in the first example to expand the source code. Then import the `Alert` component into the previous CodeSandbox:
 
 ```diff
 - import { DatePicker, message } from 'antd';
 + import { DatePicker, message, Alert } from 'antd';
 ```
 
-Now add the following jsx inside the `render` function.
+Now add the following JSX inside the `App` component.
 
 ```diff
-  <DatePicker onChange={value => this.handleChange(value)} />
-  <div style={{ marginTop: 20 }}>
+  <DatePicker onChange={handleChange} />
+  <div style={{ marginTop: 16 }}>
 -   Selected Date: {date ? date.format('YYYY-MM-DD') : 'None'}
 +   <Alert title="Selected Date" description={date ? date.format('YYYY-MM-DD') : 'None'} />
   </div>
@@ -88,9 +88,9 @@ Select a date, and you can see the effect in the preview area on the right:
 
 <img width="420" src="https://gw.alipayobjects.com/zos/antfincdn/JrXptUm1Nz/6b50edc4-3a3c-4b2a-843e-f9f0af2c4667.png" alt="CodeSandbox screenshot" />
 
-OK! Now that you know the basics of using antd components, you are welcome to explore more components in the CodeSandbox. When reporting a bug with ant design, we also strongly recommend using CodeSandbox to provide a reproducible demo as well.
+OK! Now that you know the basics of using antd components, you are welcome to explore more components in the CodeSandbox. When reporting a bug with Ant Design, we also strongly recommend using CodeSandbox to provide a reproducible demo as well.
 
-### 4. Next Steps
+### 4. Next Steps {#next-steps}
 
 During actual real-world project development, you will most likely need a development workflow consisting of `compile/build/deploy/lint/debug/` deployment. You can read the following documents on the subject or use the following scaffolds and examples provided below:
 
@@ -98,20 +98,12 @@ During actual real-world project development, you will most likely need a develo
 - [create-next-app](https://github.com/ant-design/ant-design-examples/tree/main/examples/with-nextjs-inline-style)
 - More scaffolds at [Scaffold Market](https://scaffold.ant.design/)
 
-## Test with Jest
-
-Jest does not support `esm` modules, and Ant Design uses them. In order to test your Ant Design application with Jest you have to add the following to your Jest config :
-
-```json
-"transform": { "^.+\\.(ts|tsx|js|jsx)?$": "ts-jest" }
-```
-
-## Import on Demand
+## Import on Demand {#import-on-demand}
 
 `antd` supports tree shaking of ES modules, so using `import { Button } from 'antd';` would drop js code you didn't use.
 
-## Customize your Workflow
+## Customize your Workflow {#customize-workflow}
 
-If you want to customize your workflow, we recommend using [webpack](https://webpack.js.org) or [vite](https://vite.dev/) to build and debug code. You can try out plenty of [boilerplates](https://github.com/enaqx/awesome-react#react-tools) available in the React ecosystem.
+If you want to customize your workflow, we recommend using [webpack](https://webpack.js.org) or [Vite](https://vite.dev/) to build and debug code. You can try out plenty of [boilerplates](https://github.com/enaqx/awesome-react#react-tools) available in the React ecosystem.
 
 There are also some [scaffolds](https://scaffold.ant.design/) which have already been integrated into antd, so you can try and start with one of these and even contribute.

--- a/docs/react/getting-started.zh-CN.md
+++ b/docs/react/getting-started.zh-CN.md
@@ -6,26 +6,34 @@ order: 0
 title: 快速上手
 ---
 
-Ant Design React 致力于提供给程序员**愉悦**的开发体验。
+Ant Design React 致力于提供给程序员**愉悦**的开发体验。在开始之前，推荐先学习 [React](https://zh-hans.react.dev/)，并正确安装和配置了 [Node.js](https://nodejs.org/zh-cn/) v16 或以上。
 
-> 在开始之前，推荐先学习 [React](https://react.dev)，并正确安装和配置了 [Node.js](https://nodejs.org/) v16 或以上。官方指南假设你已了解关于 HTML、CSS 和 JavaScript 的中级知识，并且已经完全掌握了 React 全家桶的正确开发方式。如果你刚开始学习前端或者 React，将 UI 框架作为你的第一步可能不是最好的主意。
+官方指南假设你已了解关于 HTML、CSS 和 JavaScript 的中级知识，并且已经完全掌握了 React 全家桶的正确开发方式。如果你刚开始学习前端或者 React，将 UI 框架作为你的第一步可能不是最好的主意。
+
+最后，如果你使用本地开发环境，请参考 [脚手架指南](/docs/react/use-with-vite-cn) 创建新项目。
 
 ---
 
-## 第一个例子
+## 第一个例子 {#first-example}
 
 这是一个最简单的 Ant Design 组件的在线 CodeSandbox 演示。
 
 <!-- prettier-ignore -->
 <code src="./_demo/first-example.tsx">第一个例子</code>
 
-### 1. 创建一个 CodeSandbox
+按照以下步骤亲自体验 Ant Design：
+
+### 1. 创建一个 CodeSandbox {#create-codesandbox}
 
 访问 https://u.ant.design/reproduce 创建一个 CodeSandbox 的在线示例，别忘了保存以创建一个新的实例。
 
-### 2. 使用组件
+### 2. 使用组件 {#use-antd-component}
 
-直接用下面的代码替换 `index.js` 的内容，用 React 的方式直接使用 antd 组件。
+如果你在本地 React 项目中开发，请先安装 `antd`。上面创建的 CodeSandbox 已经包含该依赖。
+
+<InstallDependencies npm='$ npm install antd --save' yarn='$ yarn add antd' pnpm='$ pnpm install antd --save' bun='$ bun add antd'></InstallDependencies>
+
+直接用下面的代码替换应用入口文件（例如 `src/main.jsx`）的内容，用 React 的方式直接使用 antd 组件。
 
 ```jsx
 import React, { useState } from 'react';
@@ -56,8 +64,8 @@ const App = () => {
         <div style={{ marginTop: 16 }}>
           当前日期：{date ? date.format('YYYY年MM月DD日') : '未选择'}
         </div>
+        {contextHolder}
       </div>
-      {contextHolder}
     </ConfigProvider>
   );
 };
@@ -65,23 +73,23 @@ const App = () => {
 createRoot(document.getElementById('root')).render(<App />);
 ```
 
-### 3. 探索更多组件用法
+### 3. 探索更多组件用法 {#explore-components}
 
-你可以在组件页面的左侧菜单查看组件列表，比如 [Alert](/components/alert-cn) 组件，组件文档中提供了各类演示，最下方有组件 API 文档可以查阅。在代码演示部分找到第一个例子，点击右下角的图标展开代码。
+你可以在组件页面的左侧菜单查看组件列表，比如 [Alert](/components/alert-cn) 组件，组件文档中提供了各类演示，最下方有组件 API 文档可以查阅。
 
-然后依照演示代码的写法，在之前的 CodeSandbox 里修改 `index.js`，首先在 `import` 内引入 Alert 组件：
+在代码演示部分找到第一个例子，点击“显示代码”图标查看源码。然后依照演示代码的写法，在之前的 CodeSandbox 中引入 `Alert` 组件：
 
 ```diff
 - import { ConfigProvider, DatePicker, message } from 'antd';
 + import { ConfigProvider, DatePicker, message, Alert } from 'antd';
 ```
 
-然后在 `render` 内添加相应的 jsx 代码：
+然后在 `App` 组件内添加相应的 JSX 代码：
 
 ```diff
-  <DatePicker onChange={value => this.handleChange(value)} />
+  <DatePicker onChange={handleChange} />
   <div style={{ marginTop: 16 }}>
--   当前日期：{date ? date.format('YYYY-MM-DD') : '未选择'}
+-   当前日期：{date ? date.format('YYYY年MM月DD日') : '未选择'}
 +   <Alert title="当前日期" description={date ? date.format('YYYY年MM月DD日') : '未选择'} />
   </div>
 ```
@@ -92,7 +100,7 @@ createRoot(document.getElementById('root')).render(<App />);
 
 好的，现在你已经会使用基本的 antd 组件了，你可以在这个例子中继续探索其他组件的用法。如果你遇到组件的 bug，也推荐建一个可重现的 CodeSandbox 来报告 bug。
 
-### 4. 下一步
+### 4. 下一步 {#next-steps}
 
 在实际项目开发中，你会遇到构建、调试、代理、打包部署等一系列工程化的需求。你可以阅读后面的文档或者使用以下脚手架和范例：
 
@@ -100,12 +108,12 @@ createRoot(document.getElementById('root')).render(<App />);
 - [create-next-app](https://github.com/ant-design/ant-design-examples/tree/main/examples/with-nextjs-inline-style)
 - 更多脚手架可以查看 [脚手架市场](https://scaffold.ant.design/)
 
-## 按需加载
+## 按需加载 {#import-on-demand}
 
 `antd` 默认支持基于 ES modules 的 tree shaking，直接引入 `import { Button } from 'antd';` 就会有按需加载的效果。
 
-## 自行构建
+## 自行构建 {#customize-workflow}
 
-如果想自己维护工作流，我们推荐使用 [webpack](https://webpack.js.org) 或者 [vite](https://cn.vitejs.dev/) 进行构建和调试，可以使用 React 生态圈中的 [各种脚手架](https://github.com/enaqx/awesome-react#react-tools) 进行开发。
+如果想自己维护工作流，我们推荐使用 [webpack](https://webpack.docschina.org/) 或者 [Vite](https://cn.vitejs.dev/) 进行构建和调试，可以使用 React 生态圈中的 [各种脚手架](https://github.com/enaqx/awesome-react#react-tools) 进行开发。
 
 目前社区也有很多基于 antd 定制的 [React 脚手架](https://scaffold.ant.design/)，欢迎进行试用和贡献。


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无。

### 💡 需求背景和解决方案

Getting Started 中英文教程长期存在由单语言更新造成的内容和结构差异，部分链接、操作说明和代码片段也已过时。

本次改动基于 Git 历史同步两种语言中的有效增量，同时保留中文所需的本地化内容：

- 补齐中文教程缺失的脚手架、安装和操作步骤。
- 为中英文标题添加一致的显式锚点。
- 将脚手架、React、Node.js、webpack 和 Vite 链接指向对应语言版本。
- 更新 Vite 入口文件和“显示代码”操作说明。
- 修正 Hooks 示例、日期格式、`contextHolder` 位置及专业术语大小写。
- 删除已经过时且无法独立使用的 Jest 配置说明。

### 📝 更新日志

| 语言    | 更新描述              |
| ------- | --------------------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志          |