### PR TITLE
fix: align popupRender behavior, types, and docs

### DIFF
--- a/components/auto-complete/AutoComplete.tsx
+++ b/components/auto-complete/AutoComplete.tsx
@@ -81,8 +81,8 @@ export interface AutoCompleteProps<
   classNames?: AutoCompleteSemanticAllType['classNamesAndFn'];
   styles?: AutoCompleteSemanticAllType['stylesAndFn'];
   /** @deprecated Please use `popupRender` instead */
-  dropdownRender?: (menu: React.ReactElement) => React.ReactElement;
-  popupRender?: (menu: React.ReactElement) => React.ReactElement;
+  dropdownRender?: (menu: React.ReactElement) => React.ReactNode;
+  popupRender?: (menu: React.ReactElement) => React.ReactNode;
   /** @deprecated Please use `styles.popup.root` instead */
   dropdownStyle?: React.CSSProperties;
   /** @deprecated Please use `onOpenChange` instead */

--- a/components/auto-complete/index.en-US.md
+++ b/components/auto-complete/index.en-US.md
@@ -59,8 +59,8 @@ Common props ref：[Common props](/docs/react/common-props)
 | disabled | Whether disabled select | boolean | false |  |
 | ~~dropdownClassName~~ | The className of dropdown menu, please use `classNames.popup.root` instead | string | - | - |
 | ~~dropdownMatchSelectWidth~~ | Determine whether the dropdown menu and the input are the same width, please use `popupMatchSelectWidth` instead | boolean \| number | true | - |
-| ~~dropdownRender~~ | Customize dropdown content, use `popupRender` instead | (originNode: ReactNode) => ReactNode | - | 4.24.0 |
-| popupRender | Customize dropdown content | (originNode: ReactNode) => ReactNode | - |  |
+| ~~dropdownRender~~ | Customize dropdown content, use `popupRender` instead | (originNode: ReactElement) => ReactNode | - | 4.24.0 |
+| popupRender | Customize dropdown content | (originNode: ReactElement) => ReactNode | - |  |
 | ~~dropdownStyle~~ | The style of dropdown menu, use `styles.popup.root` instead | CSSProperties | - |  |
 | ~~popupClassName~~ | The className of dropdown menu, use `classNames.popup.root` instead | string | - | 4.23.0 |
 | popupMatchSelectWidth | Determine whether the dropdown menu and the select input are the same width. Default set `min-width` same as input. Will ignore when value less than select width. `false` will disable virtual scroll | boolean \| number | true |  |

--- a/components/auto-complete/index.zh-CN.md
+++ b/components/auto-complete/index.zh-CN.md
@@ -60,8 +60,8 @@ demo:
 | disabled | 是否禁用 | boolean | false |  |
 | ~~dropdownClassName~~ | 下拉菜单的 className 属性，请使用 `classNames.popup.root` 替代 | string | - | - |
 | ~~dropdownMatchSelectWidth~~ | 下拉菜单和输入框是否同宽，请使用 `popupMatchSelectWidth` 替代 | boolean \| number | true | - |
-| ~~dropdownRender~~ | 自定义下拉框内容，使用 `popupRender` 替换 | (originNode: ReactNode) => ReactNode | - | 4.24.0 |
-| popupRender | 自定义下拉框内容 | (originNode: ReactNode) => ReactNode | - |  |
+| ~~dropdownRender~~ | 自定义下拉框内容，使用 `popupRender` 替换 | (originNode: ReactElement) => ReactNode | - | 4.24.0 |
+| popupRender | 自定义下拉框内容 | (originNode: ReactElement) => ReactNode | - |  |
 | ~~popupClassName~~ | 下拉菜单的 className 属性，使用 `classNames.popup.root` 替换 | string | - | 4.23.0 |
 | ~~dropdownStyle~~ | 下拉菜单的 style 属性，使用 `styles.popup.root` 替换 | CSSProperties | - |  |
 | popupMatchSelectWidth | 下拉菜单和选择器同宽。默认将设置 `min-width`，当值小于选择框宽度时会被忽略。false 时会关闭虚拟滚动 | boolean \| number | true |  |

--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -64,8 +64,8 @@ Common props ref：[Common props](/docs/react/common-props)
 | tagRender | Custom render function for tags in `multiple` mode | (label: string, onClose: function, value: string) => ReactNode | - |  | × |
 | ~~popupClassName~~ | The additional className of popup overlay, use `classNames.popup.root` instead | string | - | 4.23.0 | × |
 | ~~dropdownClassName~~ | The additional className of popup overlay, please use `classNames.popup.root` instead | string | - | - | × |
-| ~~dropdownRender~~ | Customize dropdown content, use `popupRender` instead | (menus: ReactNode) => ReactNode | - | 4.4.0 | × |
-| popupRender | Customize dropdown content | (menus: ReactNode) => ReactNode | - |  | × |
+| ~~dropdownRender~~ | Customize dropdown content, use `popupRender` instead | (menus: ReactElement) => ReactNode | - | 4.4.0 | × |
+| popupRender | Customize dropdown content | (menus: ReactElement) => ReactNode | - |  | × |
 | ~~dropdownStyle~~ | The style of dropdown menu, use `styles.popup.root` instead | CSSProperties | - |  | × |
 | expandIcon | Customize the current item expand icon | ReactNode | - | 4.4.0 | 6.3.0 |
 | expandTrigger | expand current item when click or hover, one of `click` `hover` | string | `click` |  | × |

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -143,7 +143,7 @@ export interface CascaderProps<
   Multiple extends boolean = boolean,
 > extends Omit<
     RcCascaderProps<OptionType, ValueField, Multiple>,
-    'checkable' | 'classNames' | 'styles'
+    'checkable' | 'classNames' | 'styles' | 'popupRender'
   > {
   multiple?: Multiple;
   size?: SizeType;
@@ -171,8 +171,8 @@ export interface CascaderProps<
   /** @deprecated Please use `styles.popup.root` instead */
   dropdownStyle?: React.CSSProperties;
   /** @deprecated Please use `popupRender` instead */
-  dropdownRender?: (menu: React.ReactElement) => React.ReactElement;
-  popupRender?: (menu: React.ReactElement) => React.ReactElement;
+  dropdownRender?: (menu: React.ReactElement) => React.ReactNode;
+  popupRender?: (menu: React.ReactElement) => React.ReactNode;
   /** @deprecated Please use `styles.popup.listItem` instead */
   dropdownMenuColumnStyle?: React.CSSProperties;
   /** @deprecated Please use `styles.popup.listItem` instead */

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -65,8 +65,8 @@ demo:
 | tagRender | 自定义 tag 内容 render，仅在多选时生效 | ({ label: string, onClose: function, value: string }) => ReactNode | - |  | × |
 | ~~popupClassName~~ | 自定义浮层类名，使用 `classNames.popup.root` 替换 | string | - | 4.23.0 | × |
 | ~~dropdownClassName~~ | 自定义浮层类名，请使用 `classNames.popup.root` 替代 | string | - | - | × |
-| ~~dropdownRender~~ | 自定义下拉框内容，请使用 `popupRender` 替换 | (menus: ReactNode) => ReactNode | - | 4.4.0 | × |
-| popupRender | 自定义下拉框内容 | (menus: ReactNode) => ReactNode | - |  | × |
+| ~~dropdownRender~~ | 自定义下拉框内容，请使用 `popupRender` 替换 | (menus: ReactElement) => ReactNode | - | 4.4.0 | × |
+| popupRender | 自定义下拉框内容 | (menus: ReactElement) => ReactNode | - |  | × |
 | ~~dropdownStyle~~ | 下拉菜单的 style 属性，使用 `styles.popup.root` 替换 | CSSProperties | - |  | × |
 | expandIcon | 自定义次级菜单展开图标 | ReactNode | - | 4.4.0 | 6.3.0 |
 | expandTrigger | 次级菜单的展开方式，可选 'click' 和 'hover' | string | `click` |  | × |

--- a/components/dropdown/__tests__/index.test.tsx
+++ b/components/dropdown/__tests__/index.test.tsx
@@ -73,6 +73,16 @@ describe('Dropdown', () => {
     expect(Array.from(asFragment().childNodes)).toMatchSnapshot();
   });
 
+  it.each([null, 'Custom popup'])('should support popupRender returning %p', (popup) => {
+    expect(() =>
+      render(
+        <Dropdown open menu={{ items }} popupRender={() => popup}>
+          <button type="button">button</button>
+        </Dropdown>,
+      ),
+    ).not.toThrow();
+  });
+
   it('support Menu expandIcon', async () => {
     jest.useFakeTimers();
     const props: DropDownProps = {
@@ -584,9 +594,7 @@ describe('Dropdown', () => {
       .join('');
     const verticalRule = cssText
       .split('}')
-      .find(
-        (rule) => rule.includes('-dropdown-menu-vertical') && rule.includes('max-height'),
-      );
+      .find((rule) => rule.includes('-dropdown-menu-vertical') && rule.includes('max-height'));
 
     expect(verticalRule).toBeTruthy();
     expect(verticalRule).toContain('calc(100vh');

--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -313,9 +313,11 @@ const Dropdown: CompoundedComponent = React.forwardRef<HTMLElement, DropdownProp
     if (mergedPopupRender) {
       overlayNode = mergedPopupRender(overlayNode);
     }
-    overlayNode = React.Children.only(
-      typeof overlayNode === 'string' ? <span>{overlayNode}</span> : overlayNode,
-    );
+    if (typeof overlayNode === 'string') {
+      overlayNode = <span>{overlayNode}</span>;
+    } else if (!React.isValidElement(overlayNode)) {
+      overlayNode = React.createElement(React.Fragment, null, overlayNode);
+    }
     return (
       <OverrideProvider
         prefixCls={`${prefixCls}-menu`}

--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -72,7 +72,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | onDeselect | Called when a menu item is deselected (multiple mode only) | function({ key, keyPath, selectedKeys, domEvent, itemData }) | - |  | × |
 | onOpenChange | Called when sub-menus are opened or closed | function(openKeys: string\[]) | - |  | × |
 | onSelect | Called when a menu item is selected | function({ key, keyPath, selectedKeys, domEvent, itemData }) | - |  | × |
-| popupRender | Custom popup renderer for submenu | (node: ReactElement, props: { item: SubMenuProps; keys: string[] }) => ReactElement | - |  | × |
+| popupRender | Custom popup renderer for submenu | (node: ReactElement, props: { item: SubMenuProps; keys: string[] }) => ReactNode | - |  | × |
 
 > More options in [@rc-component/menu](https://github.com/react-component/menu#api)
 
@@ -106,7 +106,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | popupOffset | Sub-menu offset, not working when `mode="inline"` | \[number, number] | - |  |
 | theme | Color theme of the SubMenu (inherits from Menu by default) | `light` \| `dark` | - |  |
 | onTitleClick | Callback executed when the sub-menu title is clicked | function({ key, domEvent }) | - |  |
-| popupRender | Custom popup renderer for current sub-menu | (node: ReactElement, props: { item: SubMenuProps; keys: string[] }) => ReactElement | - |  |
+| popupRender | Custom popup renderer for current sub-menu | (node: ReactElement, props: { item: SubMenuProps; keys: string[] }) => ReactNode | - |  |
 
 #### MenuItemGroupType
 

--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -73,7 +73,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*Vn4XSqJFAxcAAA
 | onDeselect | 取消选中时调用，仅在 multiple 生效 | function({ key, keyPath, selectedKeys, domEvent, itemData }) | - |  | × |
 | onOpenChange | SubMenu 展开/关闭的回调 | function(openKeys: string\[]) | - |  | × |
 | onSelect | 被选中时调用 | function({ key, keyPath, selectedKeys, domEvent, itemData }) | - |  | × |
-| popupRender | 自定义子菜单的弹出框 | (node: ReactElement, props: { item: SubMenuProps; keys: string[] }) => ReactElement | - |  | × |
+| popupRender | 自定义子菜单的弹出框 | (node: ReactElement, props: { item: SubMenuProps; keys: string[] }) => ReactNode | - |  | × |
 
 > 更多属性查看 [@rc-component/menu](https://github.com/react-component/menu#api)
 
@@ -106,7 +106,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*Vn4XSqJFAxcAAA
 | popupOffset | 子菜单偏移量，`mode="inline"` 时无效 | \[number, number] | - |  |
 | onTitleClick | 点击子菜单标题 | function({ key, domEvent }) | - |  |
 | theme | 设置子菜单的主题，默认从 Menu 上继承 | `light` \| `dark` | - |  |
-| popupRender | 自定义当前子菜单的弹出框 | (node: ReactElement, props: { item: SubMenuProps; keys: string[] }) => ReactElement | - |  |
+| popupRender | 自定义当前子菜单的弹出框 | (node: ReactElement, props: { item: SubMenuProps; keys: string[] }) => ReactNode | - |  |
 
 #### MenuItemGroupType
 

--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -74,8 +74,8 @@ Common props ref：[Common props](/docs/react/common-props)
 | ~~dropdownMatchSelectWidth~~ | Determine whether the popup menu and the select input are the same width, please use `popupMatchSelectWidth` instead | boolean \| number | true | - | × |
 | ~~popupClassName~~ | The className of dropdown menu, use `classNames.popup.root` instead | string | - | 4.23.0 | × |
 | popupMatchSelectWidth | Determine whether the popup menu and the select input are the same width. Default set `min-width` same as input. Will ignore when value less than select width. `false` will disable virtual scroll | boolean \| number | true | 5.5.0 | × |
-| ~~dropdownRender~~ | Customize dropdown content, use `popupRender` instead | (originNode: ReactNode) => ReactNode | - |  | × |
-| popupRender | Customize dropdown content | (originNode: ReactNode) => ReactNode | - | 5.25.0 | × |
+| ~~dropdownRender~~ | Customize dropdown content, use `popupRender` instead | (originNode: ReactElement) => ReactNode | - |  | × |
+| popupRender | Customize dropdown content | (originNode: ReactElement) => ReactNode | - | 5.25.0 | × |
 | ~~dropdownStyle~~ | The style of dropdown menu, use `styles.popup.root` instead | CSSProperties | - |  | × |
 | fieldNames | Customize node label, value, options，groupLabel field name | object | { label: `label`, value: `value`, options: `options`, groupLabel: `label` } | 4.17.0 (`groupLabel` added in 5.6.0) | × |
 | ~~filterOption~~ | If true, filter options by input, if function, filter options against it. The function will receive two arguments, `inputValue` and `option`, if the function returns `true`, the option will be included in the filtered set; Otherwise, it will be excluded | boolean \| function(inputValue, option) | true |  | × |

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -102,7 +102,7 @@ export interface InternalSelectProps<
   OptionType extends BaseOptionType | DefaultOptionType = DefaultOptionType,
 > extends Omit<
     RcSelectProps<ValueType, OptionType>,
-    'mode' | 'styles' | 'classNames' | 'onPopupVisibleChange'
+    'mode' | 'styles' | 'classNames' | 'onPopupVisibleChange' | 'popupRender'
   > {
   rootClassName?: string;
   prefix?: React.ReactNode;
@@ -126,6 +126,7 @@ export interface InternalSelectProps<
   styles?: SelectSemanticAllType['stylesAndFn'];
   loadingIcon?: React.ReactNode;
   showSearch?: boolean | (SearchConfig<OptionType> & { searchIcon?: React.ReactNode });
+  popupRender?: (menu: React.ReactElement) => React.ReactNode;
 }
 
 export interface SelectProps<

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -75,8 +75,8 @@ demo:
 | ~~dropdownMatchSelectWidth~~ | 下拉菜单和选择器是否同宽，请使用 `popupMatchSelectWidth` 替代 | boolean \| number | true | - | × |
 | ~~popupClassName~~ | 下拉菜单的 className 属性，使用 `classNames.popup.root` 替换 | string | - | 4.23.0 | × |
 | popupMatchSelectWidth | 下拉菜单和选择器同宽。默认将设置 `min-width`，当值小于选择框宽度时会被忽略。false 时会关闭虚拟滚动 | boolean \| number | true | 5.5.0 | × |
-| ~~dropdownRender~~ | 自定义下拉框内容，使用 `popupRender` 替换 | (originNode: ReactNode) => ReactNode | - |  | × |
-| popupRender | 自定义下拉框内容 | (originNode: ReactNode) => ReactNode | - | 5.25.0 | × |
+| ~~dropdownRender~~ | 自定义下拉框内容，使用 `popupRender` 替换 | (originNode: ReactElement) => ReactNode | - |  | × |
+| popupRender | 自定义下拉框内容 | (originNode: ReactElement) => ReactNode | - | 5.25.0 | × |
 | ~~dropdownStyle~~ | 下拉菜单的 style 属性，使用 `styles.popup.root` 替换 | CSSProperties | - |  | × |
 | fieldNames | 自定义节点 label、value、options、groupLabel 的字段 | object | { label: `label`, value: `value`, options: `options`, groupLabel: `label` } | 4.17.0（`groupLabel` 在 5.6.0 新增） | × |
 | ~~filterOption~~ | 是否根据输入项进行筛选。当其为一个函数时，会接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 true，反之则返回 false。[示例](#select-demo-search) | boolean \| function(inputValue, option) | true |  | × |

--- a/components/tree-select/index.en-US.md
+++ b/components/tree-select/index.en-US.md
@@ -50,8 +50,8 @@ Common props ref：[Common props](/docs/react/common-props)
 | ~~dropdownMatchSelectWidth~~ | Determine whether the popup menu and the select input are the same width, please use `popupMatchSelectWidth` instead | boolean \| number | true | - | × |
 | ~~popupClassName~~ | The className of dropdown menu, use `classNames.popup.root` instead | string | - | 4.23.0 | × |
 | popupMatchSelectWidth | Determine whether the popup menu and the select input are the same width. Default set `min-width` same as input. Will ignore when value less than select width. `false` will disable virtual scroll | boolean \| number | true | 5.5.0 | × |
-| ~~dropdownRender~~ | Customize dropdown content, use `popupRender` instead | (originNode: ReactNode, props) => ReactNode | - |  | × |
-| popupRender | Customize dropdown content | (originNode: ReactNode, props) => ReactNode | - |  | × |
+| ~~dropdownRender~~ | Customize dropdown content, use `popupRender` instead | (originNode: ReactElement) => ReactNode | - |  | × |
+| popupRender | Customize dropdown content | (originNode: ReactElement) => ReactNode | - |  | × |
 | ~~dropdownStyle~~ | To set the style of the dropdown menu, use `styles.popup.root` instead | CSSProperties | - |  | × |
 | fieldNames | Customize node label, value, children field name | object | { label: `label`, value: `value`, children: `children` } | 4.17.0 | × |
 | ~~filterTreeNode~~ | Whether to filter treeNodes by input value. The value of `treeNodeFilterProp` is used for filtering by default | boolean \| function(inputValue: string, treeNode: TreeNode) (should return boolean) | function |  | × |

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -110,6 +110,7 @@ interface BaseTreeSelectProps<ValueType = any, OptionType extends DataNode = Dat
       | 'switcherIcon'
       | 'classNames'
       | 'styles'
+      | 'popupRender'
     > {
   size?: SizeType;
   disabled?: boolean;
@@ -130,8 +131,8 @@ export interface TreeSelectProps<ValueType = any, OptionType extends DataNode = 
   /** @deprecated Please use `classNames.popup.root` instead */
   dropdownClassName?: string;
   /** @deprecated Please use `popupRender` instead */
-  dropdownRender?: (menu: React.ReactElement) => React.ReactElement;
-  popupRender?: (menu: React.ReactElement) => React.ReactElement;
+  dropdownRender?: (menu: React.ReactElement) => React.ReactNode;
+  popupRender?: (menu: React.ReactElement) => React.ReactNode;
   /** @deprecated Please use `styles.popup.root` instead */
   dropdownStyle?: React.CSSProperties;
   /** @deprecated Please use `onOpenChange` instead */

--- a/components/tree-select/index.zh-CN.md
+++ b/components/tree-select/index.zh-CN.md
@@ -51,8 +51,8 @@ demo:
 | ~~dropdownMatchSelectWidth~~ | 下拉菜单和选择器是否同宽，请使用 `popupMatchSelectWidth` 替代 | boolean \| number | true | - | × |
 | ~~popupClassName~~ | 下拉菜单的 className 属性，使用 `classNames.popup.root` 替换 | string | - | 4.23.0 | × |
 | popupMatchSelectWidth | 下拉菜单和选择器同宽。默认将设置 `min-width`，当值小于选择框宽度时会被忽略。false 时会关闭虚拟滚动 | boolean \| number | true | 5.5.0 | × |
-| ~~dropdownRender~~ | 自定义下拉框内容，使用 `popupRender` 替换 | (originNode: ReactNode, props) => ReactNode | - |  | × |
-| popupRender | 自定义下拉框内容 | (originNode: ReactNode, props) => ReactNode | - |  | × |
+| ~~dropdownRender~~ | 自定义下拉框内容，使用 `popupRender` 替换 | (originNode: ReactElement) => ReactNode | - |  | × |
+| popupRender | 自定义下拉框内容 | (originNode: ReactElement) => ReactNode | - |  | × |
 | ~~dropdownStyle~~ | 下拉菜单的样式，使用 `styles.popup.root` 替换 | object | - |  | × |
 | fieldNames | 自定义节点 label、value、children 的字段 | object | { label: `label`, value: `value`, children: `children` } | 4.17.0 | × |
 | ~~filterTreeNode~~ | 是否根据输入项进行筛选，默认用 treeNodeFilterProp 的值作为要筛选的 TreeNode 的属性值 | boolean \| function(inputValue: string, treeNode: TreeNode) (函数需要返回 bool 值) | function |  | × |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [x] 🤖 TypeScript 定义更新
- [x] ✅ 测试用例

### 🔗 相关 Issue

在线复现：https://codesandbox.io/p/sandbox/dropdown-de-popuprender-fan-hui-null-shi-hui-pao-chu-yun-xing-shi-cuo-wu-4shfw4

### 💡 需求背景和解决方案

多个弹出层组件的 `popupRender` 在公开类型、文档和运行时行为之间存在不一致：

- 修复 Dropdown 对 `null`、数组和数字等合法 `ReactNode` 返回值调用 `React.Children.only` 导致的运行时错误。
- 将 Select、AutoComplete、Cascader 和 TreeSelect 的公开类型调整为接收 `ReactElement`、返回 `ReactNode`，与实际包装逻辑及文档保持一致。
- 修正上述组件及 Menu 中英文文档里的回调参数和返回值类型。
- 补充 Dropdown 返回空值与字符串时的回归测试。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix popupRender runtime and type inconsistencies across popup components. |
| 🇨🇳 中文 | 🐞 修复多个弹出层组件 `popupRender` 的运行时行为与类型定义不一致问题。 |
