### PR TITLE
docs: add Listy to ConfigProvider component config

### DIFF
--- a/components/config-provider/index.en-US.md
+++ b/components/config-provider/index.en-US.md
@@ -148,6 +148,7 @@ The following config keys set common props for corresponding components or globa
 - `textArea`: [Input.TextArea](/components/input#inputtextarea) (supported since 5.15.0)
 - `layout`: [Layout](/components/layout#api) (supported since 5.7.0)
 - `list`: [List](/components/list#api) (supported since 5.7.0)
+- `listy`: [Listy](/components/listy#api) (supported since 6.6.0)
 - `masonry`: [Masonry](/components/masonry#api) (supported since 6.0.0)
 - `menu`: [Menu](/components/menu#api) (supported since 5.15.0)
 - `mentions`: [Mentions](/components/mentions#api) (supported since 5.13.0)

--- a/components/config-provider/index.zh-CN.md
+++ b/components/config-provider/index.zh-CN.md
@@ -150,6 +150,7 @@ const {
 - `textArea`：[Input.TextArea](/components/input-cn#inputtextarea)（自 5.15.0 起支持）
 - `layout`：[Layout](/components/layout-cn#api)（自 5.7.0 起支持）
 - `list`：[List](/components/list-cn#api)（自 5.7.0 起支持）
+- `listy`：[Listy](/components/listy-cn#api)（自 6.6.0 起支持）
 - `masonry`：[Masonry](/components/masonry-cn#api)（自 6.0.0 起支持）
 - `menu`：[Menu](/components/menu-cn#api)（自 5.15.0 起支持）
 - `mentions`：[Mentions](/components/mentions-cn#api)（自 5.13.0 起支持）


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

ConfigProvider 的组件配置清单缺少已支持全局配置的 Listy，导致其全局配置能力没有对应的文档入口。

在中英文 ConfigProvider 文档中补充 `listy` 配置项、对应 API 链接以及自 `6.6.0` 起支持的版本信息。

### 📝 更新日志

| 语言    | 更新描述              |
| ------- | --------------------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志          |