### PR TITLE
site: fix light/dark switcher icon alignment in theme editor

### DIFF
--- a/.dumi/pages/theme-editor/index.tsx
+++ b/.dumi/pages/theme-editor/index.tsx
@@ -16,9 +16,11 @@ const classNames = createStaticStyles(({ css }) => ({
       display: inline;
     }
 
+    /* Zero out the margin-block-end compensation that Segmented applies to
+       bare-svg icons, which lifts the light/dark switcher icons above
+       center. Unlayered here so it wins over the layered antd rule. */
     .ant-segmented-item-icon > svg {
-      display: inline-block;
-      vertical-align: middle !important;
+      margin-block-end: 0;
     }
   `,
 }));

--- a/.dumi/pages/theme-editor/index.tsx
+++ b/.dumi/pages/theme-editor/index.tsx
@@ -15,6 +15,11 @@ const classNames = createStaticStyles(({ css }) => ({
     img {
       display: inline;
     }
+
+    .ant-segmented-item-icon > svg {
+      display: inline-block;
+      vertical-align: middle !important;
+    }
   `,
 }));
 

--- a/.dumi/pages/theme-editor/index.tsx
+++ b/.dumi/pages/theme-editor/index.tsx
@@ -16,9 +16,6 @@ const classNames = createStaticStyles(({ css }) => ({
       display: inline;
     }
 
-    /* Zero out the margin-block-end compensation that Segmented applies to
-       bare-svg icons, which lifts the light/dark switcher icons above
-       center. Unlayered here so it wins over the layered antd rule. */
     .ant-segmented-item-icon > svg {
       margin-block-end: 0;
     }


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无（主题编辑器页白天/暗黑切换图标未垂直居中）。

### 💡 需求背景和解决方案

主题编辑器页（`/theme-editor-cn`）顶部的白天/暗黑 Segmented 切换图标偏上约 4px（图标上边距 1.8px、下边距 10.2px）。

根因：Segmented 对裸 `svg` 图标施加的 `margin-block-end: 0.2em` 光学补偿，在这个 28px 行高的图标独占场景里把图标往上顶出了中心。

方案：在 `.dumi/pages/theme-editor/index.tsx` 的 `editor` 样式里加一条 unlayered 豁免 `.ant-segmented-item-icon > svg { margin-block-end: 0 }`，赢过 `@layer antd` 里的补偿规则。本地 dumi 站实测图标回到接近居中（上 5px / 下 7px，中心偏差 -1.0px）。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A - site only, no changelog required |
| 🇨🇳 中文 | N/A - 仅站点样式，无需更新日志 |