### PR TITLE
docs: add missing es_US and sq_AL locales to i18n docs

### DIFF
--- a/docs/react/i18n.en-US.md
+++ b/docs/react/i18n.en-US.md
@@ -45,6 +45,7 @@ The following languages are currently supported:
 | English (United Kingdom) | en_GB    |
 | English                  | en_US    |
 | Spanish                  | es_ES    |
+| Spanish (United States)  | es_US    |
 | Basque                   | eu_ES    |
 | Estonian                 | et_EE    |
 | Persian                  | fa_IR    |
@@ -90,6 +91,7 @@ The following languages are currently supported:
 | Slovak                   | sk_SK    |
 | Serbian                  | sr_RS    |
 | Slovenian                | sl_SI    |
+| Albanian                 | sq_AL    |
 | Swedish                  | sv_SE    |
 | Tamil                    | ta_IN    |
 | Thai                     | th_TH    |

--- a/docs/react/i18n.zh-CN.md
+++ b/docs/react/i18n.zh-CN.md
@@ -45,6 +45,7 @@ return (
 | 英语                   | en_GB  |
 | 英语（美式）           | en_US  |
 | 西班牙语               | es_ES  |
+| 西班牙语（美式）       | es_US  |
 | 巴斯克语               | eu_ES  |
 | 爱沙尼亚语             | et_EE  |
 | 波斯语                 | fa_IR  |
@@ -90,6 +91,7 @@ return (
 | 斯洛伐克语             | sk_SK  |
 | 塞尔维亚语             | sr_RS  |
 | 斯洛文尼亚语           | sl_SI  |
+| 阿尔巴尼亚语           | sq_AL  |
 | 瑞典语                 | sv_SE  |
 | 泰米尔语               | ta_IN  |
 | 泰语                   | th_TH  |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

国际化文档的“支持语言”表格缺少以下两个已实现的语言：

- `es_US`（西班牙语（美式），由 #57137 添加）
- `sq_AL`（阿尔巴尼亚语，由 #58618 添加）

上述两个 PR 均遗漏了「增加语言包」步骤 8（将语言添加到 i18n 文档列表）。本 PR 在中英文 i18n 文档的支持语言表格中补充这两项，插入位置按文件名字母序排列。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |