### PR TITLE
fix(Segmented): keep icon-only bare svg icons vertically centred

### DIFF
--- a/components/segmented/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/segmented/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -1138,6 +1138,45 @@ exports[`renders components/segmented/demo/icon-only.tsx extend context correctl
         </span>
       </div>
     </label>
+    <label
+      class="ant-segmented-item"
+    >
+      <input
+        class="ant-segmented-item-input"
+        name="test-id"
+        type="radio"
+      />
+      <div
+        class="ant-segmented-item-label"
+      >
+        <span
+          class="ant-segmented-item-icon"
+        >
+          <svg
+            aria-label="Calendar"
+            fill="none"
+            height="1em"
+            role="img"
+            stroke="currentColor"
+            stroke-width="2"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 24 24"
+            width="1em"
+          >
+            <rect
+              height="18"
+              rx="2"
+              width="18"
+              x="3"
+              y="4"
+            />
+            <path
+              d="M16 2v4M8 2v4M3 10h18"
+            />
+          </svg>
+        </span>
+      </div>
+    </label>
   </div>
 </div>
 `;

--- a/components/segmented/__tests__/__snapshots__/demo.test.ts.snap
+++ b/components/segmented/__tests__/__snapshots__/demo.test.ts.snap
@@ -1059,6 +1059,45 @@ exports[`renders components/segmented/demo/icon-only.tsx correctly 1`] = `
         </span>
       </div>
     </label>
+    <label
+      class="ant-segmented-item"
+    >
+      <input
+        class="ant-segmented-item-input"
+        name="test-id"
+        type="radio"
+      />
+      <div
+        class="ant-segmented-item-label"
+      >
+        <span
+          class="ant-segmented-item-icon"
+        >
+          <svg
+            aria-label="Calendar"
+            fill="none"
+            height="1em"
+            role="img"
+            stroke="currentColor"
+            stroke-width="2"
+            style="vertical-align:-0.125em"
+            viewBox="0 0 24 24"
+            width="1em"
+          >
+            <rect
+              height="18"
+              rx="2"
+              width="18"
+              x="3"
+              y="4"
+            />
+            <path
+              d="M16 2v4M8 2v4M3 10h18"
+            />
+          </svg>
+        </span>
+      </div>
+    </label>
   </div>
 </div>
 `;

--- a/components/segmented/__tests__/index.test.tsx
+++ b/components/segmented/__tests__/index.test.tsx
@@ -327,6 +327,21 @@ describe('Segmented', () => {
     );
     expect(asFragment().firstChild).toMatchSnapshot();
     expect(container.querySelectorAll(`span.${prefixCls}-item-icon`).length).toBe(2);
+
+    // https://github.com/ant-design/ant-design/issues/59205
+    // The cap-height lift for a bare `<svg>` only applies when a label follows the icon;
+    // an icon-only item has no text to align against.
+    const cssText = Array.from(document.head.querySelectorAll('style'))
+      .map((style) => style.innerHTML)
+      .join('');
+    const svgRules = cssText
+      .split('}')
+      .filter((rule) => rule.includes(`${prefixCls}-item-icon`) && rule.includes('>svg'));
+    const liftRule = svgRules.find((rule) => rule.includes('margin-block-end'));
+    expect(liftRule).toContain(`${prefixCls}-item-icon:not(:only-child)>svg`);
+    const alignRule = svgRules.find((rule) => rule.includes('vertical-align:middle'));
+    expect(alignRule).not.toContain(':only-child');
+    expect(alignRule).not.toContain('margin-block-end');
     expect(
       container
         .querySelectorAll(`div.${prefixCls}-item-label`)[1]

--- a/components/segmented/demo/icon-only.md
+++ b/components/segmented/demo/icon-only.md
@@ -1,7 +1,7 @@
 ## zh-CN
 
-在 Segmented Item 选项中只设置 Icon。
+在 Segmented Item 选项中只设置 Icon。第三方图标库的裸 `<svg>` 元素同样会保持垂直居中。
 
 ## en-US
 
-Set `icon` without `label` for Segmented Item.
+Set `icon` without `label` for Segmented Item. A bare `<svg>` element from a third-party icon library stays vertically centred as well.

--- a/components/segmented/demo/icon-only.tsx
+++ b/components/segmented/demo/icon-only.tsx
@@ -2,11 +2,31 @@ import React from 'react';
 import { AppstoreOutlined, BarsOutlined } from '@ant-design/icons';
 import { Segmented } from 'antd';
 
+// A bare `<svg>` from a third-party icon library, which already aligns itself
+// with an inline `vertical-align`. It stays vertically centred in an icon-only item.
+const CalendarIcon: React.FC = () => (
+  <svg
+    viewBox="0 0 24 24"
+    width="1em"
+    height="1em"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    style={{ verticalAlign: '-0.125em' }}
+    role="img"
+    aria-label="Calendar"
+  >
+    <rect x="3" y="4" width="18" height="18" rx="2" />
+    <path d="M16 2v4M8 2v4M3 10h18" />
+  </svg>
+);
+
 const Demo: React.FC = () => (
   <Segmented
     options={[
       { value: 'List', icon: <BarsOutlined /> },
       { value: 'Kanban', icon: <AppstoreOutlined /> },
+      { value: 'Calendar', icon: <CalendarIcon /> },
     ]}
   />
 );

--- a/components/segmented/style/index.ts
+++ b/components/segmented/style/index.ts
@@ -209,13 +209,19 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken, CSSObject> = (token) => {
         // `display: inline-block` keeps it an atomic inline box so `vertical-align` still applies
         // even under a CSS reset that forces `svg { display: block }` (e.g. Tailwind Preflight),
         // which would otherwise drop the icon onto its own line. `vertical-align: middle` centres its
-        // margin box on the x-height line; `margin-block-end` then lifts it by half its own value onto
-        // the cap-height centre (capHeight − xHeight ≈ 0.2em across typical fonts), keeping it centred
-        // at any icon size.
+        // margin box on the x-height line.
         // Only matches a bare `<svg>`: an `.anticon` keeps its `<svg>` one level deeper.
         '&-icon > svg': {
           display: 'inline-block',
           verticalAlign: 'middle',
+        },
+
+        // When a label follows the icon, `margin-block-end` lifts the `<svg>` by half its own value
+        // from the x-height line onto the cap-height centre (capHeight − xHeight ≈ 0.2em across
+        // typical fonts), keeping it centred with the text at any icon size.
+        // An icon-only item has no text to align against, so the lift is skipped there:
+        // the `<svg>` would otherwise ride above the centre of the item.
+        '&-icon:not(:only-child) > svg': {
           marginBlockEnd: '0.2em',
         },
 


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [x] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

fix #59205

### 💡 Background and Solution

#58862 added `.ant-segmented-item-icon > svg { display: inline-block; vertical-align: middle; margin-block-end: 0.2em }` so that a bare `<svg>` from a third-party icon library sits on the cap-height centre of the label text.

The `margin-block-end` lift is only meaningful when there is label text to align against. For an **icon-only** item (no `label`) there is no cap height to compensate for, so the same `0.2em` lift pushes the icon above the vertical centre of the item. This is the regression visible in the official theme editor (antd 6.6.2), where the `Light` / `DarkTheme` icons from `antd-token-previewer` are bare `<svg>` elements with their own inline `vertical-align: -0.125em`: the inline style wins over `vertical-align: middle`, but the margin still applies, producing a mixed alignment.

This PR keeps `display: inline-block` + `vertical-align: middle` for every bare `<svg>` and moves `margin-block-end: 0.2em` to `.ant-segmented-item-icon:not(:only-child) > svg`, i.e. it is only applied when the icon wrapper is followed by a label. Icon-only items no longer get the lift. No API change.

- `components/segmented/style/index.ts`: split the rule and update the explanatory comment.
- `components/segmented/demo/icon-only.tsx` / `.md`: add an icon-only option with a bare `<svg>` that carries its own inline `vertical-align`, so the case is covered by the demo snapshots.
- `components/segmented/__tests__/index.test.tsx`: assert the generated CSS only attaches `margin-block-end` to the `:not(:only-child)` selector.

Verified locally with `npm test -- components/segmented`, `npm run lint:script` and `npm run tsc`. `npm run test:image` was not run locally (requires Docker); please rely on CI for the visual-regression report.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Segmented icon-only item with a bare `<svg>` icon being lifted above the vertical centre. |
| 🇨🇳 Chinese | 修复 Segmented 纯图标选项使用裸 `<svg>` 图标时向上偏移、未垂直居中的问题。 |
