### PR TITLE
fix(Select): keep single selector height stable under custom global lineHeight

### DIFF
--- a/components/select/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/select/__tests__/__snapshots__/index.test.tsx.snap
@@ -146,3 +146,99 @@ exports[`Select rtl render component should be rendered correctly in RTL directi
   </div>
 </div>
 `;
+
+exports[`Select single selector height vs global lineHeight locks single content line box to font-height when global lineHeight is 1: single-selector-lineHeight-1 1`] = `
+<div
+  class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
+>
+  <div
+    class="ant-select-content ant-select-content-has-value"
+    title="One"
+  >
+    One
+    <input
+      aria-autocomplete="list"
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      autocomplete="new-password"
+      class="ant-select-input"
+      id="test-id"
+      readonly=""
+      role="combobox"
+      type="text"
+      value=""
+    />
+  </div>
+  <div
+    class="ant-select-suffix"
+  >
+    <span
+      aria-label="down"
+      class="anticon anticon-down"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="down"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+        />
+      </svg>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Select single selector height vs global lineHeight locks single content line box to font-height when global lineHeight is 2: single-selector-lineHeight-2 1`] = `
+<div
+  class="ant-select ant-select-outlined css-var-test-id ant-select-css-var ant-select-single ant-select-show-arrow"
+>
+  <div
+    class="ant-select-content ant-select-content-has-value"
+    title="One"
+  >
+    One
+    <input
+      aria-autocomplete="list"
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      autocomplete="new-password"
+      class="ant-select-input"
+      id="test-id"
+      readonly=""
+      role="combobox"
+      type="text"
+      value=""
+    />
+  </div>
+  <div
+    class="ant-select-suffix"
+  >
+    <span
+      aria-label="down"
+      class="anticon anticon-down"
+      role="img"
+    >
+      <svg
+        aria-hidden="true"
+        data-icon="down"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="64 64 896 896"
+        width="1em"
+      >
+        <path
+          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+        />
+      </svg>
+    </span>
+  </div>
+</div>
+`;

--- a/components/select/__tests__/index.test.tsx
+++ b/components/select/__tests__/index.test.tsx
@@ -611,7 +611,7 @@ describe('Select', () => {
     it.each([1, 2])(
       'locks single content line box to font-height when global lineHeight is %s',
       (lineHeight) => {
-        const { unmount } = render(
+        const { container, unmount } = render(
           <ConfigProvider theme={{ token: { lineHeight } }}>
             <Select defaultValue="one" options={[{ value: 'one', label: 'One' }]} />
           </ConfigProvider>,
@@ -625,6 +625,12 @@ describe('Select', () => {
             style.innerHTML.includes('line-height:var(--ant-select-font-height)'),
         );
         expect(singleContentLocked).toBeTruthy();
+
+        // Snapshot the rendered single selector DOM per lineHeight so
+        // structural regressions in this scenario are caught as well.
+        expect(container.querySelector('.ant-select-single')).toMatchSnapshot(
+          `single-selector-lineHeight-${lineHeight}`,
+        );
 
         unmount();
       },

--- a/components/select/__tests__/index.test.tsx
+++ b/components/select/__tests__/index.test.tsx
@@ -605,4 +605,29 @@ describe('Select', () => {
       expect(container.querySelector('.ant-select-suffix')!.textContent).toBe('bamboo');
     });
   });
+
+  // https://github.com/ant-design/ant-design/issues/59091
+  describe('single selector height vs global lineHeight', () => {
+    it.each([1, 2])(
+      'locks single content line box to font-height when global lineHeight is %s',
+      (lineHeight) => {
+        const { unmount } = render(
+          <ConfigProvider theme={{ token: { lineHeight } }}>
+            <Select defaultValue="one" options={[{ value: 'one', label: 'One' }]} />
+          </ConfigProvider>,
+        );
+
+        const singleContentLocked = Array.from(
+          document.querySelectorAll('style[data-css-hash]'),
+        ).some(
+          (style) =>
+            style.innerHTML.includes('.ant-select-single') &&
+            style.innerHTML.includes('line-height:var(--ant-select-font-height)'),
+        );
+        expect(singleContentLocked).toBeTruthy();
+
+        unmount();
+      },
+    );
+  });
 });

--- a/components/select/style/select-input.ts
+++ b/components/select/style/select-input.ts
@@ -305,6 +305,11 @@ const genSelectInputStyle: GenerateStyle<SelectToken, CSSObject> = (token) => {
           [`${componentCls}-content`]: {
             ...textEllipsis,
             alignSelf: 'center',
+            // Lock the content line box to font-height so the global
+            // `lineHeight` token cannot stretch the single selector box.
+            // Padding is computed from the same `font-height`, so the total
+            // stays at `controlHeight` (see #59091).
+            lineHeight: varRef('font-height'),
 
             '&-has-value': {
               display: 'block',


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

- Fix #59091

### 💡 Background and Solution

With a custom global `lineHeight` token, the single Select box drifts away from `controlHeight` while the multiple Select stays put (e.g. `lineHeight=1` → single 24px vs multiple 32px; `lineHeight=2` → single 38px vs multiple 32px; default token is unaffected at 32/32).

Root cause: the single `.ant-select-content` line box inherits the global `lineHeight` token through the root container, but the vertical padding is computed from the fixed `font-height` (`(height - font-height) / 2 - border`), so the leftover stretches (or shrinks) the border-box past `controlHeight`. Multiple locks its content to `lineHeight: 1` and never drifts.

This PR pins the single content line box to `var(--ant-select-font-height)` so the total stays at `controlHeight` under any global `lineHeight`. Text stays vertically centered via the existing `alignSelf: center`.

Verified with a headless Chromium (puppeteer + esbuild bundle from source) measuring `.ant-select-single` / `.ant-select-multiple` offset heights under `ConfigProvider theme.token.lineHeight` in {default, 1, 2}:
- before: default 32/32, LH=1 24/32, LH=2 38/32
- after: 32/32 at all three levels; placeholder-only and showSearch single states also 32/32

### 📝 Change Log

| Language   | Changelog                                              |
| ---------- | ------------------------------------------------------ |
| 🇺🇸 English | Fix Select single selector height drifting with the global `lineHeight` token. |
| 🇨🇳 Chinese | 修复 Select 单选框高度随全局 `lineHeight` token 漂移的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed