### PR TITLE
feat: Listy support scrollWidth

### DIFF
--- a/components/listy/__tests__/demo-extend.test.ts
+++ b/components/listy/__tests__/demo-extend.test.ts
@@ -1,3 +1,3 @@
 import { extendTest } from '../../../tests/shared/demoTest';
 
-extendTest('listy', { skip: ['virtual.tsx', 'infinite.tsx'] });
+extendTest('listy', { skip: ['virtual.tsx', 'horizontal.tsx', 'infinite.tsx'] });

--- a/components/listy/__tests__/demo.test.ts
+++ b/components/listy/__tests__/demo.test.ts
@@ -1,4 +1,4 @@
 import demoTest from '../../../tests/shared/demoTest';
 
 // Virtual demos render every row without measurement in jsdom, snapshot is meaningless and huge
-demoTest('listy', { skip: ['virtual.tsx', 'infinite.tsx'] });
+demoTest('listy', { skip: ['virtual.tsx', 'horizontal.tsx', 'infinite.tsx'] });

--- a/components/listy/demo/horizontal.md
+++ b/components/listy/demo/horizontal.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+设置 `scrollWidth` 后，内容宽度超出容器时可以横向滚动，仅在开启 `virtual` 时生效。
+
+## en-US
+
+Set `scrollWidth` to scroll horizontally when the content is wider than the container. Only works when `virtual` is enabled.

--- a/components/listy/demo/horizontal.tsx
+++ b/components/listy/demo/horizontal.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Flex, Listy, Tag } from 'antd';
+
+interface Item {
+  id: number;
+  name: string;
+  email: string;
+  address: string;
+  status: string;
+}
+
+const items = Array.from<any, Item>({ length: 1000 }, (_, index) => ({
+  id: index,
+  name: `User ${index}`,
+  email: `user.${index}@ant.design`,
+  address: `No. ${index} Zhongshan Road, Xihu District, Hangzhou, Zhejiang`,
+  status: index % 2 ? 'Active' : 'Inactive',
+}));
+
+const App: React.FC = () => (
+  <Listy<Item, number>
+    virtual
+    items={items}
+    height={400}
+    scrollWidth={1000}
+    rowKey="id"
+    sticky
+    group={{
+      key: (item) => Math.floor(item.id / 50),
+      title: (groupKey) => `User ${groupKey * 50} - ${groupKey * 50 + 49}`,
+    }}
+    itemRender={(item) => (
+      <Flex gap="middle" align="center">
+        <span style={{ flex: '0 0 100px' }}>{item.name}</span>
+        <span style={{ flex: '0 0 220px' }}>{item.email}</span>
+        <span style={{ flex: '0 0 480px' }}>{item.address}</span>
+        <Tag color={item.status === 'Active' ? 'green' : 'default'}>{item.status}</Tag>
+      </Flex>
+    )}
+  />
+);
+
+export default App;

--- a/components/listy/index.en-US.md
+++ b/components/listy/index.en-US.md
@@ -19,6 +19,7 @@ tag: 6.6.0
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">Basic</code>
 <code src="./demo/virtual.tsx">Virtual scrolling</code>
+<code src="./demo/horizontal.tsx" version="6.7.0">Horizontal scrolling</code>
 <code src="./demo/group.tsx">Grouping and sticky headers</code>
 <code src="./demo/rich.tsx">Rich content</code>
 <code src="./demo/drag-sorting.tsx">Drag sorting</code>
@@ -40,6 +41,7 @@ Common props ref: [Common props](/docs/react/common-props)
 | itemRender | Render a single row | `(item: T, index: number) => ReactNode` | - | 6.6.0 | × |
 | items | Data source of the list | `T[]` | `[]` | 6.6.0 | × |
 | rowKey | Unique key of an item, a field name or a getter | `keyof T \| (item: T) => Key` | - | 6.6.0 | × |
+| scrollWidth | Horizontal scroll width of the content; scrolls horizontally when it exceeds the container, only works with `virtual` | number | - | 6.7.0 | × |
 | sticky | Whether group headers stick to the top | boolean | false | 6.6.0 | × |
 | styles | Semantic inline styles | `{ root?, item?, groupHeader? }` | - | 6.6.0 | 6.6.0 |
 | virtual | Whether to enable virtual scrolling, rendering only rows in view, requires `height` | boolean | false | 6.6.0 | × |

--- a/components/listy/index.zh-CN.md
+++ b/components/listy/index.zh-CN.md
@@ -20,6 +20,7 @@ tag: 6.6.0
 <!-- prettier-ignore -->
 <code src="./demo/basic.tsx">基础用法</code>
 <code src="./demo/virtual.tsx">虚拟滚动</code>
+<code src="./demo/horizontal.tsx" version="6.7.0">横向滚动</code>
 <code src="./demo/group.tsx">分组与吸顶</code>
 <code src="./demo/rich.tsx">复杂内容</code>
 <code src="./demo/drag-sorting.tsx">拖拽排序</code>
@@ -41,6 +42,7 @@ tag: 6.6.0
 | itemRender | 渲染单行 | `(item: T, index: number) => ReactNode` | - | 6.6.0 | × |
 | items | 列表数据源 | `T[]` | `[]` | 6.6.0 | × |
 | rowKey | 每一项的唯一键，字段名或取值函数 | `keyof T \| (item: T) => Key` | - | 6.6.0 | × |
+| scrollWidth | 内容的横向滚动宽度，超出容器宽度时可横向滚动，仅在 `virtual` 下生效 | number | - | 6.7.0 | × |
 | sticky | 分组标题是否吸顶 | boolean | false | 6.6.0 | × |
 | styles | 语义化结构 style | `{ root?, item?, groupHeader? }` | - | 6.6.0 | 6.6.0 |
 | virtual | 是否开启虚拟滚动，仅渲染视口内的行，需配合 `height` 使用 | boolean | false | 6.6.0 | × |

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@rc-component/image": "~1.10.0",
     "@rc-component/input": "~1.3.1",
     "@rc-component/input-number": "~1.6.2",
-    "@rc-component/listy": "~1.2.3",
+    "@rc-component/listy": "~1.3.0",
     "@rc-component/mentions": "~1.12.0",
     "@rc-component/menu": "~1.5.0",
     "@rc-component/motion": "^1.3.3",


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

ref https://github.com/react-component/listy/pull/65

### 💡 需求背景和解决方案

`@rc-component/listy` 1.3.0 新增了 `scrollWidth`，用于在内容宽度超出容器时提供横向滚动，并让吸顶的分组标题跟随横向偏移。此前 antd 的 Listy 没有横向滚动能力。

- 将 `@rc-component/listy` 从 `~1.2.3` 升级到 `~1.3.0`
- `scrollWidth` 随 `ListyProps` 透传，组件实现无需改动，也不需要新增样式
- 新增 `demo/horizontal.tsx` 演示横向滚动
- 中英文档补充 `scrollWidth`（6.7.0）
- 该 demo 在 jsdom 中会渲染全部行、快照无意义且体积巨大，按既有约定加入 `demo.test.ts` / `demo-extend.test.ts` 的 skip 列表（与 `virtual.tsx`、`infinite.tsx` 一致）

用法：

```tsx
<Listy virtual height={400} scrollWidth={1000} items={items} rowKey="id" itemRender={...} />
```

### 📝 更新日志

| 语言    | 更新描述                                                                                     |
| ------- | -------------------------------------------------------------------------------------------- |
| 🇺🇸 英文 | 🆕 Listy support `scrollWidth` to scroll horizontally when the content exceeds the container. |
| 🇨🇳 中文 | 🆕 Listy 新增 `scrollWidth`，内容超出容器宽度时可横向滚动。                                  |
