### PR TITLE
fix(ColorPicker): support locale for clear button aria-label

### DIFF
--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -9,6 +9,7 @@ import { waitFakeTimer } from '../../../tests/utils';
 import Button from '../../button';
 import ConfigProvider from '../../config-provider';
 import Form from '../../form';
+import zhCN from '../../locale/zh_CN';
 import theme from '../../theme';
 import { AggregationColor } from '../color';
 import ColorPicker from '../ColorPicker';
@@ -152,6 +153,19 @@ describe('ColorPicker', () => {
     expect(
       container.querySelector('.ant-color-picker-alpha-input input')?.getAttribute('value'),
     ).toBe('100%');
+  });
+
+  it('Should clear button aria-label support locale', async () => {
+    const { container } = render(
+      <ConfigProvider locale={zhCN}>
+        <ColorPicker defaultValue="#1677ff" allowClear />
+      </ConfigProvider>,
+    );
+    fireEvent.click(container.querySelector('.ant-color-picker-trigger')!);
+    await waitFakeTimer();
+    expect(container.querySelector('.ant-color-picker-clear')?.getAttribute('aria-label')).toBe(
+      '清除颜色',
+    );
   });
 
   it('Should allowClear work with keyboard', async () => {

--- a/components/color-picker/components/ColorClear.tsx
+++ b/components/color-picker/components/ColorClear.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 import React from 'react';
 import { clsx } from 'clsx';
 
+import { useLocale } from '../../locale';
 import type { AggregationColor } from '../color';
 import { generateColor } from '../util';
 
@@ -14,6 +15,8 @@ interface ColorClearProps {
 }
 
 const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, onChange, className, style }) => {
+  const [locale] = useLocale('ColorPicker');
+
   const onClick = () => {
     if (onChange && value && !value.cleared) {
       const hsba = value.toHsb();
@@ -35,7 +38,7 @@ const ColorClear: FC<ColorClearProps> = ({ prefixCls, value, onChange, className
   return (
     <div
       role="button"
-      aria-label="Clear color"
+      aria-label={locale.clear}
       tabIndex={0}
       className={clsx(`${prefixCls}-clear`, className)}
       style={style}

--- a/components/locale/ar_EG.ts
+++ b/components/locale/ar_EG.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'شفاف',
     singleColor: 'لون واحد',
     gradientColor: 'تدرج لوني',
+    clear: 'مسح اللون',
   },
 };
 

--- a/components/locale/az_AZ.ts
+++ b/components/locale/az_AZ.ts
@@ -154,6 +154,7 @@ const localeValues: Locale = {
     transparent: 'Şəffaf',
     singleColor: 'Tək rəng',
     gradientColor: 'Gradient rəng',
+    clear: 'Rəngi təmizlə',
   },
 };
 

--- a/components/locale/bg_BG.ts
+++ b/components/locale/bg_BG.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Прозрачен',
     singleColor: 'Едноцветен',
     gradientColor: 'Преливащ цвят',
+    clear: 'Изчисти цвета',
   },
 };
 

--- a/components/locale/bn_BD.ts
+++ b/components/locale/bn_BD.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'স্বচ্ছ',
     singleColor: 'একক রঙ',
     gradientColor: 'গ্রেডিয়েন্ট রঙ',
+    clear: 'রঙ মুছুন',
   },
 };
 

--- a/components/locale/by_BY.ts
+++ b/components/locale/by_BY.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'Празрысты',
     singleColor: 'Аднакаляровы',
     gradientColor: 'Градыент колеру',
+    clear: 'Ачысціць колер',
   },
 };
 

--- a/components/locale/ca_ES.ts
+++ b/components/locale/ca_ES.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparent',
     singleColor: 'Un sol',
     gradientColor: 'Color degradat',
+    clear: 'Esborra el color',
   },
 };
 

--- a/components/locale/cs_CZ.ts
+++ b/components/locale/cs_CZ.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Průhledné',
     singleColor: 'Jednobarevné',
     gradientColor: 'Přechodové',
+    clear: 'Vymazat barvu',
   },
 };
 

--- a/components/locale/da_DK.ts
+++ b/components/locale/da_DK.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Gennemsigtig',
     singleColor: 'Enkelt farve',
     gradientColor: 'Gradient farve',
+    clear: 'Ryd farve',
   },
 };
 

--- a/components/locale/de_DE.ts
+++ b/components/locale/de_DE.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparent',
     singleColor: 'Einfarbig',
     gradientColor: 'Farbverlauf',
+    clear: 'Farbe löschen',
   },
 };
 

--- a/components/locale/el_GR.ts
+++ b/components/locale/el_GR.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Διαφανές',
     singleColor: 'Μονόχρωμο',
     gradientColor: 'Διαβάθμιση χρώματος',
+    clear: 'Διαγραφή χρώματος',
   },
 };
 

--- a/components/locale/en_GB.ts
+++ b/components/locale/en_GB.ts
@@ -158,6 +158,7 @@ const localeValues: Locale = {
     transparent: 'Transparent',
     singleColor: 'Single',
     gradientColor: 'Gradient',
+    clear: 'Clear color',
   },
 };
 

--- a/components/locale/en_US.ts
+++ b/components/locale/en_US.ts
@@ -158,6 +158,7 @@ const localeValues: Locale = {
     transparent: 'Transparent',
     singleColor: 'Single',
     gradientColor: 'Gradient',
+    clear: 'Clear color',
   },
 };
 

--- a/components/locale/es_ES.ts
+++ b/components/locale/es_ES.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparente',
     singleColor: 'color único',
     gradientColor: 'Color degradado',
+    clear: 'Borrar color',
   },
 };
 

--- a/components/locale/et_EE.ts
+++ b/components/locale/et_EE.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Läbipaistev',
     singleColor: 'Ühevärviline',
     gradientColor: 'Gradiendi värv',
+    clear: 'Tühjenda värv',
   },
 };
 

--- a/components/locale/eu_ES.ts
+++ b/components/locale/eu_ES.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'Gardena',
     singleColor: 'Kolore bakarra',
     gradientColor: 'Gradiente kolorea',
+    clear: 'Garbitu kolorea',
   },
 };
 

--- a/components/locale/fa_IR.ts
+++ b/components/locale/fa_IR.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'شفاف',
     singleColor: 'تک‌رنگ',
     gradientColor: 'گرادینت',
+    clear: 'پاک کردن رنگ',
   },
 };
 

--- a/components/locale/fi_FI.ts
+++ b/components/locale/fi_FI.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Läpinäkyvä',
     singleColor: 'Yksivärinen',
     gradientColor: 'Gradienttiväri',
+    clear: 'Tyhjennä väri',
   },
 };
 

--- a/components/locale/fr_BE.ts
+++ b/components/locale/fr_BE.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparente',
     singleColor: 'Couleur unique',
     gradientColor: 'Couleur dégradée',
+    clear: 'Effacer la couleur',
   },
 };
 

--- a/components/locale/fr_CA.ts
+++ b/components/locale/fr_CA.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparente',
     singleColor: 'Couleur unique',
     gradientColor: 'Couleur dégradée',
+    clear: 'Effacer la couleur',
   },
 };
 

--- a/components/locale/fr_FR.ts
+++ b/components/locale/fr_FR.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparente',
     singleColor: 'Couleur unique',
     gradientColor: 'Couleur dégradée',
+    clear: 'Effacer la couleur',
   },
 };
 

--- a/components/locale/ga_IE.ts
+++ b/components/locale/ga_IE.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'Trédhearcach',
     singleColor: 'Dath aonair',
     gradientColor: 'Dath grádán',
+    clear: 'Glan an dath',
   },
 };
 

--- a/components/locale/gl_ES.ts
+++ b/components/locale/gl_ES.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparente',
     singleColor: 'Cor única',
     gradientColor: 'Cor degradado',
+    clear: 'Borrar a cor',
   },
 };
 

--- a/components/locale/he_IL.ts
+++ b/components/locale/he_IL.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'שקוף',
     singleColor: 'צבע יחיד',
     gradientColor: 'צבע שיפוע',
+    clear: 'נקה צבע',
   },
 };
 

--- a/components/locale/hi_IN.ts
+++ b/components/locale/hi_IN.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'पारदर्शी',
     singleColor: 'एकल रंग',
     gradientColor: 'ढाल का रंग',
+    clear: 'रंग साफ़ करें',
   },
 };
 

--- a/components/locale/hr_HR.ts
+++ b/components/locale/hr_HR.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Prozirno',
     singleColor: 'Jedna boja',
     gradientColor: 'Gradijent boje',
+    clear: 'Očisti boju',
   },
 };
 

--- a/components/locale/hu_HU.ts
+++ b/components/locale/hu_HU.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Átlátszó',
     singleColor: 'Egyszínű',
     gradientColor: 'Gradiens szín',
+    clear: 'Szín törlése',
   },
 };
 

--- a/components/locale/hy_AM.ts
+++ b/components/locale/hy_AM.ts
@@ -201,6 +201,7 @@ const localeValues: Locale = {
     transparent: 'Թափանցիկ',
     singleColor: 'Մեկ գույն',
     gradientColor: 'Գրադիենտ գույն',
+    clear: 'Մաքրել գույնը',
   },
 };
 

--- a/components/locale/id_ID.ts
+++ b/components/locale/id_ID.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparan',
     singleColor: 'Warna tunggal',
     gradientColor: 'Warna gradien',
+    clear: 'Hapus warna',
   },
 };
 

--- a/components/locale/index.tsx
+++ b/components/locale/index.tsx
@@ -68,6 +68,7 @@ export interface Locale {
     transparent: string;
     singleColor: string;
     gradientColor: string;
+    clear: string;
   };
 }
 

--- a/components/locale/is_IS.ts
+++ b/components/locale/is_IS.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'Gegnsætt',
     singleColor: 'Einlitur',
     gradientColor: 'Gradient litur',
+    clear: 'Hreinsa lit',
   },
 };
 

--- a/components/locale/it_IT.ts
+++ b/components/locale/it_IT.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Trasparente',
     singleColor: 'Tinta unita',
     gradientColor: 'Gradiente',
+    clear: 'Cancella colore',
   },
 };
 

--- a/components/locale/ja_JP.ts
+++ b/components/locale/ja_JP.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: '透明',
     singleColor: '単色',
     gradientColor: 'グラデーション',
+    clear: '色をクリア',
   },
 };
 

--- a/components/locale/ka_GE.ts
+++ b/components/locale/ka_GE.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'გამჭვირვალე',
     singleColor: 'ერთი ფერი',
     gradientColor: 'გრადიენტური ფერი',
+    clear: 'ფერის გასუფთავება',
   },
 };
 

--- a/components/locale/kk_KZ.ts
+++ b/components/locale/kk_KZ.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'Мөлдір',
     singleColor: 'Бір түсті',
     gradientColor: 'Градиент түсі',
+    clear: 'Түсті өшіру',
   },
 };
 

--- a/components/locale/km_KH.ts
+++ b/components/locale/km_KH.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'តម្លាភាព',
     singleColor: 'ពណ៌តែមួយ',
     gradientColor: 'ពណ៌ជម្រាល',
+    clear: 'សម្អាតពណ៌',
   },
 };
 

--- a/components/locale/kmr_IQ.ts
+++ b/components/locale/kmr_IQ.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'Transparent',
     singleColor: 'Yek reng',
     gradientColor: 'Rengê gradient',
+    clear: 'Rengê paqij bike',
   },
 };
 

--- a/components/locale/kn_IN.ts
+++ b/components/locale/kn_IN.ts
@@ -155,6 +155,7 @@ const localeValues: Locale = {
     transparent: 'ಪಾರದರ್ಶಕ',
     singleColor: 'ಏಕ ಬಣ್ಣ',
     gradientColor: 'ಗ್ರೇಡಿಯಂಟ್ ಬಣ್ಣ',
+    clear: 'ಬಣ್ಣ ಅಳಿಸಿ',
   },
 };
 

--- a/components/locale/ko_KR.ts
+++ b/components/locale/ko_KR.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: '투명',
     singleColor: '단색',
     gradientColor: '그라데이션',
+    clear: '색 지우기',
   },
 };
 

--- a/components/locale/ku_IQ.ts
+++ b/components/locale/ku_IQ.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparent',
     singleColor: 'Yek reng',
     gradientColor: 'Rengê gradient',
+    clear: 'Rengê paqij bike',
   },
 };
 

--- a/components/locale/lt_LT.ts
+++ b/components/locale/lt_LT.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Permatomas',
     singleColor: 'Vieno spalvos',
     gradientColor: 'Gradientas',
+    clear: 'Išvalyti spalvą',
   },
 };
 

--- a/components/locale/lv_LV.ts
+++ b/components/locale/lv_LV.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Caurspīdīgs',
     singleColor: 'Vienkrāsains',
     gradientColor: 'Gradienta krāsa',
+    clear: 'Notīrīt krāsu',
   },
 };
 

--- a/components/locale/mk_MK.ts
+++ b/components/locale/mk_MK.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'Транспарентен',
     singleColor: 'Еднобојна',
     gradientColor: 'Боја на градиент',
+    clear: 'Избриши боја',
   },
 };
 

--- a/components/locale/ml_IN.ts
+++ b/components/locale/ml_IN.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'സുതാര്യം',
     singleColor: 'ഏക നിറം',
     gradientColor: 'ഗ്രേഡിയൻ്റ് നിറം',
+    clear: 'നിറം മായ്ക്കുക',
   },
 };
 

--- a/components/locale/mn_MN.ts
+++ b/components/locale/mn_MN.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'Ил тод',
     singleColor: 'Ганц өнгө',
     gradientColor: 'Градиент өнгө',
+    clear: 'Өнгө арилгах',
   },
 };
 

--- a/components/locale/mr_IN.ts
+++ b/components/locale/mr_IN.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'पारदर्शक',
     singleColor: 'एकच रंग',
     gradientColor: 'ग्रेडियंट रंग',
+    clear: 'रंग साफ करा',
   },
 };
 

--- a/components/locale/ms_MY.ts
+++ b/components/locale/ms_MY.ts
@@ -158,6 +158,7 @@ const localeValues: Locale = {
     transparent: 'Tidak tembus cahaya',
     singleColor: 'Warna tunggal',
     gradientColor: 'Warna gradien',
+    clear: 'Kosongkan warna',
   },
 };
 

--- a/components/locale/my_MM.ts
+++ b/components/locale/my_MM.ts
@@ -154,6 +154,7 @@ const localeValues: Locale = {
     transparent: 'ပွင့်လင်းသည်။',
     singleColor: 'တစ်ရောင်တည်း',
     gradientColor: 'Gradient အရောင်',
+    clear: 'အရောင် ဖျက်ရန်',
   },
 };
 

--- a/components/locale/nb_NO.ts
+++ b/components/locale/nb_NO.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Gjennomsiktig',
     singleColor: 'Ensfarget',
     gradientColor: 'Gradient',
+    clear: 'Tøm farge',
   },
 };
 

--- a/components/locale/ne_NP.ts
+++ b/components/locale/ne_NP.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'पारदर्शी',
     singleColor: 'एक रंग',
     gradientColor: 'ग्रेडिएण्ट',
+    clear: 'रङ खाली गर्नुहोस्',
   },
 };
 

--- a/components/locale/nl_BE.ts
+++ b/components/locale/nl_BE.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparant',
     singleColor: 'Enkele kleur',
     gradientColor: 'Kleurverloop',
+    clear: 'Kleur wissen',
   },
 };
 

--- a/components/locale/nl_NL.ts
+++ b/components/locale/nl_NL.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparant',
     singleColor: 'Enkele kleur',
     gradientColor: 'Kleurverloop',
+    clear: 'Kleur wissen',
   },
 };
 

--- a/components/locale/pl_PL.ts
+++ b/components/locale/pl_PL.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Przezroczysty',
     singleColor: 'Pojedynczy kolor',
     gradientColor: 'Kolor gradientowy',
+    clear: 'Wyczyść kolor',
   },
 };
 

--- a/components/locale/pt_BR.ts
+++ b/components/locale/pt_BR.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparente',
     singleColor: 'Único',
     gradientColor: 'Gradiente',
+    clear: 'Limpar cor',
   },
 };
 

--- a/components/locale/pt_PT.ts
+++ b/components/locale/pt_PT.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparente',
     singleColor: 'Simples',
     gradientColor: 'Gradiente',
+    clear: 'Limpar cor',
   },
 };
 

--- a/components/locale/ro_RO.ts
+++ b/components/locale/ro_RO.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparent',
     singleColor: 'O singură culoare',
     gradientColor: 'Culoare gradient',
+    clear: 'Șterge culoarea',
   },
 };
 

--- a/components/locale/ru_RU.ts
+++ b/components/locale/ru_RU.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Прозрачный',
     singleColor: 'Один цвет',
     gradientColor: 'Градиент',
+    clear: 'Очистить цвет',
   },
 };
 

--- a/components/locale/si_LK.ts
+++ b/components/locale/si_LK.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'විනිවිද පෙනෙන',
     singleColor: 'තනි වර්ණය',
     gradientColor: 'Gradient වර්ණය',
+    clear: 'වර්ණය මකන්න',
   },
 };
 

--- a/components/locale/sk_SK.ts
+++ b/components/locale/sk_SK.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparentné',
     singleColor: 'Jednofarebné',
     gradientColor: 'Farba prechodu',
+    clear: 'Vymazať farbu',
   },
 };
 

--- a/components/locale/sl_SI.ts
+++ b/components/locale/sl_SI.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparentna',
     singleColor: 'Enobarvna',
     gradientColor: 'Prelivna barva',
+    clear: 'Počisti barvo',
   },
 };
 

--- a/components/locale/sq_AL.ts
+++ b/components/locale/sq_AL.ts
@@ -162,6 +162,7 @@ const localeValues: Locale = {
     transparent: 'Transparent',
     singleColor: 'Një ngjyrë',
     gradientColor: 'Ngjyrë gradient',
+    clear: 'Pastro ngjyrën',
   },
 };
 

--- a/components/locale/sr_RS.ts
+++ b/components/locale/sr_RS.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Транспарент',
     singleColor: 'Једнобојна',
     gradientColor: 'Градијентна боја',
+    clear: 'Обриши боју',
   },
 };
 

--- a/components/locale/sv_SE.ts
+++ b/components/locale/sv_SE.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Transparent',
     singleColor: 'Enfärgad',
     gradientColor: 'Gradient färg',
+    clear: 'Rensa färg',
   },
 };
 

--- a/components/locale/ta_IN.ts
+++ b/components/locale/ta_IN.ts
@@ -155,6 +155,7 @@ const localeValues: Locale = {
     transparent: 'வெளிப்படையானது',
     singleColor: 'ஒற்றை நிறம்',
     gradientColor: 'சாய்வு நிறம்',
+    clear: 'நிறத்தை அழி',
   },
 };
 

--- a/components/locale/th_TH.ts
+++ b/components/locale/th_TH.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'โปร่งใส',
     singleColor: 'สีเดียว',
     gradientColor: 'สีไล่ระดับ',
+    clear: 'ล้างสี',
   },
 };
 

--- a/components/locale/tk_TK.ts
+++ b/components/locale/tk_TK.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'Aç-açan',
     singleColor: 'Coloreke reňk',
     gradientColor: 'Gradient reňki',
+    clear: 'Reňki arassala',
   },
 };
 

--- a/components/locale/tr_TR.ts
+++ b/components/locale/tr_TR.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Şeffaf',
     singleColor: 'Tek renk',
     gradientColor: 'Gradyan rengi',
+    clear: 'Rengi temizle',
   },
 };
 

--- a/components/locale/uk_UA.ts
+++ b/components/locale/uk_UA.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Прозорий',
     singleColor: 'Одноколірний',
     gradientColor: 'Градієнтний колір',
+    clear: 'Очистити колір',
   },
 };
 

--- a/components/locale/ur_PK.ts
+++ b/components/locale/ur_PK.ts
@@ -153,6 +153,7 @@ const localeValues: Locale = {
     transparent: 'شفاف',
     singleColor: 'سنگل رنگ',
     gradientColor: 'تدریجی رنگ',
+    clear: 'رنگ صاف کریں',
   },
 };
 

--- a/components/locale/uz_UZ.ts
+++ b/components/locale/uz_UZ.ts
@@ -158,6 +158,7 @@ const localeValues: Locale = {
     transparent: 'Shaffof',
     singleColor: 'Yagona rang',
     gradientColor: 'Gradient rangi',
+    clear: 'Rangni tozalash',
   },
 };
 

--- a/components/locale/vi_VN.ts
+++ b/components/locale/vi_VN.ts
@@ -157,6 +157,7 @@ const localeValues: Locale = {
     transparent: 'Trong suốt',
     singleColor: 'Màu đơn',
     gradientColor: 'Màu chuyển sắc',
+    clear: 'Xóa màu',
   },
 };
 

--- a/components/locale/zh_CN.ts
+++ b/components/locale/zh_CN.ts
@@ -159,6 +159,7 @@ const localeValues: Locale = {
     transparent: '无色',
     singleColor: '单色',
     gradientColor: '渐变色',
+    clear: '清除颜色',
   },
 };
 

--- a/components/locale/zh_HK.ts
+++ b/components/locale/zh_HK.ts
@@ -158,6 +158,7 @@ const localeValues: Locale = {
     transparent: '透明',
     singleColor: '單色',
     gradientColor: '漸變色',
+    clear: '清除顏色',
   },
 };
 

--- a/components/locale/zh_TW.ts
+++ b/components/locale/zh_TW.ts
@@ -158,6 +158,7 @@ const localeValues: Locale = {
     transparent: '透明',
     singleColor: '單色',
     gradientColor: '漸層色',
+    clear: '清除顏色',
   },
 };
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] ⌨️ 无障碍改进

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

ColorPicker 的清除按钮 `aria-label` 此前硬编码为英文 `"Clear color"`（`ColorClear.tsx`），导致任何语言下读屏器都播报英文。同目录的 `ColorTrigger.tsx`、`ColorPresets.tsx` 均已通过 `useLocale('ColorPicker')` 获取文案，仅此处遗漏。

解决方案：

1. `ColorClear.tsx` 改用 `useLocale('ColorPicker')` 读取 `locale.clear` 作为 `aria-label`（触发器与面板两处清除按钮同时修复）；
2. `Locale` 类型的 `ColorPicker` 段新增必填键 `clear`；
3. 为全部语言文件补充 `clear` 翻译；
4. 新增测试：`zh_CN` 下清除按钮 `aria-label` 应为 `清除颜色`。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix ColorPicker clear button `aria-label` not following the current locale. |
| 🇨🇳 中文 | 🐞 修复 ColorPicker 清除按钮 `aria-label` 未跟随当前语言的问题。 |