### PR TITLE
docs: mark mask object fields optional in Modal zh-CN doc

### DIFF
--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -65,7 +65,7 @@ demo:
 | focusable | 对话框内焦点管理的配置 | `{ trap?: boolean, focusTriggerAfterClose?: boolean }` | - | 6.2.0 | 6.4.0 |
 | getContainer | 指定 Modal 挂载的节点，但依旧为全屏展示，`false` 为挂载在当前位置 | HTMLElement \| () => HTMLElement \| Selectors \| false | document.body |  | × |
 | keyboard | 是否支持键盘 esc 关闭 | boolean | true |  | × |
-| mask | 遮罩效果 | boolean \| `{enabled: boolean, blur: boolean, closable?: boolean}` | true | mask.closable: 6.3.0 | 6.0.0，mask.closable: 6.3.0 |
+| mask | 遮罩效果 | boolean \| `{enabled?: boolean, blur?: boolean, closable?: boolean}` | true | mask.closable: 6.3.0 | 6.0.0，mask.closable: 6.3.0 |
 | ~~maskClosable~~ | 点击蒙层是否允许关闭。请使用 `mask.closable` 替代。 | boolean | true | - | × |
 | modalRender | 自定义渲染对话框 | (node: ReactNode) => ReactNode | - | 4.7.0 | × |
 | okButtonProps | ok 按钮 props | [ButtonProps](/components/button-cn#api) | - |  | 6.0.0 |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Modal 中文文档中 `mask` 属性的对象类型写成了 `{enabled: boolean, blur: boolean, closable?: boolean}`，与 TypeScript 定义不符。`MaskConfig`（`components/_util/hooks/useMergedMask.ts`）中三个字段均为可选，英文文档与 Drawer 文档也都标注了 `?`。

本次修改为中文文档补充 `enabled` 与 `blur` 的可选标记，修正为 `{enabled?: boolean, blur?: boolean, closable?: boolean}`，避免中文用户误以为对象形式必须同时传入 `enabled` 和 `blur`。仅文档改动，无任何代码行为变化。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |