### PR TITLE
feat(Radio): support Radio.Group size for default Radio options

### DIFF
--- a/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/radio/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2100,253 +2100,409 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx extend context c
 
 exports[`renders components/radio/demo/size.tsx extend context correctly 1`] = `
 <div
-  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-large"
 >
   <div
-    class="ant-radio-group ant-radio-group-outline ant-radio-group-large css-var-test-id ant-radio-css-var"
-    role="radiogroup"
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
+    style="flex: 1 1 280px;"
   >
-    <label
-      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
+    <span
+      class="ant-typography css-var-test-id"
     >
-      <span
-        class="ant-radio-button ant-radio-button-checked"
-      >
-        <input
-          checked=""
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="a"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Hangzhou
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      <strong>
+        Radio
+      </strong>
+    </span>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-large css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="b"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
       >
-        Shanghai
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="c"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
       >
-        Beijing
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-small css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="d"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
       >
-        Chengdu
-      </span>
-    </label>
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
   </div>
   <div
-    class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
-    role="radiogroup"
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
+    style="flex: 1 1 280px;"
   >
-    <label
-      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
+    <span
+      class="ant-typography css-var-test-id"
     >
-      <span
-        class="ant-radio-button ant-radio-button-checked"
-      >
-        <input
-          checked=""
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="a"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Hangzhou
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      <strong>
+        Radio.Button
+      </strong>
+    </span>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-large css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="b"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        Shanghai
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="c"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        Beijing
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-small css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="d"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        Chengdu
-      </span>
-    </label>
-  </div>
-  <div
-    class="ant-radio-group ant-radio-group-outline ant-radio-group-small css-var-test-id ant-radio-css-var"
-    role="radiogroup"
-  >
-    <label
-      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button ant-radio-button-checked"
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        <input
-          checked=""
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="a"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Hangzhou
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button"
-      >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="b"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Shanghai
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button"
-      >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="c"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Beijing
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button"
-      >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="d"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Chengdu
-      </span>
-    </label>
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
   </div>
 </div>
 `;

--- a/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/demo.test.tsx.snap
@@ -2074,253 +2074,409 @@ exports[`renders components/radio/demo/radiogroup-with-name.tsx correctly 1`] = 
 
 exports[`renders components/radio/demo/size.tsx correctly 1`] = `
 <div
-  class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
+  class="ant-flex css-var-test-id ant-flex-wrap-wrap ant-flex-gap-large"
 >
   <div
-    class="ant-radio-group ant-radio-group-outline ant-radio-group-large css-var-test-id ant-radio-css-var"
-    role="radiogroup"
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
+    style="flex:1 1 280px"
   >
-    <label
-      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
+    <span
+      class="ant-typography css-var-test-id"
     >
-      <span
-        class="ant-radio-button ant-radio-button-checked"
-      >
-        <input
-          checked=""
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="a"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Hangzhou
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      <strong>
+        Radio
+      </strong>
+    </span>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-large css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="b"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
       >
-        Shanghai
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="c"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
       >
-        Beijing
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-small css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-wrapper ant-radio-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="d"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio ant-wave-target ant-radio-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
       >
-        Chengdu
-      </span>
-    </label>
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio ant-wave-target"
+        >
+          <input
+            class="ant-radio-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
   </div>
   <div
-    class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
-    role="radiogroup"
+    class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-medium ant-flex-vertical"
+    style="flex:1 1 280px"
   >
-    <label
-      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
+    <span
+      class="ant-typography css-var-test-id"
     >
-      <span
-        class="ant-radio-button ant-radio-button-checked"
-      >
-        <input
-          checked=""
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="a"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Hangzhou
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      <strong>
+        Radio.Button
+      </strong>
+    </span>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-large css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="b"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        Shanghai
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="c"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        Beijing
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
+      >
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
+    <div
+      class="ant-radio-group ant-radio-group-outline ant-radio-group-small css-var-test-id ant-radio-css-var"
+      role="radiogroup"
     >
-      <span
-        class="ant-radio-button"
+      <label
+        class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
       >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="d"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
+        <span
+          class="ant-radio-button ant-radio-button-checked"
+        >
+          <input
+            checked=""
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="a"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Hangzhou
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        Chengdu
-      </span>
-    </label>
-  </div>
-  <div
-    class="ant-radio-group ant-radio-group-outline ant-radio-group-small css-var-test-id ant-radio-css-var"
-    role="radiogroup"
-  >
-    <label
-      class="ant-radio-button-wrapper ant-radio-button-wrapper-checked css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button ant-radio-button-checked"
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="b"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Shanghai
+        </span>
+      </label>
+      <label
+        class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
       >
-        <input
-          checked=""
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="a"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Hangzhou
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button"
-      >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="b"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Shanghai
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button"
-      >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="c"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Beijing
-      </span>
-    </label>
-    <label
-      class="ant-radio-button-wrapper css-var-test-id ant-radio-css-var"
-    >
-      <span
-        class="ant-radio-button"
-      >
-        <input
-          class="ant-radio-button-input"
-          name="test-id"
-          type="radio"
-          value="d"
-        />
-      </span>
-      <span
-        class="ant-radio-button-label"
-      >
-        Chengdu
-      </span>
-    </label>
+        <span
+          class="ant-radio-button"
+        >
+          <input
+            class="ant-radio-button-input"
+            name="test-id"
+            type="radio"
+            value="c"
+          />
+        </span>
+        <span
+          class="ant-radio-button-label"
+        >
+          Beijing
+        </span>
+      </label>
+    </div>
   </div>
 </div>
 `;

--- a/components/radio/__tests__/group.test.tsx
+++ b/components/radio/__tests__/group.test.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
+import { renderToString } from 'react-dom/server';
 
 import type { RadioGroupProps } from '..';
 import Radio from '..';
 import { fireEvent, render, screen } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
 import Form from '../../form';
 
 describe('Radio Group', () => {
@@ -130,6 +133,84 @@ describe('Radio Group', () => {
     const radios = container.querySelectorAll('input');
 
     expect(radios.length).toBe(3);
+  });
+
+  it('should support size for default radio groups', () => {
+    const { container } = render(
+      <>
+        <Radio.Group size="large" options={['A']} />
+        <Radio.Group options={['B']} />
+        <Radio.Group size="small">
+          <Radio value="C">C</Radio>
+        </Radio.Group>
+      </>,
+    );
+    const [largeGroup, defaultGroup, smallGroup] = container.querySelectorAll('.ant-radio-group');
+    const getRadioStyle = (group: Element) => {
+      const radio = group.querySelector<HTMLElement>('.ant-radio')!;
+      return {
+        radioSize: getComputedStyle(radio).width,
+        labelFontSize: getComputedStyle(radio.parentElement!).fontSize,
+      };
+    };
+    const largeRadioStyle = getRadioStyle(largeGroup);
+    const defaultRadioStyle = getRadioStyle(defaultGroup);
+    const smallRadioStyle = getRadioStyle(smallGroup);
+
+    expect(largeRadioStyle).not.toEqual(defaultRadioStyle);
+    expect(defaultRadioStyle).not.toEqual(smallRadioStyle);
+
+    const getRadioGroupStyle = (wireframe: boolean) => {
+      const cache = createCache();
+      renderToString(
+        <ConfigProvider theme={wireframe ? { token: { wireframe } } : undefined}>
+          <StyleProvider cache={cache}>
+            <Radio.Group size="large" options={['A']} />
+            <Radio.Group size="small" options={['B']} />
+          </StyleProvider>
+        </ConfigProvider>,
+      );
+      return extractStyle(cache);
+    };
+    const getRadioDotSize = (style: string, size: 'large' | 'small') =>
+      style.match(
+        new RegExp(`\\.ant-radio-group-${size}[^}]*\\.ant-radio:after\\{width:([^;]+);`),
+      )?.[1];
+
+    [false, true].forEach((wireframe) => {
+      const style = getRadioGroupStyle(wireframe);
+
+      expect(style).not.toContain('NaN');
+      expect(getRadioDotSize(style, 'large')).toBeDefined();
+      expect(getRadioDotSize(style, 'small')).toBeDefined();
+      expect(getRadioDotSize(style, 'large')).not.toEqual(getRadioDotSize(style, 'small'));
+    });
+  });
+
+  it('should scale large/small sizes from customized radioSize and dotSize', () => {
+    const cache = createCache();
+    renderToString(
+      <ConfigProvider theme={{ components: { Radio: { radioSize: 24, dotSize: 12 } } }}>
+        <StyleProvider cache={cache}>
+          <Radio.Group size="large" options={['A']} />
+          <Radio.Group size="small" options={['B']} />
+        </StyleProvider>
+      </ConfigProvider>,
+    );
+    const style = extractStyle(cache);
+
+    expect(style).toContain('--ant-radio-radio-size:24');
+    expect(style).toContain('--ant-radio-dot-size:12');
+
+    // large/small should scale from the component tokens instead of global font tokens
+    ['.ant-radio-group-large', '.ant-radio-group-small'].forEach((groupCls) => {
+      expect(style).toMatch(
+        new RegExp(`${groupCls} [^{]*\\.ant-radio\\{[^}]*var\\(--ant-radio-radio-size\\)`),
+      );
+      expect(style).toMatch(
+        new RegExp(`${groupCls} [^{]*\\.ant-radio:after\\{[^}]*var\\(--ant-radio-dot-size\\)`),
+      );
+    });
   });
 
   it('all children should have a name property', () => {

--- a/components/radio/demo/size.tsx
+++ b/components/radio/demo/size.tsx
@@ -1,26 +1,26 @@
 import React from 'react';
-import { Flex, Radio } from 'antd';
+import { Flex, Radio, Typography } from 'antd';
+
+const options = [
+  { label: 'Hangzhou', value: 'a' },
+  { label: 'Shanghai', value: 'b' },
+  { label: 'Beijing', value: 'c' },
+];
 
 const App: React.FC = () => (
-  <Flex vertical gap="medium">
-    <Radio.Group defaultValue="a" size="large">
-      <Radio.Button value="a">Hangzhou</Radio.Button>
-      <Radio.Button value="b">Shanghai</Radio.Button>
-      <Radio.Button value="c">Beijing</Radio.Button>
-      <Radio.Button value="d">Chengdu</Radio.Button>
-    </Radio.Group>
-    <Radio.Group defaultValue="a">
-      <Radio.Button value="a">Hangzhou</Radio.Button>
-      <Radio.Button value="b">Shanghai</Radio.Button>
-      <Radio.Button value="c">Beijing</Radio.Button>
-      <Radio.Button value="d">Chengdu</Radio.Button>
-    </Radio.Group>
-    <Radio.Group defaultValue="a" size="small">
-      <Radio.Button value="a">Hangzhou</Radio.Button>
-      <Radio.Button value="b">Shanghai</Radio.Button>
-      <Radio.Button value="c">Beijing</Radio.Button>
-      <Radio.Button value="d">Chengdu</Radio.Button>
-    </Radio.Group>
+  <Flex gap="large" wrap>
+    <Flex vertical gap="medium" style={{ flex: '1 1 280px' }}>
+      <Typography.Text strong>Radio</Typography.Text>
+      <Radio.Group defaultValue="a" size="large" options={options} />
+      <Radio.Group defaultValue="a" options={options} />
+      <Radio.Group defaultValue="a" size="small" options={options} />
+    </Flex>
+    <Flex vertical gap="medium" style={{ flex: '1 1 280px' }}>
+      <Typography.Text strong>Radio.Button</Typography.Text>
+      <Radio.Group defaultValue="a" size="large" options={options} optionType="button" />
+      <Radio.Group defaultValue="a" options={options} optionType="button" />
+      <Radio.Group defaultValue="a" size="small" options={options} optionType="button" />
+    </Flex>
   </Flex>
 );
 

--- a/components/radio/index.en-US.md
+++ b/components/radio/index.en-US.md
@@ -88,7 +88,7 @@ Radio group can wrap a group of `Radio`.
 | options | Set children optional | string\[] \| number\[] \| Array&lt;[CheckboxOptionType](#checkboxoptiontype)> | - |  |
 | optionType | Set Radio optionType | `default` \| `button` | `default` | 4.4.0 |
 | orientation | Orientation | `horizontal` \| `vertical` | `horizontal` |  |
-| size | The size of radio button style | `large` \| `medium` \| `small` | - |  |
+| size | The size of the Radio | `large` \| `medium` \| `small` | - |  |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-group), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-group), CSSProperties> | - | 6.7.0 |
 | value | Used for setting the currently selected value | any | - |  |
 | vertical | If true, the Radio group will be vertical. Simultaneously existing with `orientation`, `orientation` takes priority | boolean | false |  |

--- a/components/radio/index.zh-CN.md
+++ b/components/radio/index.zh-CN.md
@@ -91,7 +91,7 @@ return (
 | options | 以配置形式设置子元素 | string\[] \| number\[] \| Array&lt;[CheckboxOptionType](#checkboxoptiontype)> | - |  |
 | optionType | 用于设置 Radio `options` 类型 | `default` \| `button` | `default` | 4.4.0 |
 | orientation | 排列方向 | `horizontal` \| `vertical` | `horizontal` |  |
-| size | 大小，只对按钮样式生效 | `large` \| `medium` \| `small` | - |  |
+| size | Radio 的大小 | `large` \| `medium` \| `small` | - |  |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | Record<[SemanticDOM](#semantic-group), CSSProperties> \| (info: { props })=> Record<[SemanticDOM](#semantic-group), CSSProperties> | - | 6.7.0 |
 | value | 用于设置当前选中的值 | any | - |  |
 | vertical | 值为 true，Radio Group 为垂直方向。与 `orientation` 同时存在，以 `orientation` 优先 | boolean | false |  |

--- a/components/radio/style/index.ts
+++ b/components/radio/style/index.ts
@@ -225,7 +225,36 @@ const getRadioBasicStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
     lineType,
     radioColor,
     radioBgColor,
+    fontSizeLG,
+    fontSizeSM,
+    fontHeight,
+    fontHeightLG,
+    fontHeightSM,
+    calc,
   } = token;
+
+  // Scale radio size with the fontHeight ladder, `radioSize` and `dotSize` stay as the
+  // base so customized component tokens control every size tier.
+  const genRadioSizeStyle = (
+    offset: number | string,
+    labelFontSize: number | string,
+  ): CSSObject => {
+    const scaledRadioSize = `calc(${radioSize} * 1px + ${unit(offset)})`;
+    const scaledDotSize = `calc(${dotSize} * 1px + ${unit(offset)})`;
+
+    return {
+      fontSize: labelFontSize,
+      [componentCls]: {
+        width: scaledRadioSize,
+        height: scaledRadioSize,
+
+        '&:after': {
+          width: scaledDotSize,
+          height: scaledDotSize,
+        },
+      },
+    };
+  };
 
   return {
     [`${componentCls}-wrapper`]: {
@@ -261,6 +290,16 @@ const getRadioBasicStyle: GenerateStyle<RadioToken, CSSObject> = (token) => {
         flex: 1,
         justifyContent: 'center',
       },
+
+      [`${componentCls}-group-large &`]: genRadioSizeStyle(
+        calc(fontHeightLG).sub(fontHeight).equal(),
+        fontSizeLG,
+      ),
+
+      [`${componentCls}-group-small &`]: genRadioSizeStyle(
+        calc(fontHeightSM).sub(fontHeight).equal(),
+        fontSizeSM,
+      ),
 
       // ===================== Radio =====================
       [componentCls]: {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交

### 🔗 相关 Issue

close #54558

（首个实现见已关闭的 #59170，本 PR 按讨论结论重写后重新提交。）

### 💡 需求背景和解决方案

`Radio.Group` 的 `size` 此前只对 `Radio.Button` 生效，普通 `Radio` 不响应（#54558）。#59170 的首个实现直接用全局字号 token 推导 large/small 尺寸，review 指出这会绕过 `Radio.radioSize` / `Radio.dotSize` 组件 token——单独配置 token 时 large 可能比默认档更小。讨论结论（见 #59170）：不新增 token，用 `fontHeightXXX` 推导。

实现方式：

- 三档尺寸以组件 token `radioSize` / `dotSize` 为基准，large / small 按 fontHeight 阶梯偏移（`fontHeightLG - fontHeight` / `fontHeightSM - fontHeight`，默认主题 ±2px），单独配置组件 token 时三档整体平移、层级不变；
- 偏移量是运行时 CSS calc 表达式，全局 `fontSize`、`compactAlgorithm`、`wireframe`、`lineWidth` 变化自动跟随，兼容 CSS Variable 模式；
- 默认主题视觉尺寸：外圈 18 / 16 / 14，圆点 8 / 6 / 4（wireframe 圆点 10 / 8 / 6），标签字号 `fontSizeLG` / `fontSize` / `fontSizeSM`；
- `size.tsx` demo 改为 Radio 与 Radio.Button 三档并排展示，中英文档中 `size` 的说明同步更新（不再只对按钮样式生效）。

<img width="965" height="386" alt="image" src="https://github.com/user-attachments/assets/7a74c0b9-e280-475c-b644-d883fae5b3e6" />


### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Radio Group `size` now applies to default Radio options as well. |
| 🇨🇳 中文 | Radio.Group 的 `size` 现在对普通 Radio 也生效。 |