### PR TITLE
fix(Table): preserve filters on hidden responsive columns

### DIFF
--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -501,6 +501,7 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     locale: tableLocale,
     dropdownPrefixCls,
     mergedColumns,
+    baseColumns,
     onFilterChange,
     getPopupContainer: getPopupContainer || getContextPopupContainer,
     rootClassName: clsx(rootClassName, rootCls),

--- a/components/table/__tests__/Table.filter.test.tsx
+++ b/components/table/__tests__/Table.filter.test.tsx
@@ -440,6 +440,35 @@ describe('Table.filter', () => {
     expect(container.querySelectorAll('tbody tr').length).toBe(4);
   });
 
+  it('controlled filteredValue still applies when column is hidden by responsive', () => {
+    const columns: ColumnType<any>[] = [
+      { title: 'Name', dataIndex: 'name' },
+      {
+        title: 'Status',
+        dataIndex: 'status',
+        responsive: ['md'],
+        filteredValue: ['enabled'],
+        filters: [
+          { text: 'Enabled', value: 'enabled' },
+          { text: 'Disabled', value: 'disabled' },
+        ],
+        onFilter: (value, record) => record.status === value,
+      },
+    ];
+    const dataSource = [
+      { key: '1', name: 'Alice', status: 'enabled' },
+      { key: '2', name: 'Bob', status: 'disabled' },
+      { key: '3', name: 'Carol', status: 'enabled' },
+    ];
+
+    const { container } = render(
+      <Table columns={columns} dataSource={dataSource} pagination={false} />,
+    );
+
+    expect(container.querySelectorAll('thead th')).toHaveLength(1);
+    expect(renderedNames(container)).toEqual(['Alice', 'Carol']);
+  });
+
   it('should handle filteredValue and non-array filterValue as expected', () => {
     let filterKeys = new Set();
 

--- a/components/table/hooks/useFilter/index.tsx
+++ b/components/table/hooks/useFilter/index.tsx
@@ -223,6 +223,8 @@ export interface FilterConfig<RecordType = AnyObject> {
   prefixCls: string;
   dropdownPrefixCls: string;
   mergedColumns: ColumnsType<RecordType>;
+  /** Columns before applying the responsive filter. */
+  baseColumns?: ColumnsType<RecordType>;
   locale: TableLocale;
   onFilterChange: (
     filters: Record<string, FilterValue | null>,
@@ -253,6 +255,7 @@ const useFilter = <RecordType extends AnyObject = AnyObject>(
     prefixCls,
     dropdownPrefixCls,
     mergedColumns: rawMergedColumns,
+    baseColumns,
     onFilterChange,
     getPopupContainer,
     locale: tableLocale,
@@ -261,8 +264,8 @@ const useFilter = <RecordType extends AnyObject = AnyObject>(
   const warning = devUseWarning('Table');
 
   const mergedColumns = React.useMemo(
-    () => getMergedColumns<RecordType>(rawMergedColumns || []),
-    [rawMergedColumns],
+    () => getMergedColumns<RecordType>(baseColumns ?? rawMergedColumns ?? []),
+    [baseColumns, rawMergedColumns],
   );
 
   const [filterStates, setFilterStates] = React.useState<FilterState<RecordType>[]>(() =>


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

暂无关联 GitHub Issue。

[在线最小复现](https://codesandbox.io/p/sandbox/table-xiang-ying-shi-yin-cang-lie-hou-hui-diu-shi-gai-lie-de-shou-kong-shai-xuan-j4xcyj?file=%2Findex.tsx)

### 💡 需求背景和解决方案

Table 列同时配置 `responsive`、`filteredValue` 和 `onFilter` 时，列在当前断点下隐藏后会从筛选状态收集流程中移除，导致视口变化同时改变表格数据。

本次调整让筛选状态从响应式裁剪前的列集合中收集，同时继续使用裁剪后的列集合渲染表格。因此隐藏列不会显示，但其受控筛选仍会参与数据处理。

同时添加回归测试，验证响应式列隐藏后，列头不会渲染且受控筛选结果保持不变。

验证结果：

- Table filter/sorter：135 个测试通过
- TypeScript、ESLint、antd lint 和 diff 检查通过

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | 🐞 Fix Table controlled filters not applying when responsive columns are hidden. |
| 🇨🇳 中文 | 🐞 修复 Table 响应式列隐藏后受控筛选失效的问题。 |