### PR TITLE
docs: explain SVG icon alignment in FAQ

### DIFF
--- a/docs/react/faq.en-US.md
+++ b/docs/react/faq.en-US.md
@@ -110,6 +110,16 @@ Try `onChange` to change `value`, and please read [React's documentation](https:
 
 Try [Space](https://ant.design/components/space/) component to make them aligned.
 
+## Why do third-party SVG icons have margin-block-end? {#faq-icon-margin-block-end}
+
+Components such as Breadcrumb, Collapse, Segmented, Tabs, and Tag apply `display: inline-block`, `vertical-align: middle`, and `margin-block-end: 0.2em` to SVGs rendered directly in the corresponding icon slots to adjust their visual alignment with text.
+
+In inline layout, an SVG has no text baseline, so its bottom edge participates in baseline alignment by default, which can make it appear too high next to text. `display: inline-block` keeps the icon in the inline flow, while `vertical-align: middle` aligns the center of its margin box to the parent's baseline plus half its x-height (the height of a lowercase x), making the alignment independent of the icon's height.
+
+However, the center of the x-height is usually lower than the center of capital letters, so a small upward optical adjustment is needed. `margin-block-end: 0.2em` adds a margin below the icon. Once the margin box is centered, the icon itself moves up by about `0.1em`, bringing it closer to the center of capital letters in common fonts. The `0.2em` value approximates the difference between cap height and x-height in common fonts, and using `em` makes the adjustment scale with the font size.
+
+These styles target directly rendered SVGs. Icons from `@ant-design/icons` wrap their SVG in an extra container and use their own alignment styles. Different fonts, internal icon whitespace, or an icon's own `vertical-align` can affect the result. If an icon already handles its own alignment, or an icon-only use case does not need text alignment compensation, you can locally override the corresponding SVG with `margin-block-end: 0` and adjust its own styles as needed.
+
 ## antd overrides my global styles
 
 Yes, antd is designed to help you develop a complete background application. To do so, we override some global styles for styling convenience, and currently these cannot be removed or changed. More info at https://github.com/ant-design/ant-design/issues/4331 .

--- a/docs/react/faq.zh-CN.md
+++ b/docs/react/faq.zh-CN.md
@@ -98,6 +98,16 @@ antd 内部会对 props 进行浅比较实现性能优化。当状态变更，�
 
 尝试使用 [Space](/components/space-cn) 组件来使他们对齐。
 
+## 为什么第三方 SVG 图标设置了 margin-block-end？ {#faq-icon-margin-block-end}
+
+Breadcrumb、Collapse、Segmented、Tabs、Tag 等组件会对相应图标位置直接传入的 `<svg>` 设置 `display: inline-block`、`vertical-align: middle` 和 `margin-block-end: 0.2em`，用于调整图标与文字的视觉对齐。
+
+在行内布局中，SVG 没有文字基线，默认按底部边缘参与基线对齐，容易显得比文字偏高。`display: inline-block` 让图标保持在行内参与排版，`vertical-align: middle` 则将图标外边距盒的中心对齐到父元素基线上方半个 x-height（小写字母 x 的高度）的位置，使对齐不依赖图标自身的高度。
+
+但 x-height 的中心通常低于大写字母的中心，因此还需要一点向上的视觉补偿。`margin-block-end: 0.2em` 在图标底部增加外边距，外边距盒居中后，图标本身便会向上移动约 `0.1em`，更接近常见字体的大写字母中心。`0.2em` 是基于常见字体中大写字母与小写字母 x 的高度差所做的近似补偿，使用 `em` 使补偿量随字号缩放。
+
+这套样式针对直接传入的 SVG；`@ant-design/icons` 的 SVG 有额外容器包裹，使用自身的对齐样式。不同字体、图标内部留白或图标自带的 `vertical-align` 都可能影响最终效果。如果图标已经自行处理对齐，或纯图标场景无需文字对齐补偿，可以局部覆盖对应 SVG 的 `margin-block-end: 0`，并结合图标自身样式调整。
+
 ## antd 覆盖了我的全局样式！
 
 是的，antd 在设计的时候就是用来开发一个完整的应用的，为了方便，我们覆盖了一些全局样式，现在还不能移除，想要了解更多请追踪 [这个 issue](https://github.com/ant-design/ant-design/issues/4331)，或者参考这个教程 [How to avoid modifying global styles?](/docs/react/customize-theme-cn#how-to-avoid-modifying-global-styles)


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Related to #59205

### 💡 需求背景和解决方案

Breadcrumb、Collapse、Segmented、Tabs、Tag 等组件使用 `margin-block-end: 0.2em` 配合 `vertical-align: middle` 调整第三方 SVG 图标与文字的视觉对齐，但现有文档缺少对这一设计的说明。

在全局中英文 FAQ 中补充对齐原理：解释 x-height 与大写字母中心的差异、底部外边距如何让图标向上补偿约 `0.1em`，以及 `em` 随字号缩放的作用。同时说明该规则的适用范围和自定义图标的调整方式。

验证：Prettier、remark 和 `git diff --check` 均通过。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | 仅文档补充，无需更新日志 |
