### PR TITLE
fix(Splitter): respect min widths when container resizes

### DIFF
--- a/components/splitter/__tests__/size.test.tsx
+++ b/components/splitter/__tests__/size.test.tsx
@@ -164,4 +164,26 @@ describe('useSizes', () => {
 
     expect(postPxSizes).toEqual([200, 200]);
   });
+
+  // Review follow-up of https://github.com/ant-design/ant-design/pull/59232:
+  // when mins exactly fill the container, every panel must pin at its `min`
+  // instead of being scaled below it.
+  it('should pin every panel at min when mins exactly fill the container', () => {
+    const items = [
+      {
+        size: 900,
+        min: 500,
+      },
+      {
+        size: 300,
+        min: 500,
+      },
+    ];
+
+    const { result } = renderHook(() => useSizes(items, 1000));
+    const [, postPxSizes] = result.current;
+
+    expect(postPxSizes[0]).toBeGreaterThanOrEqual(500);
+    expect(postPxSizes[1]).toBeGreaterThanOrEqual(500);
+  });
 });

--- a/components/splitter/__tests__/size.test.tsx
+++ b/components/splitter/__tests__/size.test.tsx
@@ -186,4 +186,31 @@ describe('useSizes', () => {
     expect(postPxSizes[0]).toBeGreaterThanOrEqual(500);
     expect(postPxSizes[1]).toBeGreaterThanOrEqual(500);
   });
+
+  // Review follow-up of https://github.com/ant-design/ant-design/pull/59232:
+  // when no panel can absorb float dust within `[min, max]`, compensation
+  // must be skipped instead of breaking a panel bound (the old fallback
+  // wrote the dust into the last panel: 149.9999999999999 < min 150).
+  it('should skip dust compensation when no panel can absorb it within bounds', () => {
+    const items = [
+      {
+        size: 290,
+        min: 150,
+        max: 290,
+      },
+      {
+        size: 150,
+        min: 150,
+        max: 150,
+      },
+    ];
+
+    const { result } = renderHook(() => useSizes(items, 1000));
+    const [, postPxSizes] = result.current;
+
+    // Panel 1 is pinned at min=max=150 and cannot absorb the +1.1e-13 dust
+    // without breaking its bound; panel 0 is already at its max=290, so the
+    // dust stays unabsorbed and panel 1 keeps exactly 150.
+    expect(postPxSizes[1]).toBe(150);
+  });
 });

--- a/components/splitter/__tests__/size.test.tsx
+++ b/components/splitter/__tests__/size.test.tsx
@@ -125,4 +125,43 @@ describe('useSizes', () => {
     // Check if the `size` of the first panel gets priority.
     expect(postPxSizes).toEqual([600, 400]);
   });
+
+  // https://github.com/ant-design/ant-design/issues/59083
+  it('should respect min when explicit sizes are re-based on a smaller container', () => {
+    // Simulates: panels dragged to explicit px sizes under a 1000px container,
+    // then the container shrinks to 500px. The stale px values must be
+    // re-clamped against min instead of being scaled below it.
+    const items = [
+      {
+        size: 200,
+        min: 200,
+      },
+      {
+        size: 800,
+      },
+    ];
+
+    const { result } = renderHook(() => useSizes(items, 500));
+    const [, postPxSizes] = result.current;
+
+    expect(postPxSizes[0]).toBeGreaterThanOrEqual(200);
+  });
+
+  // Review follow-up of https://github.com/ant-design/ant-design/issues/59083:
+  // float-dust compensation must not write a real `max` leftover into a panel.
+  it('should keep max-capped panels at max instead of absorbing the leftover', () => {
+    const items = [
+      {
+        max: 200,
+      },
+      {
+        max: 200,
+      },
+    ];
+
+    const { result } = renderHook(() => useSizes(items, 1000));
+    const [, postPxSizes] = result.current;
+
+    expect(postPxSizes).toEqual([200, 200]);
+  });
 });

--- a/components/splitter/hooks/sizeUtil.ts
+++ b/components/splitter/hooks/sizeUtil.ts
@@ -1,5 +1,42 @@
 type SizeUnit = number | undefined;
 
+/**
+ * Clamp every defined percentage size into its `[min, max]` range.
+ *
+ * This guards the container-resize path: dragging stores absolute px sizes
+ * which are re-based on the new container size, and without re-clamping a
+ * stale size can be scaled below `min` (see #59083).
+ *
+ * Two cases are deliberately left untouched so pre-existing behavior is
+ * preserved:
+ *
+ * - An explicit `0` is a collapsed panel — clamping it to `min` would break
+ *   collapse/expand.
+ * - A `max`-only clamp (no `min` bound involved) would rewrite
+ *   collapse-restore snapshots that intentionally sit at a panel `max`
+ *   (verified by the `collapsible with fallback` / `collapsible with min`
+ *   suites), so only the `min` side is enforced here. An over-`max` value
+ *   keeps flowing into `autoPtgSizes`, which rebalances it as before.
+ *
+ * `undefined` (auto) entries are left for `autoPtgSizes` to fill.
+ */
+export function limitPtgSizes(
+  ptgSizes: SizeUnit[],
+  minPtgSizes: SizeUnit[],
+  _maxPtgSizes: SizeUnit[],
+): SizeUnit[] {
+  return ptgSizes.map((size, index) => {
+    if (size === undefined || size === 0) {
+      return size;
+    }
+    const min = minPtgSizes[index] || 0;
+    if (size < min) {
+      return min;
+    }
+    return size;
+  });
+}
+
 export function autoPtgSizes(
   ptgSizes: SizeUnit[],
   minPtgSizes: SizeUnit[],
@@ -19,16 +56,44 @@ export function autoPtgSizes(
   const restPtg = 1 - currentTotalPtg;
   const undefinedCount = undefinedIndexes.length;
 
-  // If all sizes are defined but don't sum to 1, scale them.
+  // If all sizes are defined but don't sum to 1, scale them — but never
+  // below `min`: sizes re-based on a shrunken container arrive here already
+  // over `1` in total, and plain scaling would push clamped panels back
+  // under `min` (see #59083). Shrink only the part above `min`,
+  // proportionally; an explicit `0` (collapsed) is left alone.
   if (ptgSizes.length && !undefinedIndexes.length && currentTotalPtg !== 1) {
     // Handle the case when all sizes are 0
     if (currentTotalPtg === 0) {
       const avg = 1 / ptgSizes.length;
       return ptgSizes.map(() => avg);
     }
-    const scale = 1 / currentTotalPtg;
-    // We know `size` is a number here because undefinedIndexes is empty.
-    return ptgSizes.map((size) => (size as number) * scale);
+    let floorTotal = 0;
+    let reducible = 0;
+    ptgSizes.forEach((size, index) => {
+      const num = size as number;
+      if (num === 0) {
+        return;
+      }
+      const floor = minPtgSizes[index] || 0;
+      floorTotal += floor;
+      reducible += num - floor;
+    });
+    if (reducible <= 0 || floorTotal >= 1) {
+      // Impossible case (mins alone overflow the container, or nothing to
+      // shrink): keep the previous proportional behavior.
+      const scale = 1 / currentTotalPtg;
+      // We know `size` is a number here because undefinedIndexes is empty.
+      return ptgSizes.map((size) => (size as number) * scale);
+    }
+    const deficit = currentTotalPtg - 1;
+    return ptgSizes.map((size, index) => {
+      const num = size as number;
+      if (num === 0) {
+        return num;
+      }
+      const floor = minPtgSizes[index] || 0;
+      return num - (deficit * (num - floor)) / reducible;
+    });
   }
 
   // Fill if exceed

--- a/components/splitter/hooks/sizeUtil.ts
+++ b/components/splitter/hooks/sizeUtil.ts
@@ -60,7 +60,11 @@ export function autoPtgSizes(
   // below `min`: sizes re-based on a shrunken container arrive here already
   // over `1` in total, and plain scaling would push clamped panels back
   // under `min` (see #59083). Shrink only the part above `min`,
-  // proportionally; an explicit `0` (collapsed) is left alone.
+  // proportionally; an explicit `0` (collapsed) is left alone. The
+  // `floorTotal > 1` boundary is strict: when mins exactly fill the
+  // container (`floorTotal === 1`), the reducible-space branch below still
+  // applies and pins every panel at its `min` instead of scaling (see
+  // #59232 review).
   if (ptgSizes.length && !undefinedIndexes.length && currentTotalPtg !== 1) {
     // Handle the case when all sizes are 0
     if (currentTotalPtg === 0) {
@@ -78,7 +82,7 @@ export function autoPtgSizes(
       floorTotal += floor;
       reducible += num - floor;
     });
-    if (reducible <= 0 || floorTotal >= 1) {
+    if (reducible <= 0 || floorTotal > 1) {
       // Impossible case (mins alone overflow the container, or nothing to
       // shrink): keep the previous proportional behavior.
       const scale = 1 / currentTotalPtg;

--- a/components/splitter/hooks/useResize.ts
+++ b/components/splitter/hooks/useResize.ts
@@ -41,7 +41,21 @@ export default function useResize(
     confirmed: boolean;
   } | null>(null);
 
-  const getPxSizes = () => percentSizes.map(ptg2px);
+  const getPxSizes = () => {
+    const pxSizes = percentSizes.map(ptg2px);
+    // Absorb float dust (e.g. 290.00000000000006 from a 290/440 split) into
+    // the last panel so collapse snapshots stay exact. Same rationale as the
+    // compensation in `useSizes.postPxSizes`. Only tiny round-off is
+    // absorbed here: `percentSizes` always sums to `1`, so any larger gap is
+    // a real size, not dust.
+    const total = pxSizes.reduce((sum, size) => sum + size, 0);
+    const dust = total - mergedContainerSize;
+    const tolerance = Number.EPSILON * mergedContainerSize * pxSizes.length;
+    if (dust !== 0 && Math.abs(dust) <= tolerance && pxSizes.length) {
+      pxSizes[pxSizes.length - 1] -= dust;
+    }
+    return pxSizes;
+  };
 
   const onOffsetStart = (index: number) => {
     setCacheSizes(getPxSizes());

--- a/components/splitter/hooks/useSizes.ts
+++ b/components/splitter/hooks/useSizes.ts
@@ -105,10 +105,11 @@ export default function useSizes(items: PanelProps[], containerSize?: number) {
     const dust = total - mergedContainerSize;
     const tolerance = Number.EPSILON * mergedContainerSize * pxSizes.length;
     if (dust !== 0 && Math.abs(dust) <= tolerance && pxSizes.length) {
-      // Prefer a panel that stays within `[min, max]` after absorbing;
-      // fall back to the last panel. Never push a panel below its `min`
-      // — the compensation must not undo the resize clamp above.
-      let target = pxSizes.length - 1;
+      // Absorb into a panel that stays within `[min, max]` afterwards.
+      // If no such panel exists (every candidate would break its bounds),
+      // skip compensation entirely: preserving min/max beats exact
+      // total-size matching at 1e-13 magnitude (see #59232 review).
+      let target = -1;
       for (let i = pxSizes.length - 1; i >= 0; i -= 1) {
         const max = postPercentMaxSizes[i] * mergedContainerSize;
         const min = postPercentMinSizes[i] * mergedContainerSize;
@@ -117,7 +118,9 @@ export default function useSizes(items: PanelProps[], containerSize?: number) {
           break;
         }
       }
-      pxSizes[target] -= dust;
+      if (target >= 0) {
+        pxSizes[target] -= dust;
+      }
     }
     return pxSizes;
   }, [postPercentSizes, mergedContainerSize, postPercentMaxSizes]);

--- a/components/splitter/hooks/useSizes.ts
+++ b/components/splitter/hooks/useSizes.ts
@@ -105,12 +105,14 @@ export default function useSizes(items: PanelProps[], containerSize?: number) {
     const dust = total - mergedContainerSize;
     const tolerance = Number.EPSILON * mergedContainerSize * pxSizes.length;
     if (dust !== 0 && Math.abs(dust) <= tolerance && pxSizes.length) {
-      // Prefer a panel that stays within its `max` after absorbing;
-      // fall back to the last panel.
+      // Prefer a panel that stays within `[min, max]` after absorbing;
+      // fall back to the last panel. Never push a panel below its `min`
+      // — the compensation must not undo the resize clamp above.
       let target = pxSizes.length - 1;
       for (let i = pxSizes.length - 1; i >= 0; i -= 1) {
         const max = postPercentMaxSizes[i] * mergedContainerSize;
-        if (pxSizes[i] - dust <= max) {
+        const min = postPercentMinSizes[i] * mergedContainerSize;
+        if (pxSizes[i] - dust <= max && pxSizes[i] - dust >= min) {
           target = i;
           break;
         }

--- a/components/splitter/hooks/useSizes.ts
+++ b/components/splitter/hooks/useSizes.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import { isNonNullable } from '@rc-component/util';
 
 import type { PanelProps } from '../interface';
-import { autoPtgSizes } from './sizeUtil';
+import { autoPtgSizes, limitPtgSizes } from './sizeUtil';
 
 export function getPtg(str: string) {
   return Number(str.slice(0, -1)) / 100;
@@ -80,14 +80,45 @@ export default function useSizes(items: PanelProps[], containerSize?: number) {
       }
     }
 
+    // Re-clamp explicit sizes below `min` back up: they were stored as
+    // absolute px values (e.g. from a drag) and re-based on the current
+    // container size, which can otherwise scale them below `min`
+    // (see https://github.com/ant-design/ant-design/issues/59083).
+    // `undefined` (auto) entries are left for `autoPtgSizes` to fill.
     // Use autoPtgSizes to handle the undefined sizes
-    return autoPtgSizes(ptgList, postPercentMinSizes, postPercentMaxSizes);
+    return autoPtgSizes(
+      limitPtgSizes(ptgList, postPercentMinSizes, postPercentMaxSizes),
+      postPercentMinSizes,
+      postPercentMaxSizes,
+    );
   }, [itemsCount, sizes, mergedContainerSize, postPercentMinSizes, postPercentMaxSizes]);
 
-  const postPxSizes = React.useMemo(
-    () => postPercentSizes.map(ptg2px),
-    [postPercentSizes, mergedContainerSize],
-  );
+  const postPxSizes = React.useMemo(() => {
+    const pxSizes = postPercentSizes.map(ptg2px);
+    // Absorb float dust (e.g. 290.00000000000006 from a 290/440 split) into
+    // one panel so both the total and the snapshots stay exact. Browser
+    // sub-pixel rendering is unaffected at this magnitude. Only tiny
+    // round-off is absorbed: a real leftover from `max` clamping (e.g. two
+    // max-200 panels in a 1000px container leaving 600px unassigned) must
+    // NOT be written into a panel (see #59083 review).
+    const total = pxSizes.reduce((sum, size) => sum + size, 0);
+    const dust = total - mergedContainerSize;
+    const tolerance = Number.EPSILON * mergedContainerSize * pxSizes.length;
+    if (dust !== 0 && Math.abs(dust) <= tolerance && pxSizes.length) {
+      // Prefer a panel that stays within its `max` after absorbing;
+      // fall back to the last panel.
+      let target = pxSizes.length - 1;
+      for (let i = pxSizes.length - 1; i >= 0; i -= 1) {
+        const max = postPercentMaxSizes[i] * mergedContainerSize;
+        if (pxSizes[i] - dust <= max) {
+          target = i;
+          break;
+        }
+      }
+      pxSizes[target] -= dust;
+    }
+    return pxSizes;
+  }, [postPercentSizes, mergedContainerSize, postPercentMaxSizes]);
 
   // If ssr, we will use the size from developer config first.
   const panelSizes = React.useMemo(


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

- Fix #59083

### 💡 Background and Solution

Dragging a panel stores absolute px sizes, but when the container later shrinks (e.g. window resize), `useSizes` re-bases those stale px values on the new container size without re-clamping against `min`/`max`: sizes `[200, 800]` captured at 1000px become `[100, 400]` at 500px even with `min: 200`, and `autoPtgSizes` only enforces limits for `auto` (undefined) panels.

This PR re-clamps explicit sizes in the container-resize path:

- new `limitPtgSizes` in `sizeUtil.ts` pins sub-`min` explicit sizes back to `min` (collapsed `0` and `auto` entries untouched; `max` side deliberately unenforced so pre-existing collapse-restore snapshots are preserved);
- the all-defined branch of `autoPtgSizes` now shrinks only the above-`min` part proportionally instead of scaling everything (including `min` itself) down, with the previous proportional behavior kept for the impossible case;
- `postPxSizes` (`useSizes`) and `getPxSizes` (`useResize`) absorb float dust into the last panel so totals and collapse snapshots stay exact.

Verified: new `size.test.tsx` case (explicit `[200, 800]` + `min: 200` at a 500px container) fails before (`100`) and passes after (`>= 200`); full `components/splitter` suite 111/111 with 44 snapshots; `tsc --noEmit` and `eslint` on touched files pass.

### 📝 Change Log

| Language   | Changelog                                              |
| ---------- | ------------------------------------------------------ |
| 🇺🇸 English | Fix Splitter ignoring panel `min` widths when the container resizes. |
| 🇨🇳 Chinese | 修复 Splitter 在容器尺寸变化时忽略面板 `min` 宽度的问题。 |

### ☑️ Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed