### PR TITLE
fix(ConfigProvider): inherit zeroRuntime in nested themes

### DIFF
--- a/components/config-provider/hooks/useTheme.ts
+++ b/components/config-provider/hooks/useTheme.ts
@@ -23,6 +23,7 @@ export default function useTheme(
           ...defaultConfig,
           hashed: parentTheme?.hashed ?? defaultConfig.hashed,
           cssVar: parentTheme?.cssVar,
+          zeroRuntime: parentTheme?.zeroRuntime,
         }
       : parentTheme;
 


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

- close #59247

### 💡 需求背景和解决方案

官网生产环境启用了 `zeroRuntime`，但嵌套 `ConfigProvider` 设置 `inherit: false` 后会丢失父级的 `zeroRuntime` 配置，导致首页主题预览重新生成并残留运行时组件样式。后续通过 SPA 导航进入 FloatButton 页面时，这些 Button 样式会覆盖 FloatButton 的布局样式。

本 PR 让 `zeroRuntime` 与 `hashed`、`cssVar` 一样，在隔离主题 Token 时继续继承父级配置。子级显式设置 `zeroRuntime` 时仍以子级配置为准。

已验证：

- 首页 → 组件 → FloatButton 的 Semantic DOM 示例样式正常
- 首页全部主题可以正常切换
- `npm run site`
- `npm run tsc`
- ConfigProvider theme 测试通过

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix ConfigProvider losing zero-runtime mode in nested themes with inheritance disabled. |
| 🇨🇳 中文 | 🐞 修复 ConfigProvider 在禁用主题继承的嵌套场景中丢失零运行时模式的问题。 |
