### PR TITLE
fix(FloatButton): apply ConfigProvider styles to standalone buttons

### DIFF
--- a/components/float-button/FloatButton.tsx
+++ b/components/float-button/FloatButton.tsx
@@ -5,7 +5,7 @@ import { clsx } from 'clsx';
 
 import convertToTooltipProps from '../_util/convertToTooltipProps';
 import { useZIndex } from '../_util/hooks';
-import { useMergeSemantic } from '../_util/hooks/useMergeSemantic';
+import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { devUseWarning } from '../_util/warning';
 import Badge from '../badge';
@@ -13,7 +13,7 @@ import type { BadgeProps } from '../badge';
 import type { ButtonSemanticType } from '../button/Button';
 import Button from '../button/Button';
 import type { ButtonHTMLType } from '../button/buttonHelpers';
-import { ConfigContext } from '../config-provider';
+import { useComponentConfig } from '../config-provider/context';
 import useCSSVarCls from '../config-provider/hooks/useCSSVarCls';
 import Tooltip from '../tooltip';
 import type { TooltipProps } from '../tooltip';
@@ -92,7 +92,14 @@ const InternalFloatButton = React.forwardRef<FloatButtonElement, FloatButtonProp
     styles,
     ...restProps
   } = props;
-  const { getPrefixCls, direction } = React.useContext(ConfigContext);
+  const {
+    getPrefixCls,
+    direction,
+    className: contextClassName,
+    style: contextStyle,
+    classNames: contextClassNames,
+    styles: contextStyles,
+  } = useComponentConfig('floatButton');
   const groupContext = React.useContext(GroupContext);
   const prefixCls = getPrefixCls(floatButtonPrefixCls, customizePrefixCls);
   const rootCls = useCSSVarCls(prefixCls);
@@ -100,8 +107,8 @@ const InternalFloatButton = React.forwardRef<FloatButtonElement, FloatButtonProp
   const {
     shape: contextShape,
     individual: contextIndividual,
-    classNames: contextClassNames,
-    styles: contextStyles,
+    classNames: groupClassNames,
+    styles: groupStyles,
   } = groupContext || {};
 
   const mergedShape = contextShape || shape;
@@ -124,9 +131,12 @@ const InternalFloatButton = React.forwardRef<FloatButtonElement, FloatButtonProp
     [prefixCls],
   );
 
+  const contextStyleRoot = useSemanticRootStyle(contextStyle);
+  const styleRoot = useSemanticRootStyle(style);
+
   const [mergedClassNames, mergedStyles] = useMergeSemantic(
-    [floatButtonClassNames, contextClassNames, classNames],
-    [contextStyles, styles],
+    [floatButtonClassNames, contextClassNames, groupClassNames, classNames],
+    [contextStyles, contextStyleRoot, groupStyles, styles, styleRoot],
     {
       props: mergedProps,
     },
@@ -137,9 +147,9 @@ const InternalFloatButton = React.forwardRef<FloatButtonElement, FloatButtonProp
 
   // ============================ zIndex ============================
 
-  const [zIndex] = useZIndex('FloatButton', style?.zIndex as number);
+  const [zIndex] = useZIndex('FloatButton', mergedStyles.root?.zIndex as number);
 
-  const mergedStyle: React.CSSProperties = { ...style, zIndex };
+  const mergedStyle: React.CSSProperties = { ...mergedStyles.root, zIndex };
 
   // ============================ Badge =============================
   // 虽然在 ts 中已经 omit 过了，但是为了防止多余的属性被透传进来，这里再 omit 一遍，以防万一
@@ -181,6 +191,7 @@ const InternalFloatButton = React.forwardRef<FloatButtonElement, FloatButtonProp
         cssVarCls,
         rootCls,
         prefixCls,
+        contextClassName,
         className,
         rootClassName,
         `${prefixCls}-${type}`,

--- a/components/float-button/__tests__/semantic.test.tsx
+++ b/components/float-button/__tests__/semantic.test.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 import FloatButton from '..';
 import type { FloatButtonGroupProps, FloatButtonProps } from '..';
 import type { GetProp } from '../../_util/type';
-import { render } from '../../../tests/utils';
-import type { ButtonProps } from '../../button/Button';
-import ConfigProvider from '../../config-provider';
 import {
   expectSemanticRootStylePriority,
   semanticRootStylePriority,
 } from '../../../tests/shared/semanticStylePriority';
+import { render } from '../../../tests/utils';
+import type { ButtonProps } from '../../button/Button';
+import ConfigProvider from '../../config-provider';
 
 describe('FloatButton.Semantic', () => {
   it('should update classNames when props change (FloatButton)', () => {
@@ -193,6 +193,130 @@ describe('FloatButton.Semantic', () => {
     const { container } = render(<FloatButton classNames={classNames} styles={styles} />);
     expect(container.querySelector('.float-btn-custom')).toBeTruthy();
     expect(container.querySelector('.float-btn-icon-custom')).toBeTruthy();
+  });
+
+  it('should apply className and styles from ConfigProvider', () => {
+    const { container } = render(
+      <ConfigProvider
+        floatButton={{
+          className: 'global-float',
+          style: { right: 120 },
+          classNames: { root: 'global-root' },
+          styles: { root: { bottom: 99 } },
+        }}
+      >
+        <FloatButton />
+      </ConfigProvider>,
+    );
+
+    const floatButton = container.querySelector('.ant-float-btn');
+    expect(floatButton).toHaveClass('global-float', 'global-root');
+    expect(floatButton).toHaveStyle({ right: '120px', bottom: '99px' });
+  });
+
+  it('should apply ConfigProvider classNames and styles to semantic elements', () => {
+    const { container } = render(
+      <ConfigProvider
+        floatButton={{
+          classNames: { icon: 'global-icon', content: 'global-content' },
+          styles: {
+            icon: { color: 'rgb(255, 0, 0)', fontSize: '20px' },
+            content: { color: 'rgb(0, 0, 255)' },
+          },
+        }}
+      >
+        <FloatButton
+          shape="square"
+          icon="little"
+          content="bamboo"
+          classNames={{ icon: 'custom-icon' }}
+          styles={{ icon: { color: 'rgb(0, 128, 0)' } }}
+        />
+      </ConfigProvider>,
+    );
+
+    const icon = container.querySelector<HTMLElement>('.ant-float-btn-icon');
+    expect(icon).toHaveClass('global-icon', 'custom-icon');
+    expect(icon).toHaveStyle({ color: 'rgb(0, 128, 0)', fontSize: '20px' });
+
+    const content = container.querySelector<HTMLElement>('.ant-float-btn-content');
+    expect(content).toHaveClass('global-content');
+    expect(content).toHaveStyle({ color: 'rgb(0, 0, 255)' });
+  });
+
+  it('should merge ConfigProvider and Group classNames and styles for items', () => {
+    const { container } = render(
+      <ConfigProvider
+        floatButton={{
+          classNames: { root: 'global-root' },
+          styles: {
+            root: {
+              marginTop: '1px',
+              paddingTop: '1px',
+              paddingBottom: '1px',
+            },
+          },
+          style: { marginTop: '2px', paddingTop: '2px' },
+        }}
+      >
+        <FloatButton.Group
+          classNames={{ item: 'group-item' }}
+          styles={{ item: { paddingTop: '3px' } }}
+        >
+          <FloatButton
+            shape="square"
+            icon="little"
+            content="bamboo"
+            style={{ paddingBottom: '4px' }}
+          />
+        </FloatButton.Group>
+      </ConfigProvider>,
+    );
+
+    const item = container.querySelector<HTMLElement>('.ant-float-btn-group-list .ant-float-btn');
+    expect(item).toHaveClass('global-root', 'group-item');
+    expect(item).toHaveStyle({
+      marginTop: '2px',
+      paddingTop: '3px',
+      paddingBottom: '4px',
+    });
+  });
+
+  it('should apply className and styles from ConfigProvider to BackTop', () => {
+    const { container } = render(
+      <ConfigProvider
+        floatButton={{
+          className: 'global-float',
+          classNames: { root: 'global-root' },
+          style: { right: 120, zIndex: 2001 },
+          styles: { root: { bottom: 99 } },
+        }}
+      >
+        <FloatButton.BackTop visibilityHeight={0} />
+      </ConfigProvider>,
+    );
+
+    const backTop = container.querySelector('.ant-float-btn');
+    expect(backTop).toHaveClass('global-float', 'global-root');
+    expect(backTop).toHaveStyle({ right: '120px', bottom: '99px', zIndex: 2001 });
+  });
+
+  it('FloatButton should follow root style priority', () => {
+    const { container } = render(
+      <ConfigProvider
+        floatButton={{
+          styles: semanticRootStylePriority.contextStyles,
+          style: semanticRootStylePriority.contextStyle,
+        }}
+      >
+        <FloatButton
+          styles={semanticRootStylePriority.styles}
+          style={semanticRootStylePriority.style}
+        />
+      </ConfigProvider>,
+    );
+
+    expectSemanticRootStylePriority(container.querySelector('.ant-float-btn'));
   });
 
   it('FloatButton.Group should follow root style priority', () => {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [ ] 🆕 新特性提交
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

ConfigProvider 已声明 FloatButton 支持全局 `className`、`style`、`classNames` 和 `styles`，但独立 FloatButton 没有消费这些配置。

本次修改使 FloatButton 读取并合并全局配置，同时保留 Group 和组件自身配置的正确优先级，并使用最终根节点样式计算 `zIndex`。不涉及公开 API 变更。

新增回归测试，覆盖全局类名、样式和根节点样式优先级。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix FloatButton not applying ConfigProvider class names and styles to standalone buttons. |
| 🇨🇳 中文 | 🐞 修复 FloatButton 独立按钮不应用 ConfigProvider 类名和样式的问题。 |