### PR TITLE
fix(Tabs): apply styles.popup.root to the more dropdown

### DIFF
--- a/components/tabs/__tests__/semantic.test.tsx
+++ b/components/tabs/__tests__/semantic.test.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 import Tabs from '..';
 import type { TabsProps } from '..';
-import { fireEvent, render, triggerResize, waitFakeTimer } from '../../../tests/utils';
-import ConfigProvider from '../../config-provider';
 import {
   expectSemanticRootStylePriority,
   semanticRootStylePriority,
 } from '../../../tests/shared/semanticStylePriority';
+import { render } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
 
 describe('Tabs.Semantic', () => {
   it('support classnames and styles', () => {
@@ -102,65 +102,25 @@ describe('Tabs.Semantic', () => {
     expect(root).toHaveClass('custom-card-root');
     expect(root).toHaveStyle({ backgroundColor: 'rgb(255, 0, 0)' });
   });
-  it('support popup classNames and styles', async () => {
-    // The more dropdown only mounts when the tabs overflow, so fake the layout
-    // Longest first: `ant-tabs-nav` is a prefix of the other two
-    const sizes: Record<string, number> = {
-      'ant-tabs-nav-operations': 40,
-      'ant-tabs-nav-list': 2000,
-      'ant-tabs-nav': 200,
-    };
-    const descriptors = (['offsetWidth', 'offsetHeight', 'offsetLeft'] as const).map(
-      (name) => [name, Object.getOwnPropertyDescriptor(HTMLElement.prototype, name)] as const,
+  it('support popup classNames and styles', () => {
+    // `more.visible` is spread over rc-tabs' own `visible`, so the popup mounts
+    // without having to fake element sizes to force tab overflow.
+    render(
+      <Tabs
+        defaultActiveKey="0"
+        more={{ visible: true }}
+        classNames={{ popup: { root: 'test-popup' } }}
+        styles={{ popup: { root: { color: 'rgb(255, 0, 0)' } } }}
+        items={[
+          { key: '0', label: 'Tab-0', children: 'Content of tab 0' },
+          { key: '1', label: 'Tab-1', children: 'Content of tab 1' },
+        ]}
+      />,
     );
-    const define = (name: string, get: (ele: HTMLElement) => number) => {
-      Object.defineProperty(HTMLElement.prototype, name, {
-        configurable: true,
-        get() {
-          return get(this);
-        },
-      });
-    };
-    define('offsetWidth', (ele) => {
-      if (ele.getAttribute('data-node-key')) {
-        return 100;
-      }
-      const matched = Object.keys(sizes).find((cls) => ele.className.includes(cls));
-      return matched ? sizes[matched] : 0;
-    });
-    define('offsetHeight', () => 20);
-    define('offsetLeft', (ele) => Number(ele.getAttribute('data-node-key') ?? 0) * 100);
 
-    jest.useFakeTimers();
-    try {
-      const { container } = render(
-        <Tabs
-          defaultActiveKey="0"
-          classNames={{ popup: { root: 'test-popup' } }}
-          styles={{ popup: { root: { color: 'rgb(255, 0, 0)' } } }}
-          items={Array.from({ length: 20 }, (_, i) => ({
-            key: String(i),
-            label: `Tab-${i}`,
-            children: `Content of tab ${i}`,
-          }))}
-        />,
-      );
-      triggerResize(container.querySelector('.ant-tabs-nav') as HTMLElement);
-      await waitFakeTimer();
-      fireEvent.mouseEnter(container.querySelector('.ant-tabs-nav-more') as HTMLElement);
-      await waitFakeTimer();
-
-      const popup = document.body.querySelector('.ant-tabs-dropdown');
-      expect(popup).toHaveClass('test-popup');
-      expect(popup).toHaveStyle({ color: 'rgb(255, 0, 0)' });
-    } finally {
-      jest.useRealTimers();
-      descriptors.forEach(([name, descriptor]) => {
-        if (descriptor) {
-          Object.defineProperty(HTMLElement.prototype, name, descriptor);
-        }
-      });
-    }
+    const popup = document.body.querySelector('.ant-tabs-dropdown');
+    expect(popup).toHaveClass('test-popup');
+    expect(popup).toHaveStyle({ color: 'rgb(255, 0, 0)' });
   });
 
   it('should follow root style priority', () => {

--- a/components/tabs/__tests__/semantic.test.tsx
+++ b/components/tabs/__tests__/semantic.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Tabs from '..';
 import type { TabsProps } from '..';
-import { render } from '../../../tests/utils';
+import { fireEvent, render, triggerResize, waitFakeTimer } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
 import {
   expectSemanticRootStylePriority,
@@ -102,6 +102,67 @@ describe('Tabs.Semantic', () => {
     expect(root).toHaveClass('custom-card-root');
     expect(root).toHaveStyle({ backgroundColor: 'rgb(255, 0, 0)' });
   });
+  it('support popup classNames and styles', async () => {
+    // The more dropdown only mounts when the tabs overflow, so fake the layout
+    // Longest first: `ant-tabs-nav` is a prefix of the other two
+    const sizes: Record<string, number> = {
+      'ant-tabs-nav-operations': 40,
+      'ant-tabs-nav-list': 2000,
+      'ant-tabs-nav': 200,
+    };
+    const descriptors = (['offsetWidth', 'offsetHeight', 'offsetLeft'] as const).map(
+      (name) => [name, Object.getOwnPropertyDescriptor(HTMLElement.prototype, name)] as const,
+    );
+    const define = (name: string, get: (ele: HTMLElement) => number) => {
+      Object.defineProperty(HTMLElement.prototype, name, {
+        configurable: true,
+        get() {
+          return get(this);
+        },
+      });
+    };
+    define('offsetWidth', (ele) => {
+      if (ele.getAttribute('data-node-key')) {
+        return 100;
+      }
+      const matched = Object.keys(sizes).find((cls) => ele.className.includes(cls));
+      return matched ? sizes[matched] : 0;
+    });
+    define('offsetHeight', () => 20);
+    define('offsetLeft', (ele) => Number(ele.getAttribute('data-node-key') ?? 0) * 100);
+
+    jest.useFakeTimers();
+    try {
+      const { container } = render(
+        <Tabs
+          defaultActiveKey="0"
+          classNames={{ popup: { root: 'test-popup' } }}
+          styles={{ popup: { root: { color: 'rgb(255, 0, 0)' } } }}
+          items={Array.from({ length: 20 }, (_, i) => ({
+            key: String(i),
+            label: `Tab-${i}`,
+            children: `Content of tab ${i}`,
+          }))}
+        />,
+      );
+      triggerResize(container.querySelector('.ant-tabs-nav') as HTMLElement);
+      await waitFakeTimer();
+      fireEvent.mouseEnter(container.querySelector('.ant-tabs-nav-more') as HTMLElement);
+      await waitFakeTimer();
+
+      const popup = document.body.querySelector('.ant-tabs-dropdown');
+      expect(popup).toHaveClass('test-popup');
+      expect(popup).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+    } finally {
+      jest.useRealTimers();
+      descriptors.forEach(([name, descriptor]) => {
+        if (descriptor) {
+          Object.defineProperty(HTMLElement.prototype, name, descriptor);
+        }
+      });
+    }
+  });
+
   it('should follow root style priority', () => {
     const { container } = render(
       <ConfigProvider

--- a/components/tabs/__tests__/semantic.test.tsx
+++ b/components/tabs/__tests__/semantic.test.tsx
@@ -19,6 +19,7 @@ describe('Tabs.Semantic', () => {
       header: 'test-header',
       body: 'test-body',
       content: 'test-content',
+      popup: { root: 'test-popup' },
     };
     const customStyles = {
       root: { color: 'rgb(255, 0, 0)' },
@@ -28,11 +29,15 @@ describe('Tabs.Semantic', () => {
       header: { color: 'rgb(0, 255, 0)' },
       body: { color: 'rgb(0, 128, 128)' },
       content: { color: 'rgb(128, 0, 128)' },
+      popup: { root: { color: 'rgb(0, 255, 255)' } },
     };
     const { container } = render(
       <Tabs
         defaultActiveKey="1"
         type="editable-card"
+        // `more.visible` is spread over rc-tabs' own `visible`, so the popup mounts
+        // without having to fake element sizes to force tab overflow.
+        more={{ visible: true }}
         styles={customStyles}
         classNames={customClassnames}
         items={Array.from({ length: 30 }, (_, i) => {
@@ -53,6 +58,7 @@ describe('Tabs.Semantic', () => {
     const header = container.querySelector('.ant-tabs-nav');
     const body = container.querySelector('.ant-tabs-body');
     const content = container.querySelector('.ant-tabs-content');
+    const popup = document.body.querySelector('.ant-tabs-dropdown');
     expect(root).toHaveClass(customClassnames.root);
     expect(item).toHaveClass(customClassnames.item);
     expect(remove).toHaveClass(customClassnames.remove);
@@ -60,6 +66,7 @@ describe('Tabs.Semantic', () => {
     expect(header).toHaveClass(customClassnames.header);
     expect(body).toHaveClass(customClassnames.body);
     expect(content).toHaveClass(customClassnames.content);
+    expect(popup).toHaveClass(customClassnames.popup.root);
     expect(root).toHaveStyle({ color: customStyles.root.color });
     expect(item).toHaveStyle({ color: customStyles.item.color });
     expect(remove).toHaveStyle({ color: customStyles.remove.color });
@@ -67,6 +74,7 @@ describe('Tabs.Semantic', () => {
     expect(header).toHaveStyle({ color: customStyles.header.color });
     expect(body).toHaveStyle({ color: customStyles.body.color });
     expect(content).toHaveStyle({ color: customStyles.content.color });
+    expect(popup).toHaveStyle({ color: customStyles.popup.root.color });
   });
 
   it('support function classNames and styles', () => {
@@ -101,26 +109,6 @@ describe('Tabs.Semantic', () => {
     const root = container.querySelector('.ant-tabs');
     expect(root).toHaveClass('custom-card-root');
     expect(root).toHaveStyle({ backgroundColor: 'rgb(255, 0, 0)' });
-  });
-  it('support popup classNames and styles', () => {
-    // `more.visible` is spread over rc-tabs' own `visible`, so the popup mounts
-    // without having to fake element sizes to force tab overflow.
-    render(
-      <Tabs
-        defaultActiveKey="0"
-        more={{ visible: true }}
-        classNames={{ popup: { root: 'test-popup' } }}
-        styles={{ popup: { root: { color: 'rgb(255, 0, 0)' } } }}
-        items={[
-          { key: '0', label: 'Tab-0', children: 'Content of tab 0' },
-          { key: '1', label: 'Tab-1', children: 'Content of tab 1' },
-        ]}
-      />,
-    );
-
-    const popup = document.body.querySelector('.ant-tabs-dropdown');
-    expect(popup).toHaveClass('test-popup');
-    expect(popup).toHaveStyle({ color: 'rgb(255, 0, 0)' });
   });
 
   it('should follow root style priority', () => {

--- a/components/tabs/index.tsx
+++ b/components/tabs/index.tsx
@@ -273,7 +273,8 @@ const InternalTabs = React.forwardRef<TabsRef, TabsProps>((props, ref) => {
         ...mergedClassNames,
         popup: clsx(popupClassName, hashId, cssVarCls, rootCls, mergedClassNames.popup?.root),
       }}
-      styles={mergedStyles}
+      // `popup` is nested as `{ root }` in antd but flat in rc-tabs, same as `classNames` above
+      styles={{ ...mergedStyles, popup: mergedStyles.popup?.root }}
       style={mergedStyles.root}
       editable={editable}
       more={{


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

No linked issue. The problem is visible in the repository itself: `components/tabs/demo/_semantic.tsx` sets `styles={{ popup: { root: { background: '#fff' } } }}`, and that value never reaches the DOM.

### 💡 Background and Solution

`Tabs` declares the popup semantic node as a nested object on both sides (`components/tabs/index.tsx`):

```ts
classNames?: { ...; popup?: { root?: string } };
styles?:     { ...; popup?: { root?: React.CSSProperties } };
```

`@rc-component/tabs` keeps `popup` flat (`Partial<Record<SemanticName, string>>` / `Partial<Record<SemanticName, CSSProperties>>`), so the nested value has to be unwrapped on the way down. `classNames` is unwrapped:

```tsx
classNames={{
  ...mergedClassNames,
  popup: clsx(popupClassName, hashId, cssVarCls, rootCls, mergedClassNames.popup?.root),
}}
styles={mergedStyles}
```

`styles` is not. `mergedStyles.popup` therefore arrives at rc-tabs as `{ root: CSSProperties }`, is forwarded as `popupStyle` -> `overlayStyle` on the more dropdown, and React drops it because `root` is not a CSS property. The result is that `classNames.popup.root` works and `styles.popup.root` silently does nothing on the same element.

`styles` is now unwrapped the same way `classNames` already is. This is how every sibling component with the same nested popup semantic already behaves, for example `components/select/index.tsx` (`popupStyle={{ ...mergedStyles.popup.root, ... }}`), `components/cascader/index.tsx` and `components/auto-complete/AutoComplete.tsx`.

Nothing else changes: the layout, the public API, and the `classNames` path are untouched, and no snapshot moves because the more dropdown is not opened in any snapshot test.

`components/tabs/__tests__/semantic.test.tsx` gains a case that overflows the tab bar, opens the more dropdown and asserts both halves on the popup element. Reverting only `components/tabs/index.tsx` turns it red on the style assertion while the class assertion above it still passes:

```
● Tabs.Semantic › support popup classNames and styles

  expect(element).toHaveStyle()

  - Expected

  - color: rgb(255, 0, 0);
  + color: var(--ant-color-text);
```

Verification:

- `npx jest --config .jest.js --no-cache components/tabs components/config-provider` -> 27 suites passed, 662 tests passed, 455 snapshots passed, 0 snapshots written.
- `npx vitest run components/tabs/__tests__/semantic.test.tsx` -> 4 passed.
- `npm run tsc`, `eslint`, `biome lint`, `biome format` -> clean.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 🐞 Fix Tabs ignoring `styles.popup.root` on the more dropdown. |
| 🇨🇳 Chinese | 🐞 修复 Tabs 折叠下拉菜单未应用 `styles.popup.root` 的问题。 |
