### PR TITLE
fix: preserve nested semantic style properties

### DIFF
--- a/components/_util/__tests__/useMergeSemanticNew.test.tsx
+++ b/components/_util/__tests__/useMergeSemanticNew.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { renderHook } from '@testing-library/react';
 
 import { render } from '../../../tests/utils';
-import { useMergeSemantic } from '../hooks/useMergeSemantic';
+import { mergeStyles, useMergeSemantic } from '../hooks/useMergeSemantic';
 import type { SemanticSchema } from '../hooks/useMergeSemantic';
 import { fillObjectBySchema } from '../hooks/useMergeSemantic/utils';
 
@@ -20,6 +20,21 @@ type DemoSemanticType = {
 };
 
 describe('useMergeSemantic,', () => {
+  it('preserves the exported flat merge interface and explicit CSS resets', () => {
+    const contextStyles = Object.freeze({ root: Object.freeze({ color: 'red', padding: 12 }) });
+    const localStyles = { root: { color: undefined, padding: 0 } };
+
+    expect(
+      mergeStyles<{ root?: React.CSSProperties }>(contextStyles, undefined, localStyles, {
+        root: undefined,
+      }),
+    ).toEqual({
+      root: { color: undefined, padding: 0 },
+    });
+    expect(mergeStyles()).toEqual({});
+    expect(contextStyles.root).toEqual({ color: 'red', padding: 12 });
+  });
+
   it('merges nested style properties without mutating the sources', () => {
     const contextStyles = Object.freeze({
       popup: Object.freeze({

--- a/components/_util/__tests__/useMergeSemanticNew.test.tsx
+++ b/components/_util/__tests__/useMergeSemanticNew.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { renderHook } from '@testing-library/react';
 
 import { render } from '../../../tests/utils';
 import { useMergeSemantic } from '../hooks/useMergeSemantic';
+import type { SemanticSchema } from '../hooks/useMergeSemantic';
 import { fillObjectBySchema } from '../hooks/useMergeSemantic/utils';
 
 type DemoSemanticType = {
@@ -18,6 +20,78 @@ type DemoSemanticType = {
 };
 
 describe('useMergeSemantic,', () => {
+  it('merges nested style properties without mutating the sources', () => {
+    const contextStyles = Object.freeze({
+      popup: Object.freeze({
+        root: Object.freeze({ color: 'red', padding: 12 }),
+        list: Object.freeze({ margin: 8 }),
+      }),
+    });
+    const localStyles = Object.freeze({
+      popup: Object.freeze({ root: Object.freeze({ color: 'blue' }) }),
+    });
+
+    const { result } = renderHook(() =>
+      useMergeSemantic(
+        [],
+        [contextStyles, localStyles],
+        { props: {} },
+        {
+          popup: { _default: 'root' },
+        },
+      ),
+    );
+
+    expect(result.current[1]).toEqual({
+      popup: { root: { color: 'blue', padding: 12 }, list: { margin: 8 } },
+    });
+    expect(contextStyles.popup.root).toEqual({ color: 'red', padding: 12 });
+    expect(localStyles.popup.root).toEqual({ color: 'blue' });
+  });
+
+  it('merges multiple semantic levels and preserves explicit CSS property resets', () => {
+    const { result } = renderHook(() =>
+      useMergeSemantic<NonNullable<DemoSemanticType['classNames']>, DemoSemanticType['styles']>(
+        [],
+        [
+          {
+            root: { color: 'red', padding: 12 },
+            dragger: { default: { color: 'red', margin: 4 } },
+            level1: { level2: { level3: { color: 'red', margin: 4, opacity: 0.5 } } },
+          },
+          undefined,
+          {
+            root: { padding: 0 },
+            dragger: { default: undefined },
+            level1: { level2: { level3: { color: undefined, opacity: 0 } } },
+          },
+        ],
+        { props: {} },
+        { dragger: { _default: 'default' }, level1: { level2: {} } },
+      ),
+    );
+
+    expect(result.current[1]).toEqual({
+      root: { color: 'red', padding: 0 },
+      dragger: { default: { color: 'red', margin: 4 } },
+      level1: { level2: { level3: { color: undefined, margin: 4, opacity: 0 } } },
+    });
+  });
+
+  it('recomputes styles when the semantic schema changes', () => {
+    const contextStyles = { popup: { root: { color: 'red', padding: 12 } } };
+    const localStyles = { popup: { root: { color: 'blue' } } };
+    const { result, rerender } = renderHook(
+      ({ schema }: { schema: SemanticSchema }) =>
+        useMergeSemantic([], [contextStyles, localStyles], { props: {} }, schema),
+      { initialProps: { schema: {} } },
+    );
+    expect(result.current[1].popup.root).toEqual({ color: 'blue' });
+
+    rerender({ schema: { popup: { _default: 'root' } } });
+    expect(result.current[1].popup.root).toEqual({ color: 'blue', padding: 12 });
+  });
+
   it('utils fillObjectBySchema', () => {
     const schema = { dragger: { _default: 'default' }, level1: { level2: {} } };
     // test 1

--- a/components/_util/__tests__/useMergeSemanticNew.test.tsx
+++ b/components/_util/__tests__/useMergeSemanticNew.test.tsx
@@ -28,7 +28,7 @@ describe('useMergeSemantic,', () => {
       mergeStyles<{ root?: React.CSSProperties }>(contextStyles, undefined, localStyles, {
         root: undefined,
       }),
-    ).toEqual({
+    ).toStrictEqual({
       root: { color: undefined, padding: 0 },
     });
     expect(mergeStyles()).toEqual({});

--- a/components/_util/hooks/useMergeSemantic/index.ts
+++ b/components/_util/hooks/useMergeSemantic/index.ts
@@ -54,23 +54,39 @@ const useSemanticClassNames = <ClassNamesType extends AnyObject>(
 };
 
 // =========================== Styles ===========================
-export const mergeStyles = <StylesType extends AnyObject>(
+const mergeStylesBySchema = <StylesType extends AnyObject>(
+  schema: SemanticSchema = {},
   ...styles: (Partial<StylesType> | undefined)[]
 ) => {
   return styles
     .filter((item): item is Partial<StylesType> => Boolean(item))
-    .reduce<Record<PropertyKey, React.CSSProperties>>((acc, cur = {}) => {
+    .reduce<Record<PropertyKey, AnyObject>>((acc, cur = {}) => {
       Object.keys(cur).forEach((key) => {
-        acc[key] = { ...acc[key], ...cur[key] };
+        const keySchema = schema[key as keyof SemanticSchema] as SemanticSchema;
+        // Some existing callers still provide flat CSS at a schema node.
+        const hasNestedStyles =
+          keySchema &&
+          [...Object.values(acc[key] || {}), ...Object.values(cur[key] || {})].some(isPlainObject);
+        acc[key] = hasNestedStyles
+          ? mergeStylesBySchema(keySchema, acc[key], cur[key])
+          : { ...acc[key], ...cur[key] };
       });
       return acc;
     }, {});
 };
 
+export const mergeStyles = <StylesType extends AnyObject>(
+  ...styles: (Partial<StylesType> | undefined)[]
+): Record<PropertyKey, React.CSSProperties> => mergeStylesBySchema({}, ...styles);
+
 const useSemanticStyles = <StylesType extends AnyObject>(
+  schema?: SemanticSchema,
   ...styles: (Partial<StylesType> | undefined)[]
 ) => {
-  return React.useMemo(() => mergeStyles(...styles), [...styles]) as StylesType;
+  return React.useMemo(
+    () => mergeStylesBySchema(schema, ...styles),
+    [schema, ...styles],
+  ) as StylesType;
 };
 
 export const useSemanticRootStyle = <Key extends string = 'root'>(
@@ -121,7 +137,7 @@ export const useMergeSemantic = <
     ...resolvedClassNamesList,
   );
 
-  const mergedStyles = useSemanticStyles<NonNullable<StylesType>>(...resolvedStylesList);
+  const mergedStyles = useSemanticStyles<NonNullable<StylesType>>(schema, ...resolvedStylesList);
 
   return React.useMemo(() => {
     if (!schema) {

--- a/components/_util/hooks/useMergeSemantic/index.ts
+++ b/components/_util/hooks/useMergeSemantic/index.ts
@@ -54,13 +54,17 @@ const useSemanticClassNames = <ClassNamesType extends AnyObject>(
 };
 
 // =========================== Styles ===========================
+interface SemanticStyles {
+  [key: PropertyKey]: React.CSSProperties | SemanticStyles;
+}
+
 const mergeStylesBySchema = <StylesType extends AnyObject>(
   schema: SemanticSchema = {},
   ...styles: (Partial<StylesType> | undefined)[]
 ) => {
   return styles
     .filter((item): item is Partial<StylesType> => Boolean(item))
-    .reduce<Record<PropertyKey, AnyObject>>((acc, cur = {}) => {
+    .reduce<SemanticStyles>((acc, cur = {}) => {
       Object.keys(cur).forEach((key) => {
         const keySchema = schema[key as keyof SemanticSchema] as SemanticSchema;
         // Some existing callers still provide flat CSS at a schema node.
@@ -77,7 +81,8 @@ const mergeStylesBySchema = <StylesType extends AnyObject>(
 
 export const mergeStyles = <StylesType extends AnyObject>(
   ...styles: (Partial<StylesType> | undefined)[]
-): Record<PropertyKey, React.CSSProperties> => mergeStylesBySchema({}, ...styles);
+): Record<PropertyKey, React.CSSProperties> =>
+  mergeStylesBySchema({}, ...styles) as Record<PropertyKey, React.CSSProperties>;
 
 const useSemanticStyles = <StylesType extends AnyObject>(
   schema?: SemanticSchema,

--- a/components/select/__tests__/semantic.test.tsx
+++ b/components/select/__tests__/semantic.test.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 
 import Select from '..';
 import type { SelectProps, SelectSemanticAllType } from '..';
-import { render } from '../../../tests/utils';
-import ConfigProvider from '../../config-provider';
 import {
   expectSemanticRootStylePriority,
   semanticRootStylePriority,
 } from '../../../tests/shared/semanticStylePriority';
+import { render } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
 
 describe('Select.Semantic', () => {
   const options = [
@@ -20,6 +20,68 @@ describe('Select.Semantic', () => {
       label: 'ShenZhen',
     },
   ];
+  it('preserves global popup style properties when local styles override one property', () => {
+    const { container } = render(
+      <ConfigProvider
+        select={{
+          styles: {
+            popup: {
+              root: { color: 'rgb(255, 0, 0)', padding: 12 },
+              list: { margin: 8 },
+            },
+          },
+        }}
+      >
+        <Select
+          open
+          options={options}
+          classNames={{ popup: { list: 'global-style-list' } }}
+          styles={{ popup: { root: { color: 'rgb(0, 0, 255)' } } }}
+        />
+      </ConfigProvider>,
+    );
+    expect(container.querySelector('.ant-select-dropdown')).toHaveStyle({
+      color: 'rgb(0, 0, 255)',
+      padding: '12px',
+    });
+    expect(container.querySelector('.global-style-list')).toHaveStyle({ margin: '8px' });
+  });
+
+  it('merges popup style callbacks and clears or restores properties on rerender', () => {
+    const styles: SelectProps['styles'] = ({ props }) => ({
+      popup: { root: { color: props.size === 'large' ? 'rgb(0, 0, 255)' : undefined } },
+    });
+    const Demo = ({
+      localStyles,
+      size,
+    }: {
+      localStyles?: SelectProps['styles'];
+      size?: SelectProps['size'];
+    }) => (
+      <ConfigProvider
+        select={{ styles: { popup: { root: { color: 'rgb(255, 0, 0)', padding: 12 } } } }}
+      >
+        <Select open options={options} size={size} styles={localStyles} />
+      </ConfigProvider>
+    );
+    const { container, rerender } = render(<Demo size="large" localStyles={styles} />);
+    expect(container.querySelector('.ant-select-dropdown')).toHaveStyle({
+      color: 'rgb(0, 0, 255)',
+      padding: '12px',
+    });
+
+    rerender(<Demo size="small" localStyles={styles} />);
+    const popup = container.querySelector<HTMLElement>('.ant-select-dropdown');
+    expect(popup?.style.color).toBe('');
+    expect(popup).toHaveStyle({ padding: '12px' });
+
+    rerender(<Demo size="small" />);
+    expect(container.querySelector('.ant-select-dropdown')).toHaveStyle({
+      color: 'rgb(255, 0, 0)',
+      padding: '12px',
+    });
+  });
+
   it('support classNames and styles', () => {
     const classNames: SelectSemanticAllType['classNames'] = {
       root: 'custom-root',

--- a/components/select/__tests__/semantic.test.tsx
+++ b/components/select/__tests__/semantic.test.tsx
@@ -10,6 +10,11 @@ import { render } from '../../../tests/utils';
 import ConfigProvider from '../../config-provider';
 
 describe('Select.Semantic', () => {
+  const getPopupStyles = (container: HTMLElement) => {
+    const popup = container.querySelector<HTMLElement>('.ant-select-dropdown');
+    return { color: popup?.style.color, padding: popup?.style.padding };
+  };
+
   const options = [
     {
       value: 'GuangZhou',
@@ -45,6 +50,12 @@ describe('Select.Semantic', () => {
       padding: '12px',
     });
     expect(container.querySelector('.global-style-list')).toHaveStyle({ margin: '8px' });
+    expect(getPopupStyles(container)).toMatchInlineSnapshot(`
+      {
+        "color": "rgb(0, 0, 255)",
+        "padding": "12px",
+      }
+    `);
   });
 
   it('merges popup style callbacks and clears or restores properties on rerender', () => {
@@ -65,17 +76,35 @@ describe('Select.Semantic', () => {
       </ConfigProvider>
     );
     const { container, rerender } = render(<Demo size="large" localStyles={styles} />);
+    expect(getPopupStyles(container)).toMatchInlineSnapshot(`
+      {
+        "color": "rgb(0, 0, 255)",
+        "padding": "12px",
+      }
+    `);
     expect(container.querySelector('.ant-select-dropdown')).toHaveStyle({
       color: 'rgb(0, 0, 255)',
       padding: '12px',
     });
 
     rerender(<Demo size="small" localStyles={styles} />);
+    expect(getPopupStyles(container)).toMatchInlineSnapshot(`
+      {
+        "color": "",
+        "padding": "12px",
+      }
+    `);
     const popup = container.querySelector<HTMLElement>('.ant-select-dropdown');
     expect(popup?.style.color).toBe('');
     expect(popup).toHaveStyle({ padding: '12px' });
 
     rerender(<Demo size="small" />);
+    expect(getPopupStyles(container)).toMatchInlineSnapshot(`
+      {
+        "color": "rgb(255, 0, 0)",
+        "padding": "12px",
+      }
+    `);
     expect(container.querySelector('.ant-select-dropdown')).toHaveStyle({
       color: 'rgb(255, 0, 0)',
       padding: '12px',


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Follow-up to the separate existing merge behavior identified in [the review of #59221](https://github.com/ant-design/ant-design/pull/59221#pullrequestreview-5120796382). This fix is based on master and does not depend on the Tabs popup projection change.

### 💡 Background and Solution

Overriding one nested semantic style currently replaces the whole nested CSS object. For example, changing a Select popup's color drops the padding supplied by ConfigProvider:

```tsx
<ConfigProvider
  select={{ styles: { popup: { root: { color: 'red', padding: 12 } } } }}
>
  <Select
    open
    options={[{ value: 'example' }]}
    styles={{ popup: { root: { color: 'blue' } } }}
  />
</ConfigProvider>
```

The popup should be blue and retain 12px padding. The shared merger now follows the existing semantic schema through nested style slots, then merges CSS properties at the leaves. It preserves the flat `mergeStyles(...styles)` interface and existing flat CSS inputs at schema nodes. Explicitly resetting a CSS property to `undefined` still clears it, and schema changes invalidate the memoized result.

Validation at `1e1f458357f9b21558d311798563cbe3a020cfb3`, against base `58b0ee1554835b3ea2d0541f4986306f3d70d0ce`:

- All five added regressions fail on the base and pass with this fix. The focused hook and Select semantic run now passes 15 tests across 3 suites, including a direct strict-equality regression for the exported flat merge interface and explicit undefined CSS resets.
- Tests cover real Select popup rendering, preserved sibling styles, callback evaluation, rerender clearing/restoration, multiple semantic levels, frozen input objects, and schema changes. Existing root style priority and flat-input tests remain intact.
- The initial runtime cross-component run at `17f603bf582afc67bf1a2825ae88ca8ac64cfc27` covers 121 suites (the follow-ups change types and tests only): 119 suites / 309 tests pass; 71 snapshots pass. Two semantic-demo snapshots (Select and AutoComplete) differ only in Select option `aria-posinset`/`aria-setsize` attributes. Both exact diffs reproduce on the base with the same dependencies. These two existing demo snapshots were not updated. Four focused inline snapshots were added for the new Select popup style states.
- The follow-up covers the previously uncovered exported wrapper: the changed hook file now has 100% local statement, line and function coverage (90% branch coverage). Its recursive accumulator uses a CSS/semantic-style interface instead of `AnyObject`.
- The previous visual job timed out in Typography screenshot generation. Both affected demos (`paragraph-debug` and `link-danger-debug`) complete locally in all three themes: 6 image-generation cases pass. This is a completion check, not a claim of cross-platform pixel equality; all three upstream visual shards and their report passed on `a6f6b4df1dd4331e911321fe27821c7f358f651e`; all three visual shards and the report also pass at the final head.
- ESLint, Biome, focused Prettier and `git diff --check` pass.
- Full TypeScript checking reports the same six existing Table demo `FullToken.antCls` errors on base and head, with identical output; no changed-file type errors were introduced. This is not a claim of a clean full-repository type check.

Final upstream verification at `1e1f458357f9b21558d311798563cbe3a020cfb3`: 43 successful checks and 2 skipped checks, including React 18/19 source tests, module/dist tests, lint/build, coverage, and all visual shards. Codecov confirms all modified coverable lines are covered and project coverage is 100.00%. All four review threads are resolved.

Implemented and validated with OpenAI Codex assistance.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix nested semantic styles losing properties supplied by ConfigProvider when a component overrides another property. |
| 🇨🇳 Chinese | 修复组件覆盖嵌套语义样式时丢失 ConfigProvider 中其他样式属性的问题。 |
