### PR TITLE
docs: fix API table default values and version metadata

### DIFF
--- a/components/anchor/index.en-US.md
+++ b/components/anchor/index.en-US.md
@@ -62,9 +62,9 @@ Common props ref：[Common props](/docs/react/common-props)
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | key | The unique identifier of the Anchor Link | string \| number | - |  |
-| href | The target of hyperlink | string |  |  |
-| target | Specifies where to display the linked URL | string |  |  |
-| title | The content of hyperlink | ReactNode |  |  |
+| href | The target of hyperlink | string | - |  |
+| target | Specifies where to display the linked URL | string | - |  |
+| title | The content of hyperlink | ReactNode | - |  |
 | children | Nested Anchor Link, `Attention: This attribute does not support horizontal orientation` | [AnchorItem](#anchoritem)\[] | - |  |
 | replace | Replace item href in browser history instead of pushing it | boolean | false | 5.7.0 |
 | targetOffset | Customize scroll offset for this anchor link. It takes precedence over the `targetOffset` prop of the Anchor component | number | - | 6.4.0 |
@@ -75,9 +75,9 @@ We recommend using the items form instead.
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
-| href | The target of hyperlink | string |  |  |
-| target | Specifies where to display the linked URL | string |  |  |
-| title | The content of hyperlink | ReactNode |  |  |
+| href | The target of hyperlink | string | - |  |
+| target | Specifies where to display the linked URL | string | - |  |
+| title | The content of hyperlink | ReactNode | - |  |
 | targetOffset | Customize scroll offset for this anchor link. It takes precedence over the `targetOffset` prop of the Anchor component | number | - | 6.4.0 |
 
 ## Semantic DOM

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -160,11 +160,11 @@ interface CountConfig {
 
 #### VisibilityToggle
 
-| 参数            | 说明                      | 类型              | 默认值 | 版本  |
-| --------------- | ------------------------- | ----------------- | ------ | ----- |
-| tabIndex        | 设置切换按钮的 `tabIndex` | number            | 0      | 6.5.0 |
-| visible         | 用于手动控制密码显隐      | boolean           | false  | 4.24  |
-| onVisibleChange | 显隐密码的回调            | (visible) => void | -      | 4.24  |
+| 参数            | 说明                      | 类型              | 默认值 | 版本   |
+| --------------- | ------------------------- | ----------------- | ------ | ------ |
+| tabIndex        | 设置切换按钮的 `tabIndex` | number            | 0      | 6.5.0  |
+| visible         | 用于手动控制密码显隐      | boolean           | false  | 4.24.0 |
+| onVisibleChange | 显隐密码的回调            | (visible) => void | -      | 4.24.0 |
 
 #### Input Methods
 

--- a/components/notification/index.en-US.md
+++ b/components/notification/index.en-US.md
@@ -97,7 +97,7 @@ The properties of config are as follows:
 | Property  | Description                     | Type      | Default   | Version |
 | --------- | ------------------------------- | --------- | --------- | ------- |
 | closeIcon | Custom close icon               | ReactNode | undefined | -       |
-| onClose   | Trigger when notification close | Function  | undefined | -       |
+| onClose   | Trigger when notification close | Function  | -         | -       |
 
 ### Global configuration
 

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -204,7 +204,7 @@ const columns = [
 | filterDropdown | 可以自定义筛选菜单，此函数只负责渲染图层，需要自行编写各种交互 | ReactNode \| (props: [FilterDropdownProps](https://github.com/ant-design/ant-design/blob/ecc54dda839619e921c0ace530408871f0281c2a/components/table/interface.tsx#L79)) => ReactNode | - |  |
 | filtered | 标识数据是否经过过滤，筛选图标会高亮 | boolean | false |  |
 | filteredValue | 筛选的受控属性，外界可用此控制列的筛选状态，值为已筛选的 value 数组 | string\[] | - |  |
-| filterIcon | 自定义 filter 图标。 | ReactNode \| (filtered: boolean) => ReactNode | false |  |
+| filterIcon | 自定义 filter 图标。 | ReactNode \| (filtered: boolean) => ReactNode | - |  |
 | filterOnClose | 是否在筛选菜单关闭时触发筛选 | boolean | true | 5.15.0 |
 | filterMultiple | 是否多选 | boolean | true |  |
 | filterMode | 指定筛选菜单的用户界面 | 'menu' \| 'tree' | 'menu' | 4.17.0 |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

部分组件 API 表格的中英文元数据不一致，或与运行时行为、文档规范不符，具体四处：

1. Notification 英文文档 ClosableType 表中 `onClose` 默认值写作 `undefined`，中文文档与规范均为 `-`；
2. Anchor 英文文档 AnchorItem 与 Link Props 两个子表中 `href` / `target` / `title` 默认值为空单元格，中文文档均为 `-`；
3. Input.Password 中文文档 VisibilityToggle 子表中 `visible` / `onVisibleChange` 版本号写作 `4.24`，英文文档为 `4.24.0`；
4. Table 中文文档 `filterIcon` 默认值写作 `false`，但运行时（FilterDropdown.tsx）对 falsy `filterIcon` 会回退默认图标，`false` 并非默认值，与英文文档一致应为 `-`。

解决方案：统一上述默认值与版本号写法，与中文/英文档及运行时行为保持一致。纯文档改动，不涉及任何代码与 API 行为变化。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |