### PR TITLE
demo: avoid third-party utility in Table ajax example

### DIFF
--- a/components/table/demo/ajax.tsx
+++ b/components/table/demo/ajax.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { isNonNullable } from '@rc-component/util';
 import type { GetProp, TableProps } from 'antd';
 import { Table } from 'antd';
 import type { SorterResult } from 'antd/es/table/interface';
@@ -43,6 +42,10 @@ const columns: ColumnsType<DataType> = [
     dataIndex: 'email',
   },
 ];
+
+const isNonNullable = <T,>(val: T): val is NonNullable<T> => {
+  return val !== undefined && val !== null;
+};
 
 const toURLSearchParams = <T extends Record<PropertyKey, any>>(record: T) => {
   const params = new URLSearchParams();


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/ant-design/ant-design/pull/59182#discussion_r3905677118

### 💡 需求背景和解决方案

在 #59182 中，Table ajax demo 内部的 `isNonNullable` 被替换为从 `@rc-component/util` 导入。

根据 review 意见，demo 不应仅为简单类型判断引入第三方工具。本 PR 恢复 demo 内部的局部 `isNonNullable` 类型守卫，保持示例自包含。

本次调整不涉及组件 API 或运行时行为变化。TypeScript、ESLint、Biome 及相关检查均已通过。

### 📝 更新日志

| 语言    | 更新描述              |
| ------- | --------------------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志          |
