### PR TITLE
fix: avoid duplicate screen reader stop in Radio label

### DIFF
--- a/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -986,6 +986,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Large"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -994,6 +995,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Large
@@ -1006,6 +1008,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Medium"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1013,6 +1016,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Medium
@@ -1025,6 +1029,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Small"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1032,6 +1037,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Small
@@ -2781,6 +2787,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="start"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -2788,6 +2795,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             start
@@ -2800,6 +2808,7 @@ Array [
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="end"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -2808,6 +2817,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             end
@@ -4096,6 +4106,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Large"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -4104,6 +4115,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Large
@@ -4116,6 +4128,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Medium"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -4123,6 +4136,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Medium
@@ -4135,6 +4149,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Small"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -4142,6 +4157,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Small

--- a/components/button/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.ts.snap
@@ -968,6 +968,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Large"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -976,6 +977,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Large
@@ -988,6 +990,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Medium"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -995,6 +998,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Medium
@@ -1007,6 +1011,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Small"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1014,6 +1019,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Small
@@ -2587,6 +2593,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="start"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -2594,6 +2601,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             start
@@ -2606,6 +2614,7 @@ Array [
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="end"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -2614,6 +2623,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             end
@@ -3569,6 +3579,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Large"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -3577,6 +3588,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Large
@@ -3589,6 +3601,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Medium"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -3596,6 +3609,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Medium
@@ -3608,6 +3622,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Small"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -3615,6 +3630,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Small

--- a/components/calendar/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/calendar/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -744,6 +744,7 @@ exports[`renders components/calendar/demo/basic.tsx extend context correctly 1`]
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="Month"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -752,6 +753,7 @@ exports[`renders components/calendar/demo/basic.tsx extend context correctly 1`]
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Month
@@ -764,6 +766,7 @@ exports[`renders components/calendar/demo/basic.tsx extend context correctly 1`]
           class="ant-radio-button"
         >
           <input
+            aria-label="Year"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -771,6 +774,7 @@ exports[`renders components/calendar/demo/basic.tsx extend context correctly 1`]
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Year
@@ -2300,6 +2304,7 @@ exports[`renders components/calendar/demo/card.tsx extend context correctly 1`] 
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -2308,6 +2313,7 @@ exports[`renders components/calendar/demo/card.tsx extend context correctly 1`] 
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -2320,6 +2326,7 @@ exports[`renders components/calendar/demo/card.tsx extend context correctly 1`] 
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -2327,6 +2334,7 @@ exports[`renders components/calendar/demo/card.tsx extend context correctly 1`] 
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -3855,6 +3863,7 @@ Array [
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -3863,6 +3872,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -3875,6 +3885,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -3882,6 +3893,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -5404,6 +5416,7 @@ Array [
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -5412,6 +5425,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -5424,6 +5438,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -5431,6 +5446,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -6244,6 +6260,7 @@ exports[`renders components/calendar/demo/customize-header.tsx extend context co
               class="ant-radio-button ant-radio-button-checked"
             >
               <input
+                aria-label="Month"
                 checked=""
                 class="ant-radio-button-input"
                 name="test-id"
@@ -6252,6 +6269,7 @@ exports[`renders components/calendar/demo/customize-header.tsx extend context co
               />
             </span>
             <span
+              aria-hidden="true"
               class="ant-radio-button-label"
             >
               Month
@@ -6264,6 +6282,7 @@ exports[`renders components/calendar/demo/customize-header.tsx extend context co
               class="ant-radio-button"
             >
               <input
+                aria-label="Year"
                 class="ant-radio-button-input"
                 name="test-id"
                 type="radio"
@@ -6271,6 +6290,7 @@ exports[`renders components/calendar/demo/customize-header.tsx extend context co
               />
             </span>
             <span
+              aria-hidden="true"
               class="ant-radio-button-label"
             >
               Year
@@ -8581,6 +8601,7 @@ exports[`renders components/calendar/demo/event-range.tsx extend context correct
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="Month"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -8589,6 +8610,7 @@ exports[`renders components/calendar/demo/event-range.tsx extend context correct
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Month
@@ -8601,6 +8623,7 @@ exports[`renders components/calendar/demo/event-range.tsx extend context correct
           class="ant-radio-button"
         >
           <input
+            aria-label="Year"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -8608,6 +8631,7 @@ exports[`renders components/calendar/demo/event-range.tsx extend context correct
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Year
@@ -10528,6 +10552,7 @@ exports[`renders components/calendar/demo/notice-calendar.tsx extend context cor
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="Month"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -10536,6 +10561,7 @@ exports[`renders components/calendar/demo/notice-calendar.tsx extend context cor
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Month
@@ -10548,6 +10574,7 @@ exports[`renders components/calendar/demo/notice-calendar.tsx extend context cor
           class="ant-radio-button"
         >
           <input
+            aria-label="Year"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -10555,6 +10582,7 @@ exports[`renders components/calendar/demo/notice-calendar.tsx extend context cor
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Year
@@ -12494,6 +12522,7 @@ Array [
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -12502,6 +12531,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -12514,6 +12544,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -12521,6 +12552,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -14052,6 +14084,7 @@ exports[`renders components/calendar/demo/style-class.tsx extend context correct
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -14060,6 +14093,7 @@ exports[`renders components/calendar/demo/style-class.tsx extend context correct
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -14072,6 +14106,7 @@ exports[`renders components/calendar/demo/style-class.tsx extend context correct
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -14079,6 +14114,7 @@ exports[`renders components/calendar/demo/style-class.tsx extend context correct
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -15601,6 +15637,7 @@ exports[`renders components/calendar/demo/style-class.tsx extend context correct
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -15609,6 +15646,7 @@ exports[`renders components/calendar/demo/style-class.tsx extend context correct
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -15621,6 +15659,7 @@ exports[`renders components/calendar/demo/style-class.tsx extend context correct
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -15628,6 +15667,7 @@ exports[`renders components/calendar/demo/style-class.tsx extend context correct
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -17156,6 +17196,7 @@ Array [
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -17164,6 +17205,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -17176,6 +17218,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -17183,6 +17226,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -18766,6 +18810,7 @@ Array [
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -18774,6 +18819,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -18786,6 +18832,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -18793,6 +18840,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year

--- a/components/calendar/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/calendar/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -117,6 +117,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                 class="ant-radio-button ant-radio-button-checked"
               >
                 <input
+                  aria-label="Month"
                   checked=""
                   class="ant-radio-button-input"
                   name="test-id"
@@ -125,6 +126,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                 />
               </span>
               <span
+                aria-hidden="true"
                 class="ant-radio-button-label"
               >
                 Month
@@ -137,6 +139,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                 class="ant-radio-button"
               >
                 <input
+                  aria-label="Year"
                   class="ant-radio-button-input"
                   name="test-id"
                   type="radio"
@@ -144,6 +147,7 @@ exports[`renders components/calendar/demo/_semantic.tsx correctly 1`] = `
                 />
               </span>
               <span
+                aria-hidden="true"
                 class="ant-radio-button-label"
               >
                 Year

--- a/components/calendar/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/calendar/__tests__/__snapshots__/demo.test.ts.snap
@@ -108,6 +108,7 @@ exports[`renders components/calendar/demo/basic.tsx correctly 1`] = `
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="Month"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -116,6 +117,7 @@ exports[`renders components/calendar/demo/basic.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Month
@@ -128,6 +130,7 @@ exports[`renders components/calendar/demo/basic.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Year"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -135,6 +138,7 @@ exports[`renders components/calendar/demo/basic.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Year
@@ -1026,6 +1030,7 @@ exports[`renders components/calendar/demo/card.tsx correctly 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -1034,6 +1039,7 @@ exports[`renders components/calendar/demo/card.tsx correctly 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -1046,6 +1052,7 @@ exports[`renders components/calendar/demo/card.tsx correctly 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -1053,6 +1060,7 @@ exports[`renders components/calendar/demo/card.tsx correctly 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -1943,6 +1951,7 @@ Array [
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -1951,6 +1960,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -1963,6 +1973,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -1970,6 +1981,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -2856,6 +2868,7 @@ Array [
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -2864,6 +2877,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -2876,6 +2890,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -2883,6 +2898,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -3694,6 +3710,7 @@ exports[`renders components/calendar/demo/customize-header.tsx correctly 1`] = `
               class="ant-radio-button ant-radio-button-checked"
             >
               <input
+                aria-label="Month"
                 checked=""
                 class="ant-radio-button-input"
                 name="test-id"
@@ -3702,6 +3719,7 @@ exports[`renders components/calendar/demo/customize-header.tsx correctly 1`] = `
               />
             </span>
             <span
+              aria-hidden="true"
               class="ant-radio-button-label"
             >
               Month
@@ -3714,6 +3732,7 @@ exports[`renders components/calendar/demo/customize-header.tsx correctly 1`] = `
               class="ant-radio-button"
             >
               <input
+                aria-label="Year"
                 class="ant-radio-button-input"
                 name="test-id"
                 type="radio"
@@ -3721,6 +3740,7 @@ exports[`renders components/calendar/demo/customize-header.tsx correctly 1`] = `
               />
             </span>
             <span
+              aria-hidden="true"
               class="ant-radio-button-label"
             >
               Year
@@ -4701,6 +4721,7 @@ exports[`renders components/calendar/demo/event-range.tsx correctly 1`] = `
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="Month"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -4709,6 +4730,7 @@ exports[`renders components/calendar/demo/event-range.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Month
@@ -4721,6 +4743,7 @@ exports[`renders components/calendar/demo/event-range.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Year"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -4728,6 +4751,7 @@ exports[`renders components/calendar/demo/event-range.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Year
@@ -6010,6 +6034,7 @@ exports[`renders components/calendar/demo/notice-calendar.tsx correctly 1`] = `
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="Month"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -6018,6 +6043,7 @@ exports[`renders components/calendar/demo/notice-calendar.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Month
@@ -6030,6 +6056,7 @@ exports[`renders components/calendar/demo/notice-calendar.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Year"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -6037,6 +6064,7 @@ exports[`renders components/calendar/demo/notice-calendar.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Year
@@ -7338,6 +7366,7 @@ Array [
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -7346,6 +7375,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -7358,6 +7388,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -7365,6 +7396,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -8258,6 +8290,7 @@ exports[`renders components/calendar/demo/style-class.tsx correctly 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -8266,6 +8299,7 @@ exports[`renders components/calendar/demo/style-class.tsx correctly 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -8278,6 +8312,7 @@ exports[`renders components/calendar/demo/style-class.tsx correctly 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -8285,6 +8320,7 @@ exports[`renders components/calendar/demo/style-class.tsx correctly 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -9171,6 +9207,7 @@ exports[`renders components/calendar/demo/style-class.tsx correctly 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -9179,6 +9216,7 @@ exports[`renders components/calendar/demo/style-class.tsx correctly 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -9191,6 +9229,7 @@ exports[`renders components/calendar/demo/style-class.tsx correctly 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -9198,6 +9237,7 @@ exports[`renders components/calendar/demo/style-class.tsx correctly 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -10088,6 +10128,7 @@ Array [
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -10096,6 +10137,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -10108,6 +10150,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -10115,6 +10158,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -11062,6 +11106,7 @@ Array [
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -11070,6 +11115,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -11082,6 +11128,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -11089,6 +11136,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year

--- a/components/calendar/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/calendar/__tests__/__snapshots__/index.test.tsx.snap
@@ -108,6 +108,7 @@ exports[`Calendar Calendar MonthSelect should display correct label 1`] = `
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="Month"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -116,6 +117,7 @@ exports[`Calendar Calendar MonthSelect should display correct label 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Month
@@ -128,6 +130,7 @@ exports[`Calendar Calendar MonthSelect should display correct label 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Year"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -135,6 +138,7 @@ exports[`Calendar Calendar MonthSelect should display correct label 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Year
@@ -1023,6 +1027,7 @@ exports[`Calendar Calendar should support locale 1`] = `
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="月"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -1031,6 +1036,7 @@ exports[`Calendar Calendar should support locale 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           月
@@ -1043,6 +1049,7 @@ exports[`Calendar Calendar should support locale 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="年"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -1050,6 +1057,7 @@ exports[`Calendar Calendar should support locale 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           年
@@ -1938,6 +1946,7 @@ exports[`Calendar rtl render component should be rendered correctly in RTL direc
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="Month"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -1946,6 +1955,7 @@ exports[`Calendar rtl render component should be rendered correctly in RTL direc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Month
@@ -1958,6 +1968,7 @@ exports[`Calendar rtl render component should be rendered correctly in RTL direc
           class="ant-radio-button"
         >
           <input
+            aria-label="Year"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -1965,6 +1976,7 @@ exports[`Calendar rtl render component should be rendered correctly in RTL direc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Year
@@ -2853,6 +2865,7 @@ exports[`Calendar support Calendar.generateCalendar 1`] = `
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="Month"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -2861,6 +2874,7 @@ exports[`Calendar support Calendar.generateCalendar 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Month
@@ -2873,6 +2887,7 @@ exports[`Calendar support Calendar.generateCalendar 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Year"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -2880,6 +2895,7 @@ exports[`Calendar support Calendar.generateCalendar 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Year

--- a/components/carousel/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/carousel/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1154,6 +1154,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Top"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1162,6 +1163,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Top
@@ -1174,6 +1176,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Bottom"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1181,6 +1184,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Bottom
@@ -1193,6 +1197,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Start"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1200,6 +1205,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Start
@@ -1212,6 +1218,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="End"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1219,6 +1226,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         End

--- a/components/carousel/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/carousel/__tests__/__snapshots__/demo.test.ts.snap
@@ -1141,6 +1141,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Top"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1149,6 +1150,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Top
@@ -1161,6 +1163,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Bottom"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1168,6 +1171,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Bottom
@@ -1180,6 +1184,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Start"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1187,6 +1192,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Start
@@ -1199,6 +1205,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="End"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1206,6 +1213,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         End

--- a/components/cascader/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/cascader/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2257,6 +2257,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="topLeft"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -2265,6 +2266,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topLeft
@@ -2277,6 +2279,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="topRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2284,6 +2287,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topRight
@@ -2296,6 +2300,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomLeft"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2303,6 +2308,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomLeft
@@ -2315,6 +2321,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2322,6 +2329,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomRight

--- a/components/cascader/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/cascader/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1009,6 +1009,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="topLeft"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1017,6 +1018,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topLeft
@@ -1029,6 +1031,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="topRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1036,6 +1039,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topRight
@@ -1048,6 +1052,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomLeft"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1055,6 +1060,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomLeft
@@ -1067,6 +1073,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1074,6 +1081,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomRight

--- a/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -424,12 +424,14 @@ exports[`renders components/checkbox/demo/debug-line.tsx extend context correctl
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="Little"
             class="ant-radio-input"
             type="radio"
             value="little"
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           Little
@@ -501,12 +503,14 @@ exports[`renders components/checkbox/demo/debug-line.tsx extend context correctl
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Little"
           class="ant-radio-input"
           type="radio"
           value="little"
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Little

--- a/components/checkbox/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.tsx.snap
@@ -387,12 +387,14 @@ exports[`renders components/checkbox/demo/debug-line.tsx correctly 1`] = `
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="Little"
             class="ant-radio-input"
             type="radio"
             value="little"
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           Little
@@ -464,12 +466,14 @@ exports[`renders components/checkbox/demo/debug-line.tsx correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Little"
           class="ant-radio-input"
           type="radio"
           value="little"
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Little

--- a/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
+++ b/components/config-provider/__tests__/__snapshots__/components.test.tsx.snap
@@ -1688,6 +1688,7 @@ exports[`ConfigProvider components Calendar configProvider 1`] = `
             class="config-radio-button config-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="config-radio-button-input"
               name="test-id"
@@ -1696,6 +1697,7 @@ exports[`ConfigProvider components Calendar configProvider 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Month
@@ -1708,6 +1710,7 @@ exports[`ConfigProvider components Calendar configProvider 1`] = `
             class="config-radio-button"
           >
             <input
+              aria-label="Year"
               class="config-radio-button-input"
               name="test-id"
               type="radio"
@@ -1715,6 +1718,7 @@ exports[`ConfigProvider components Calendar configProvider 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Year
@@ -2555,6 +2559,7 @@ exports[`ConfigProvider components Calendar configProvider 1`] = `
             class="config-radio-button"
           >
             <input
+              aria-label="Month"
               class="config-radio-button-input"
               name="test-id"
               type="radio"
@@ -2562,6 +2567,7 @@ exports[`ConfigProvider components Calendar configProvider 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Month
@@ -2574,6 +2580,7 @@ exports[`ConfigProvider components Calendar configProvider 1`] = `
             class="config-radio-button config-radio-button-checked"
           >
             <input
+              aria-label="Year"
               checked=""
               class="config-radio-button-input"
               name="test-id"
@@ -2582,6 +2589,7 @@ exports[`ConfigProvider components Calendar configProvider 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Year
@@ -2935,6 +2943,7 @@ exports[`ConfigProvider components Calendar configProvider componentDisabled 1`]
             class="config-radio-button config-radio-button-checked config-radio-button-disabled"
           >
             <input
+              aria-label="Month"
               checked=""
               class="config-radio-button-input"
               disabled=""
@@ -2944,6 +2953,7 @@ exports[`ConfigProvider components Calendar configProvider componentDisabled 1`]
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Month
@@ -2956,6 +2966,7 @@ exports[`ConfigProvider components Calendar configProvider componentDisabled 1`]
             class="config-radio-button config-radio-button-disabled"
           >
             <input
+              aria-label="Year"
               class="config-radio-button-input"
               disabled=""
               name="test-id"
@@ -2964,6 +2975,7 @@ exports[`ConfigProvider components Calendar configProvider componentDisabled 1`]
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Year
@@ -3805,6 +3817,7 @@ exports[`ConfigProvider components Calendar configProvider componentDisabled 1`]
             class="config-radio-button config-radio-button-disabled"
           >
             <input
+              aria-label="Month"
               class="config-radio-button-input"
               disabled=""
               name="test-id"
@@ -3813,6 +3826,7 @@ exports[`ConfigProvider components Calendar configProvider componentDisabled 1`]
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Month
@@ -3825,6 +3839,7 @@ exports[`ConfigProvider components Calendar configProvider componentDisabled 1`]
             class="config-radio-button config-radio-button-checked config-radio-button-disabled"
           >
             <input
+              aria-label="Year"
               checked=""
               class="config-radio-button-input"
               disabled=""
@@ -3834,6 +3849,7 @@ exports[`ConfigProvider components Calendar configProvider componentDisabled 1`]
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Year
@@ -4185,6 +4201,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize large 1
             class="config-radio-button config-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="config-radio-button-input"
               name="test-id"
@@ -4193,6 +4210,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize large 1
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Month
@@ -4205,6 +4223,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize large 1
             class="config-radio-button"
           >
             <input
+              aria-label="Year"
               class="config-radio-button-input"
               name="test-id"
               type="radio"
@@ -4212,6 +4231,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize large 1
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Year
@@ -5052,6 +5072,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize large 1
             class="config-radio-button"
           >
             <input
+              aria-label="Month"
               class="config-radio-button-input"
               name="test-id"
               type="radio"
@@ -5059,6 +5080,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize large 1
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Month
@@ -5071,6 +5093,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize large 1
             class="config-radio-button config-radio-button-checked"
           >
             <input
+              aria-label="Year"
               checked=""
               class="config-radio-button-input"
               name="test-id"
@@ -5079,6 +5102,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize large 1
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Year
@@ -5430,6 +5454,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize medium 
             class="config-radio-button config-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="config-radio-button-input"
               name="test-id"
@@ -5438,6 +5463,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize medium 
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Month
@@ -5450,6 +5476,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize medium 
             class="config-radio-button"
           >
             <input
+              aria-label="Year"
               class="config-radio-button-input"
               name="test-id"
               type="radio"
@@ -5457,6 +5484,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize medium 
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Year
@@ -6297,6 +6325,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize medium 
             class="config-radio-button"
           >
             <input
+              aria-label="Month"
               class="config-radio-button-input"
               name="test-id"
               type="radio"
@@ -6304,6 +6333,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize medium 
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Month
@@ -6316,6 +6346,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize medium 
             class="config-radio-button config-radio-button-checked"
           >
             <input
+              aria-label="Year"
               checked=""
               class="config-radio-button-input"
               name="test-id"
@@ -6324,6 +6355,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize medium 
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Year
@@ -6675,6 +6707,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize small 1
             class="config-radio-button config-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="config-radio-button-input"
               name="test-id"
@@ -6683,6 +6716,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize small 1
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Month
@@ -6695,6 +6729,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize small 1
             class="config-radio-button"
           >
             <input
+              aria-label="Year"
               class="config-radio-button-input"
               name="test-id"
               type="radio"
@@ -6702,6 +6737,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize small 1
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Year
@@ -7542,6 +7578,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize small 1
             class="config-radio-button"
           >
             <input
+              aria-label="Month"
               class="config-radio-button-input"
               name="test-id"
               type="radio"
@@ -7549,6 +7586,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize small 1
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Month
@@ -7561,6 +7599,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize small 1
             class="config-radio-button config-radio-button-checked"
           >
             <input
+              aria-label="Year"
               checked=""
               class="config-radio-button-input"
               name="test-id"
@@ -7569,6 +7608,7 @@ exports[`ConfigProvider components Calendar configProvider componentSize small 1
             />
           </span>
           <span
+            aria-hidden="true"
             class="config-radio-button-label"
           >
             Year
@@ -7920,6 +7960,7 @@ exports[`ConfigProvider components Calendar normal 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -7928,6 +7969,7 @@ exports[`ConfigProvider components Calendar normal 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -7940,6 +7982,7 @@ exports[`ConfigProvider components Calendar normal 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -7947,6 +7990,7 @@ exports[`ConfigProvider components Calendar normal 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -8787,6 +8831,7 @@ exports[`ConfigProvider components Calendar normal 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Month"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -8794,6 +8839,7 @@ exports[`ConfigProvider components Calendar normal 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -8806,6 +8852,7 @@ exports[`ConfigProvider components Calendar normal 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Year"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -8814,6 +8861,7 @@ exports[`ConfigProvider components Calendar normal 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -9165,6 +9213,7 @@ exports[`ConfigProvider components Calendar prefixCls 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -9173,6 +9222,7 @@ exports[`ConfigProvider components Calendar prefixCls 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -9185,6 +9235,7 @@ exports[`ConfigProvider components Calendar prefixCls 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -9192,6 +9243,7 @@ exports[`ConfigProvider components Calendar prefixCls 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -10032,6 +10084,7 @@ exports[`ConfigProvider components Calendar prefixCls 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Month"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -10039,6 +10092,7 @@ exports[`ConfigProvider components Calendar prefixCls 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -10051,6 +10105,7 @@ exports[`ConfigProvider components Calendar prefixCls 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Year"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -10059,6 +10114,7 @@ exports[`ConfigProvider components Calendar prefixCls 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -21086,6 +21142,7 @@ exports[`ConfigProvider components Radio configProvider 1`] = `
         class="config-radio ant-wave-target config-radio-checked"
       >
         <input
+          aria-label="Bamboo"
           checked=""
           class="config-radio-input"
           name="test-id"
@@ -21093,6 +21150,7 @@ exports[`ConfigProvider components Radio configProvider 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="config-radio-label"
       >
         Bamboo
@@ -21110,6 +21168,7 @@ exports[`ConfigProvider components Radio configProvider 1`] = `
         class="config-radio-button config-radio-button-checked"
       >
         <input
+          aria-label="Light"
           checked=""
           class="config-radio-button-input"
           name="test-id"
@@ -21117,6 +21176,7 @@ exports[`ConfigProvider components Radio configProvider 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="config-radio-button-label"
       >
         Light
@@ -21139,6 +21199,7 @@ exports[`ConfigProvider components Radio configProvider componentDisabled 1`] = 
         class="config-radio ant-wave-target config-radio-checked config-radio-disabled"
       >
         <input
+          aria-label="Bamboo"
           checked=""
           class="config-radio-input"
           disabled=""
@@ -21147,6 +21208,7 @@ exports[`ConfigProvider components Radio configProvider componentDisabled 1`] = 
         />
       </span>
       <span
+        aria-hidden="true"
         class="config-radio-label"
       >
         Bamboo
@@ -21164,6 +21226,7 @@ exports[`ConfigProvider components Radio configProvider componentDisabled 1`] = 
         class="config-radio-button config-radio-button-checked config-radio-button-disabled"
       >
         <input
+          aria-label="Light"
           checked=""
           class="config-radio-button-input"
           disabled=""
@@ -21172,6 +21235,7 @@ exports[`ConfigProvider components Radio configProvider componentDisabled 1`] = 
         />
       </span>
       <span
+        aria-hidden="true"
         class="config-radio-button-label"
       >
         Light
@@ -21194,6 +21258,7 @@ exports[`ConfigProvider components Radio configProvider componentSize large 1`] 
         class="config-radio ant-wave-target config-radio-checked"
       >
         <input
+          aria-label="Bamboo"
           checked=""
           class="config-radio-input"
           name="test-id"
@@ -21201,6 +21266,7 @@ exports[`ConfigProvider components Radio configProvider componentSize large 1`] 
         />
       </span>
       <span
+        aria-hidden="true"
         class="config-radio-label"
       >
         Bamboo
@@ -21218,6 +21284,7 @@ exports[`ConfigProvider components Radio configProvider componentSize large 1`] 
         class="config-radio-button config-radio-button-checked"
       >
         <input
+          aria-label="Light"
           checked=""
           class="config-radio-button-input"
           name="test-id"
@@ -21225,6 +21292,7 @@ exports[`ConfigProvider components Radio configProvider componentSize large 1`] 
         />
       </span>
       <span
+        aria-hidden="true"
         class="config-radio-button-label"
       >
         Light
@@ -21247,6 +21315,7 @@ exports[`ConfigProvider components Radio configProvider componentSize medium 1`]
         class="config-radio ant-wave-target config-radio-checked"
       >
         <input
+          aria-label="Bamboo"
           checked=""
           class="config-radio-input"
           name="test-id"
@@ -21254,6 +21323,7 @@ exports[`ConfigProvider components Radio configProvider componentSize medium 1`]
         />
       </span>
       <span
+        aria-hidden="true"
         class="config-radio-label"
       >
         Bamboo
@@ -21271,6 +21341,7 @@ exports[`ConfigProvider components Radio configProvider componentSize medium 1`]
         class="config-radio-button config-radio-button-checked"
       >
         <input
+          aria-label="Light"
           checked=""
           class="config-radio-button-input"
           name="test-id"
@@ -21278,6 +21349,7 @@ exports[`ConfigProvider components Radio configProvider componentSize medium 1`]
         />
       </span>
       <span
+        aria-hidden="true"
         class="config-radio-button-label"
       >
         Light
@@ -21300,6 +21372,7 @@ exports[`ConfigProvider components Radio configProvider componentSize small 1`] 
         class="config-radio ant-wave-target config-radio-checked"
       >
         <input
+          aria-label="Bamboo"
           checked=""
           class="config-radio-input"
           name="test-id"
@@ -21307,6 +21380,7 @@ exports[`ConfigProvider components Radio configProvider componentSize small 1`] 
         />
       </span>
       <span
+        aria-hidden="true"
         class="config-radio-label"
       >
         Bamboo
@@ -21324,6 +21398,7 @@ exports[`ConfigProvider components Radio configProvider componentSize small 1`] 
         class="config-radio-button config-radio-button-checked"
       >
         <input
+          aria-label="Light"
           checked=""
           class="config-radio-button-input"
           name="test-id"
@@ -21331,6 +21406,7 @@ exports[`ConfigProvider components Radio configProvider componentSize small 1`] 
         />
       </span>
       <span
+        aria-hidden="true"
         class="config-radio-button-label"
       >
         Light
@@ -21353,6 +21429,7 @@ exports[`ConfigProvider components Radio normal 1`] = `
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Bamboo"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -21360,6 +21437,7 @@ exports[`ConfigProvider components Radio normal 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Bamboo
@@ -21377,6 +21455,7 @@ exports[`ConfigProvider components Radio normal 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Light"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -21384,6 +21463,7 @@ exports[`ConfigProvider components Radio normal 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Light
@@ -21406,6 +21486,7 @@ exports[`ConfigProvider components Radio prefixCls 1`] = `
         class="prefix-Radio ant-wave-target prefix-Radio-checked"
       >
         <input
+          aria-label="Bamboo"
           checked=""
           class="prefix-Radio-input"
           name="test-id"
@@ -21413,6 +21494,7 @@ exports[`ConfigProvider components Radio prefixCls 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="prefix-Radio-label"
       >
         Bamboo
@@ -21430,6 +21512,7 @@ exports[`ConfigProvider components Radio prefixCls 1`] = `
         class="prefix-Radio-button prefix-Radio-button-checked"
       >
         <input
+          aria-label="Light"
           checked=""
           class="prefix-Radio-button-input"
           name="test-id"
@@ -21437,6 +21520,7 @@ exports[`ConfigProvider components Radio prefixCls 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="prefix-Radio-button-label"
       >
         Light

--- a/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -49438,6 +49438,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="topLeft"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -49446,6 +49447,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topLeft
@@ -49458,6 +49460,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="topRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -49465,6 +49468,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topRight
@@ -49477,6 +49481,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomLeft"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -49484,6 +49489,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomLeft
@@ -49496,6 +49502,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -49503,6 +49510,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomRight
@@ -63713,6 +63721,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
           class="ant-radio-button"
         >
           <input
+            aria-label="Large"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -63720,6 +63729,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Large
@@ -63732,6 +63742,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="Medium"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -63740,6 +63751,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Medium
@@ -63752,6 +63764,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
           class="ant-radio-button"
         >
           <input
+            aria-label="Small"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -63759,6 +63772,7 @@ exports[`renders components/date-picker/demo/size.tsx extend context correctly 1
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Small

--- a/components/date-picker/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo.test.tsx.snap
@@ -4925,6 +4925,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="topLeft"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -4933,6 +4934,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topLeft
@@ -4945,6 +4947,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="topRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -4952,6 +4955,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topRight
@@ -4964,6 +4968,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomLeft"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -4971,6 +4976,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomLeft
@@ -4983,6 +4989,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -4990,6 +4997,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomRight
@@ -6158,6 +6166,7 @@ exports[`renders components/date-picker/demo/size.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Large"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -6165,6 +6174,7 @@ exports[`renders components/date-picker/demo/size.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Large
@@ -6177,6 +6187,7 @@ exports[`renders components/date-picker/demo/size.tsx correctly 1`] = `
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="Medium"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -6185,6 +6196,7 @@ exports[`renders components/date-picker/demo/size.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Medium
@@ -6197,6 +6209,7 @@ exports[`renders components/date-picker/demo/size.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Small"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -6204,6 +6217,7 @@ exports[`renders components/date-picker/demo/size.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Small

--- a/components/descriptions/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/descriptions/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -512,6 +512,7 @@ exports[`renders components/descriptions/demo/component-token.tsx extend context
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="large"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -520,6 +521,7 @@ exports[`renders components/descriptions/demo/component-token.tsx extend context
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         large
@@ -532,6 +534,7 @@ exports[`renders components/descriptions/demo/component-token.tsx extend context
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="medium"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -539,6 +542,7 @@ exports[`renders components/descriptions/demo/component-token.tsx extend context
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         medium
@@ -551,6 +555,7 @@ exports[`renders components/descriptions/demo/component-token.tsx extend context
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="small"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -558,6 +563,7 @@ exports[`renders components/descriptions/demo/component-token.tsx extend context
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         small
@@ -1604,6 +1610,7 @@ exports[`renders components/descriptions/demo/size.tsx extend context correctly 
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="large"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -1612,6 +1619,7 @@ exports[`renders components/descriptions/demo/size.tsx extend context correctly 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         large
@@ -1624,6 +1632,7 @@ exports[`renders components/descriptions/demo/size.tsx extend context correctly 
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="medium"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1631,6 +1640,7 @@ exports[`renders components/descriptions/demo/size.tsx extend context correctly 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         medium
@@ -1643,6 +1653,7 @@ exports[`renders components/descriptions/demo/size.tsx extend context correctly 
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="small"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1650,6 +1661,7 @@ exports[`renders components/descriptions/demo/size.tsx extend context correctly 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         small
@@ -2061,6 +2073,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="horizontal"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -2069,6 +2082,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         horizontal
@@ -2081,6 +2095,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="vertical"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -2088,6 +2103,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         vertical

--- a/components/descriptions/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/descriptions/__tests__/__snapshots__/demo.test.ts.snap
@@ -466,6 +466,7 @@ exports[`renders components/descriptions/demo/component-token.tsx correctly 1`] 
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="large"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -474,6 +475,7 @@ exports[`renders components/descriptions/demo/component-token.tsx correctly 1`] 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         large
@@ -486,6 +488,7 @@ exports[`renders components/descriptions/demo/component-token.tsx correctly 1`] 
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="medium"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -493,6 +496,7 @@ exports[`renders components/descriptions/demo/component-token.tsx correctly 1`] 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         medium
@@ -505,6 +509,7 @@ exports[`renders components/descriptions/demo/component-token.tsx correctly 1`] 
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="small"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -512,6 +517,7 @@ exports[`renders components/descriptions/demo/component-token.tsx correctly 1`] 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         small
@@ -1486,6 +1492,7 @@ exports[`renders components/descriptions/demo/size.tsx correctly 1`] = `
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="large"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -1494,6 +1501,7 @@ exports[`renders components/descriptions/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         large
@@ -1506,6 +1514,7 @@ exports[`renders components/descriptions/demo/size.tsx correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="medium"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1513,6 +1522,7 @@ exports[`renders components/descriptions/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         medium
@@ -1525,6 +1535,7 @@ exports[`renders components/descriptions/demo/size.tsx correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="small"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1532,6 +1543,7 @@ exports[`renders components/descriptions/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         small
@@ -1909,6 +1921,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="horizontal"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -1917,6 +1930,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         horizontal
@@ -1929,6 +1943,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="vertical"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1936,6 +1951,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         vertical

--- a/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
+++ b/components/drawer/__tests__/__snapshots__/demo-extend.test.tsx.snap
@@ -349,6 +349,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="top"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -356,6 +357,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             top
@@ -368,6 +370,7 @@ Array [
             class="ant-radio ant-wave-target ant-radio-checked"
           >
             <input
+              aria-label="right"
               checked=""
               class="ant-radio-input"
               name="test-id"
@@ -376,6 +379,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             right
@@ -388,6 +392,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="bottom"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -395,6 +400,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             bottom
@@ -407,6 +413,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="left"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -414,6 +421,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             left
@@ -3163,6 +3171,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="top"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -3170,6 +3179,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             top
@@ -3182,6 +3192,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="right"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -3189,6 +3200,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             right
@@ -3201,6 +3213,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="bottom"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -3208,6 +3221,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             bottom
@@ -3220,6 +3234,7 @@ Array [
             class="ant-radio ant-wave-target ant-radio-checked"
           >
             <input
+              aria-label="left"
               checked=""
               class="ant-radio-input"
               name="test-id"
@@ -3228,6 +3243,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             left
@@ -3446,6 +3462,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="top"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -3453,6 +3470,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             top
@@ -3465,6 +3483,7 @@ Array [
             class="ant-radio ant-wave-target ant-radio-checked"
           >
             <input
+              aria-label="right"
               checked=""
               class="ant-radio-input"
               name="test-id"
@@ -3473,6 +3492,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             right
@@ -3485,6 +3505,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="bottom"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -3492,6 +3513,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             bottom
@@ -3504,6 +3526,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="left"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -3511,6 +3534,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             left
@@ -3953,6 +3977,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="Large Size (736px)"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -3960,6 +3985,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             Large Size (736px)
@@ -3972,6 +3998,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="Default Size (378px)"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -3979,6 +4006,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             Default Size (378px)
@@ -3991,6 +4019,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="256"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -3998,6 +4027,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             256
@@ -4010,6 +4040,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="500px"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -4017,6 +4048,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             500px
@@ -4029,6 +4061,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="50%"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -4036,6 +4069,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             50%
@@ -4048,6 +4082,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="20vw"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -4055,6 +4090,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             20vw

--- a/components/drawer/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/drawer/__tests__/__snapshots__/demo.test.ts.snap
@@ -116,6 +116,7 @@ exports[`renders components/drawer/demo/extra.tsx correctly 1`] = `
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="top"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -123,6 +124,7 @@ exports[`renders components/drawer/demo/extra.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           top
@@ -135,6 +137,7 @@ exports[`renders components/drawer/demo/extra.tsx correctly 1`] = `
           class="ant-radio ant-wave-target ant-radio-checked"
         >
           <input
+            aria-label="right"
             checked=""
             class="ant-radio-input"
             name="test-id"
@@ -143,6 +146,7 @@ exports[`renders components/drawer/demo/extra.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           right
@@ -155,6 +159,7 @@ exports[`renders components/drawer/demo/extra.tsx correctly 1`] = `
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="bottom"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -162,6 +167,7 @@ exports[`renders components/drawer/demo/extra.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           bottom
@@ -174,6 +180,7 @@ exports[`renders components/drawer/demo/extra.tsx correctly 1`] = `
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="left"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -181,6 +188,7 @@ exports[`renders components/drawer/demo/extra.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           left
@@ -344,6 +352,7 @@ exports[`renders components/drawer/demo/placement.tsx correctly 1`] = `
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="top"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -351,6 +360,7 @@ exports[`renders components/drawer/demo/placement.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           top
@@ -363,6 +373,7 @@ exports[`renders components/drawer/demo/placement.tsx correctly 1`] = `
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="right"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -370,6 +381,7 @@ exports[`renders components/drawer/demo/placement.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           right
@@ -382,6 +394,7 @@ exports[`renders components/drawer/demo/placement.tsx correctly 1`] = `
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="bottom"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -389,6 +402,7 @@ exports[`renders components/drawer/demo/placement.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           bottom
@@ -401,6 +415,7 @@ exports[`renders components/drawer/demo/placement.tsx correctly 1`] = `
           class="ant-radio ant-wave-target ant-radio-checked"
         >
           <input
+            aria-label="left"
             checked=""
             class="ant-radio-input"
             name="test-id"
@@ -409,6 +424,7 @@ exports[`renders components/drawer/demo/placement.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           left
@@ -532,6 +548,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="top"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -539,6 +556,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             top
@@ -551,6 +569,7 @@ Array [
             class="ant-radio ant-wave-target ant-radio-checked"
           >
             <input
+              aria-label="right"
               checked=""
               class="ant-radio-input"
               name="test-id"
@@ -559,6 +578,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             right
@@ -571,6 +591,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="bottom"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -578,6 +599,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             bottom
@@ -590,6 +612,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="left"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -597,6 +620,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             left
@@ -770,6 +794,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="Large Size (736px)"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -777,6 +802,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             Large Size (736px)
@@ -789,6 +815,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="Default Size (378px)"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -796,6 +823,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             Default Size (378px)
@@ -808,6 +836,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="256"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -815,6 +844,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             256
@@ -827,6 +857,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="500px"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -834,6 +865,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             500px
@@ -846,6 +878,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="50%"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -853,6 +886,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             50%
@@ -865,6 +899,7 @@ Array [
             class="ant-radio ant-wave-target"
           >
             <input
+              aria-label="20vw"
               class="ant-radio-input"
               name="test-id"
               type="radio"
@@ -872,6 +907,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-label"
           >
             20vw

--- a/components/flex/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/flex/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -228,6 +228,7 @@ exports[`renders components/flex/demo/basic.tsx extend context correctly 1`] = `
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="horizontal"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -236,6 +237,7 @@ exports[`renders components/flex/demo/basic.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         horizontal
@@ -248,6 +250,7 @@ exports[`renders components/flex/demo/basic.tsx extend context correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="vertical"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -255,6 +258,7 @@ exports[`renders components/flex/demo/basic.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         vertical
@@ -383,6 +387,7 @@ exports[`renders components/flex/demo/gap.tsx extend context correctly 1`] = `
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="small"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -391,6 +396,7 @@ exports[`renders components/flex/demo/gap.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         small
@@ -403,6 +409,7 @@ exports[`renders components/flex/demo/gap.tsx extend context correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="medium"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -410,6 +417,7 @@ exports[`renders components/flex/demo/gap.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         medium
@@ -422,6 +430,7 @@ exports[`renders components/flex/demo/gap.tsx extend context correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="large"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -429,6 +438,7 @@ exports[`renders components/flex/demo/gap.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         large
@@ -441,6 +451,7 @@ exports[`renders components/flex/demo/gap.tsx extend context correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="customize"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -448,6 +459,7 @@ exports[`renders components/flex/demo/gap.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         customize

--- a/components/flex/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/flex/__tests__/__snapshots__/demo.test.ts.snap
@@ -226,6 +226,7 @@ exports[`renders components/flex/demo/basic.tsx correctly 1`] = `
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="horizontal"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -234,6 +235,7 @@ exports[`renders components/flex/demo/basic.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         horizontal
@@ -246,6 +248,7 @@ exports[`renders components/flex/demo/basic.tsx correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="vertical"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -253,6 +256,7 @@ exports[`renders components/flex/demo/basic.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         vertical
@@ -375,6 +379,7 @@ exports[`renders components/flex/demo/gap.tsx correctly 1`] = `
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="small"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -383,6 +388,7 @@ exports[`renders components/flex/demo/gap.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         small
@@ -395,6 +401,7 @@ exports[`renders components/flex/demo/gap.tsx correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="medium"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -402,6 +409,7 @@ exports[`renders components/flex/demo/gap.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         medium
@@ -414,6 +422,7 @@ exports[`renders components/flex/demo/gap.tsx correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="large"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -421,6 +430,7 @@ exports[`renders components/flex/demo/gap.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         large
@@ -433,6 +443,7 @@ exports[`renders components/flex/demo/gap.tsx correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="customize"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -440,6 +451,7 @@ exports[`renders components/flex/demo/gap.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         customize

--- a/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/form/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2444,6 +2444,7 @@ Array [
                     class="ant-radio ant-wave-target ant-radio-disabled"
                   >
                     <input
+                      aria-label=" Apple "
                       class="ant-radio-input"
                       disabled=""
                       name="test-id"
@@ -2452,6 +2453,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-label"
                   >
                      Apple 
@@ -2464,6 +2466,7 @@ Array [
                     class="ant-radio ant-wave-target ant-radio-disabled"
                   >
                     <input
+                      aria-label=" Pear "
                       class="ant-radio-input"
                       disabled=""
                       name="test-id"
@@ -2472,6 +2475,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-label"
                   >
                      Pear 
@@ -9978,6 +9982,7 @@ exports[`renders components/form/demo/layout.tsx extend context correctly 1`] = 
                   class="ant-radio-button ant-radio-button-checked"
                 >
                   <input
+                    aria-label="Horizontal"
                     checked=""
                     class="ant-radio-button-input"
                     name="layout"
@@ -9986,6 +9991,7 @@ exports[`renders components/form/demo/layout.tsx extend context correctly 1`] = 
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Horizontal
@@ -9998,6 +10004,7 @@ exports[`renders components/form/demo/layout.tsx extend context correctly 1`] = 
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="Vertical"
                     class="ant-radio-button-input"
                     name="layout"
                     type="radio"
@@ -10005,6 +10012,7 @@ exports[`renders components/form/demo/layout.tsx extend context correctly 1`] = 
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Vertical
@@ -10017,6 +10025,7 @@ exports[`renders components/form/demo/layout.tsx extend context correctly 1`] = 
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="Inline"
                     class="ant-radio-button-input"
                     name="layout"
                     type="radio"
@@ -10024,6 +10033,7 @@ exports[`renders components/form/demo/layout.tsx extend context correctly 1`] = 
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Inline
@@ -12562,6 +12572,7 @@ exports[`renders components/form/demo/required-mark.tsx extend context correctly
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="Default"
                     class="ant-radio-button-input"
                     name="requiredMarkValue"
                     type="radio"
@@ -12569,6 +12580,7 @@ exports[`renders components/form/demo/required-mark.tsx extend context correctly
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Default
@@ -12581,6 +12593,7 @@ exports[`renders components/form/demo/required-mark.tsx extend context correctly
                   class="ant-radio-button ant-radio-button-checked"
                 >
                   <input
+                    aria-label="Optional"
                     checked=""
                     class="ant-radio-button-input"
                     name="requiredMarkValue"
@@ -12589,6 +12602,7 @@ exports[`renders components/form/demo/required-mark.tsx extend context correctly
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Optional
@@ -12601,6 +12615,7 @@ exports[`renders components/form/demo/required-mark.tsx extend context correctly
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="Hidden"
                     class="ant-radio-button-input"
                     name="requiredMarkValue"
                     type="radio"
@@ -12608,6 +12623,7 @@ exports[`renders components/form/demo/required-mark.tsx extend context correctly
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Hidden
@@ -12620,6 +12636,7 @@ exports[`renders components/form/demo/required-mark.tsx extend context correctly
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="Customize"
                     class="ant-radio-button-input"
                     name="requiredMarkValue"
                     type="radio"
@@ -12627,6 +12644,7 @@ exports[`renders components/form/demo/required-mark.tsx extend context correctly
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Customize
@@ -12887,6 +12905,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="Small"
                     class="ant-radio-button-input"
                     name="size"
                     type="radio"
@@ -12894,6 +12913,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Small
@@ -12906,6 +12926,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
                   class="ant-radio-button ant-radio-button-checked"
                 >
                   <input
+                    aria-label="Medium"
                     checked=""
                     class="ant-radio-button-input"
                     name="size"
@@ -12914,6 +12935,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Medium
@@ -12926,6 +12948,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="Large"
                     class="ant-radio-button-input"
                     name="size"
                     type="radio"
@@ -12933,6 +12956,7 @@ exports[`renders components/form/demo/size.tsx extend context correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Large
@@ -23623,6 +23647,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                   class="ant-radio ant-wave-target"
                 >
                   <input
+                    aria-label="item 1"
                     class="ant-radio-input"
                     name="radio-group"
                     type="radio"
@@ -23630,6 +23655,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-label"
                 >
                   item 1
@@ -23642,6 +23668,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                   class="ant-radio ant-wave-target"
                 >
                   <input
+                    aria-label="item 2"
                     class="ant-radio-input"
                     name="radio-group"
                     type="radio"
@@ -23649,6 +23676,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-label"
                 >
                   item 2
@@ -23661,6 +23689,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                   class="ant-radio ant-wave-target"
                 >
                   <input
+                    aria-label="item 3"
                     class="ant-radio-input"
                     name="radio-group"
                     type="radio"
@@ -23668,6 +23697,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-label"
                 >
                   item 3
@@ -23718,6 +23748,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="item 1"
                     class="ant-radio-button-input"
                     name="radio-button"
                     type="radio"
@@ -23725,6 +23756,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   item 1
@@ -23737,6 +23769,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="item 2"
                     class="ant-radio-button-input"
                     name="radio-button"
                     type="radio"
@@ -23744,6 +23777,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   item 2
@@ -23756,6 +23790,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="item 3"
                     class="ant-radio-button-input"
                     name="radio-button"
                     type="radio"
@@ -23763,6 +23798,7 @@ exports[`renders components/form/demo/validate-other.tsx extend context correctl
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   item 3

--- a/components/form/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1857,6 +1857,7 @@ Array [
                     class="ant-radio ant-wave-target ant-radio-disabled"
                   >
                     <input
+                      aria-label=" Apple "
                       class="ant-radio-input"
                       disabled=""
                       name="test-id"
@@ -1865,6 +1866,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-label"
                   >
                      Apple 
@@ -1877,6 +1879,7 @@ Array [
                     class="ant-radio ant-wave-target ant-radio-disabled"
                   >
                     <input
+                      aria-label=" Pear "
                       class="ant-radio-input"
                       disabled=""
                       name="test-id"
@@ -1885,6 +1888,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-label"
                   >
                      Pear 
@@ -6290,6 +6294,7 @@ exports[`renders components/form/demo/layout.tsx correctly 1`] = `
                   class="ant-radio-button ant-radio-button-checked"
                 >
                   <input
+                    aria-label="Horizontal"
                     checked=""
                     class="ant-radio-button-input"
                     name="layout"
@@ -6298,6 +6303,7 @@ exports[`renders components/form/demo/layout.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Horizontal
@@ -6310,6 +6316,7 @@ exports[`renders components/form/demo/layout.tsx correctly 1`] = `
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="Vertical"
                     class="ant-radio-button-input"
                     name="layout"
                     type="radio"
@@ -6317,6 +6324,7 @@ exports[`renders components/form/demo/layout.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Vertical
@@ -6329,6 +6337,7 @@ exports[`renders components/form/demo/layout.tsx correctly 1`] = `
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="Inline"
                     class="ant-radio-button-input"
                     name="layout"
                     type="radio"
@@ -6336,6 +6345,7 @@ exports[`renders components/form/demo/layout.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Inline
@@ -8419,6 +8429,7 @@ exports[`renders components/form/demo/required-mark.tsx correctly 1`] = `
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="Default"
                     class="ant-radio-button-input"
                     name="requiredMarkValue"
                     type="radio"
@@ -8426,6 +8437,7 @@ exports[`renders components/form/demo/required-mark.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Default
@@ -8438,6 +8450,7 @@ exports[`renders components/form/demo/required-mark.tsx correctly 1`] = `
                   class="ant-radio-button ant-radio-button-checked"
                 >
                   <input
+                    aria-label="Optional"
                     checked=""
                     class="ant-radio-button-input"
                     name="requiredMarkValue"
@@ -8446,6 +8459,7 @@ exports[`renders components/form/demo/required-mark.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Optional
@@ -8458,6 +8472,7 @@ exports[`renders components/form/demo/required-mark.tsx correctly 1`] = `
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="Hidden"
                     class="ant-radio-button-input"
                     name="requiredMarkValue"
                     type="radio"
@@ -8465,6 +8480,7 @@ exports[`renders components/form/demo/required-mark.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Hidden
@@ -8477,6 +8493,7 @@ exports[`renders components/form/demo/required-mark.tsx correctly 1`] = `
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="Customize"
                     class="ant-radio-button-input"
                     name="requiredMarkValue"
                     type="radio"
@@ -8484,6 +8501,7 @@ exports[`renders components/form/demo/required-mark.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Customize
@@ -8700,6 +8718,7 @@ exports[`renders components/form/demo/size.tsx correctly 1`] = `
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="Small"
                     class="ant-radio-button-input"
                     name="size"
                     type="radio"
@@ -8707,6 +8726,7 @@ exports[`renders components/form/demo/size.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Small
@@ -8719,6 +8739,7 @@ exports[`renders components/form/demo/size.tsx correctly 1`] = `
                   class="ant-radio-button ant-radio-button-checked"
                 >
                   <input
+                    aria-label="Medium"
                     checked=""
                     class="ant-radio-button-input"
                     name="size"
@@ -8727,6 +8748,7 @@ exports[`renders components/form/demo/size.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Medium
@@ -8739,6 +8761,7 @@ exports[`renders components/form/demo/size.tsx correctly 1`] = `
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="Large"
                     class="ant-radio-button-input"
                     name="size"
                     type="radio"
@@ -8746,6 +8769,7 @@ exports[`renders components/form/demo/size.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   Large
@@ -10946,6 +10970,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                   class="ant-radio ant-wave-target"
                 >
                   <input
+                    aria-label="item 1"
                     class="ant-radio-input"
                     name="radio-group"
                     type="radio"
@@ -10953,6 +10978,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-label"
                 >
                   item 1
@@ -10965,6 +10991,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                   class="ant-radio ant-wave-target"
                 >
                   <input
+                    aria-label="item 2"
                     class="ant-radio-input"
                     name="radio-group"
                     type="radio"
@@ -10972,6 +10999,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-label"
                 >
                   item 2
@@ -10984,6 +11012,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                   class="ant-radio ant-wave-target"
                 >
                   <input
+                    aria-label="item 3"
                     class="ant-radio-input"
                     name="radio-group"
                     type="radio"
@@ -10991,6 +11020,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-label"
                 >
                   item 3
@@ -11041,6 +11071,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="item 1"
                     class="ant-radio-button-input"
                     name="radio-button"
                     type="radio"
@@ -11048,6 +11079,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   item 1
@@ -11060,6 +11092,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="item 2"
                     class="ant-radio-button-input"
                     name="radio-button"
                     type="radio"
@@ -11067,6 +11100,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   item 2
@@ -11079,6 +11113,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                   class="ant-radio-button"
                 >
                   <input
+                    aria-label="item 3"
                     class="ant-radio-button-input"
                     name="radio-button"
                     type="radio"
@@ -11086,6 +11121,7 @@ exports[`renders components/form/demo/validate-other.tsx correctly 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-button-label"
                 >
                   item 3

--- a/components/form/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/form/__tests__/__snapshots__/index.test.tsx.snap
@@ -187,6 +187,7 @@ exports[`Form form should support disabled 1`] = `
                   class="ant-radio ant-wave-target ant-radio-disabled"
                 >
                   <input
+                    aria-label="Apple"
                     class="ant-radio-input"
                     disabled=""
                     name="test-id"
@@ -195,6 +196,7 @@ exports[`Form form should support disabled 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-label"
                 >
                   Apple
@@ -207,6 +209,7 @@ exports[`Form form should support disabled 1`] = `
                   class="ant-radio ant-wave-target ant-radio-disabled"
                 >
                   <input
+                    aria-label="Pear"
                     class="ant-radio-input"
                     disabled=""
                     name="test-id"
@@ -215,6 +218,7 @@ exports[`Form form should support disabled 1`] = `
                   />
                 </span>
                 <span
+                  aria-hidden="true"
                   class="ant-radio-label"
                 >
                   Pear

--- a/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5174,6 +5174,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -5182,6 +5183,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -5194,6 +5196,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -5201,6 +5204,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai

--- a/components/input/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input/__tests__/__snapshots__/demo.test.tsx.snap
@@ -1024,6 +1024,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1032,6 +1033,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -1044,6 +1046,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1051,6 +1054,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai

--- a/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -3046,6 +3046,7 @@ Array [
                 class="ant-radio-button"
               >
                 <input
+                  aria-label="top"
                   class="ant-radio-button-input"
                   name="test-id"
                   type="radio"
@@ -3053,6 +3054,7 @@ Array [
                 />
               </span>
               <span
+                aria-hidden="true"
                 class="ant-radio-button-label"
               >
                 top
@@ -3065,6 +3067,7 @@ Array [
                 class="ant-radio-button ant-radio-button-checked"
               >
                 <input
+                  aria-label="bottom"
                   checked=""
                   class="ant-radio-button-input"
                   name="test-id"
@@ -3073,6 +3076,7 @@ Array [
                 />
               </span>
               <span
+                aria-hidden="true"
                 class="ant-radio-button-label"
               >
                 bottom
@@ -3085,6 +3089,7 @@ Array [
                 class="ant-radio-button"
               >
                 <input
+                  aria-label="both"
                   class="ant-radio-button-input"
                   name="test-id"
                   type="radio"
@@ -3092,6 +3097,7 @@ Array [
                 />
               </span>
               <span
+                aria-hidden="true"
                 class="ant-radio-button-label"
               >
                 both
@@ -3128,6 +3134,7 @@ Array [
                 class="ant-radio-button"
               >
                 <input
+                  aria-label="start"
                   class="ant-radio-button-input"
                   name="test-id"
                   type="radio"
@@ -3135,6 +3142,7 @@ Array [
                 />
               </span>
               <span
+                aria-hidden="true"
                 class="ant-radio-button-label"
               >
                 start
@@ -3147,6 +3155,7 @@ Array [
                 class="ant-radio-button ant-radio-button-checked"
               >
                 <input
+                  aria-label="center"
                   checked=""
                   class="ant-radio-button-input"
                   name="test-id"
@@ -3155,6 +3164,7 @@ Array [
                 />
               </span>
               <span
+                aria-hidden="true"
                 class="ant-radio-button-label"
               >
                 center
@@ -3167,6 +3177,7 @@ Array [
                 class="ant-radio-button"
               >
                 <input
+                  aria-label="end"
                   class="ant-radio-button-input"
                   name="test-id"
                   type="radio"
@@ -3174,6 +3185,7 @@ Array [
                 />
               </span>
               <span
+                aria-hidden="true"
                 class="ant-radio-button-label"
               >
                 end

--- a/components/list/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.ts.snap
@@ -2972,6 +2972,7 @@ Array [
                 class="ant-radio-button"
               >
                 <input
+                  aria-label="top"
                   class="ant-radio-button-input"
                   name="test-id"
                   type="radio"
@@ -2979,6 +2980,7 @@ Array [
                 />
               </span>
               <span
+                aria-hidden="true"
                 class="ant-radio-button-label"
               >
                 top
@@ -2991,6 +2993,7 @@ Array [
                 class="ant-radio-button ant-radio-button-checked"
               >
                 <input
+                  aria-label="bottom"
                   checked=""
                   class="ant-radio-button-input"
                   name="test-id"
@@ -2999,6 +3002,7 @@ Array [
                 />
               </span>
               <span
+                aria-hidden="true"
                 class="ant-radio-button-label"
               >
                 bottom
@@ -3011,6 +3015,7 @@ Array [
                 class="ant-radio-button"
               >
                 <input
+                  aria-label="both"
                   class="ant-radio-button-input"
                   name="test-id"
                   type="radio"
@@ -3018,6 +3023,7 @@ Array [
                 />
               </span>
               <span
+                aria-hidden="true"
                 class="ant-radio-button-label"
               >
                 both
@@ -3054,6 +3060,7 @@ Array [
                 class="ant-radio-button"
               >
                 <input
+                  aria-label="start"
                   class="ant-radio-button-input"
                   name="test-id"
                   type="radio"
@@ -3061,6 +3068,7 @@ Array [
                 />
               </span>
               <span
+                aria-hidden="true"
                 class="ant-radio-button-label"
               >
                 start
@@ -3073,6 +3081,7 @@ Array [
                 class="ant-radio-button ant-radio-button-checked"
               >
                 <input
+                  aria-label="center"
                   checked=""
                   class="ant-radio-button-input"
                   name="test-id"
@@ -3081,6 +3090,7 @@ Array [
                 />
               </span>
               <span
+                aria-hidden="true"
                 class="ant-radio-button-label"
               >
                 center
@@ -3093,6 +3103,7 @@ Array [
                 class="ant-radio-button"
               >
                 <input
+                  aria-label="end"
                   class="ant-radio-button-input"
                   name="test-id"
                   type="radio"
@@ -3100,6 +3111,7 @@ Array [
                 />
               </span>
               <span
+                aria-hidden="true"
                 class="ant-radio-button-label"
               >
                 end

--- a/components/locale/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/index.test.tsx.snap
@@ -6128,6 +6128,7 @@ exports[`Locale Provider should display the text as ar 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="الشهر"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -6136,6 +6137,7 @@ exports[`Locale Provider should display the text as ar 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             الشهر
@@ -6148,6 +6150,7 @@ exports[`Locale Provider should display the text as ar 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="السنة"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -6155,6 +6158,7 @@ exports[`Locale Provider should display the text as ar 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             السنة
@@ -11363,6 +11367,7 @@ exports[`Locale Provider should display the text as az 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Ay"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -11371,6 +11376,7 @@ exports[`Locale Provider should display the text as az 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Ay
@@ -11383,6 +11389,7 @@ exports[`Locale Provider should display the text as az 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="İl"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -11390,6 +11397,7 @@ exports[`Locale Provider should display the text as az 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             İl
@@ -16598,6 +16606,7 @@ exports[`Locale Provider should display the text as bg 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Месец"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -16606,6 +16615,7 @@ exports[`Locale Provider should display the text as bg 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Месец
@@ -16618,6 +16628,7 @@ exports[`Locale Provider should display the text as bg 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Година"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -16625,6 +16636,7 @@ exports[`Locale Provider should display the text as bg 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Година
@@ -21833,6 +21845,7 @@ exports[`Locale Provider should display the text as bn-bd 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="মাস"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -21841,6 +21854,7 @@ exports[`Locale Provider should display the text as bn-bd 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             মাস
@@ -21853,6 +21867,7 @@ exports[`Locale Provider should display the text as bn-bd 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="বছর"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -21860,6 +21875,7 @@ exports[`Locale Provider should display the text as bn-bd 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             বছর
@@ -27068,6 +27084,7 @@ exports[`Locale Provider should display the text as by 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Месяц"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -27076,6 +27093,7 @@ exports[`Locale Provider should display the text as by 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Месяц
@@ -27088,6 +27106,7 @@ exports[`Locale Provider should display the text as by 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Год"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -27095,6 +27114,7 @@ exports[`Locale Provider should display the text as by 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Год
@@ -32303,6 +32323,7 @@ exports[`Locale Provider should display the text as ca 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mes"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -32311,6 +32332,7 @@ exports[`Locale Provider should display the text as ca 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mes
@@ -32323,6 +32345,7 @@ exports[`Locale Provider should display the text as ca 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Any"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -32330,6 +32353,7 @@ exports[`Locale Provider should display the text as ca 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Any
@@ -37538,6 +37562,7 @@ exports[`Locale Provider should display the text as cs 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Měsíc"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -37546,6 +37571,7 @@ exports[`Locale Provider should display the text as cs 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Měsíc
@@ -37558,6 +37584,7 @@ exports[`Locale Provider should display the text as cs 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Rok"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -37565,6 +37592,7 @@ exports[`Locale Provider should display the text as cs 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Rok
@@ -42773,6 +42801,7 @@ exports[`Locale Provider should display the text as da 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Måned"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -42781,6 +42810,7 @@ exports[`Locale Provider should display the text as da 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Måned
@@ -42793,6 +42823,7 @@ exports[`Locale Provider should display the text as da 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="År"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -42800,6 +42831,7 @@ exports[`Locale Provider should display the text as da 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             År
@@ -48008,6 +48040,7 @@ exports[`Locale Provider should display the text as de 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Monat"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -48016,6 +48049,7 @@ exports[`Locale Provider should display the text as de 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Monat
@@ -48028,6 +48062,7 @@ exports[`Locale Provider should display the text as de 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Jahr"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -48035,6 +48070,7 @@ exports[`Locale Provider should display the text as de 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Jahr
@@ -53243,6 +53279,7 @@ exports[`Locale Provider should display the text as el 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Μήνας"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -53251,6 +53288,7 @@ exports[`Locale Provider should display the text as el 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Μήνας
@@ -53263,6 +53301,7 @@ exports[`Locale Provider should display the text as el 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Έτος"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -53270,6 +53309,7 @@ exports[`Locale Provider should display the text as el 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Έτος
@@ -58478,6 +58518,7 @@ exports[`Locale Provider should display the text as en 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -58486,6 +58527,7 @@ exports[`Locale Provider should display the text as en 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -58498,6 +58540,7 @@ exports[`Locale Provider should display the text as en 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -58505,6 +58548,7 @@ exports[`Locale Provider should display the text as en 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -63713,6 +63757,7 @@ exports[`Locale Provider should display the text as en-gb 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -63721,6 +63766,7 @@ exports[`Locale Provider should display the text as en-gb 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -63733,6 +63779,7 @@ exports[`Locale Provider should display the text as en-gb 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -63740,6 +63787,7 @@ exports[`Locale Provider should display the text as en-gb 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -68948,6 +68996,7 @@ exports[`Locale Provider should display the text as es 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mes"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -68956,6 +69005,7 @@ exports[`Locale Provider should display the text as es 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mes
@@ -68968,6 +69018,7 @@ exports[`Locale Provider should display the text as es 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Año"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -68975,6 +69026,7 @@ exports[`Locale Provider should display the text as es 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Año
@@ -74183,6 +74235,7 @@ exports[`Locale Provider should display the text as es-us 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mes"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -74191,6 +74244,7 @@ exports[`Locale Provider should display the text as es-us 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mes
@@ -74203,6 +74257,7 @@ exports[`Locale Provider should display the text as es-us 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Año"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -74210,6 +74265,7 @@ exports[`Locale Provider should display the text as es-us 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Año
@@ -79418,6 +79474,7 @@ exports[`Locale Provider should display the text as et 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Kuu"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -79426,6 +79483,7 @@ exports[`Locale Provider should display the text as et 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Kuu
@@ -79438,6 +79496,7 @@ exports[`Locale Provider should display the text as et 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Aasta"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -79445,6 +79504,7 @@ exports[`Locale Provider should display the text as et 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Aasta
@@ -84653,6 +84713,7 @@ exports[`Locale Provider should display the text as eu 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Hilabete"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -84661,6 +84722,7 @@ exports[`Locale Provider should display the text as eu 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Hilabete
@@ -84673,6 +84735,7 @@ exports[`Locale Provider should display the text as eu 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Urte"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -84680,6 +84743,7 @@ exports[`Locale Provider should display the text as eu 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Urte
@@ -89888,6 +89952,7 @@ exports[`Locale Provider should display the text as fa 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="ماه"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -89896,6 +89961,7 @@ exports[`Locale Provider should display the text as fa 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             ماه
@@ -89908,6 +89974,7 @@ exports[`Locale Provider should display the text as fa 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="سال"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -89915,6 +89982,7 @@ exports[`Locale Provider should display the text as fa 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             سال
@@ -95123,6 +95191,7 @@ exports[`Locale Provider should display the text as fi 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Kuukausi"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -95131,6 +95200,7 @@ exports[`Locale Provider should display the text as fi 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Kuukausi
@@ -95143,6 +95213,7 @@ exports[`Locale Provider should display the text as fi 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Vuosi"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -95150,6 +95221,7 @@ exports[`Locale Provider should display the text as fi 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Vuosi
@@ -100358,6 +100430,7 @@ exports[`Locale Provider should display the text as fr 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mois"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -100366,6 +100439,7 @@ exports[`Locale Provider should display the text as fr 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mois
@@ -100378,6 +100452,7 @@ exports[`Locale Provider should display the text as fr 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Année"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -100385,6 +100460,7 @@ exports[`Locale Provider should display the text as fr 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Année
@@ -105593,6 +105669,7 @@ exports[`Locale Provider should display the text as fr 2`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mois"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -105601,6 +105678,7 @@ exports[`Locale Provider should display the text as fr 2`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mois
@@ -105613,6 +105691,7 @@ exports[`Locale Provider should display the text as fr 2`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Année"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -105620,6 +105699,7 @@ exports[`Locale Provider should display the text as fr 2`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Année
@@ -110828,6 +110908,7 @@ exports[`Locale Provider should display the text as fr 3`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mois"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -110836,6 +110917,7 @@ exports[`Locale Provider should display the text as fr 3`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mois
@@ -110848,6 +110930,7 @@ exports[`Locale Provider should display the text as fr 3`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Année"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -110855,6 +110938,7 @@ exports[`Locale Provider should display the text as fr 3`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Année
@@ -116063,6 +116147,7 @@ exports[`Locale Provider should display the text as ga 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="mhí"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -116071,6 +116156,7 @@ exports[`Locale Provider should display the text as ga 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             mhí
@@ -116083,6 +116169,7 @@ exports[`Locale Provider should display the text as ga 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="bhliain"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -116090,6 +116177,7 @@ exports[`Locale Provider should display the text as ga 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             bhliain
@@ -121298,6 +121386,7 @@ exports[`Locale Provider should display the text as gl 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mes"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -121306,6 +121395,7 @@ exports[`Locale Provider should display the text as gl 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mes
@@ -121318,6 +121408,7 @@ exports[`Locale Provider should display the text as gl 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Ano"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -121325,6 +121416,7 @@ exports[`Locale Provider should display the text as gl 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Ano
@@ -126533,6 +126625,7 @@ exports[`Locale Provider should display the text as he 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="חודש"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -126541,6 +126634,7 @@ exports[`Locale Provider should display the text as he 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             חודש
@@ -126553,6 +126647,7 @@ exports[`Locale Provider should display the text as he 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="שנה"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -126560,6 +126655,7 @@ exports[`Locale Provider should display the text as he 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             שנה
@@ -131768,6 +131864,7 @@ exports[`Locale Provider should display the text as hi 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="महीना"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -131776,6 +131873,7 @@ exports[`Locale Provider should display the text as hi 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             महीना
@@ -131788,6 +131886,7 @@ exports[`Locale Provider should display the text as hi 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="साल"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -131795,6 +131894,7 @@ exports[`Locale Provider should display the text as hi 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             साल
@@ -137003,6 +137103,7 @@ exports[`Locale Provider should display the text as hr 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mjesec"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -137011,6 +137112,7 @@ exports[`Locale Provider should display the text as hr 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mjesec
@@ -137023,6 +137125,7 @@ exports[`Locale Provider should display the text as hr 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Godina"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -137030,6 +137133,7 @@ exports[`Locale Provider should display the text as hr 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Godina
@@ -142238,6 +142342,7 @@ exports[`Locale Provider should display the text as hu 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Hónap"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -142246,6 +142351,7 @@ exports[`Locale Provider should display the text as hu 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Hónap
@@ -142258,6 +142364,7 @@ exports[`Locale Provider should display the text as hu 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Év"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -142265,6 +142372,7 @@ exports[`Locale Provider should display the text as hu 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Év
@@ -147473,6 +147581,7 @@ exports[`Locale Provider should display the text as hy-am 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Ամիս"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -147481,6 +147590,7 @@ exports[`Locale Provider should display the text as hy-am 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Ամիս
@@ -147493,6 +147603,7 @@ exports[`Locale Provider should display the text as hy-am 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Տարի"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -147500,6 +147611,7 @@ exports[`Locale Provider should display the text as hy-am 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Տարի
@@ -152708,6 +152820,7 @@ exports[`Locale Provider should display the text as id 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Bulan"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -152716,6 +152829,7 @@ exports[`Locale Provider should display the text as id 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Bulan
@@ -152728,6 +152842,7 @@ exports[`Locale Provider should display the text as id 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Tahun"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -152735,6 +152850,7 @@ exports[`Locale Provider should display the text as id 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Tahun
@@ -157943,6 +158059,7 @@ exports[`Locale Provider should display the text as is 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mánuður"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -157951,6 +158068,7 @@ exports[`Locale Provider should display the text as is 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mánuður
@@ -157963,6 +158081,7 @@ exports[`Locale Provider should display the text as is 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Ár"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -157970,6 +158089,7 @@ exports[`Locale Provider should display the text as is 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Ár
@@ -163178,6 +163298,7 @@ exports[`Locale Provider should display the text as it 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mese"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -163186,6 +163307,7 @@ exports[`Locale Provider should display the text as it 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mese
@@ -163198,6 +163320,7 @@ exports[`Locale Provider should display the text as it 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Anno"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -163205,6 +163328,7 @@ exports[`Locale Provider should display the text as it 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Anno
@@ -168413,6 +168537,7 @@ exports[`Locale Provider should display the text as ja 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="月"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -168421,6 +168546,7 @@ exports[`Locale Provider should display the text as ja 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             月
@@ -168433,6 +168559,7 @@ exports[`Locale Provider should display the text as ja 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="年"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -168440,6 +168567,7 @@ exports[`Locale Provider should display the text as ja 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             年
@@ -173648,6 +173776,7 @@ exports[`Locale Provider should display the text as ka 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="თვე"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -173656,6 +173785,7 @@ exports[`Locale Provider should display the text as ka 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             თვე
@@ -173668,6 +173798,7 @@ exports[`Locale Provider should display the text as ka 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="წელი"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -173675,6 +173806,7 @@ exports[`Locale Provider should display the text as ka 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             წელი
@@ -178883,6 +179015,7 @@ exports[`Locale Provider should display the text as kk 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Ай"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -178891,6 +179024,7 @@ exports[`Locale Provider should display the text as kk 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Ай
@@ -178903,6 +179037,7 @@ exports[`Locale Provider should display the text as kk 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Жыл"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -178910,6 +179045,7 @@ exports[`Locale Provider should display the text as kk 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Жыл
@@ -184116,6 +184252,7 @@ exports[`Locale Provider should display the text as km 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="ខែ"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -184124,6 +184261,7 @@ exports[`Locale Provider should display the text as km 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             ខែ
@@ -184136,6 +184274,7 @@ exports[`Locale Provider should display the text as km 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="ឆ្នាំ"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -184143,6 +184282,7 @@ exports[`Locale Provider should display the text as km 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             ឆ្នាំ
@@ -189351,6 +189491,7 @@ exports[`Locale Provider should display the text as kn 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="ತಿಂಗಳು"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -189359,6 +189500,7 @@ exports[`Locale Provider should display the text as kn 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             ತಿಂಗಳು
@@ -189371,6 +189513,7 @@ exports[`Locale Provider should display the text as kn 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="ವರ್ಷ"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -189378,6 +189521,7 @@ exports[`Locale Provider should display the text as kn 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             ವರ್ಷ
@@ -194586,6 +194730,7 @@ exports[`Locale Provider should display the text as ko 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="월"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -194594,6 +194739,7 @@ exports[`Locale Provider should display the text as ko 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             월
@@ -194606,6 +194752,7 @@ exports[`Locale Provider should display the text as ko 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="년"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -194613,6 +194760,7 @@ exports[`Locale Provider should display the text as ko 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             년
@@ -199821,6 +199969,7 @@ exports[`Locale Provider should display the text as ku 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Meh"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -199829,6 +199978,7 @@ exports[`Locale Provider should display the text as ku 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Meh
@@ -199841,6 +199991,7 @@ exports[`Locale Provider should display the text as ku 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Sal"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -199848,6 +199999,7 @@ exports[`Locale Provider should display the text as ku 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Sal
@@ -205056,6 +205208,7 @@ exports[`Locale Provider should display the text as ku-iq 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Meh"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -205064,6 +205217,7 @@ exports[`Locale Provider should display the text as ku-iq 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Meh
@@ -205076,6 +205230,7 @@ exports[`Locale Provider should display the text as ku-iq 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Sal"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -205083,6 +205238,7 @@ exports[`Locale Provider should display the text as ku-iq 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Sal
@@ -210291,6 +210447,7 @@ exports[`Locale Provider should display the text as lt 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mėnesis"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -210299,6 +210456,7 @@ exports[`Locale Provider should display the text as lt 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mėnesis
@@ -210311,6 +210469,7 @@ exports[`Locale Provider should display the text as lt 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Metai"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -210318,6 +210477,7 @@ exports[`Locale Provider should display the text as lt 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Metai
@@ -215526,6 +215686,7 @@ exports[`Locale Provider should display the text as lv 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mēnesis"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -215534,6 +215695,7 @@ exports[`Locale Provider should display the text as lv 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mēnesis
@@ -215546,6 +215708,7 @@ exports[`Locale Provider should display the text as lv 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Gads"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -215553,6 +215716,7 @@ exports[`Locale Provider should display the text as lv 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Gads
@@ -220761,6 +220925,7 @@ exports[`Locale Provider should display the text as mk 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Месец"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -220769,6 +220934,7 @@ exports[`Locale Provider should display the text as mk 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Месец
@@ -220781,6 +220947,7 @@ exports[`Locale Provider should display the text as mk 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Година"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -220788,6 +220955,7 @@ exports[`Locale Provider should display the text as mk 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Година
@@ -225996,6 +226164,7 @@ exports[`Locale Provider should display the text as ml 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="മാസം"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -226004,6 +226173,7 @@ exports[`Locale Provider should display the text as ml 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             മാസം
@@ -226016,6 +226186,7 @@ exports[`Locale Provider should display the text as ml 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="വർഷം"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -226023,6 +226194,7 @@ exports[`Locale Provider should display the text as ml 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             വർഷം
@@ -231231,6 +231403,7 @@ exports[`Locale Provider should display the text as mn-mn 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Сар"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -231239,6 +231412,7 @@ exports[`Locale Provider should display the text as mn-mn 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Сар
@@ -231251,6 +231425,7 @@ exports[`Locale Provider should display the text as mn-mn 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Жил"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -231258,6 +231433,7 @@ exports[`Locale Provider should display the text as mn-mn 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Жил
@@ -236466,6 +236642,7 @@ exports[`Locale Provider should display the text as mr 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="महिना"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -236474,6 +236651,7 @@ exports[`Locale Provider should display the text as mr 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             महिना
@@ -236486,6 +236664,7 @@ exports[`Locale Provider should display the text as mr 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="वर्ष"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -236493,6 +236672,7 @@ exports[`Locale Provider should display the text as mr 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             वर्ष
@@ -241701,6 +241881,7 @@ exports[`Locale Provider should display the text as ms-my 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Bulan"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -241709,6 +241890,7 @@ exports[`Locale Provider should display the text as ms-my 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Bulan
@@ -241721,6 +241903,7 @@ exports[`Locale Provider should display the text as ms-my 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Tahun"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -241728,6 +241911,7 @@ exports[`Locale Provider should display the text as ms-my 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Tahun
@@ -246936,6 +247120,7 @@ exports[`Locale Provider should display the text as my 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="လ"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -246944,6 +247129,7 @@ exports[`Locale Provider should display the text as my 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             လ
@@ -246956,6 +247142,7 @@ exports[`Locale Provider should display the text as my 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="နှစ်"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -246963,6 +247150,7 @@ exports[`Locale Provider should display the text as my 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             နှစ်
@@ -252171,6 +252359,7 @@ exports[`Locale Provider should display the text as nb 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Måned"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -252179,6 +252368,7 @@ exports[`Locale Provider should display the text as nb 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Måned
@@ -252191,6 +252381,7 @@ exports[`Locale Provider should display the text as nb 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="År"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -252198,6 +252389,7 @@ exports[`Locale Provider should display the text as nb 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             År
@@ -257406,6 +257598,7 @@ exports[`Locale Provider should display the text as ne-np 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Month"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -257414,6 +257607,7 @@ exports[`Locale Provider should display the text as ne-np 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Month
@@ -257426,6 +257620,7 @@ exports[`Locale Provider should display the text as ne-np 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Year"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -257433,6 +257628,7 @@ exports[`Locale Provider should display the text as ne-np 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Year
@@ -262641,6 +262837,7 @@ exports[`Locale Provider should display the text as nl 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Maand"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -262649,6 +262846,7 @@ exports[`Locale Provider should display the text as nl 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Maand
@@ -262661,6 +262859,7 @@ exports[`Locale Provider should display the text as nl 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Jaar"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -262668,6 +262867,7 @@ exports[`Locale Provider should display the text as nl 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Jaar
@@ -267876,6 +268076,7 @@ exports[`Locale Provider should display the text as nl-be 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Maand"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -267884,6 +268085,7 @@ exports[`Locale Provider should display the text as nl-be 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Maand
@@ -267896,6 +268098,7 @@ exports[`Locale Provider should display the text as nl-be 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Jaar"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -267903,6 +268106,7 @@ exports[`Locale Provider should display the text as nl-be 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Jaar
@@ -273111,6 +273315,7 @@ exports[`Locale Provider should display the text as pl 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Miesiąc"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -273119,6 +273324,7 @@ exports[`Locale Provider should display the text as pl 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Miesiąc
@@ -273131,6 +273337,7 @@ exports[`Locale Provider should display the text as pl 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Rok"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -273138,6 +273345,7 @@ exports[`Locale Provider should display the text as pl 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Rok
@@ -278346,6 +278554,7 @@ exports[`Locale Provider should display the text as pt 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mês"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -278354,6 +278563,7 @@ exports[`Locale Provider should display the text as pt 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mês
@@ -278366,6 +278576,7 @@ exports[`Locale Provider should display the text as pt 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Ano"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -278373,6 +278584,7 @@ exports[`Locale Provider should display the text as pt 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Ano
@@ -283581,6 +283793,7 @@ exports[`Locale Provider should display the text as pt-br 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mês"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -283589,6 +283802,7 @@ exports[`Locale Provider should display the text as pt-br 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mês
@@ -283601,6 +283815,7 @@ exports[`Locale Provider should display the text as pt-br 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Ano"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -283608,6 +283823,7 @@ exports[`Locale Provider should display the text as pt-br 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Ano
@@ -288816,6 +289032,7 @@ exports[`Locale Provider should display the text as ro 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Lună"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -288824,6 +289041,7 @@ exports[`Locale Provider should display the text as ro 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Lună
@@ -288836,6 +289054,7 @@ exports[`Locale Provider should display the text as ro 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="An"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -288843,6 +289062,7 @@ exports[`Locale Provider should display the text as ro 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             An
@@ -294051,6 +294271,7 @@ exports[`Locale Provider should display the text as ru 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Месяц"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -294059,6 +294280,7 @@ exports[`Locale Provider should display the text as ru 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Месяц
@@ -294071,6 +294293,7 @@ exports[`Locale Provider should display the text as ru 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Год"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -294078,6 +294301,7 @@ exports[`Locale Provider should display the text as ru 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Год
@@ -299286,6 +299510,7 @@ exports[`Locale Provider should display the text as si 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="මාසය"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -299294,6 +299519,7 @@ exports[`Locale Provider should display the text as si 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             මාසය
@@ -299306,6 +299532,7 @@ exports[`Locale Provider should display the text as si 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="අවුරුද්ද"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -299313,6 +299540,7 @@ exports[`Locale Provider should display the text as si 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             අවුරුද්ද
@@ -304521,6 +304749,7 @@ exports[`Locale Provider should display the text as sk 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mesiac"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -304529,6 +304758,7 @@ exports[`Locale Provider should display the text as sk 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mesiac
@@ -304541,6 +304771,7 @@ exports[`Locale Provider should display the text as sk 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Rok"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -304548,6 +304779,7 @@ exports[`Locale Provider should display the text as sk 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Rok
@@ -309756,6 +309988,7 @@ exports[`Locale Provider should display the text as sl 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mesec"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -309764,6 +309997,7 @@ exports[`Locale Provider should display the text as sl 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mesec
@@ -309776,6 +310010,7 @@ exports[`Locale Provider should display the text as sl 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Leto"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -309783,6 +310018,7 @@ exports[`Locale Provider should display the text as sl 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Leto
@@ -314991,6 +315227,7 @@ exports[`Locale Provider should display the text as sq 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Muaj"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -314999,6 +315236,7 @@ exports[`Locale Provider should display the text as sq 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Muaj
@@ -315011,6 +315249,7 @@ exports[`Locale Provider should display the text as sq 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Vit"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -315018,6 +315257,7 @@ exports[`Locale Provider should display the text as sq 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Vit
@@ -320226,6 +320466,7 @@ exports[`Locale Provider should display the text as sr 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Mesec"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -320234,6 +320475,7 @@ exports[`Locale Provider should display the text as sr 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Mesec
@@ -320246,6 +320488,7 @@ exports[`Locale Provider should display the text as sr 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Godina"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -320253,6 +320496,7 @@ exports[`Locale Provider should display the text as sr 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Godina
@@ -325461,6 +325705,7 @@ exports[`Locale Provider should display the text as sv 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Månad"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -325469,6 +325714,7 @@ exports[`Locale Provider should display the text as sv 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Månad
@@ -325481,6 +325727,7 @@ exports[`Locale Provider should display the text as sv 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="År"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -325488,6 +325735,7 @@ exports[`Locale Provider should display the text as sv 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             År
@@ -330696,6 +330944,7 @@ exports[`Locale Provider should display the text as ta 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="மாதம்"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -330704,6 +330953,7 @@ exports[`Locale Provider should display the text as ta 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             மாதம்
@@ -330716,6 +330966,7 @@ exports[`Locale Provider should display the text as ta 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="வருடம்"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -330723,6 +330974,7 @@ exports[`Locale Provider should display the text as ta 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             வருடம்
@@ -335931,6 +336183,7 @@ exports[`Locale Provider should display the text as th 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="เดือน"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -335939,6 +336192,7 @@ exports[`Locale Provider should display the text as th 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             เดือน
@@ -335951,6 +336205,7 @@ exports[`Locale Provider should display the text as th 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="ปี"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -335958,6 +336213,7 @@ exports[`Locale Provider should display the text as th 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             ปี
@@ -341166,6 +341422,7 @@ exports[`Locale Provider should display the text as tk 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Aý"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -341174,6 +341431,7 @@ exports[`Locale Provider should display the text as tk 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Aý
@@ -341186,6 +341444,7 @@ exports[`Locale Provider should display the text as tk 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Ýyl"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -341193,6 +341452,7 @@ exports[`Locale Provider should display the text as tk 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Ýyl
@@ -346401,6 +346661,7 @@ exports[`Locale Provider should display the text as tr 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Ay"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -346409,6 +346670,7 @@ exports[`Locale Provider should display the text as tr 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Ay
@@ -346421,6 +346683,7 @@ exports[`Locale Provider should display the text as tr 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Yıl"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -346428,6 +346691,7 @@ exports[`Locale Provider should display the text as tr 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Yıl
@@ -351636,6 +351900,7 @@ exports[`Locale Provider should display the text as uk 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Місяць"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -351644,6 +351909,7 @@ exports[`Locale Provider should display the text as uk 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Місяць
@@ -351656,6 +351922,7 @@ exports[`Locale Provider should display the text as uk 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Рік"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -351663,6 +351930,7 @@ exports[`Locale Provider should display the text as uk 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Рік
@@ -356871,6 +357139,7 @@ exports[`Locale Provider should display the text as ur 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="مہینہ"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -356879,6 +357148,7 @@ exports[`Locale Provider should display the text as ur 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             مہینہ
@@ -356891,6 +357161,7 @@ exports[`Locale Provider should display the text as ur 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="سال"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -356898,6 +357169,7 @@ exports[`Locale Provider should display the text as ur 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             سال
@@ -362106,6 +362378,7 @@ exports[`Locale Provider should display the text as uz-latn 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Oy"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -362114,6 +362387,7 @@ exports[`Locale Provider should display the text as uz-latn 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Oy
@@ -362126,6 +362400,7 @@ exports[`Locale Provider should display the text as uz-latn 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Yil"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -362133,6 +362408,7 @@ exports[`Locale Provider should display the text as uz-latn 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Yil
@@ -367341,6 +367617,7 @@ exports[`Locale Provider should display the text as vi 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="Tháng"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -367349,6 +367626,7 @@ exports[`Locale Provider should display the text as vi 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Tháng
@@ -367361,6 +367639,7 @@ exports[`Locale Provider should display the text as vi 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="Năm"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -367368,6 +367647,7 @@ exports[`Locale Provider should display the text as vi 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             Năm
@@ -372576,6 +372856,7 @@ exports[`Locale Provider should display the text as zh-cn 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="月"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -372584,6 +372865,7 @@ exports[`Locale Provider should display the text as zh-cn 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             月
@@ -372596,6 +372878,7 @@ exports[`Locale Provider should display the text as zh-cn 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="年"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -372603,6 +372886,7 @@ exports[`Locale Provider should display the text as zh-cn 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             年
@@ -377811,6 +378095,7 @@ exports[`Locale Provider should display the text as zh-hk 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="月"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -377819,6 +378104,7 @@ exports[`Locale Provider should display the text as zh-hk 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             月
@@ -377831,6 +378117,7 @@ exports[`Locale Provider should display the text as zh-hk 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="年"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -377838,6 +378125,7 @@ exports[`Locale Provider should display the text as zh-hk 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             年
@@ -383046,6 +383334,7 @@ exports[`Locale Provider should display the text as zh-tw 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="月"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -383054,6 +383343,7 @@ exports[`Locale Provider should display the text as zh-tw 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             月
@@ -383066,6 +383356,7 @@ exports[`Locale Provider should display the text as zh-tw 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="年"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -383073,6 +383364,7 @@ exports[`Locale Provider should display the text as zh-tw 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             年

--- a/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -18,6 +18,7 @@ exports[`renders components/radio/demo/badge.tsx extend context correctly 1`] = 
           class="ant-radio-button"
         >
           <input
+            aria-label="Click Me"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -25,6 +26,7 @@ exports[`renders components/radio/demo/badge.tsx extend context correctly 1`] = 
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Click Me
@@ -59,6 +61,7 @@ exports[`renders components/radio/demo/badge.tsx extend context correctly 1`] = 
           class="ant-radio-button"
         >
           <input
+            aria-label="Not Me"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -66,6 +69,7 @@ exports[`renders components/radio/demo/badge.tsx extend context correctly 1`] = 
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Not Me
@@ -105,6 +109,7 @@ exports[`renders components/radio/demo/badge.tsx extend context correctly 1`] = 
           class="ant-radio-button"
         >
           <input
+            aria-label="Click Me"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -112,6 +117,7 @@ exports[`renders components/radio/demo/badge.tsx extend context correctly 1`] = 
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Click Me
@@ -146,6 +152,7 @@ exports[`renders components/radio/demo/badge.tsx extend context correctly 1`] = 
           class="ant-radio-button"
         >
           <input
+            aria-label="Hidden Badge"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -153,6 +160,7 @@ exports[`renders components/radio/demo/badge.tsx extend context correctly 1`] = 
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Hidden Badge
@@ -169,6 +177,7 @@ exports[`renders components/radio/demo/badge.tsx extend context correctly 1`] = 
           class="ant-radio-button"
         >
           <input
+            aria-label="Not Me"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -176,6 +185,7 @@ exports[`renders components/radio/demo/badge.tsx extend context correctly 1`] = 
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Not Me
@@ -214,11 +224,13 @@ exports[`renders components/radio/demo/basic.tsx extend context correctly 1`] = 
     class="ant-radio ant-wave-target"
   >
     <input
+      aria-label="Radio"
       class="ant-radio-input"
       type="radio"
     />
   </span>
   <span
+    aria-hidden="true"
     class="ant-radio-label"
   >
     Radio
@@ -242,12 +254,14 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Test"
           checked=""
           class="ant-radio-input"
           type="radio"
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Test
@@ -264,6 +278,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
         class="ant-radio ant-wave-target ant-radio-checked ant-radio-disabled"
       >
         <input
+          aria-label="Disabled"
           checked=""
           class="ant-radio-input"
           disabled=""
@@ -271,6 +286,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Disabled
@@ -291,6 +307,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="Hangzhou"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -299,6 +316,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Hangzhou
@@ -311,6 +329,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           class="ant-radio-button"
         >
           <input
+            aria-label="Shanghai"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -318,6 +337,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Shanghai
@@ -330,6 +350,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           class="ant-radio-button"
         >
           <input
+            aria-label="Beijing"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -337,6 +358,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Beijing
@@ -349,6 +371,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           class="ant-radio-button"
         >
           <input
+            aria-label="Chengdu"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -356,6 +379,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Chengdu
@@ -377,6 +401,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           class="ant-radio-button ant-radio-button-checked ant-radio-button-disabled"
         >
           <input
+            aria-label="Hangzhou"
             checked=""
             class="ant-radio-button-input"
             disabled=""
@@ -386,6 +411,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Hangzhou
@@ -398,6 +424,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           class="ant-radio-button ant-radio-button-disabled"
         >
           <input
+            aria-label="Shanghai"
             class="ant-radio-button-input"
             disabled=""
             name="test-id"
@@ -406,6 +433,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Shanghai
@@ -418,6 +446,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           class="ant-radio-button ant-radio-button-disabled"
         >
           <input
+            aria-label="Beijing"
             class="ant-radio-button-input"
             disabled=""
             name="test-id"
@@ -426,6 +455,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Beijing
@@ -438,6 +468,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           class="ant-radio-button ant-radio-button-disabled"
         >
           <input
+            aria-label="Chengdu"
             class="ant-radio-button-input"
             disabled=""
             name="test-id"
@@ -446,6 +477,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Chengdu
@@ -467,6 +499,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="Hangzhou"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -475,6 +508,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Hangzhou
@@ -487,6 +521,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           class="ant-radio-button"
         >
           <input
+            aria-label="Shanghai"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -494,6 +529,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Shanghai
@@ -506,6 +542,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           class="ant-radio-button"
         >
           <input
+            aria-label="Beijing"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -513,6 +550,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Beijing
@@ -525,6 +563,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           class="ant-radio-button"
         >
           <input
+            aria-label="Chengdu"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -532,6 +571,7 @@ exports[`renders components/radio/demo/component-token.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Chengdu
@@ -559,6 +599,7 @@ exports[`renders components/radio/demo/debug-group-width.tsx extend context corr
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Short"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -567,6 +608,7 @@ exports[`renders components/radio/demo/debug-group-width.tsx extend context corr
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Short
@@ -579,6 +621,7 @@ exports[`renders components/radio/demo/debug-group-width.tsx extend context corr
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Long label that may wrap in narrow container"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -586,6 +629,7 @@ exports[`renders components/radio/demo/debug-group-width.tsx extend context corr
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Long label that may wrap in narrow container
@@ -598,6 +642,7 @@ exports[`renders components/radio/demo/debug-group-width.tsx extend context corr
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Medium"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -605,6 +650,7 @@ exports[`renders components/radio/demo/debug-group-width.tsx extend context corr
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Medium
@@ -645,11 +691,13 @@ exports[`renders components/radio/demo/debug-upload.tsx extend context correctly
               class="ant-radio ant-wave-target"
             >
               <input
+                aria-label="Radio"
                 class="ant-radio-input"
                 type="radio"
               />
             </span>
             <span
+              aria-hidden="true"
               class="ant-radio-label"
             >
               Radio
@@ -718,12 +766,14 @@ Array [
       class="ant-radio ant-wave-target ant-radio-disabled"
     >
       <input
+        aria-label="Disabled"
         class="ant-radio-input"
         disabled=""
         type="radio"
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label"
     >
       Disabled
@@ -736,6 +786,7 @@ Array [
       class="ant-radio ant-wave-target ant-radio-checked ant-radio-disabled"
     >
       <input
+        aria-label="Disabled"
         checked=""
         class="ant-radio-input"
         disabled=""
@@ -743,6 +794,7 @@ Array [
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label"
     >
       Disabled
@@ -778,6 +830,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -786,6 +839,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -798,6 +852,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         class="ant-radio-button"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -805,6 +860,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -817,6 +873,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         class="ant-radio-button"
       >
         <input
+          aria-label="Beijing"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -824,6 +881,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -836,6 +894,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         class="ant-radio-button"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -843,6 +902,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -860,6 +920,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -868,6 +929,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -880,6 +942,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         class="ant-radio-button ant-radio-button-disabled"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           disabled=""
           name="test-id"
@@ -888,6 +951,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -900,6 +964,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         class="ant-radio-button"
       >
         <input
+          aria-label="Beijing"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -907,6 +972,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -919,6 +985,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         class="ant-radio-button"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -926,6 +993,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -943,6 +1011,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         class="ant-radio-button ant-radio-button-checked ant-radio-button-disabled"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           disabled=""
@@ -952,6 +1021,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -964,6 +1034,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         class="ant-radio-button ant-radio-button-disabled"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           disabled=""
           name="test-id"
@@ -972,6 +1043,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -984,6 +1056,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         class="ant-radio-button ant-radio-button-disabled"
       >
         <input
+          aria-label="Beijing"
           class="ant-radio-button-input"
           disabled=""
           name="test-id"
@@ -992,6 +1065,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -1004,6 +1078,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         class="ant-radio-button ant-radio-button-disabled"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           disabled=""
           name="test-id"
@@ -1012,6 +1087,7 @@ exports[`renders components/radio/demo/radiobutton.tsx extend context correctly 
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -1038,6 +1114,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1046,6 +1123,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -1058,6 +1136,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         class="ant-radio-button"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1065,6 +1144,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -1077,6 +1157,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         class="ant-radio-button"
       >
         <input
+          aria-label="Beijing"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1084,6 +1165,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -1096,6 +1178,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         class="ant-radio-button"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1103,6 +1186,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -1120,6 +1204,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         class="ant-radio-button"
       >
         <input
+          aria-label="Hangzhou"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1127,6 +1212,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -1139,6 +1225,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         class="ant-radio-button ant-radio-button-disabled"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           disabled=""
           name="test-id"
@@ -1147,6 +1234,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -1159,6 +1247,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Beijing"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1167,6 +1256,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -1179,6 +1269,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         class="ant-radio-button"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1186,6 +1277,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx extend context corr
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -1395,6 +1487,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Apple"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -1403,6 +1496,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Apple
@@ -1415,6 +1509,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Pear"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1422,6 +1517,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Pear
@@ -1434,6 +1530,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Orange"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1441,6 +1538,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Orange
@@ -1458,6 +1556,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Apple"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1466,6 +1565,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Apple
@@ -1478,6 +1578,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         class="ant-radio-button"
       >
         <input
+          aria-label="Pear"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1485,6 +1586,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Pear
@@ -1497,6 +1599,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         class="ant-radio-button"
       >
         <input
+          aria-label="Orange"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1504,6 +1607,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Orange
@@ -1521,6 +1625,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         class="ant-radio-button"
       >
         <input
+          aria-label="Apple"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1528,6 +1633,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Apple
@@ -1540,6 +1646,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Pear"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1548,6 +1655,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Pear
@@ -1560,6 +1668,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         class="ant-radio-button"
       >
         <input
+          aria-label="Orange"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1567,6 +1676,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx extend context corre
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Orange
@@ -1597,6 +1707,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
           class="ant-radio ant-wave-target ant-radio-checked"
         >
           <input
+            aria-label="Option A"
             checked=""
             class="ant-radio-input"
             name="test-id"
@@ -1605,6 +1716,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           Option A
@@ -1618,6 +1730,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="Option B"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -1625,6 +1738,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           Option B
@@ -1638,6 +1752,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="Option C"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -1645,6 +1760,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           Option C
@@ -1686,6 +1802,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
           class="ant-radio-button"
         >
           <input
+            aria-label="Apple"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -1693,6 +1810,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Apple
@@ -1705,6 +1823,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
           class="ant-radio-button"
         >
           <input
+            aria-label="Pear"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -1712,6 +1831,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Pear
@@ -1725,6 +1845,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
           class="ant-radio-button"
         >
           <input
+            aria-label="Orange"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -1732,6 +1853,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx extend context correc
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Orange
@@ -1757,6 +1879,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Apple"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -1765,6 +1888,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Apple
@@ -1777,6 +1901,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Pear"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1784,6 +1909,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Pear
@@ -1796,6 +1922,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Orange"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1803,6 +1930,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Orange
@@ -1821,6 +1949,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Apple"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -1829,6 +1958,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Apple
@@ -1841,6 +1971,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Pear"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1848,6 +1979,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Pear
@@ -1860,6 +1992,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
+          aria-label="Orange"
           class="ant-radio-input"
           disabled=""
           name="test-id"
@@ -1868,6 +2001,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Orange
@@ -1887,6 +2021,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Apple"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1895,6 +2030,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Apple
@@ -1907,6 +2043,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Pear"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1914,6 +2051,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Pear
@@ -1927,6 +2065,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Orange"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1934,6 +2073,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Orange
@@ -1953,6 +2093,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Apple"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1961,6 +2102,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Apple
@@ -1973,6 +2115,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Pear"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1980,6 +2123,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Pear
@@ -1992,6 +2136,7 @@ Array [
         class="ant-radio-button ant-radio-button-disabled"
       >
         <input
+          aria-label="Orange"
           class="ant-radio-button-input"
           disabled=""
           name="test-id"
@@ -2000,6 +2145,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Orange
@@ -2023,6 +2169,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx extend context c
       class="ant-radio ant-wave-target ant-radio-checked"
     >
       <input
+        aria-label="A"
         checked=""
         class="ant-radio-input"
         name="radiogroup"
@@ -2031,6 +2178,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx extend context c
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label"
     >
       A
@@ -2043,6 +2191,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx extend context c
       class="ant-radio ant-wave-target"
     >
       <input
+        aria-label="B"
         class="ant-radio-input"
         name="radiogroup"
         type="radio"
@@ -2050,6 +2199,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx extend context c
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label"
     >
       B
@@ -2062,6 +2212,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx extend context c
       class="ant-radio ant-wave-target"
     >
       <input
+        aria-label="C"
         class="ant-radio-input"
         name="radiogroup"
         type="radio"
@@ -2069,6 +2220,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx extend context c
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label"
     >
       C
@@ -2081,6 +2233,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx extend context c
       class="ant-radio ant-wave-target"
     >
       <input
+        aria-label="D"
         class="ant-radio-input"
         name="radiogroup"
         type="radio"
@@ -2088,6 +2241,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx extend context c
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label"
     >
       D
@@ -2113,6 +2267,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -2121,6 +2276,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -2133,6 +2289,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2140,6 +2297,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -2152,6 +2310,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Beijing"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2159,6 +2318,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -2171,6 +2331,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2178,6 +2339,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -2195,6 +2357,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -2203,6 +2366,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -2215,6 +2379,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2222,6 +2387,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -2234,6 +2400,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Beijing"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2241,6 +2408,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -2253,6 +2421,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2260,6 +2429,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -2277,6 +2447,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -2285,6 +2456,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -2297,6 +2469,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2304,6 +2477,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -2316,6 +2490,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Beijing"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2323,6 +2498,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -2335,6 +2511,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2342,6 +2519,7 @@ exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -2365,6 +2543,7 @@ exports[`renders components/radio/demo/style-class.tsx extend context correctly 
       style="border-radius: 6px;"
     >
       <input
+        aria-label="Object styles"
         checked=""
         class="ant-radio-input"
         name="style-class"
@@ -2372,6 +2551,7 @@ exports[`renders components/radio/demo/style-class.tsx extend context correctly 
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label"
       style="color: blue;"
     >
@@ -2385,12 +2565,14 @@ exports[`renders components/radio/demo/style-class.tsx extend context correctly 
       class="ant-radio acss-1sy50lm ant-wave-target"
     >
       <input
+        aria-label="Function classNames"
         class="ant-radio-input"
         name="style-class"
         type="radio"
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label acss-eesh8g"
     >
       Function classNames
@@ -2414,6 +2596,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="A"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -2422,6 +2605,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         A
@@ -2434,6 +2618,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="B"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -2441,6 +2626,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         B
@@ -2453,6 +2639,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="C"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -2460,6 +2647,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         C
@@ -2472,6 +2660,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="D"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -2479,6 +2668,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         D
@@ -2497,6 +2687,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked ant-radio-disabled"
       >
         <input
+          aria-label="A"
           checked=""
           class="ant-radio-input"
           disabled=""
@@ -2506,6 +2697,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         A
@@ -2518,6 +2710,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
+          aria-label="B"
           class="ant-radio-input"
           disabled=""
           name="test-id"
@@ -2526,6 +2719,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         B
@@ -2538,6 +2732,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
+          aria-label="C"
           class="ant-radio-input"
           disabled=""
           name="test-id"
@@ -2546,6 +2741,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         C
@@ -2558,6 +2754,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
+          aria-label="D"
           class="ant-radio-input"
           disabled=""
           name="test-id"
@@ -2566,6 +2763,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         D

--- a/components/radio/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -17,11 +17,13 @@ exports[`renders components/radio/demo/_semantic.tsx correctly 1`] = `
           class="ant-radio semantic-mark-icon ant-wave-target"
         >
           <input
+            aria-label="Radio"
             class="ant-radio-input"
             type="radio"
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label semantic-mark-label"
         >
           Radio

--- a/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`renders components/radio/demo/badge.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Click Me"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -25,6 +26,7 @@ exports[`renders components/radio/demo/badge.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Click Me
@@ -59,6 +61,7 @@ exports[`renders components/radio/demo/badge.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Not Me"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -66,6 +69,7 @@ exports[`renders components/radio/demo/badge.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Not Me
@@ -105,6 +109,7 @@ exports[`renders components/radio/demo/badge.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Click Me"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -112,6 +117,7 @@ exports[`renders components/radio/demo/badge.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Click Me
@@ -146,6 +152,7 @@ exports[`renders components/radio/demo/badge.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Hidden Badge"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -153,6 +160,7 @@ exports[`renders components/radio/demo/badge.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Hidden Badge
@@ -169,6 +177,7 @@ exports[`renders components/radio/demo/badge.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Not Me"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -176,6 +185,7 @@ exports[`renders components/radio/demo/badge.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Not Me
@@ -212,11 +222,13 @@ exports[`renders components/radio/demo/basic.tsx correctly 1`] = `
     class="ant-radio ant-wave-target"
   >
     <input
+      aria-label="Radio"
       class="ant-radio-input"
       type="radio"
     />
   </span>
   <span
+    aria-hidden="true"
     class="ant-radio-label"
   >
     Radio
@@ -238,12 +250,14 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Test"
           checked=""
           class="ant-radio-input"
           type="radio"
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Test
@@ -260,6 +274,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
         class="ant-radio ant-wave-target ant-radio-checked ant-radio-disabled"
       >
         <input
+          aria-label="Disabled"
           checked=""
           class="ant-radio-input"
           disabled=""
@@ -267,6 +282,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Disabled
@@ -287,6 +303,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="Hangzhou"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -295,6 +312,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Hangzhou
@@ -307,6 +325,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Shanghai"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -314,6 +333,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Shanghai
@@ -326,6 +346,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Beijing"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -333,6 +354,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Beijing
@@ -345,6 +367,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Chengdu"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -352,6 +375,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Chengdu
@@ -373,6 +397,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           class="ant-radio-button ant-radio-button-checked ant-radio-button-disabled"
         >
           <input
+            aria-label="Hangzhou"
             checked=""
             class="ant-radio-button-input"
             disabled=""
@@ -382,6 +407,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Hangzhou
@@ -394,6 +420,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           class="ant-radio-button ant-radio-button-disabled"
         >
           <input
+            aria-label="Shanghai"
             class="ant-radio-button-input"
             disabled=""
             name="test-id"
@@ -402,6 +429,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Shanghai
@@ -414,6 +442,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           class="ant-radio-button ant-radio-button-disabled"
         >
           <input
+            aria-label="Beijing"
             class="ant-radio-button-input"
             disabled=""
             name="test-id"
@@ -422,6 +451,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Beijing
@@ -434,6 +464,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           class="ant-radio-button ant-radio-button-disabled"
         >
           <input
+            aria-label="Chengdu"
             class="ant-radio-button-input"
             disabled=""
             name="test-id"
@@ -442,6 +473,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Chengdu
@@ -463,6 +495,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           class="ant-radio-button ant-radio-button-checked"
         >
           <input
+            aria-label="Hangzhou"
             checked=""
             class="ant-radio-button-input"
             name="test-id"
@@ -471,6 +504,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Hangzhou
@@ -483,6 +517,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Shanghai"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -490,6 +525,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Shanghai
@@ -502,6 +538,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Beijing"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -509,6 +546,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Beijing
@@ -521,6 +559,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Chengdu"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -528,6 +567,7 @@ exports[`renders components/radio/demo/component-token.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Chengdu
@@ -553,6 +593,7 @@ exports[`renders components/radio/demo/debug-group-width.tsx correctly 1`] = `
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Short"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -561,6 +602,7 @@ exports[`renders components/radio/demo/debug-group-width.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Short
@@ -573,6 +615,7 @@ exports[`renders components/radio/demo/debug-group-width.tsx correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Long label that may wrap in narrow container"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -580,6 +623,7 @@ exports[`renders components/radio/demo/debug-group-width.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Long label that may wrap in narrow container
@@ -592,6 +636,7 @@ exports[`renders components/radio/demo/debug-group-width.tsx correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Medium"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -599,6 +644,7 @@ exports[`renders components/radio/demo/debug-group-width.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Medium
@@ -637,11 +683,13 @@ exports[`renders components/radio/demo/debug-upload.tsx correctly 1`] = `
               class="ant-radio ant-wave-target"
             >
               <input
+                aria-label="Radio"
                 class="ant-radio-input"
                 type="radio"
               />
             </span>
             <span
+              aria-hidden="true"
               class="ant-radio-label"
             >
               Radio
@@ -708,12 +756,14 @@ Array [
       class="ant-radio ant-wave-target ant-radio-disabled"
     >
       <input
+        aria-label="Disabled"
         class="ant-radio-input"
         disabled=""
         type="radio"
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label"
     >
       Disabled
@@ -726,6 +776,7 @@ Array [
       class="ant-radio ant-wave-target ant-radio-checked ant-radio-disabled"
     >
       <input
+        aria-label="Disabled"
         checked=""
         class="ant-radio-input"
         disabled=""
@@ -733,6 +784,7 @@ Array [
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label"
     >
       Disabled
@@ -766,6 +818,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -774,6 +827,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -786,6 +840,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -793,6 +848,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -805,6 +861,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Beijing"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -812,6 +869,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -824,6 +882,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -831,6 +890,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -848,6 +908,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -856,6 +917,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -868,6 +930,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-disabled"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           disabled=""
           name="test-id"
@@ -876,6 +939,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -888,6 +952,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Beijing"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -895,6 +960,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -907,6 +973,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -914,6 +981,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -931,6 +999,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked ant-radio-button-disabled"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           disabled=""
@@ -940,6 +1009,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -952,6 +1022,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-disabled"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           disabled=""
           name="test-id"
@@ -960,6 +1031,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -972,6 +1044,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-disabled"
       >
         <input
+          aria-label="Beijing"
           class="ant-radio-button-input"
           disabled=""
           name="test-id"
@@ -980,6 +1053,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -992,6 +1066,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-disabled"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           disabled=""
           name="test-id"
@@ -1000,6 +1075,7 @@ exports[`renders components/radio/demo/radiobutton.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -1024,6 +1100,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1032,6 +1109,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -1044,6 +1122,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1051,6 +1130,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -1063,6 +1143,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Beijing"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1070,6 +1151,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -1082,6 +1164,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1089,6 +1172,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -1106,6 +1190,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Hangzhou"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1113,6 +1198,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -1125,6 +1211,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-disabled"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           disabled=""
           name="test-id"
@@ -1133,6 +1220,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -1145,6 +1233,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Beijing"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1153,6 +1242,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -1165,6 +1255,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1172,6 +1263,7 @@ exports[`renders components/radio/demo/radiobutton-solid.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -1377,6 +1469,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Apple"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -1385,6 +1478,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Apple
@@ -1397,6 +1491,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Pear"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1404,6 +1499,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Pear
@@ -1416,6 +1512,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Orange"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1423,6 +1520,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Orange
@@ -1440,6 +1538,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Apple"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1448,6 +1547,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Apple
@@ -1460,6 +1560,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Pear"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1467,6 +1568,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Pear
@@ -1479,6 +1581,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Orange"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1486,6 +1589,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Orange
@@ -1503,6 +1607,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Apple"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1510,6 +1615,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Apple
@@ -1522,6 +1628,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Pear"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1530,6 +1637,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Pear
@@ -1542,6 +1650,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Orange"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1549,6 +1658,7 @@ exports[`renders components/radio/demo/radiogroup-block.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Orange
@@ -1577,6 +1687,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
           class="ant-radio ant-wave-target ant-radio-checked"
         >
           <input
+            aria-label="Option A"
             checked=""
             class="ant-radio-input"
             name="test-id"
@@ -1585,6 +1696,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           Option A
@@ -1598,6 +1710,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="Option B"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -1605,6 +1718,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           Option B
@@ -1618,6 +1732,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="Option C"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -1625,6 +1740,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           Option C
@@ -1666,6 +1782,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Apple"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -1673,6 +1790,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Apple
@@ -1685,6 +1803,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Pear"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -1692,6 +1811,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Pear
@@ -1705,6 +1825,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
           class="ant-radio-button"
         >
           <input
+            aria-label="Orange"
             class="ant-radio-button-input"
             name="test-id"
             type="radio"
@@ -1712,6 +1833,7 @@ exports[`renders components/radio/demo/radiogroup-more.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-button-label"
         >
           Orange
@@ -1735,6 +1857,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Apple"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -1743,6 +1866,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Apple
@@ -1755,6 +1879,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Pear"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1762,6 +1887,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Pear
@@ -1774,6 +1900,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Orange"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1781,6 +1908,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Orange
@@ -1799,6 +1927,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Apple"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -1807,6 +1936,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Apple
@@ -1819,6 +1949,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Pear"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1826,6 +1957,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Pear
@@ -1838,6 +1970,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
+          aria-label="Orange"
           class="ant-radio-input"
           disabled=""
           name="test-id"
@@ -1846,6 +1979,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Orange
@@ -1865,6 +1999,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Apple"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1873,6 +2008,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Apple
@@ -1885,6 +2021,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Pear"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1892,6 +2029,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Pear
@@ -1905,6 +2043,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Orange"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1912,6 +2051,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Orange
@@ -1931,6 +2071,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Apple"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1939,6 +2080,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Apple
@@ -1951,6 +2093,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Pear"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1958,6 +2101,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Pear
@@ -1970,6 +2114,7 @@ Array [
         class="ant-radio-button ant-radio-button-disabled"
       >
         <input
+          aria-label="Orange"
           class="ant-radio-button-input"
           disabled=""
           name="test-id"
@@ -1978,6 +2123,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Orange
@@ -1999,6 +2145,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx correctly 1`] = 
       class="ant-radio ant-wave-target ant-radio-checked"
     >
       <input
+        aria-label="A"
         checked=""
         class="ant-radio-input"
         name="radiogroup"
@@ -2007,6 +2154,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx correctly 1`] = 
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label"
     >
       A
@@ -2019,6 +2167,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx correctly 1`] = 
       class="ant-radio ant-wave-target"
     >
       <input
+        aria-label="B"
         class="ant-radio-input"
         name="radiogroup"
         type="radio"
@@ -2026,6 +2175,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx correctly 1`] = 
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label"
     >
       B
@@ -2038,6 +2188,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx correctly 1`] = 
       class="ant-radio ant-wave-target"
     >
       <input
+        aria-label="C"
         class="ant-radio-input"
         name="radiogroup"
         type="radio"
@@ -2045,6 +2196,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx correctly 1`] = 
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label"
     >
       C
@@ -2057,6 +2209,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx correctly 1`] = 
       class="ant-radio ant-wave-target"
     >
       <input
+        aria-label="D"
         class="ant-radio-input"
         name="radiogroup"
         type="radio"
@@ -2064,6 +2217,7 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx correctly 1`] = 
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label"
     >
       D
@@ -2087,6 +2241,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -2095,6 +2250,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -2107,6 +2263,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2114,6 +2271,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -2126,6 +2284,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Beijing"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2133,6 +2292,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -2145,6 +2305,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2152,6 +2313,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -2169,6 +2331,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -2177,6 +2340,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -2189,6 +2353,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2196,6 +2361,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -2208,6 +2374,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Beijing"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2215,6 +2382,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -2227,6 +2395,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2234,6 +2403,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -2251,6 +2421,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Hangzhou"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -2259,6 +2430,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Hangzhou
@@ -2271,6 +2443,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Shanghai"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2278,6 +2451,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Shanghai
@@ -2290,6 +2464,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Beijing"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2297,6 +2472,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Beijing
@@ -2309,6 +2485,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Chengdu"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -2316,6 +2493,7 @@ exports[`renders components/radio/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Chengdu
@@ -2337,6 +2515,7 @@ exports[`renders components/radio/demo/style-class.tsx correctly 1`] = `
       style="border-radius:6px"
     >
       <input
+        aria-label="Object styles"
         checked=""
         class="ant-radio-input"
         name="style-class"
@@ -2344,6 +2523,7 @@ exports[`renders components/radio/demo/style-class.tsx correctly 1`] = `
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label"
       style="color:blue"
     >
@@ -2357,12 +2537,14 @@ exports[`renders components/radio/demo/style-class.tsx correctly 1`] = `
       class="ant-radio acss-1sy50lm ant-wave-target"
     >
       <input
+        aria-label="Function classNames"
         class="ant-radio-input"
         name="style-class"
         type="radio"
       />
     </span>
     <span
+      aria-hidden="true"
       class="ant-radio-label acss-eesh8g"
     >
       Function classNames
@@ -2384,6 +2566,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="A"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -2392,6 +2575,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         A
@@ -2404,6 +2588,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="B"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -2411,6 +2596,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         B
@@ -2423,6 +2609,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="C"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -2430,6 +2617,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         C
@@ -2442,6 +2630,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="D"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -2449,6 +2638,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         D
@@ -2467,6 +2657,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked ant-radio-disabled"
       >
         <input
+          aria-label="A"
           checked=""
           class="ant-radio-input"
           disabled=""
@@ -2476,6 +2667,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         A
@@ -2488,6 +2680,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
+          aria-label="B"
           class="ant-radio-input"
           disabled=""
           name="test-id"
@@ -2496,6 +2689,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         B
@@ -2508,6 +2702,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
+          aria-label="C"
           class="ant-radio-input"
           disabled=""
           name="test-id"
@@ -2516,6 +2711,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         C
@@ -2528,6 +2724,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-disabled"
       >
         <input
+          aria-label="D"
           class="ant-radio-input"
           disabled=""
           name="test-id"
@@ -2536,6 +2733,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         D

--- a/components/radio/__tests__/__snapshots__/group.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/group.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Radio Group passes prefixCls down to radio 1`] = `
       class="my-radio ant-wave-target"
     >
       <input
+        aria-label="Apple"
         class="my-radio-input"
         name="test-id"
         type="radio"
@@ -19,6 +20,7 @@ exports[`Radio Group passes prefixCls down to radio 1`] = `
       />
     </span>
     <span
+      aria-hidden="true"
       class="my-radio-label"
     >
       Apple
@@ -32,6 +34,7 @@ exports[`Radio Group passes prefixCls down to radio 1`] = `
       class="my-radio ant-wave-target"
     >
       <input
+        aria-label="Orange"
         class="my-radio-input"
         name="test-id"
         type="radio"
@@ -39,6 +42,7 @@ exports[`Radio Group passes prefixCls down to radio 1`] = `
       />
     </span>
     <span
+      aria-hidden="true"
       class="my-radio-label"
     >
       Orange

--- a/components/radio/__tests__/__snapshots__/radio-button.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/radio-button.test.tsx.snap
@@ -8,11 +8,13 @@ exports[`Radio Button should render correctly 1`] = `
     class="ant-radio-button"
   >
     <input
+      aria-label="Test"
       class="ant-radio-button-input"
       type="radio"
     />
   </span>
   <span
+    aria-hidden="true"
     class="ant-radio-button-label"
   >
     Test
@@ -32,6 +34,7 @@ exports[`Radio Group passes prefixCls down to radio 1`] = `
       class="my-radio ant-wave-target"
     >
       <input
+        aria-label="Apple"
         class="my-radio-input"
         name="test-id"
         type="radio"
@@ -39,6 +42,7 @@ exports[`Radio Group passes prefixCls down to radio 1`] = `
       />
     </span>
     <span
+      aria-hidden="true"
       class="my-radio-label"
     >
       Apple
@@ -52,6 +56,7 @@ exports[`Radio Group passes prefixCls down to radio 1`] = `
       class="my-radio ant-wave-target"
     >
       <input
+        aria-label="Orange"
         class="my-radio-input"
         name="test-id"
         type="radio"
@@ -59,6 +64,7 @@ exports[`Radio Group passes prefixCls down to radio 1`] = `
       />
     </span>
     <span
+      aria-hidden="true"
       class="my-radio-label"
     >
       Orange

--- a/components/radio/__tests__/__snapshots__/radio.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/radio.test.tsx.snap
@@ -45,11 +45,13 @@ exports[`Radio should render correctly 1`] = `
     class="ant-radio ant-wave-target"
   >
     <input
+      aria-label="Test"
       class="ant-radio-input"
       type="radio"
     />
   </span>
   <span
+    aria-hidden="true"
     class="ant-radio-label"
   >
     Test

--- a/components/radio/__tests__/radio.test.tsx
+++ b/components/radio/__tests__/radio.test.tsx
@@ -180,4 +180,41 @@ describe('Radio', () => {
     expect(iconElement).toHaveStyle({ backgroundColor: customStyles.icon.backgroundColor });
     expect(labelElement).toHaveStyle({ backgroundColor: customStyles.label.backgroundColor });
   });
+
+  // https://github.com/ant-design/ant-design/issues/53636
+  it('should expose a single accessible stop for a text label', () => {
+    const { container } = render(<Radio>Apple</Radio>);
+
+    const input = container.querySelector<HTMLInputElement>('.ant-radio-input');
+    const label = container.querySelector<HTMLElement>('.ant-radio-label');
+
+    expect(input).toHaveAttribute('aria-label', 'Apple');
+    expect(label).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('should keep the user provided aria-label', () => {
+    // `aria-label` is not declared on RadioProps, it reaches the input through rest props
+    const ariaProps = { 'aria-label': 'Custom' };
+    const { container } = render(<Radio {...ariaProps}>Apple</Radio>);
+
+    const input = container.querySelector<HTMLInputElement>('.ant-radio-input');
+    const label = container.querySelector<HTMLElement>('.ant-radio-label');
+
+    expect(input).toHaveAttribute('aria-label', 'Custom');
+    expect(label).not.toHaveAttribute('aria-hidden');
+  });
+
+  it('should not hide a label which is not plain text', () => {
+    const { container } = render(
+      <Radio>
+        <a href="#test">Apple</a>
+      </Radio>,
+    );
+
+    const input = container.querySelector<HTMLInputElement>('.ant-radio-input');
+    const label = container.querySelector<HTMLElement>('.ant-radio-label');
+
+    expect(input).not.toHaveAttribute('aria-label');
+    expect(label).not.toHaveAttribute('aria-hidden');
+  });
 });

--- a/components/radio/__tests__/radio.test.tsx
+++ b/components/radio/__tests__/radio.test.tsx
@@ -204,6 +204,29 @@ describe('Radio', () => {
     expect(label).not.toHaveAttribute('aria-hidden');
   });
 
+  it('should keep the user provided aria-labelledby', () => {
+    const ariaProps = { 'aria-labelledby': 'outside-label' };
+    const { container } = render(<Radio {...ariaProps}>Apple</Radio>);
+
+    const input = container.querySelector<HTMLInputElement>('.ant-radio-input');
+    const label = container.querySelector<HTMLElement>('.ant-radio-label');
+
+    expect(input).toHaveAttribute('aria-labelledby', 'outside-label');
+    expect(input).not.toHaveAttribute('aria-label');
+    expect(label).not.toHaveAttribute('aria-hidden');
+  });
+
+  it('should name the input when aria-label is passed as undefined', () => {
+    const ariaProps = { 'aria-label': undefined };
+    const { container } = render(<Radio {...ariaProps}>Apple</Radio>);
+
+    const input = container.querySelector<HTMLInputElement>('.ant-radio-input');
+    const label = container.querySelector<HTMLElement>('.ant-radio-label');
+
+    expect(input).toHaveAttribute('aria-label', 'Apple');
+    expect(label).toHaveAttribute('aria-hidden', 'true');
+  });
+
   it('should not hide a label which is not plain text', () => {
     const { container } = render(
       <Radio>

--- a/components/radio/__tests__/radio.test.tsx
+++ b/components/radio/__tests__/radio.test.tsx
@@ -192,6 +192,16 @@ describe('Radio', () => {
     expect(label).toHaveAttribute('aria-hidden', 'true');
   });
 
+  it('should name the input from a numeric label', () => {
+    const { container } = render(<Radio>{42}</Radio>);
+
+    const input = container.querySelector<HTMLInputElement>('.ant-radio-input');
+    const label = container.querySelector<HTMLElement>('.ant-radio-label');
+
+    expect(input).toHaveAttribute('aria-label', '42');
+    expect(label).toHaveAttribute('aria-hidden', 'true');
+  });
+
   it('should keep the user provided aria-label', () => {
     // `aria-label` is not declared on RadioProps, it reaches the input through rest props
     const ariaProps = { 'aria-label': 'Custom' };

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -4,6 +4,7 @@ import { composeRef, isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
+import { isNumber, isString } from '../_util/is';
 import { devUseWarning } from '../_util/warning';
 import Wave from '../_util/wave';
 import { TARGET_CLS } from '../_util/wave/interface';
@@ -91,6 +92,15 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
     checked: mergedChecked,
   };
 
+  // ================= Accessibility =================
+  // The wrapper is a `label` that also contains the input, so screen readers expose
+  // two stops for a single option: the text and the control. When the label is plain
+  // text and the user has not provided their own name, move the name onto the input
+  // and hide the visual copy, which leaves one stop with the correct name.
+  const labelText = isString(children) || isNumber(children) ? String(children) : '';
+  const hasCustomLabel = 'aria-label' in restProps || 'aria-labelledby' in restProps;
+  const inputAriaLabel = !hasCustomLabel && labelText ? labelText : undefined;
+
   const contextStyleRoot = useSemanticRootStyle(contextStyle);
   const styleRoot = useSemanticRootStyle(style);
 
@@ -136,6 +146,7 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
       >
         {/* @ts-ignore */}
         <RcCheckbox
+          aria-label={inputAriaLabel}
           {...radioProps}
           className={clsx(mergedClassNames.icon, { [TARGET_CLS]: !isButtonType })}
           style={mergedStyles.icon}
@@ -148,6 +159,7 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
           <span
             className={clsx(`${prefixCls}-label`, mergedClassNames.label)}
             style={mergedStyles.label}
+            aria-hidden={inputAriaLabel ? true : undefined}
           >
             {children}
           </span>

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import RcCheckbox from '@rc-component/checkbox';
-import { composeRef, isReactRenderable } from '@rc-component/util';
+import { composeRef, isNonNullable, isReactRenderable } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
@@ -98,7 +98,9 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
   // text and the user has not provided their own name, move the name onto the input
   // and hide the visual copy, which leaves one stop with the correct name.
   const labelText = isString(children) || isNumber(children) ? String(children) : '';
-  const hasCustomLabel = 'aria-label' in restProps || 'aria-labelledby' in restProps;
+  const { 'aria-label': customAriaLabel, 'aria-labelledby': customAriaLabelledBy } =
+    restProps as React.AriaAttributes;
+  const hasCustomLabel = isNonNullable(customAriaLabel) || isNonNullable(customAriaLabelledBy);
   const inputAriaLabel = !hasCustomLabel && labelText ? labelText : undefined;
 
   const contextStyleRoot = useSemanticRootStyle(contextStyle);
@@ -146,8 +148,8 @@ const InternalRadio: React.ForwardRefRenderFunction<RadioRef, RadioProps> = (pro
       >
         {/* @ts-ignore */}
         <RcCheckbox
-          aria-label={inputAriaLabel}
           {...radioProps}
+          aria-label={customAriaLabel ?? inputAriaLabel}
           className={clsx(mergedClassNames.icon, { [TARGET_CLS]: !isButtonType })}
           style={mergedStyles.icon}
           type="radio"

--- a/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -11690,6 +11690,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="topLeft"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -11698,6 +11699,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topLeft
@@ -11710,6 +11712,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="topRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -11717,6 +11720,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topRight
@@ -11729,6 +11733,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomLeft"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -11736,6 +11741,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomLeft
@@ -11748,6 +11754,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -11755,6 +11762,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomRight
@@ -11922,6 +11930,7 @@ exports[`renders components/select/demo/placement-debug.tsx extend context corre
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="TL"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -11930,6 +11939,7 @@ exports[`renders components/select/demo/placement-debug.tsx extend context corre
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             TL
@@ -11942,6 +11952,7 @@ exports[`renders components/select/demo/placement-debug.tsx extend context corre
             class="ant-radio-button"
           >
             <input
+              aria-label="TR"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -11949,6 +11960,7 @@ exports[`renders components/select/demo/placement-debug.tsx extend context corre
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             TR
@@ -11961,6 +11973,7 @@ exports[`renders components/select/demo/placement-debug.tsx extend context corre
             class="ant-radio-button"
           >
             <input
+              aria-label="BL"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -11968,6 +11981,7 @@ exports[`renders components/select/demo/placement-debug.tsx extend context corre
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             BL
@@ -11980,6 +11994,7 @@ exports[`renders components/select/demo/placement-debug.tsx extend context corre
             class="ant-radio-button"
           >
             <input
+              aria-label="BR"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -11987,6 +12002,7 @@ exports[`renders components/select/demo/placement-debug.tsx extend context corre
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             BR
@@ -14437,6 +14453,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Large"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -14444,6 +14461,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Large
@@ -14456,6 +14474,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Medium"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -14464,6 +14483,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Medium
@@ -14476,6 +14496,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Small"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -14483,6 +14504,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Small

--- a/components/select/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/select/__tests__/__snapshots__/demo.test.tsx.snap
@@ -3992,6 +3992,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="topLeft"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -4000,6 +4001,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topLeft
@@ -4012,6 +4014,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="topRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -4019,6 +4022,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topRight
@@ -4031,6 +4035,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomLeft"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -4038,6 +4043,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomLeft
@@ -4050,6 +4056,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -4057,6 +4064,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomRight
@@ -4136,6 +4144,7 @@ exports[`renders components/select/demo/placement-debug.tsx correctly 1`] = `
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="TL"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -4144,6 +4153,7 @@ exports[`renders components/select/demo/placement-debug.tsx correctly 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             TL
@@ -4156,6 +4166,7 @@ exports[`renders components/select/demo/placement-debug.tsx correctly 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="TR"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -4163,6 +4174,7 @@ exports[`renders components/select/demo/placement-debug.tsx correctly 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             TR
@@ -4175,6 +4187,7 @@ exports[`renders components/select/demo/placement-debug.tsx correctly 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="BL"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -4182,6 +4195,7 @@ exports[`renders components/select/demo/placement-debug.tsx correctly 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             BL
@@ -4194,6 +4208,7 @@ exports[`renders components/select/demo/placement-debug.tsx correctly 1`] = `
             class="ant-radio-button"
           >
             <input
+              aria-label="BR"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -4201,6 +4216,7 @@ exports[`renders components/select/demo/placement-debug.tsx correctly 1`] = `
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             BR
@@ -4778,6 +4794,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Large"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -4785,6 +4802,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Large
@@ -4797,6 +4815,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Medium"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -4805,6 +4824,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Medium
@@ -4817,6 +4837,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Small"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -4824,6 +4845,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Small

--- a/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -433,6 +433,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         class="ant-radio-button"
                       >
                         <input
+                          aria-label="Large"
                           class="ant-radio-button-input"
                           name="test-id"
                           type="radio"
@@ -440,6 +441,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Large
@@ -452,6 +454,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         class="ant-radio-button ant-radio-button-checked"
                       >
                         <input
+                          aria-label="Medium"
                           checked=""
                           class="ant-radio-button-input"
                           name="test-id"
@@ -460,6 +463,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Medium
@@ -472,6 +476,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         class="ant-radio-button"
                       >
                         <input
+                          aria-label="Small"
                           class="ant-radio-button-input"
                           name="test-id"
                           type="radio"
@@ -479,6 +484,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Small
@@ -530,6 +536,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         class="ant-radio-button ant-radio-button-checked"
                       >
                         <input
+                          aria-label="Default"
                           checked=""
                           class="ant-radio-button-input"
                           name="test-id"
@@ -538,6 +545,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Default
@@ -550,6 +558,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         class="ant-radio-button"
                       >
                         <input
+                          aria-label="Square"
                           class="ant-radio-button-input"
                           name="test-id"
                           type="radio"
@@ -557,6 +566,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Square
@@ -569,6 +579,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         class="ant-radio-button"
                       >
                         <input
+                          aria-label="Round"
                           class="ant-radio-button-input"
                           name="test-id"
                           type="radio"
@@ -576,6 +587,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Round
@@ -588,6 +600,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         class="ant-radio-button"
                       >
                         <input
+                          aria-label="Circle"
                           class="ant-radio-button-input"
                           name="test-id"
                           type="radio"
@@ -595,6 +608,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Circle
@@ -646,6 +660,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         class="ant-radio-button"
                       >
                         <input
+                          aria-label="Square"
                           class="ant-radio-button-input"
                           name="test-id"
                           type="radio"
@@ -653,6 +668,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Square
@@ -665,6 +681,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         class="ant-radio-button ant-radio-button-checked"
                       >
                         <input
+                          aria-label="Circle"
                           checked=""
                           class="ant-radio-button-input"
                           name="test-id"
@@ -673,6 +690,7 @@ exports[`renders components/skeleton/demo/element.tsx extend context correctly 1
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Circle

--- a/components/skeleton/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/skeleton/__tests__/__snapshots__/demo.test.tsx.snap
@@ -423,6 +423,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         class="ant-radio-button"
                       >
                         <input
+                          aria-label="Large"
                           class="ant-radio-button-input"
                           name="test-id"
                           type="radio"
@@ -430,6 +431,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Large
@@ -442,6 +444,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         class="ant-radio-button ant-radio-button-checked"
                       >
                         <input
+                          aria-label="Medium"
                           checked=""
                           class="ant-radio-button-input"
                           name="test-id"
@@ -450,6 +453,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Medium
@@ -462,6 +466,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         class="ant-radio-button"
                       >
                         <input
+                          aria-label="Small"
                           class="ant-radio-button-input"
                           name="test-id"
                           type="radio"
@@ -469,6 +474,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Small
@@ -520,6 +526,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         class="ant-radio-button ant-radio-button-checked"
                       >
                         <input
+                          aria-label="Default"
                           checked=""
                           class="ant-radio-button-input"
                           name="test-id"
@@ -528,6 +535,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Default
@@ -540,6 +548,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         class="ant-radio-button"
                       >
                         <input
+                          aria-label="Square"
                           class="ant-radio-button-input"
                           name="test-id"
                           type="radio"
@@ -547,6 +556,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Square
@@ -559,6 +569,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         class="ant-radio-button"
                       >
                         <input
+                          aria-label="Round"
                           class="ant-radio-button-input"
                           name="test-id"
                           type="radio"
@@ -566,6 +577,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Round
@@ -578,6 +590,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         class="ant-radio-button"
                       >
                         <input
+                          aria-label="Circle"
                           class="ant-radio-button-input"
                           name="test-id"
                           type="radio"
@@ -585,6 +598,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Circle
@@ -636,6 +650,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         class="ant-radio-button"
                       >
                         <input
+                          aria-label="Square"
                           class="ant-radio-button-input"
                           name="test-id"
                           type="radio"
@@ -643,6 +658,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Square
@@ -655,6 +671,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         class="ant-radio-button ant-radio-button-checked"
                       >
                         <input
+                          aria-label="Circle"
                           checked=""
                           class="ant-radio-button-input"
                           name="test-id"
@@ -663,6 +680,7 @@ exports[`renders components/skeleton/demo/element.tsx correctly 1`] = `
                         />
                       </span>
                       <span
+                        aria-hidden="true"
                         class="ant-radio-button-label"
                       >
                         Circle

--- a/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/space/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -16489,6 +16489,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="small"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -16497,6 +16498,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         small
@@ -16509,6 +16511,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="medium"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -16516,6 +16519,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         medium
@@ -16528,6 +16532,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="large"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -16535,6 +16540,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         large
@@ -16547,6 +16553,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="customize"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -16554,6 +16561,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         customize

--- a/components/space/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/space/__tests__/__snapshots__/demo.test.tsx.snap
@@ -4315,6 +4315,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="small"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -4323,6 +4324,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         small
@@ -4335,6 +4337,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="medium"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -4342,6 +4345,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         medium
@@ -4354,6 +4358,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="large"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -4361,6 +4366,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         large
@@ -4373,6 +4379,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="customize"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -4380,6 +4387,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         customize

--- a/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -160,6 +160,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx extend context cor
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="Auto"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -167,6 +168,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx extend context cor
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           Auto
@@ -179,6 +181,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx extend context cor
           class="ant-radio ant-wave-target ant-radio-checked"
         >
           <input
+            aria-label="True"
             checked=""
             class="ant-radio-input"
             name="test-id"
@@ -187,6 +190,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx extend context cor
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           True
@@ -199,6 +203,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx extend context cor
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="False"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -206,6 +211,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx extend context cor
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           False
@@ -1452,6 +1458,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Size Bucket 1"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1460,6 +1467,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Size Bucket 1
@@ -1472,6 +1480,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Size Bucket 2"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1479,6 +1488,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Size Bucket 2

--- a/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/splitter/__tests__/__snapshots__/demo.test.ts.snap
@@ -158,6 +158,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx correctly 1`] = `
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="Auto"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -165,6 +166,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           Auto
@@ -177,6 +179,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx correctly 1`] = `
           class="ant-radio ant-wave-target ant-radio-checked"
         >
           <input
+            aria-label="True"
             checked=""
             class="ant-radio-input"
             name="test-id"
@@ -185,6 +188,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           True
@@ -197,6 +201,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx correctly 1`] = `
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="False"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -204,6 +209,7 @@ exports[`renders components/splitter/demo/collapsibleIcon.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           False
@@ -1439,6 +1445,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Size Bucket 1"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1447,6 +1454,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Size Bucket 1
@@ -1459,6 +1467,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="Size Bucket 2"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1466,6 +1475,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Size Bucket 2

--- a/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -6424,6 +6424,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Small"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -6431,6 +6432,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Small
@@ -6443,6 +6445,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Medium"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -6451,6 +6454,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Medium

--- a/components/steps/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/steps/__tests__/__snapshots__/demo.test.ts.snap
@@ -5753,6 +5753,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Small"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -5760,6 +5761,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Small
@@ -5772,6 +5774,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Medium"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -5780,6 +5783,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Medium

--- a/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1553,6 +1553,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="Large"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -1561,6 +1562,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Large
@@ -1573,6 +1575,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Medium"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1580,6 +1583,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Medium
@@ -1592,6 +1596,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Small"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1599,6 +1604,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Small
@@ -1646,6 +1652,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="Unset"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -1654,6 +1661,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Unset
@@ -1666,6 +1674,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Scroll"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1673,6 +1682,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Scroll
@@ -1685,6 +1695,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Fixed Columns"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1692,6 +1703,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Fixed Columns
@@ -1739,6 +1751,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="Unset"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -1747,6 +1760,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Unset
@@ -1759,6 +1773,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Fixed"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1766,6 +1781,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Fixed
@@ -1813,6 +1829,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="TopStart"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1820,6 +1837,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     TopStart
@@ -1832,6 +1850,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="TopCenter"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1839,6 +1858,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     TopCenter
@@ -1851,6 +1871,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="TopEnd"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1858,6 +1879,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     TopEnd
@@ -1870,6 +1892,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="None"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -1878,6 +1901,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     None
@@ -1925,6 +1949,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="BottomStart"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1932,6 +1957,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     BottomStart
@@ -1944,6 +1970,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="BottomCenter"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1951,6 +1978,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     BottomCenter
@@ -1963,6 +1991,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="BottomEnd"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -1971,6 +2000,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     BottomEnd
@@ -1983,6 +2013,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="None"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1990,6 +2021,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     None
@@ -6098,6 +6130,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="Large"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -6106,6 +6139,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Large
@@ -6118,6 +6152,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Medium"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -6125,6 +6160,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Medium
@@ -6137,6 +6173,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Small"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -6144,6 +6181,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Small
@@ -6191,6 +6229,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="Unset"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -6199,6 +6238,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Unset
@@ -6211,6 +6251,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Scroll"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -6218,6 +6259,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Scroll
@@ -6230,6 +6272,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Fixed Columns"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -6237,6 +6280,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Fixed Columns
@@ -6284,6 +6328,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="Unset"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -6292,6 +6337,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Unset
@@ -6304,6 +6350,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Fixed"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -6311,6 +6358,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Fixed
@@ -6358,6 +6406,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="TopStart"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -6365,6 +6414,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     TopStart
@@ -6377,6 +6427,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="TopCenter"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -6384,6 +6435,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     TopCenter
@@ -6396,6 +6448,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="TopEnd"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -6403,6 +6456,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     TopEnd
@@ -6415,6 +6469,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="None"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -6423,6 +6478,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     None
@@ -6470,6 +6526,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="BottomStart"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -6477,6 +6534,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     BottomStart
@@ -6489,6 +6547,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="BottomCenter"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -6496,6 +6555,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     BottomCenter
@@ -6508,6 +6568,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="BottomEnd"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -6516,6 +6577,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     BottomEnd
@@ -6528,6 +6590,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="None"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -6535,6 +6598,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     None
@@ -22803,6 +22867,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
           class="ant-radio ant-wave-target ant-radio-checked"
         >
           <input
+            aria-label="topStart"
             checked=""
             class="ant-radio-input"
             name="test-id"
@@ -22811,6 +22876,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           topStart
@@ -22823,6 +22889,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="topCenter"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -22830,6 +22897,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           topCenter
@@ -22842,6 +22910,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="topEnd"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -22849,6 +22918,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           topEnd
@@ -22861,6 +22931,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="none"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -22868,6 +22939,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           none
@@ -22887,6 +22959,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="bottomStart"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -22894,6 +22967,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         bottomStart
@@ -22906,6 +22980,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="bottomCenter"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -22913,6 +22988,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         bottomCenter
@@ -22925,6 +23001,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="bottomEnd"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -22933,6 +23010,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         bottomEnd
@@ -22945,6 +23023,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="none"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -22952,6 +23031,7 @@ exports[`renders components/table/demo/pagination.tsx extend context correctly 1
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         none
@@ -24374,6 +24454,7 @@ exports[`renders components/table/demo/row-selection.tsx extend context correctl
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Checkbox"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -24382,6 +24463,7 @@ exports[`renders components/table/demo/row-selection.tsx extend context correctl
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Checkbox
@@ -24394,6 +24476,7 @@ exports[`renders components/table/demo/row-selection.tsx extend context correctl
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="radio"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -24401,6 +24484,7 @@ exports[`renders components/table/demo/row-selection.tsx extend context correctl
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         radio

--- a/components/table/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/table/__tests__/__snapshots__/demo.test.ts.snap
@@ -1551,6 +1551,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="Large"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -1559,6 +1560,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Large
@@ -1571,6 +1573,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Medium"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1578,6 +1581,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Medium
@@ -1590,6 +1594,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Small"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1597,6 +1602,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Small
@@ -1644,6 +1650,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="Unset"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -1652,6 +1659,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Unset
@@ -1664,6 +1672,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Scroll"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1671,6 +1680,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Scroll
@@ -1683,6 +1693,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Fixed Columns"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1690,6 +1701,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Fixed Columns
@@ -1737,6 +1749,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="Unset"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -1745,6 +1758,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Unset
@@ -1757,6 +1771,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Fixed"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1764,6 +1779,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Fixed
@@ -1811,6 +1827,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="TopStart"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1818,6 +1835,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     TopStart
@@ -1830,6 +1848,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="TopCenter"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1837,6 +1856,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     TopCenter
@@ -1849,6 +1869,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="TopEnd"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1856,6 +1877,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     TopEnd
@@ -1868,6 +1890,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="None"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -1876,6 +1899,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     None
@@ -1923,6 +1947,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="BottomStart"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1930,6 +1955,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     BottomStart
@@ -1942,6 +1968,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="BottomCenter"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1949,6 +1976,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     BottomCenter
@@ -1961,6 +1989,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="BottomEnd"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -1969,6 +1998,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     BottomEnd
@@ -1981,6 +2011,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="None"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -1988,6 +2019,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     None
@@ -5416,6 +5448,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="Large"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -5424,6 +5457,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Large
@@ -5436,6 +5470,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Medium"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -5443,6 +5478,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Medium
@@ -5455,6 +5491,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Small"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -5462,6 +5499,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Small
@@ -5509,6 +5547,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="Unset"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -5517,6 +5556,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Unset
@@ -5529,6 +5569,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Scroll"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -5536,6 +5577,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Scroll
@@ -5548,6 +5590,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Fixed Columns"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -5555,6 +5598,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Fixed Columns
@@ -5602,6 +5646,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="Unset"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -5610,6 +5655,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Unset
@@ -5622,6 +5668,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="Fixed"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -5629,6 +5676,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     Fixed
@@ -5676,6 +5724,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="TopStart"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -5683,6 +5732,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     TopStart
@@ -5695,6 +5745,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="TopCenter"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -5702,6 +5753,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     TopCenter
@@ -5714,6 +5766,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="TopEnd"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -5721,6 +5774,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     TopEnd
@@ -5733,6 +5787,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="None"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -5741,6 +5796,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     None
@@ -5788,6 +5844,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="BottomStart"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -5795,6 +5852,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     BottomStart
@@ -5807,6 +5865,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="BottomCenter"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -5814,6 +5873,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     BottomCenter
@@ -5826,6 +5886,7 @@ Array [
                     class="ant-radio-button ant-radio-button-checked"
                   >
                     <input
+                      aria-label="BottomEnd"
                       checked=""
                       class="ant-radio-button-input"
                       name="test-id"
@@ -5834,6 +5895,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     BottomEnd
@@ -5846,6 +5908,7 @@ Array [
                     class="ant-radio-button"
                   >
                     <input
+                      aria-label="None"
                       class="ant-radio-button-input"
                       name="test-id"
                       type="radio"
@@ -5853,6 +5916,7 @@ Array [
                     />
                   </span>
                   <span
+                    aria-hidden="true"
                     class="ant-radio-button-label"
                   >
                     None
@@ -21111,6 +21175,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
           class="ant-radio ant-wave-target ant-radio-checked"
         >
           <input
+            aria-label="topStart"
             checked=""
             class="ant-radio-input"
             name="test-id"
@@ -21119,6 +21184,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           topStart
@@ -21131,6 +21197,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="topCenter"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -21138,6 +21205,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           topCenter
@@ -21150,6 +21218,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="topEnd"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -21157,6 +21226,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           topEnd
@@ -21169,6 +21239,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
           class="ant-radio ant-wave-target"
         >
           <input
+            aria-label="none"
             class="ant-radio-input"
             name="test-id"
             type="radio"
@@ -21176,6 +21247,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
           />
         </span>
         <span
+          aria-hidden="true"
           class="ant-radio-label"
         >
           none
@@ -21195,6 +21267,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="bottomStart"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -21202,6 +21275,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         bottomStart
@@ -21214,6 +21288,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="bottomCenter"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -21221,6 +21296,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         bottomCenter
@@ -21233,6 +21309,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="bottomEnd"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -21241,6 +21318,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         bottomEnd
@@ -21253,6 +21331,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="none"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -21260,6 +21339,7 @@ exports[`renders components/table/demo/pagination.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         none
@@ -22355,6 +22435,7 @@ exports[`renders components/table/demo/row-selection.tsx correctly 1`] = `
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Checkbox"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -22363,6 +22444,7 @@ exports[`renders components/table/demo/row-selection.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Checkbox
@@ -22375,6 +22457,7 @@ exports[`renders components/table/demo/row-selection.tsx correctly 1`] = `
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="radio"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -22382,6 +22465,7 @@ exports[`renders components/table/demo/row-selection.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         radio

--- a/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -5471,6 +5471,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="top"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -5478,6 +5479,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             top
@@ -5490,6 +5492,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="bottom"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -5497,6 +5500,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             bottom
@@ -5509,6 +5513,7 @@ Array [
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="start"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -5517,6 +5522,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             start
@@ -5529,6 +5535,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="end"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -5536,6 +5543,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             end
@@ -6349,6 +6357,7 @@ exports[`renders components/tabs/demo/size.tsx extend context correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Small"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -6357,6 +6366,7 @@ exports[`renders components/tabs/demo/size.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Small
@@ -6369,6 +6379,7 @@ exports[`renders components/tabs/demo/size.tsx extend context correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Medium"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -6376,6 +6387,7 @@ exports[`renders components/tabs/demo/size.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Medium
@@ -6388,6 +6400,7 @@ exports[`renders components/tabs/demo/size.tsx extend context correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Large"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -6395,6 +6408,7 @@ exports[`renders components/tabs/demo/size.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Large
@@ -6964,6 +6978,7 @@ exports[`renders components/tabs/demo/slide.tsx extend context correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Horizontal"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -6972,6 +6987,7 @@ exports[`renders components/tabs/demo/slide.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Horizontal
@@ -6984,6 +7000,7 @@ exports[`renders components/tabs/demo/slide.tsx extend context correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Vertical"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -6991,6 +7008,7 @@ exports[`renders components/tabs/demo/slide.tsx extend context correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Vertical

--- a/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/tabs/__tests__/__snapshots__/demo.test.ts.snap
@@ -4286,6 +4286,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="top"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -4293,6 +4294,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             top
@@ -4305,6 +4307,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="bottom"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -4312,6 +4315,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             bottom
@@ -4324,6 +4328,7 @@ Array [
             class="ant-radio-button ant-radio-button-checked"
           >
             <input
+              aria-label="start"
               checked=""
               class="ant-radio-button-input"
               name="test-id"
@@ -4332,6 +4337,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             start
@@ -4344,6 +4350,7 @@ Array [
             class="ant-radio-button"
           >
             <input
+              aria-label="end"
               class="ant-radio-button-input"
               name="test-id"
               type="radio"
@@ -4351,6 +4358,7 @@ Array [
             />
           </span>
           <span
+            aria-hidden="true"
             class="ant-radio-button-label"
           >
             end
@@ -4979,6 +4987,7 @@ exports[`renders components/tabs/demo/size.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Small"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -4987,6 +4996,7 @@ exports[`renders components/tabs/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Small
@@ -4999,6 +5009,7 @@ exports[`renders components/tabs/demo/size.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Medium"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -5006,6 +5017,7 @@ exports[`renders components/tabs/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Medium
@@ -5018,6 +5030,7 @@ exports[`renders components/tabs/demo/size.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Large"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -5025,6 +5038,7 @@ exports[`renders components/tabs/demo/size.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Large
@@ -5517,6 +5531,7 @@ exports[`renders components/tabs/demo/slide.tsx correctly 1`] = `
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="Horizontal"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -5525,6 +5540,7 @@ exports[`renders components/tabs/demo/slide.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Horizontal
@@ -5537,6 +5553,7 @@ exports[`renders components/tabs/demo/slide.tsx correctly 1`] = `
         class="ant-radio-button"
       >
         <input
+          aria-label="Vertical"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -5544,6 +5561,7 @@ exports[`renders components/tabs/demo/slide.tsx correctly 1`] = `
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         Vertical

--- a/components/timeline/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/timeline/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2103,6 +2103,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Start"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -2111,6 +2112,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Start
@@ -2123,6 +2125,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="End"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -2130,6 +2133,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         End
@@ -2142,6 +2146,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Alternate"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -2149,6 +2154,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Alternate

--- a/components/timeline/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/timeline/__tests__/__snapshots__/demo.test.ts.snap
@@ -2076,6 +2076,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="Start"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -2084,6 +2085,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Start
@@ -2096,6 +2098,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="End"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -2103,6 +2106,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         End
@@ -2115,6 +2119,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="Alternate"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -2122,6 +2127,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         Alternate

--- a/components/tree-select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tree-select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1829,6 +1829,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="topLeft"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -1837,6 +1838,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topLeft
@@ -1849,6 +1851,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="topRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1856,6 +1859,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topRight
@@ -1868,6 +1872,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomLeft"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1875,6 +1880,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomLeft
@@ -1887,6 +1893,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -1894,6 +1901,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomRight

--- a/components/tree-select/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/tree-select/__tests__/__snapshots__/demo.test.tsx.snap
@@ -441,6 +441,7 @@ Array [
         class="ant-radio-button ant-radio-button-checked"
       >
         <input
+          aria-label="topLeft"
           checked=""
           class="ant-radio-button-input"
           name="test-id"
@@ -449,6 +450,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topLeft
@@ -461,6 +463,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="topRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -468,6 +471,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         topRight
@@ -480,6 +484,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomLeft"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -487,6 +492,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomLeft
@@ -499,6 +505,7 @@ Array [
         class="ant-radio-button"
       >
         <input
+          aria-label="bottomRight"
           class="ant-radio-button-input"
           name="test-id"
           type="radio"
@@ -506,6 +513,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-button-label"
       >
         bottomRight

--- a/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/typography/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1010,6 +1010,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="icon"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -1018,6 +1019,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         icon
@@ -1030,6 +1032,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="text"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1037,6 +1040,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         text
@@ -1049,6 +1053,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="both"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -1056,6 +1061,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         both

--- a/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/typography/__tests__/__snapshots__/demo.test.tsx.snap
@@ -801,6 +801,7 @@ Array [
         class="ant-radio ant-wave-target ant-radio-checked"
       >
         <input
+          aria-label="icon"
           checked=""
           class="ant-radio-input"
           name="test-id"
@@ -809,6 +810,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         icon
@@ -821,6 +823,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="text"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -828,6 +831,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         text
@@ -840,6 +844,7 @@ Array [
         class="ant-radio ant-wave-target"
       >
         <input
+          aria-label="both"
           class="ant-radio-input"
           name="test-id"
           type="radio"
@@ -847,6 +852,7 @@ Array [
         />
       </span>
       <span
+        aria-hidden="true"
         class="ant-radio-label"
       >
         both


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [x] ⌨️ Accessibility improvement

### 🔗 Related Issues

fix #53636

### 💡 Background and Solution

The `Radio` wrapper is a `<label>` that contains both the input and the text:

```html
<label class="ant-radio-wrapper">
  <span class="ant-radio">
    <input class="ant-radio-input" type="radio" />
    <span class="ant-radio-inner"></span>
  </span>
  <span class="ant-radio-label">Apple</span>
</label>
```

Because the text is a separate node inside the label, screen readers expose **two stops for a
single option**: first the text, then the control. Navigating a group of N options takes 2N key
presses, and each option is announced twice — once as bare text, once as an unnamed radio button.
Reproduced with VoiceOver on macOS against 6.6.2; the original report was filed against 5.24.7.

The native pattern (`<input>` and `<label for>` as siblings) produces a single stop, so the
problem is in the wrapper structure rather than in the screen reader.

**Solution.** When the label is plain text and the user has not supplied their own
`aria-label` / `aria-labelledby`, the name is moved onto the input and the visual copy is taken
out of the accessibility tree:

```html
<input class="ant-radio-input" type="radio" aria-label="Apple" />
<span class="ant-radio-label" aria-hidden="true">Apple</span>
```

One stop remains, with the correct name. Deliberately kept narrow:

- the wrapper stays a `<label>`, so clicking the text still selects the option and nothing that
  relies on the current DOM shape breaks;
- a user supplied `aria-label` / `aria-labelledby` always wins — `aria-label` is passed before the
  rest props spread;
- a non-text label (a link, an icon, any element) is left untouched, so `aria-hidden` can never
  swallow a focusable child.

Snapshots were regenerated for the components whose demos render a Radio.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | ⌨️ Fix Radio announcing the label text and the input as two separate stops in screen readers. |
| 🇨🇳 Chinese | ⌨️ 修复 Radio 的标签文本与输入框在屏幕阅读器中被识别为两个独立节点的问题。 |
