### PR TITLE
fix(locale): de_DE DatePicker fieldDateFormat DD.MM.YYYY

### DIFF
--- a/components/date-picker/locale/de_DE.ts
+++ b/components/date-picker/locale/de_DE.ts
@@ -23,6 +23,8 @@ const locale: PickerLocale = {
       'Nov',
       'Dez',
     ],
+    fieldDateFormat: 'DD.MM.YYYY',
+    fieldDateTimeFormat: 'DD.MM.YYYY HH:mm:ss',
     ...CalendarLocale,
   },
   timePickerLocale: {

--- a/components/locale/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/locale/__tests__/__snapshots__/index.test.tsx.snap
@@ -44193,7 +44193,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                     <tr>
                       <td
                         class="ant-picker-cell"
-                        title="2017-08-28"
+                        title="28.08.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44203,7 +44203,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell"
-                        title="2017-08-29"
+                        title="29.08.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44213,7 +44213,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell"
-                        title="2017-08-30"
+                        title="30.08.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44223,7 +44223,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell"
-                        title="2017-08-31"
+                        title="31.08.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44233,7 +44233,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-01"
+                        title="01.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44243,7 +44243,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-02"
+                        title="02.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44253,7 +44253,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-03"
+                        title="03.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44265,7 +44265,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                     <tr>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-04"
+                        title="04.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44275,7 +44275,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-05"
+                        title="05.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44285,7 +44285,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-06"
+                        title="06.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44295,7 +44295,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-07"
+                        title="07.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44305,7 +44305,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-08"
+                        title="08.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44315,7 +44315,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-09"
+                        title="09.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44325,7 +44325,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-10"
+                        title="10.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44337,7 +44337,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                     <tr>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-11"
+                        title="11.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44347,7 +44347,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-12"
+                        title="12.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44357,7 +44357,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-13"
+                        title="13.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44367,7 +44367,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-14"
+                        title="14.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44377,7 +44377,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-15"
+                        title="15.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44387,7 +44387,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-16"
+                        title="16.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44397,7 +44397,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-17"
+                        title="17.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44409,7 +44409,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                     <tr>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view ant-picker-cell-today"
-                        title="2017-09-18"
+                        title="18.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44419,7 +44419,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-19"
+                        title="19.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44429,7 +44429,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-20"
+                        title="20.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44439,7 +44439,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-21"
+                        title="21.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44449,7 +44449,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-22"
+                        title="22.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44459,7 +44459,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-23"
+                        title="23.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44469,7 +44469,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-24"
+                        title="24.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44481,7 +44481,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                     <tr>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-25"
+                        title="25.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44491,7 +44491,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-26"
+                        title="26.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44501,7 +44501,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-27"
+                        title="27.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44511,7 +44511,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-28"
+                        title="28.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44521,7 +44521,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-29"
+                        title="29.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44531,7 +44531,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell ant-picker-cell-in-view"
-                        title="2017-09-30"
+                        title="30.09.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44541,7 +44541,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell"
-                        title="2017-10-01"
+                        title="01.10.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44553,7 +44553,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                     <tr>
                       <td
                         class="ant-picker-cell"
-                        title="2017-10-02"
+                        title="02.10.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44563,7 +44563,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell"
-                        title="2017-10-03"
+                        title="03.10.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44573,7 +44573,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell"
-                        title="2017-10-04"
+                        title="04.10.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44583,7 +44583,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell"
-                        title="2017-10-05"
+                        title="05.10.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44593,7 +44593,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell"
-                        title="2017-10-06"
+                        title="06.10.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44603,7 +44603,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell"
-                        title="2017-10-07"
+                        title="07.10.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -44613,7 +44613,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                       </td>
                       <td
                         class="ant-picker-cell"
-                        title="2017-10-08"
+                        title="08.10.2017"
                       >
                         <div
                           class="ant-picker-cell-inner"
@@ -46422,7 +46422,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                         <tr>
                           <td
                             class="ant-picker-cell"
-                            title="2017-08-28"
+                            title="28.08.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46432,7 +46432,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-08-29"
+                            title="29.08.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46442,7 +46442,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-08-30"
+                            title="30.08.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46452,7 +46452,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-08-31"
+                            title="31.08.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46462,7 +46462,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-01"
+                            title="01.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46472,7 +46472,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-02"
+                            title="02.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46482,7 +46482,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-03"
+                            title="03.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46494,7 +46494,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                         <tr>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-04"
+                            title="04.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46504,7 +46504,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-05"
+                            title="05.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46514,7 +46514,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-06"
+                            title="06.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46524,7 +46524,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-07"
+                            title="07.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46534,7 +46534,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-08"
+                            title="08.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46544,7 +46544,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-09"
+                            title="09.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46554,7 +46554,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-10"
+                            title="10.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46566,7 +46566,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                         <tr>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-11"
+                            title="11.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46576,7 +46576,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-12"
+                            title="12.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46586,7 +46586,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-13"
+                            title="13.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46596,7 +46596,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-14"
+                            title="14.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46606,7 +46606,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-15"
+                            title="15.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46616,7 +46616,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-16"
+                            title="16.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46626,7 +46626,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-17"
+                            title="17.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46638,7 +46638,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                         <tr>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view ant-picker-cell-today"
-                            title="2017-09-18"
+                            title="18.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46648,7 +46648,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-19"
+                            title="19.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46658,7 +46658,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-20"
+                            title="20.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46668,7 +46668,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-21"
+                            title="21.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46678,7 +46678,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-22"
+                            title="22.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46688,7 +46688,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-23"
+                            title="23.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46698,7 +46698,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-24"
+                            title="24.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46710,7 +46710,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                         <tr>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-25"
+                            title="25.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46720,7 +46720,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-26"
+                            title="26.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46730,7 +46730,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-27"
+                            title="27.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46740,7 +46740,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-28"
+                            title="28.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46750,7 +46750,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-29"
+                            title="29.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46760,7 +46760,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-09-30"
+                            title="30.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46770,7 +46770,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-10-01"
+                            title="01.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46782,7 +46782,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                         <tr>
                           <td
                             class="ant-picker-cell"
-                            title="2017-10-02"
+                            title="02.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46792,7 +46792,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-10-03"
+                            title="03.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46802,7 +46802,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-10-04"
+                            title="04.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46812,7 +46812,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-10-05"
+                            title="05.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46822,7 +46822,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-10-06"
+                            title="06.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46832,7 +46832,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-10-07"
+                            title="07.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46842,7 +46842,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-10-08"
+                            title="08.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46964,7 +46964,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                         <tr>
                           <td
                             class="ant-picker-cell"
-                            title="2017-09-25"
+                            title="25.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46974,7 +46974,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-09-26"
+                            title="26.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46984,7 +46984,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-09-27"
+                            title="27.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -46994,7 +46994,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-09-28"
+                            title="28.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47004,7 +47004,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-09-29"
+                            title="29.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47014,7 +47014,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-09-30"
+                            title="30.09.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47024,7 +47024,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-01"
+                            title="01.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47036,7 +47036,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                         <tr>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-02"
+                            title="02.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47046,7 +47046,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-03"
+                            title="03.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47056,7 +47056,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-04"
+                            title="04.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47066,7 +47066,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-05"
+                            title="05.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47076,7 +47076,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-06"
+                            title="06.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47086,7 +47086,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-07"
+                            title="07.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47096,7 +47096,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-08"
+                            title="08.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47108,7 +47108,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                         <tr>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-09"
+                            title="09.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47118,7 +47118,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-10"
+                            title="10.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47128,7 +47128,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-11"
+                            title="11.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47138,7 +47138,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-12"
+                            title="12.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47148,7 +47148,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-13"
+                            title="13.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47158,7 +47158,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-14"
+                            title="14.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47168,7 +47168,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-15"
+                            title="15.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47180,7 +47180,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                         <tr>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-16"
+                            title="16.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47190,7 +47190,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-17"
+                            title="17.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47200,7 +47200,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-18"
+                            title="18.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47210,7 +47210,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-19"
+                            title="19.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47220,7 +47220,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-20"
+                            title="20.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47230,7 +47230,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-21"
+                            title="21.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47240,7 +47240,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-22"
+                            title="22.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47252,7 +47252,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                         <tr>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-23"
+                            title="23.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47262,7 +47262,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-24"
+                            title="24.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47272,7 +47272,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-25"
+                            title="25.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47282,7 +47282,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-26"
+                            title="26.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47292,7 +47292,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-27"
+                            title="27.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47302,7 +47302,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-28"
+                            title="28.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47312,7 +47312,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-29"
+                            title="29.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47324,7 +47324,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                         <tr>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-30"
+                            title="30.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47334,7 +47334,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell ant-picker-cell-in-view"
-                            title="2017-10-31"
+                            title="31.10.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47344,7 +47344,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-11-01"
+                            title="01.11.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47354,7 +47354,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-11-02"
+                            title="02.11.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47364,7 +47364,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-11-03"
+                            title="03.11.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47374,7 +47374,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-11-04"
+                            title="04.11.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -47384,7 +47384,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                           </td>
                           <td
                             class="ant-picker-cell"
-                            title="2017-11-05"
+                            title="05.11.2017"
                           >
                             <div
                               class="ant-picker-cell-inner"
@@ -48084,7 +48084,7 @@ exports[`Locale Provider should display the text as de 1`] = `
               <tr>
                 <td
                   class="ant-picker-cell"
-                  title="2017-08-28"
+                  title="28.08.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48101,7 +48101,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell"
-                  title="2017-08-29"
+                  title="29.08.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48118,7 +48118,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell"
-                  title="2017-08-30"
+                  title="30.08.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48135,7 +48135,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell"
-                  title="2017-08-31"
+                  title="31.08.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48152,7 +48152,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-01"
+                  title="01.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48169,7 +48169,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-02"
+                  title="02.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48186,7 +48186,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-03"
+                  title="03.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48205,7 +48205,7 @@ exports[`Locale Provider should display the text as de 1`] = `
               <tr>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-04"
+                  title="04.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48222,7 +48222,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-05"
+                  title="05.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48239,7 +48239,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-06"
+                  title="06.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48256,7 +48256,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-07"
+                  title="07.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48273,7 +48273,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-08"
+                  title="08.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48290,7 +48290,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-09"
+                  title="09.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48307,7 +48307,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-10"
+                  title="10.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48326,7 +48326,7 @@ exports[`Locale Provider should display the text as de 1`] = `
               <tr>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-11"
+                  title="11.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48343,7 +48343,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-12"
+                  title="12.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48360,7 +48360,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-13"
+                  title="13.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48377,7 +48377,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-14"
+                  title="14.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48394,7 +48394,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-15"
+                  title="15.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48411,7 +48411,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-16"
+                  title="16.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48428,7 +48428,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-17"
+                  title="17.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48447,7 +48447,7 @@ exports[`Locale Provider should display the text as de 1`] = `
               <tr>
                 <td
                   class="ant-picker-cell ant-picker-cell-selected ant-picker-cell-in-view ant-picker-cell-today"
-                  title="2017-09-18"
+                  title="18.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date ant-picker-calendar-date-today"
@@ -48464,7 +48464,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-19"
+                  title="19.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48481,7 +48481,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-20"
+                  title="20.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48498,7 +48498,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-21"
+                  title="21.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48515,7 +48515,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-22"
+                  title="22.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48532,7 +48532,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-23"
+                  title="23.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48549,7 +48549,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-24"
+                  title="24.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48568,7 +48568,7 @@ exports[`Locale Provider should display the text as de 1`] = `
               <tr>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-25"
+                  title="25.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48585,7 +48585,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-26"
+                  title="26.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48602,7 +48602,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-27"
+                  title="27.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48619,7 +48619,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-28"
+                  title="28.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48636,7 +48636,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-29"
+                  title="29.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48653,7 +48653,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell ant-picker-cell-in-view"
-                  title="2017-09-30"
+                  title="30.09.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48670,7 +48670,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell"
-                  title="2017-10-01"
+                  title="01.10.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48689,7 +48689,7 @@ exports[`Locale Provider should display the text as de 1`] = `
               <tr>
                 <td
                   class="ant-picker-cell"
-                  title="2017-10-02"
+                  title="02.10.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48706,7 +48706,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell"
-                  title="2017-10-03"
+                  title="03.10.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48723,7 +48723,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell"
-                  title="2017-10-04"
+                  title="04.10.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48740,7 +48740,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell"
-                  title="2017-10-05"
+                  title="05.10.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48757,7 +48757,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell"
-                  title="2017-10-06"
+                  title="06.10.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48774,7 +48774,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell"
-                  title="2017-10-07"
+                  title="07.10.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"
@@ -48791,7 +48791,7 @@ exports[`Locale Provider should display the text as de 1`] = `
                 </td>
                 <td
                   class="ant-picker-cell"
-                  title="2017-10-08"
+                  title="08.10.2017"
                 >
                   <div
                     class="ant-picker-cell-inner ant-picker-calendar-date"


### PR DESCRIPTION
### 🤔 This is a ...
- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 🌐 Internationalization

Closes #59149.

### 改动点
- components/date-picker/locale/de_DE.ts :: lang 加 fieldDateFormat='DD.MM.YYYY' + fieldDateTimeFormat='DD.MM.YYYY HH:mm:ss'（sq_AL同形；rc-picker de_DE无此四键，唯一德语值）。
- components/locale/__tests__/__snapshots__/index.test.tsx.snap 更新（de快照title US→德语，改动生效证据）。

### 验证命令与结果（短ASCII路径 C:/a/ad 实跑）
- npx tsc --noEmit → exit 0（全仓）
- npx eslint components/date-picker/locale/de_DE.ts → exit 0
- npx jest --config .jest.js components/locale/__tests__/index.test.tsx --no-cache → 77/77（-u 1 updated）；复跑77/77无flake