### PR TITLE
fix(TreeSelect): isolate root semantic styles from popup

### DIFF
--- a/components/tree-select/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/tree-select/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -2730,7 +2730,7 @@ exports[`renders components/tree-select/demo/style-class.tsx extend context corr
     </div>
   </div>
   <div
-    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tree-select-dropdown acss-aylixc css-var-test-id ant-select-css-var ant-tree-select-css-var ant-select-dropdown-placement-bottomLeft"
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tree-select-dropdown css-var-test-id ant-select-css-var ant-tree-select-css-var ant-select-dropdown-placement-bottomLeft"
     style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; border: 1px solid rgb(24, 144, 255);"
   >
     <div>
@@ -2870,7 +2870,7 @@ exports[`renders components/tree-select/demo/style-class.tsx extend context corr
     </div>
   </div>
   <div
-    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tree-select-dropdown acss-aylixc css-var-test-id ant-select-css-var ant-tree-select-css-var ant-select-dropdown-placement-bottomLeft"
+    class="ant-select-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-tree-select-dropdown css-var-test-id ant-select-css-var ant-tree-select-css-var ant-select-dropdown-placement-bottomLeft"
     style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
   >
     <div>

--- a/components/tree-select/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/tree-select/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`renders components/tree-select/demo/_semantic.tsx correctly 1`] = `
           </button>
         </div>
         <div
-          class="ant-select-dropdown ant-tree-select-dropdown semantic-mark-root semantic-mark-popup-root css-var-test-id ant-select-css-var ant-tree-select-css-var ant-select-dropdown-placement-bottomLeft"
+          class="ant-select-dropdown ant-tree-select-dropdown semantic-mark-popup-root css-var-test-id ant-select-css-var ant-tree-select-css-var ant-select-dropdown-placement-bottomLeft"
           style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box;"
         >
           <div>

--- a/components/tree-select/__tests__/semantic.test.tsx
+++ b/components/tree-select/__tests__/semantic.test.tsx
@@ -4,6 +4,32 @@ import TreeSelect from '..';
 import { render } from '../../../tests/utils';
 
 describe('TreeSelect.Semantic', () => {
+  it('should isolate root className and style from popup root', () => {
+    const rootStyle = { height: '40px', overflow: 'hidden' } as const;
+    const popupRootStyle = { color: 'rgb(255, 0, 0)' };
+    const treeData = [{ value: 'node', title: 'Node' }];
+
+    const { container } = render(
+      <TreeSelect
+        open
+        treeData={treeData}
+        classNames={{ root: 'custom-root', popup: { root: 'custom-popup-root' } }}
+        styles={{ root: rootStyle, popup: { root: popupRootStyle } }}
+      />,
+    );
+
+    const root = container.querySelector('.ant-tree-select');
+    const popup = document.querySelector<HTMLElement>('.ant-tree-select-dropdown');
+
+    expect(root).toHaveClass('custom-root');
+    expect(root).toHaveStyle(rootStyle);
+    expect(popup).toHaveClass('custom-popup-root');
+    expect(popup).toHaveStyle(popupRootStyle);
+    expect(popup).not.toHaveClass('custom-root');
+    expect(popup?.style.height).toBe('');
+    expect(popup?.style.overflow).toBe('');
+  });
+
   it('support classNames and styles as functions', () => {
     const treeData = [
       {

--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -315,7 +315,6 @@ const InternalTreeSelect: InternalTreeSelectRef = (props, ref) => {
       [`${treeSelectPrefixCls}-dropdown-rtl`]: direction === 'rtl',
     },
     rootClassName,
-    mergedClassNames.root,
     mergedClassNames.popup?.root,
     cssVarCls,
     rootCls,
@@ -441,7 +440,7 @@ const InternalTreeSelect: InternalTreeSelectRef = (props, ref) => {
       getPopupContainer={getPopupContainer || getContextPopupContainer}
       treeMotion={null}
       popupClassName={mergedPopupClassName}
-      popupStyle={{ ...mergedStyles.root, ...mergedStyles.popup?.root, zIndex }}
+      popupStyle={{ ...mergedStyles.popup?.root, zIndex }}
       popupRender={mergedPopupRender}
       onPopupVisibleChange={mergedOnOpenChange}
       choiceTransitionName={getTransitionName(rootPrefixCls, '', choiceTransitionName)}


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] ✅ 测试用例

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

TreeSelect 的 `classNames.root` 和 `styles.root` 会同时应用到组件根节点和弹出层，导致根节点的类名及样式意外影响下拉面板。

<img width="1937" height="516" alt="tree-select-semantic-root-2" src="https://github.com/user-attachments/assets/d29e5809-c2df-4531-a0d1-e9cef958652c" />

本次修改将根节点语义配置与 `popup.root` 隔离：

- `classNames.root` 仅应用于 TreeSelect 根节点。
- `styles.root` 仅应用于 TreeSelect 根节点。
- 弹出层仅使用 `classNames.popup.root` 和 `styles.popup.root`。
- 添加回归测试验证类名及样式不会从根节点泄漏到弹出层。

<img width="1951" height="531" alt="tree-select-semantic-root-1" src="https://github.com/user-attachments/assets/f4a4418e-363a-46ad-83c5-8bae0800a088" />

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix TreeSelect `classNames.root` and `styles.root` incorrectly affecting the popup. |
| 🇨🇳 中文 | 🐞 修复 TreeSelect `classNames.root` 和 `styles.root` 错误影响弹出层的问题。 |