### PR TITLE
docs: explain renderable content behavior in FAQ

### DIFF
--- a/docs/react/faq.en-US.md
+++ b/docs/react/faq.en-US.md
@@ -19,6 +19,21 @@ But in antd, `undefined` is treated as uncontrolled, and `null` is used as an ex
 
 Note: For `options` in `Select-like` components, it is **strongly recommended not** to use `undefined` and `null` as `value` in `option`. Please use `string | number` as a valid `value` in `option`.
 
+## Why is a DOM node still rendered for some empty content? {#react-renderable}
+
+antd uses `isReactRenderable` from `@rc-component/util` to determine whether a content wrapper DOM should be created. It is designed as a compatibility-oriented content presence check, not a validator for valid React nodes, and it does not recursively predict whether React will eventually produce visible content.
+
+`isReactRenderable` treats only `null`, `undefined`, `false`, and the empty string `''` as having no content. All other values are treated as content. Therefore, when it controls whether a wrapper DOM is rendered:
+
+| Value | `isReactRenderable` | Result |
+| --- | --- | --- |
+| `null`, `undefined`, `false`, `''` | `false` | Neither the wrapper DOM nor any content is rendered |
+| `true` | `true` | The wrapper DOM is created, but React renders no text content for `true` |
+| `0` | `true` | The wrapper DOM is created and `0` is rendered normally |
+| Non-empty strings, other numbers, React elements, etc. | `true` | The wrapper DOM is created and React handles the content |
+
+Here, `false` is treated as an explicit no-content marker, while `true` means that content was provided. Although `true` itself produces no text node, the wrapper DOM is still created. Similarly, an empty array, an empty Fragment, or a React element that eventually returns `null` passes the check. The number `0` is not mistaken for empty content and is rendered normally.
+
 ## Can I use internal API which is not documented on the site?
 
 NOT RECOMMENDED. Internal API is not guaranteed to be compatible with future versions. It may be removed or changed in some versions. If you really need to use it, you should make sure these APIs are still valid when upgrading to a new version or just lock version for usage.

--- a/docs/react/faq.zh-CN.md
+++ b/docs/react/faq.zh-CN.md
@@ -19,6 +19,21 @@ title: FAQ
 
 注意：对于类 `Select` 组件的 `options`，我们**强烈不建议**使用 `undefined` 和 `null` 作为 `option` 中的 `value`，请使用 `string | number` 作为 `option` 的 `value`。
 
+## 为什么有些空内容仍然会渲染 DOM？ {#react-renderable}
+
+antd 在判断是否需要创建内容的包裹 DOM 时，采用 `@rc-component/util` 提供的 `isReactRenderable`。它的设计目标是做兼容性的“内容存在性”检查，而不是验证一个值是否为合法的 React 节点，也不会递归预测 React 最终能否渲染出可见内容。
+
+`isReactRenderable` 只将 `null`、`undefined`、`false` 和空字符串 `''` 判定为无内容，其他值均判定为有内容。因此，在由它控制包裹 DOM 是否渲染的场景中：
+
+| 传入值 | `isReactRenderable` | 渲染结果 |
+| --- | --- | --- |
+| `null`、`undefined`、`false`、`''` | `false` | 不创建包裹 DOM，也不渲染内容 |
+| `true` | `true` | 创建包裹 DOM，但 React 不会为 `true` 渲染文本内容 |
+| `0` | `true` | 创建包裹 DOM，并正常渲染 `0` |
+| 非空字符串、其他数字、React 元素等 | `true` | 创建包裹 DOM，并交由 React 渲染内容 |
+
+其中 `false` 被视为显式的无内容标记，而 `true` 则表示内容已提供。虽然 `true` 本身不会产生文本节点，但包裹 DOM 仍然会被创建。类似地，空数组、空 Fragment 或最终返回 `null` 的 React 元素也会通过检查。数字 `0` 则不会被误判为空内容，会被正常渲染。
+
 ## 官方文档中没有提供的隐藏 API 我可以使用吗？
 
 不推荐。对内接口不保证兼容性，它很可能在某个版本中因重构而移除。如果你确实需要使用，需自行确保版本升级时隐藏接口仍旧可用，或者锁定版本。


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

FAQ 缺少对 antd 内容包裹 DOM 渲染规则的说明。

补充中英文 FAQ，介绍 `isReactRenderable` 的内容存在性检查设计，并说明 `null`、`undefined`、`false`、空字符串、`true` 和数字 `0` 等值对应的渲染行为。

本次改动仅补充设计说明，不涉及 API 或组件行为变化。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A      |
| 🇨🇳 中文 | 无需更新日志 |
