### PR TITLE
fix(FloatButton): prevent hover menu flickering

### DIFF
--- a/components/float-button/style/group.ts
+++ b/components/float-button/style/group.ts
@@ -14,6 +14,24 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
 
   const [varName, varRef] = genCssVar(antCls, 'float-btn');
 
+  const menuBridgeOffset = unit(token.calc(padding).mul(-1).equal());
+  const menuBridgeStyle: CSSObject = {
+    content: '""',
+    position: 'absolute',
+  };
+  const verticalMenuBridgeStyle: CSSObject = {
+    ...menuBridgeStyle,
+    insetInlineStart: 0,
+    width: '100%',
+    height: unit(padding),
+  };
+  const horizontalMenuBridgeStyle: CSSObject = {
+    ...menuBridgeStyle,
+    insetBlockStart: 0,
+    width: unit(padding),
+    height: '100%',
+  };
+
   return {
     [groupCls]: [
       // ==============================================================
@@ -101,6 +119,11 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
         '&-top': {
           [listCls]: {
             bottom: varRef('list-trigger-offset'),
+
+            '&::after': {
+              ...verticalMenuBridgeStyle,
+              bottom: menuBridgeOffset,
+            },
           },
         },
 
@@ -108,6 +131,11 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
           [listCls]: {
             [varName('list-transform-start')]: `translate(0, calc(${unit(floatButtonSize)} * -1))`,
             top: varRef('list-trigger-offset'),
+
+            '&::after': {
+              ...verticalMenuBridgeStyle,
+              top: menuBridgeOffset,
+            },
           },
         },
 
@@ -115,6 +143,11 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
           [listCls]: {
             [varName('list-transform-start')]: `translate(${unit(floatButtonSize)}, 0)`,
             right: varRef('list-trigger-offset'),
+
+            '&::after': {
+              ...horizontalMenuBridgeStyle,
+              right: menuBridgeOffset,
+            },
           },
         },
 
@@ -122,6 +155,11 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
           [listCls]: {
             [varName('list-transform-start')]: `translate(calc(${unit(floatButtonSize)} * -1), 0)`,
             left: varRef('list-trigger-offset'),
+
+            '&::after': {
+              ...horizontalMenuBridgeStyle,
+              left: menuBridgeOffset,
+            },
           },
         },
       },

--- a/components/float-button/style/group.ts
+++ b/components/float-button/style/group.ts
@@ -15,22 +15,6 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
   const [varName, varRef] = genCssVar(antCls, 'float-btn');
 
   const menuBridgeOffset = unit(token.calc(padding).mul(-1).equal());
-  const menuBridgeStyle: CSSObject = {
-    content: '""',
-    position: 'absolute',
-  };
-  const verticalMenuBridgeStyle: CSSObject = {
-    ...menuBridgeStyle,
-    insetInlineStart: 0,
-    width: '100%',
-    height: unit(padding),
-  };
-  const horizontalMenuBridgeStyle: CSSObject = {
-    ...menuBridgeStyle,
-    insetBlockStart: 0,
-    width: unit(padding),
-    height: '100%',
-  };
 
   return {
     [groupCls]: [
@@ -87,6 +71,12 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
         // =========================== Menu ===========================
         [`&-menu-mode ${listCls}`]: {
           position: 'absolute',
+
+          '&::after': {
+            content: '""',
+            position: 'absolute',
+            inset: 0,
+          },
         },
 
         // ========================== Motion ==========================
@@ -121,7 +111,7 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
             bottom: varRef('list-trigger-offset'),
 
             '&::after': {
-              ...verticalMenuBridgeStyle,
+              top: '100%',
               bottom: menuBridgeOffset,
             },
           },
@@ -133,8 +123,8 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
             top: varRef('list-trigger-offset'),
 
             '&::after': {
-              ...verticalMenuBridgeStyle,
               top: menuBridgeOffset,
+              bottom: '100%',
             },
           },
         },
@@ -145,7 +135,7 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
             right: varRef('list-trigger-offset'),
 
             '&::after': {
-              ...horizontalMenuBridgeStyle,
+              left: '100%',
               right: menuBridgeOffset,
             },
           },
@@ -157,8 +147,8 @@ const genGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = (token) => {
             left: varRef('list-trigger-offset'),
 
             '&::after': {
-              ...horizontalMenuBridgeStyle,
               left: menuBridgeOffset,
+              right: '100%',
             },
           },
         },


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

ref https://github.com/antdv-next/antdv-next/pull/836  
ref #51208

### 💡 需求背景和解决方案

FloatButton.Group 的菜单与触发按钮之间存在间距。v6 语义化结构调整后，v5 中用于连接该间距的透明交互区域被遗漏，导致 `trigger="hover"` 时鼠标移向菜单会触发关闭并产生闪烁。

本次为四种 `placement` 的菜单列表恢复与间距等宽的透明交互区域，使鼠标可以连续移入菜单。不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix FloatButton.Group hover menu flickering when moving the pointer between the trigger and menu |
| 🇨🇳 中文 | 修复 FloatButton.Group 鼠标从触发按钮移向菜单时出现闪烁的问题 |
