### PR TITLE
refactor(Dropdown): simplify popup node normalization

### DIFF
--- a/components/dropdown/dropdown.tsx
+++ b/components/dropdown/dropdown.tsx
@@ -10,7 +10,7 @@ import { clsx } from 'clsx';
 import { useZIndex } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
-import { isPlainObject, isPrimitive } from '../_util/is';
+import { isPlainObject, isPrimitive, isString } from '../_util/is';
 import type { AdjustOverflow } from '../_util/placements';
 import getPlacements from '../_util/placements';
 import genPurePanel from '../_util/PurePanel';
@@ -313,10 +313,10 @@ const Dropdown: CompoundedComponent = React.forwardRef<HTMLElement, DropdownProp
     if (mergedPopupRender) {
       overlayNode = mergedPopupRender(overlayNode);
     }
-    if (typeof overlayNode === 'string') {
+    if (isString(overlayNode)) {
       overlayNode = <span>{overlayNode}</span>;
     } else if (!React.isValidElement(overlayNode)) {
-      overlayNode = React.createElement(React.Fragment, null, overlayNode);
+      overlayNode = <>{overlayNode}</>;
     }
     return (
       <OverrideProvider


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🛠 重构

### 🔗 相关 Issue

跟进 #59207 合并后的两条审查评论：

- https://github.com/ant-design/ant-design/pull/59207#discussion_r3939250915
- https://github.com/ant-design/ant-design/pull/59207#discussion_r3939252862

### 💡 需求背景和解决方案

统一 Dropdown 弹层节点处理的代码写法：使用已有的 `isString` 工具判断字符串，并将 `React.createElement(React.Fragment, null, overlayNode)` 改为 JSX Fragment 简写。现有渲染行为和公开 API 保持一致。

验证：Dropdown 单测 27 项、快照 3 项通过；ESLint、Prettier 和 antd lint 检查通过。

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | 无需更新日志 |
