### PR TITLE
fix(Anchor): render children when items is undefined

### DIFF
--- a/components/anchor/Anchor.tsx
+++ b/components/anchor/Anchor.tsx
@@ -393,7 +393,7 @@ const Anchor: React.FC<AnchorProps> = (props) => {
     <div ref={wrapperRef} className={wrapperClass} style={wrapperStyle}>
       <div className={anchorClass}>
         <span className={inkClass} ref={spanLinkNodeRef} style={mergedStyles.indicator} />
-        {'items' in props ? createNestedLink(items) : children}
+        {items !== undefined ? createNestedLink(items) : children}
       </div>
     </div>
   );

--- a/components/anchor/__tests__/Anchor.test.tsx
+++ b/components/anchor/__tests__/Anchor.test.tsx
@@ -157,6 +157,16 @@ describe('Anchor Render', () => {
     expect(asFragment().firstChild).toMatchSnapshot();
   });
 
+  it('renders children when items is undefined', () => {
+    const { getByText } = render(
+      <Anchor items={undefined}>
+        <div>fallback</div>
+      </Anchor>,
+    );
+
+    expect(getByText('fallback')).toBeInTheDocument();
+  });
+
   it('actives the target when clicking a link', async () => {
     const hash = getHashUrl();
     const { container } = render(


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Anchor 使用属性是否存在来决定渲染 `items` 还是 `children`，导致显式传入 `items={undefined}` 时合法的 fallback children 被静默丢弃。

本次调整为仅在 `items` 不为 `undefined` 时使用数据配置，并补充回归测试。空数组仍会明确覆盖 children，不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Anchor dropping `children` when `items={undefined}` is explicitly provided. |
| 🇨🇳 中文 | 🐞 修复 Anchor 显式传入 `items={undefined}` 时丢弃 `children` 的问题。 |