### PR TITLE
fix: stop mutating the mask config object passed by the user

### DIFF
--- a/components/_util/hooks/useMergedMask.ts
+++ b/components/_util/hooks/useMergedMask.ts
@@ -13,7 +13,8 @@ export const normalizeMaskConfig = (mask?: MaskType, maskClosable?: boolean): Ma
   let maskConfig: MaskConfig = {};
 
   if (isPlainObject(mask)) {
-    maskConfig = mask;
+    // Copy so that filling `closable` below never writes back to the user's `mask` object
+    maskConfig = { ...mask };
   }
   if (typeof mask === 'boolean') {
     maskConfig = {

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -4,6 +4,7 @@ import { warning } from '@rc-component/util';
 
 import type { ModalFuncProps } from '..';
 import Modal from '..';
+import type { MaskType } from '../../_util/hooks';
 import { act, fireEvent, render, waitFakeTimer } from '../../../tests/utils';
 import App from '../../app';
 import ConfigProvider, { defaultPrefixCls } from '../../config-provider';
@@ -1334,6 +1335,28 @@ describe('Modal.confirm triggers callbacks correctly', () => {
       </ConfigProvider>,
     );
     expect(document.querySelector('.custom-error-icon')).toBeTruthy();
+  });
+
+  it('should not mutate the mask config object', async () => {
+    const mask: MaskType = { blur: true };
+    await open({ mask });
+    expect(mask).toEqual({ blur: true });
+  });
+
+  it('should keep mask closable when the mask config object is reused', async () => {
+    const mask: MaskType = { blur: true };
+    await open({ mask });
+    Modal.destroyAll();
+    await waitFakeTimer();
+
+    const onCancel = jest.fn();
+    render(<Modal open mask={mask} onCancel={onCancel} />);
+    await waitFakeTimer();
+
+    const wrap = $$('.ant-modal-wrap')[0];
+    fireEvent.mouseDown(wrap);
+    fireEvent.click(wrap);
+    expect(onCancel).toHaveBeenCalled();
   });
 
   it('should be able to config warning icon', async () => {


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None.

### 💡 Background and Solution

`normalizeMaskConfig` returns the caller's `mask` object itself when `mask` is a plain object, and both of its callers then write `closable` onto the returned object. antd therefore mutates a prop that the user owns.

Reproduction, with a `mask` object that is not re-created on every render:

```tsx
const mask = { blur: true };

Modal.confirm({ title: 'Delete?', mask });
// `mask` is now { blur: true, closable: false }

// Somewhere else, reusing the same object:
<Modal open mask={mask} onCancel={onCancel} />
// clicking the mask no longer closes the Modal
```

`ConfirmDialog` does `nextMaskConfig.closable ??= false` to keep the old confirm behaviour, which lands on the user's object. `useMergedMask` has the same problem through `maskConfig.closable = maskClosable`, so on Modal and Drawer a stable `mask` object plus a changing `maskClosable` also gets stuck on the first value. Image preview shares the helper but never passes `maskClosable`, so it is not affected today.

Fix: copy the object in `normalizeMaskConfig` so the later `closable` fill stays local.

Tests added to `components/modal/__tests__/confirm.test.tsx`: one asserts the `mask` object passed to `Modal.confirm` is unchanged afterwards, the other reuses that object on a `Modal` and asserts a mask click still fires `onCancel`. Both fail on master and pass with this change.

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | 🐞 Fix Modal and Drawer writing `closable` back onto the `mask` object passed by the user, which broke the mask click when that object was reused. |
| 🇨🇳 Chinese | 🐞 修复 Modal 和 Drawer 会把 `closable` 写回用户传入的 `mask` 对象的问题，该对象被复用时会导致点击遮罩失效。 |
