### PR TITLE
site: fix token customization popover code selection

### DIFF
--- a/.dumi/theme/builtins/ComponentTokenTable/index.tsx
+++ b/.dumi/theme/builtins/ComponentTokenTable/index.tsx
@@ -165,30 +165,29 @@ const SubTokenTable: React.FC<SubTokenTableProps> = (props) => {
         <RightOutlined className={styles.arrowIcon} rotate={open ? 90 : 0} />
         <Flex className={styles.tokenTitle} gap="small" justify="flex-start" align="center">
           {title}
-          <Popover
-            title={null}
-            destroyOnHidden
-            styles={{ root: { width: 400 } }}
-            content={
-              <Typography>
-                <pre dir="ltr" style={{ fontSize: 12 }}>
-                  <code
-                    dir="ltr"
-                    dangerouslySetInnerHTML={{ __html: highlightedCode }}
-                  />
-                </pre>
-                <a href={helpLink} target="_blank" rel="noopener noreferrer">
-                  <LinkOutlined style={{ marginInlineEnd: 4 }} />
-                  {helpText}
-                </a>
-              </Typography>
-            }
-          >
-            <span className={styles.help}>
-              <QuestionCircleOutlined style={{ marginInlineEnd: 4 }} />
-              {helpText}
-            </span>
-          </Popover>
+          <span onClick={(event) => event.stopPropagation()}>
+            <Popover
+              title={null}
+              destroyOnHidden
+              styles={{ root: { width: 400 } }}
+              content={
+                <Typography>
+                  <pre dir="ltr" style={{ fontSize: 12 }}>
+                    <code dir="ltr" dangerouslySetInnerHTML={{ __html: highlightedCode }} />
+                  </pre>
+                  <a href={helpLink} target="_blank" rel="noopener noreferrer">
+                    <LinkOutlined style={{ marginInlineEnd: 4 }} />
+                    {helpText}
+                  </a>
+                </Typography>
+              }
+            >
+              <span className={styles.help}>
+                <QuestionCircleOutlined style={{ marginInlineEnd: 4 }} />
+                {helpText}
+              </span>
+            </Popover>
+          </span>
         </Flex>
       </div>
       {open && (


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无，来自文档站使用反馈。

### 💡 需求背景和解决方案

组件文档中，点击 Token「如何定制？」弹层内的代码会触发 Token 表格的展开/收起，导致无法正常选取并复制代码。

在 Popover 外层阻止点击事件冒泡，覆盖帮助入口和整个弹层，避免触发标题的折叠逻辑。组件 Token 和全局 Token 均可正常选取、复制配置代码，点击标题仍可展开或收起表格。

验证：

- 本地 Alert 中文文档中，实际拖选并复制组件 Token、全局 Token 的完整配置代码。
- 点击帮助入口、弹层代码及空白处不会折叠表格；点击标题可正常收起并重新展开。
- TypeScript、ESLint、antd lint 和 git diff --check 均通过。

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | 仅文档站交互修复，无需更新日志。 |
