### PR TITLE
docs: align open-state callback parameter names

### DIFF
--- a/.dumi/theme/builtins/InlinePopover/index.tsx
+++ b/.dumi/theme/builtins/InlinePopover/index.tsx
@@ -21,12 +21,12 @@ export interface InlinePopoverProps {
 const InlinePopover: React.FC<InlinePopoverProps> = (props) => {
   const { previewURL } = props;
   const [locale] = useLocale(locales);
-  const [visible, setVisible] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
 
   return (
     <>
       <Tooltip title={locale.tip}>
-        <Typography.Link onClick={() => setVisible(true)}>
+        <Typography.Link onClick={() => setOpen(true)}>
           <PictureOutlined />
         </Typography.Link>
       </Tooltip>
@@ -36,10 +36,10 @@ const InlinePopover: React.FC<InlinePopoverProps> = (props) => {
         style={{ display: 'none' }}
         src={previewURL}
         preview={{
-          visible,
+          open,
           src: previewURL,
-          onVisibleChange: (value) => {
-            setVisible(value);
+          onOpenChange: (nextOpen) => {
+            setOpen(nextOpen);
           },
         }}
       />

--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -241,8 +241,8 @@ const Header: React.FC = () => {
     setHeaderState((prev) => ({ ...prev, windowWidth: window.innerWidth }));
   }, []);
 
-  const onMenuVisibleChange = useCallback((visible: boolean) => {
-    setHeaderState((prev) => ({ ...prev, menuVisible: visible }));
+  const onMenuOpenChange = useCallback((open: boolean) => {
+    setHeaderState((prev) => ({ ...prev, menuVisible: open }));
   }, []);
 
   const onDirectionChange = () => {
@@ -422,7 +422,7 @@ const Header: React.FC = () => {
           trigger="click"
           open={menuVisible}
           arrow={{ pointAtCenter: true }}
-          onOpenChange={onMenuVisibleChange}
+          onOpenChange={onMenuOpenChange}
         >
           <MenuOutlined className="nav-phone-icon" />
         </Popover>

--- a/components/auto-complete/AutoComplete.tsx
+++ b/components/auto-complete/AutoComplete.tsx
@@ -87,7 +87,7 @@ export interface AutoCompleteProps<
   dropdownStyle?: React.CSSProperties;
   /** @deprecated Please use `onOpenChange` instead */
   onDropdownVisibleChange?: (visible: boolean) => void;
-  onOpenChange?: (visible: boolean) => void;
+  onOpenChange?: (open: boolean) => void;
   showSearch?:
     | boolean
     | Pick<

--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -93,7 +93,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | onChange | Callback when finishing cascader select | (value, selectedOptions) => void | - |  | × |
 | onClear | Called when clear | () => void | - | - | × |
 | ~~onDropdownVisibleChange~~ | Callback when popup shown or hidden, use `onOpenChange` instead | (value) => void | - | 4.17.0 | × |
-| onOpenChange | Callback when popup shown or hidden | (value) => void | - |  | × |
+| onOpenChange | Callback when popup shown or hidden | (open: boolean) => void | - |  | × |
 | ~~onPopupVisibleChange~~ | Callback when popup shown or hidden, please use `onOpenChange` instead | (value) => void | - | - | × |
 | multiple | Support multiple or not | boolean | - | 4.17.0 | × |
 | removeIcon | The custom remove icon | ReactNode | - |  | 6.4.0 |

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -181,7 +181,7 @@ export interface CascaderProps<
   onDropdownVisibleChange?: (visible: boolean) => void;
   /** @deprecated Please use `onOpenChange` instead */
   onPopupVisibleChange?: (visible: boolean) => void;
-  onOpenChange?: (visible: boolean) => void;
+  onOpenChange?: (open: boolean) => void;
   /**
    * @since 5.13.0
    * @default "outlined"

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -94,7 +94,7 @@ demo:
 | onChange | 选择完成后的回调 | (value, selectedOptions) => void | - |  | × |
 | onClear | 清除内容时回调 | () => void | - | - | × |
 | ~~onDropdownVisibleChange~~ | 显示/隐藏浮层的回调，请使用 `onOpenChange` 替换 | (value) => void | - | 4.17.0 | × |
-| onOpenChange | 显示/隐藏浮层的回调 | (value) => void | - |  | × |
+| onOpenChange | 显示/隐藏浮层的回调 | (open: boolean) => void | - |  | × |
 | ~~onPopupVisibleChange~~ | 显示或隐藏浮层的回调，请使用 `onOpenChange` 替代 | (value) => void | - | - | × |
 | multiple | 支持多选节点 | boolean | - | 4.17.0 | × |
 | removeIcon | 自定义的多选框清除图标 | ReactNode | - |  | 6.4.0 |

--- a/components/color-picker/ColorPicker.tsx
+++ b/components/color-picker/ColorPicker.tsx
@@ -139,10 +139,10 @@ const ColorPicker: CompoundedComponent = (props) => {
     }
   };
 
-  const triggerOpenChange = (visible: boolean) => {
-    if (!visible || !mergedDisabled) {
-      setPopupOpen(visible);
-      onOpenChange?.(visible);
+  const triggerOpenChange = (open: boolean) => {
+    if (!open || !mergedDisabled) {
+      setPopupOpen(open);
+      onOpenChange?.(open);
     }
   };
 

--- a/components/image/demo/controlled-preview.tsx
+++ b/components/image/demo/controlled-preview.tsx
@@ -30,8 +30,8 @@ const App: React.FC = () => {
           open,
           scaleStep,
           src: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
-          onOpenChange: (value) => {
-            setOpen(value);
+          onOpenChange: (nextOpen) => {
+            setOpen(nextOpen);
           },
         }}
       />

--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -93,7 +93,7 @@ Other Property ref [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/
 | wheel | Whether to enable mouse wheel zoom | boolean | true | 6.6.0 |
 | ~~toolbarRender~~ | Custom toolbar; please use 'actionsRender' instead | (originalNode: React.ReactElement, info: Omit<ToolbarRenderInfoType, 'current' \| 'total'>) => React.ReactNode | - |  |
 | ~~visible~~ | Whether to show; please use 'open' instead | boolean | - |  |
-| onOpenChange | Callback when preview open state changes | (visible: boolean) => void | - |  |
+| onOpenChange | Callback when preview open state changes | (open: boolean) => void | - |  |
 | onTransform | Callback for preview transform changes | { transform: [TransformType](#transformtype), action: [TransformAction](#transformaction) } | - |  |
 | ~~onVisibleChange~~ | Callback when 'visible' changes; please use 'onOpenChange' instead | (visible: boolean, prevVisible: boolean) => void | - |  |
 
@@ -130,7 +130,7 @@ Other Property ref [&lt;img>](https://developer.mozilla.org/en-US/docs/Web/HTML/
 | scaleStep | Each step's zoom multiplier is 1 + scaleStep | number | 0.5 |  |
 | ~~toolbarRender~~ | Custom toolbar; please use 'actionsRender' instead | (originalNode: React.ReactElement, info: ToolbarRenderInfoType) => React.ReactNode | - |  |
 | ~~visible~~ | Whether to show; please use 'open' instead | boolean | - |  |
-| onOpenChange | Callback when preview open state changes, includes current preview index | (visible: boolean, info: { current: number }) => void | - |  |
+| onOpenChange | Callback when preview open state changes, includes current preview index | (open: boolean, info: { current: number }) => void | - |  |
 | onChange | Callback when changing preview image | (current: number, prevCurrent: number) => void | - |  |
 | onTransform | Callback for preview transform changes | { transform: [TransformType](#transformtype), action: [TransformAction](#transformaction) } | - |  |
 | ~~onVisibleChange~~ | Callback when 'visible' changes; please use 'onOpenChange' instead | (visible: boolean, prevVisible: boolean, current: number) => void | - |  |

--- a/components/image/index.zh-CN.md
+++ b/components/image/index.zh-CN.md
@@ -94,7 +94,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | wheel | 是否启用鼠标滚轮缩放 | boolean | true | 6.6.0 |
 | ~~toolbarRender~~ | 自定义工具栏，请使用 `actionsRender` 替换 | (originalNode: React.ReactElement, info: Omit<ToolbarRenderInfoType, 'current' \| 'total'>) => React.ReactNode | - |  |
 | ~~visible~~ | 是否显示，请使用 `open` 替换 | boolean | - |  |
-| onOpenChange | 预览打开状态变化的回调 | (visible: boolean) => void | - |  |
+| onOpenChange | 预览打开状态变化的回调 | (open: boolean) => void | - |  |
 | onTransform | 预览图 transform 变化的回调 | { transform: [TransformType](#transformtype), action: [TransformAction](#transformaction) } | - |  |
 | ~~onVisibleChange~~ | 当 `visible` 发生改变时的回调，请使用 `onOpenChange` 替换 | (visible: boolean, prevVisible: boolean) => void | - |  |
 
@@ -131,7 +131,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | scaleStep | `1 + scaleStep` 为缩放放大的每步倍数 | number | 0.5 |  |
 | ~~toolbarRender~~ | 自定义工具栏，请使用 `actionsRender` 替换 | (originalNode: React.ReactElement, info: ToolbarRenderInfoType) => React.ReactNode | - |  |
 | ~~visible~~ | 是否显示，请使用 `open` 替换 | boolean | - |  |
-| onOpenChange | 预览打开状态变化回调，额外携带当前预览图索引 | (visible: boolean, info: { current: number }) => void | - |  |
+| onOpenChange | 预览打开状态变化回调，额外携带当前预览图索引 | (open: boolean, info: { current: number }) => void | - |  |
 | onChange | 切换预览图的回调 | (current: number, prevCurrent: number) => void | - |  |
 | onTransform | 预览图 transform 变化的回调 | { transform: [TransformType](#transformtype), action: [TransformAction](#transformaction) } | - |  |
 | ~~onVisibleChange~~ | 当 `visible` 发生改变时的回调，请使用 `onOpenChange` 替换 | (visible: boolean, prevVisible: boolean, current: number) => void | - |  |

--- a/components/popconfirm/index.tsx
+++ b/components/popconfirm/index.tsx
@@ -98,9 +98,9 @@ const InternalPopconfirm = React.forwardRef<TooltipRef, PopconfirmProps>((props,
     );
   }
 
-  const settingOpen: PopoverProps['onOpenChange'] = (value) => {
-    setOpen(value);
-    onOpenChange?.(value);
+  const settingOpen: PopoverProps['onOpenChange'] = (nextOpen) => {
+    setOpen(nextOpen);
+    onOpenChange?.(nextOpen);
   };
 
   const close = () => {
@@ -114,11 +114,11 @@ const InternalPopconfirm = React.forwardRef<TooltipRef, PopconfirmProps>((props,
     props.onCancel?.call(this, e);
   };
 
-  const onInternalOpenChange: PopoverProps['onOpenChange'] = (value) => {
+  const onInternalOpenChange: PopoverProps['onOpenChange'] = (nextOpen) => {
     if (disabled) {
       return;
     }
-    settingOpen(value);
+    settingOpen(nextOpen);
   };
 
   const prefixCls = getPrefixCls('popconfirm', customizePrefixCls);

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -121,9 +121,9 @@ const InternalPopover = React.forwardRef<TooltipRef, PopoverProps>((props, ref) 
 
   const [open, setOpen] = useControlledState(props.defaultOpen ?? false, props.open);
 
-  const settingOpen = (value: boolean) => {
-    setOpen(value);
-    onOpenChange?.(value);
+  const settingOpen = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    onOpenChange?.(nextOpen);
   };
 
   const titleNode = getRenderPropValue(title);

--- a/components/select/__tests__/index.test.tsx
+++ b/components/select/__tests__/index.test.tsx
@@ -71,9 +71,9 @@ describe('Select', () => {
     const onOpenChange = jest.fn();
     const TestComponent: React.FC = () => {
       const [open, setOpen] = React.useState(false);
-      const handleChange: SelectProps['onOpenChange'] = (value) => {
-        onOpenChange(value);
-        setOpen(value);
+      const handleChange: SelectProps['onOpenChange'] = (nextOpen) => {
+        onOpenChange(nextOpen);
+        setOpen(nextOpen);
       };
       return (
         <Select open={open} onOpenChange={handleChange} options={[{ label: '1', value: '1' }]} />

--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -158,7 +158,7 @@ export interface SelectProps<
   /** @deprecated Please use `popupMatchSelectWidth` instead */
   dropdownMatchSelectWidth?: boolean | number;
   popupMatchSelectWidth?: boolean | number;
-  onOpenChange?: (visible: boolean) => void;
+  onOpenChange?: (open: boolean) => void;
 }
 
 const SECRET_COMBOBOX_MODE_DO_NOT_USE = 'SECRET_COMBOBOX_MODE_DO_NOT_USE';

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -188,11 +188,11 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
     filterState &&
     (filterState.filteredKeys?.length || filterState.forceFiltered)
   );
-  const triggerVisible = (newVisible: boolean) => {
-    setVisible(newVisible);
-    filterDropdownProps.onOpenChange?.(newVisible);
+  const triggerOpen = (nextOpen: boolean) => {
+    setVisible(nextOpen);
+    filterDropdownProps.onOpenChange?.(nextOpen);
     // deprecated
-    onFilterDropdownOpenChange?.(newVisible);
+    onFilterDropdownOpenChange?.(nextOpen);
   };
 
   // =================Warning===================
@@ -291,7 +291,7 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
   };
 
   const onConfirm = () => {
-    triggerVisible(false);
+    triggerOpen(false);
     internalTriggerFilter(getFilteredKeysSync());
   };
 
@@ -302,7 +302,7 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
       internalTriggerFilter([]);
     }
     if (closeDropdown) {
-      triggerVisible(false);
+      triggerOpen(false);
     }
 
     setSearchValue('');
@@ -316,22 +316,22 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
 
   const doFilter = ({ closeDropdown } = { closeDropdown: true }) => {
     if (closeDropdown) {
-      triggerVisible(false);
+      triggerOpen(false);
     }
     internalTriggerFilter(getFilteredKeysSync());
   };
 
-  const onVisibleChange: DropdownProps['onOpenChange'] = (newVisible, info) => {
+  const onDropdownOpenChange: DropdownProps['onOpenChange'] = (nextOpen, info) => {
     if (info.source === 'trigger') {
-      if (newVisible && propFilteredKeys !== undefined) {
+      if (nextOpen && propFilteredKeys !== undefined) {
         // Sync filteredKeys on appear in controlled mode (propFilteredKeys !== undefined)
         setFilteredKeysSync(wrapStringListType(propFilteredKeys));
       }
 
-      if (!newVisible && !column.filterDropdown && filterOnClose) {
+      if (!nextOpen && !column.filterDropdown && filterOnClose) {
         onConfirm();
       } else {
-        triggerVisible(newVisible);
+        triggerOpen(nextOpen);
       }
     }
   };
@@ -384,7 +384,7 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
       filters: column.filters,
       visible: mergedVisible,
       close: () => {
-        triggerVisible(false);
+        triggerOpen(false);
       },
     });
   } else if (column.filterDropdown) {
@@ -586,7 +586,7 @@ const FilterDropdown = <RecordType extends AnyObject = AnyObject>(
       ...filterDropdownProps,
       rootClassName: clsx(rootClassName, filterDropdownProps.rootClassName),
       open: mergedVisible,
-      onOpenChange: onVisibleChange,
+      onOpenChange: onDropdownOpenChange,
       popupRender: () => {
         if (isFunction(filterDropdownProps?.dropdownRender)) {
           return filterDropdownProps.dropdownRender(dropdownContent);

--- a/components/table/interface.ts
+++ b/components/table/interface.ts
@@ -191,7 +191,7 @@ export interface ColumnType<RecordType = AnyObject>
    * @deprecated Please use `filterDropdownProps.onOpenChange` instead.
    * @since 4.23.0
    */
-  onFilterDropdownOpenChange?: (visible: boolean) => void;
+  onFilterDropdownOpenChange?: (open: boolean) => void;
 }
 
 export interface ColumnGroupType<RecordType = AnyObject>

--- a/components/tooltip/index.tsx
+++ b/components/tooltip/index.tsx
@@ -84,8 +84,8 @@ interface LegacyTooltipProps
   > {
   open?: RcTooltipProps['visible'];
   defaultOpen?: RcTooltipProps['defaultVisible'];
-  onOpenChange?: RcTooltipProps['onVisibleChange'];
-  afterOpenChange?: RcTooltipProps['afterVisibleChange'];
+  onOpenChange?: (open: boolean) => void;
+  afterOpenChange?: (open: boolean) => void;
 }
 
 export type TooltipSemanticType = {
@@ -257,10 +257,10 @@ const InternalTooltip = React.forwardRef<TooltipRef, InternalTooltipProps>((prop
 
   const noTitle = !title && !overlay && title !== 0; // overlay for old version compatibility
 
-  const onInternalOpenChange = (vis: boolean) => {
-    setOpen(noTitle ? false : vis);
+  const onInternalOpenChange = (nextOpen: boolean) => {
+    setOpen(noTitle ? false : nextOpen);
     if (!noTitle && onOpenChange) {
-      onOpenChange(vis);
+      onOpenChange(nextOpen);
     }
   };
 

--- a/components/upload/demo/file-type.tsx
+++ b/components/upload/demo/file-type.tsx
@@ -116,8 +116,8 @@ const App: React.FC = () => {
           styles={{ root: { display: 'none' } }}
           preview={{
             open: previewOpen,
-            onOpenChange: (visible) => setPreviewOpen(visible),
-            afterOpenChange: (visible) => !visible && setPreviewImage(''),
+            onOpenChange: (open) => setPreviewOpen(open),
+            afterOpenChange: (open) => !open && setPreviewImage(''),
           }}
           src={previewImage}
         />

--- a/components/upload/demo/picture-card.tsx
+++ b/components/upload/demo/picture-card.tsx
@@ -89,8 +89,8 @@ const App: React.FC = () => {
           styles={{ root: { display: 'none' } }}
           preview={{
             open: previewOpen,
-            onOpenChange: (visible) => setPreviewOpen(visible),
-            afterOpenChange: (visible) => !visible && setPreviewImage(''),
+            onOpenChange: (open) => setPreviewOpen(open),
+            afterOpenChange: (open) => !open && setPreviewImage(''),
           }}
           src={previewImage}
         />

--- a/components/upload/demo/picture-circle.tsx
+++ b/components/upload/demo/picture-circle.tsx
@@ -71,8 +71,8 @@ const App: React.FC = () => {
           styles={{ root: { display: 'none' } }}
           preview={{
             open: previewOpen,
-            onOpenChange: (visible) => setPreviewOpen(visible),
-            afterOpenChange: (visible) => !visible && setPreviewImage(''),
+            onOpenChange: (open) => setPreviewOpen(open),
+            afterOpenChange: (open) => !open && setPreviewImage(''),
           }}
           src={previewImage}
         />


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [x] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无。

### 💡 需求背景和解决方案

弹层 API 已统一使用 `open`，但部分 `onOpenChange`、`afterOpenChange` 回调在文档、类型声明和示例中仍沿用 `visible`、`vis` 或 `value` 参数名，造成阅读和编辑器提示不一致。

- 统一 antd 自身声明及相关实现、示例中的打开状态回调参数为 `open` / `nextOpen`，同步修正 Image、Cascader 的中英文 API 文档。
- 将站点内嵌图片预览迁移至 `open` / `onOpenChange`。保留已废弃 API 的兼容声明，rc 依赖直接继承的类型不在本次调整范围内。

回调参数类型、数量和组件交互行为保持一致。

验证：TypeScript 全量检查、ESLint、Markdown 检查和 `git diff --check` 通过；9 个组件测试套件通过，共 417 项测试通过、1 项跳过，48 个快照通过。

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | 无需更新日志 |
