### PR TITLE
feat(InputNumber): support allowClear

### DIFF
--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -424,7 +424,7 @@ export type ResultConfig = ComponentStyleConfig & Pick<ResultProps, 'classNames'
 export type RadioConfig = ComponentStyleConfig & Pick<RadioProps, 'classNames' | 'styles'>;
 
 export type InputNumberConfig = ComponentStyleConfig &
-  Pick<InputNumberProps, 'variant' | 'classNames' | 'styles'>;
+  Pick<InputNumberProps, 'variant' | 'classNames' | 'styles' | 'allowClear'>;
 
 export type CascaderConfig = ComponentStyleConfig &
   Pick<

--- a/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -892,6 +892,431 @@ exports[`renders components/input-number/demo/addon.tsx extend context correctly
 ]
 `;
 
+exports[`renders components/input-number/demo/allow-clear.tsx extend context correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"
+>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+    >
+      <input
+        aria-valuenow="100"
+        autocomplete="off"
+        class="ant-input-number-input"
+        role="spinbutton"
+        step="1"
+        value="100"
+      />
+      <div
+        class="ant-input-number-suffix"
+      >
+        <button
+          aria-label="Clear"
+          class="ant-input-number-clear-icon"
+          type="button"
+        >
+          <span
+            aria-label="close-circle"
+            class="anticon anticon-close-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="close-circle"
+              fill="currentColor"
+              fill-rule="evenodd"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-input-number-actions"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Increase Value"
+          class="ant-input-number-action ant-input-number-action-up"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="up"
+            class="anticon anticon-up"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="up"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          aria-disabled="false"
+          aria-label="Decrease Value"
+          class="ant-input-number-action ant-input-number-action-down"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+    >
+      <input
+        aria-valuenow="0"
+        autocomplete="off"
+        class="ant-input-number-input"
+        role="spinbutton"
+        step="1"
+        value="0"
+      />
+      <div
+        class="ant-input-number-suffix"
+      >
+        <button
+          aria-label="Clear"
+          class="ant-input-number-clear-icon ant-input-number-clear-icon-has-suffix"
+          type="button"
+        >
+          <span
+            aria-label="close-circle"
+            class="anticon anticon-close-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="close-circle"
+              fill="currentColor"
+              fill-rule="evenodd"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+              />
+            </svg>
+          </span>
+        </button>
+        kg
+      </div>
+      <div
+        class="ant-input-number-actions"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Increase Value"
+          class="ant-input-number-action ant-input-number-action-up"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="up"
+            class="anticon anticon-up"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="up"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          aria-disabled="false"
+          aria-label="Decrease Value"
+          class="ant-input-number-action ant-input-number-action-down"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-input-number ant-input-number-mode-spinner css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+    >
+      <span
+        aria-disabled="false"
+        aria-label="Decrease Value"
+        class="ant-input-number-action ant-input-number-action-down"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="minus"
+          class="anticon anticon-minus"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="minus"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M872 474H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h720c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
+            />
+          </svg>
+        </span>
+      </span>
+      <input
+        aria-valuenow="0"
+        autocomplete="off"
+        class="ant-input-number-input"
+        role="spinbutton"
+        step="1"
+        value="0"
+      />
+      <div
+        class="ant-input-number-suffix"
+      >
+        <button
+          aria-label="Clear"
+          class="ant-input-number-clear-icon"
+          type="button"
+        >
+          <span
+            aria-label="close-circle"
+            class="anticon anticon-close-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="close-circle"
+              fill="currentColor"
+              fill-rule="evenodd"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <span
+        aria-disabled="false"
+        aria-label="Increase Value"
+        class="ant-input-number-action ant-input-number-action-up"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="plus"
+          class="anticon anticon-plus"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="plus"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
+            />
+            <path
+              d="M192 474h672q8 0 8 8v60q0 8-8 8H160q-8 0-8-8v-60q0-8 8-8z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+    >
+      <input
+        aria-valuenow="100"
+        autocomplete="off"
+        class="ant-input-number-input"
+        role="spinbutton"
+        step="1"
+        value="100"
+      />
+      <div
+        class="ant-input-number-suffix"
+      >
+        <button
+          aria-label="Clear"
+          class="ant-input-number-clear-icon"
+          type="button"
+        >
+          <span
+            aria-label="close-square"
+            class="anticon anticon-close-square"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="close-square"
+              fill="currentColor"
+              fill-rule="evenodd"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M880 112c17.7 0 32 14.3 32 32v736c0 17.7-14.3 32-32 32H144c-17.7 0-32-14.3-32-32V144c0-17.7 14.3-32 32-32zM639.98 338.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-input-number-actions"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Increase Value"
+          class="ant-input-number-action ant-input-number-action-up"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="up"
+            class="anticon anticon-up"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="up"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          aria-disabled="false"
+          aria-label="Decrease Value"
+          class="ant-input-number-action ant-input-number-action-down"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders components/input-number/demo/allow-clear.tsx extend context correctly 2`] = `[]`;
+
 exports[`renders components/input-number/demo/basic.tsx extend context correctly 1`] = `
 <div
   class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"

--- a/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
+++ b/components/input-number/__tests__/__snapshots__/demo-extend.test.ts.snap
@@ -901,6 +901,7 @@ exports[`renders components/input-number/demo/allow-clear.tsx extend context cor
   >
     <div
       class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+      style="width: 120px;"
     >
       <input
         aria-valuenow="100"
@@ -1005,6 +1006,7 @@ exports[`renders components/input-number/demo/allow-clear.tsx extend context cor
   >
     <div
       class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+      style="width: 120px;"
     >
       <input
         aria-valuenow="0"
@@ -1110,6 +1112,7 @@ exports[`renders components/input-number/demo/allow-clear.tsx extend context cor
   >
     <div
       class="ant-input-number ant-input-number-mode-spinner css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+      style="width: 150px;"
     >
       <span
         aria-disabled="false"
@@ -1206,110 +1209,6 @@ exports[`renders components/input-number/demo/allow-clear.tsx extend context cor
           </svg>
         </span>
       </span>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
-    >
-      <input
-        aria-valuenow="100"
-        autocomplete="off"
-        class="ant-input-number-input"
-        role="spinbutton"
-        step="1"
-        value="100"
-      />
-      <div
-        class="ant-input-number-suffix"
-      >
-        <button
-          aria-label="Clear"
-          class="ant-input-number-clear-icon"
-          type="button"
-        >
-          <span
-            aria-label="close-square"
-            class="anticon anticon-close-square"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="close-square"
-              fill="currentColor"
-              fill-rule="evenodd"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M880 112c17.7 0 32 14.3 32 32v736c0 17.7-14.3 32-32 32H144c-17.7 0-32-14.3-32-32V144c0-17.7 14.3-32 32-32zM639.98 338.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-      <div
-        class="ant-input-number-actions"
-      >
-        <span
-          aria-disabled="false"
-          aria-label="Increase Value"
-          class="ant-input-number-action ant-input-number-action-up"
-          role="button"
-          unselectable="on"
-        >
-          <span
-            aria-label="up"
-            class="anticon anticon-up"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="up"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          aria-disabled="false"
-          aria-label="Decrease Value"
-          class="ant-input-number-action ant-input-number-action-down"
-          role="button"
-          unselectable="on"
-        >
-          <span
-            aria-label="down"
-            class="anticon anticon-down"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="down"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
     </div>
   </div>
 </div>

--- a/components/input-number/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/input-number/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -34,6 +34,32 @@ exports[`renders components/input-number/demo/_semantic.tsx correctly 1`] = `
             class="ant-input-number-suffix semantic-mark-suffix"
             style="margin-inline-end: 28px;"
           >
+            <button
+              aria-label="Clear"
+              class="ant-input-number-clear-icon ant-input-number-clear-icon-has-suffix semantic-mark-clear"
+              type="button"
+            >
+              <span
+                aria-label="close-circle"
+                class="anticon anticon-close-circle"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="close-circle"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                  />
+                </svg>
+              </span>
+            </button>
             RMB
           </div>
           <div
@@ -135,6 +161,37 @@ exports[`renders components/input-number/demo/_semantic.tsx correctly 1`] = `
             step="1"
             value="100"
           />
+          <div
+            class="ant-input-number-suffix semantic-mark-suffix"
+            style="margin-inline-end: 28px;"
+          >
+            <button
+              aria-label="Clear"
+              class="ant-input-number-clear-icon semantic-mark-clear"
+              type="button"
+            >
+              <span
+                aria-label="close-circle"
+                class="anticon anticon-close-circle"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="close-circle"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
           <span
             aria-disabled="false"
             aria-label="Increase Value"
@@ -729,6 +786,104 @@ exports[`renders components/input-number/demo/_semantic.tsx correctly 1`] = `
               style="margin: 0px; font-size: 12px;"
             >
               单个操作按钮元素，设置按钮的样式、悬浮效果和点击交互
+            </div>
+          </div>
+        </li>
+        <li
+          class="acss-1ehfz5v"
+        >
+          <div
+            class="ant-flex css-var-test-id ant-flex-align-stretch ant-flex-gap-small ant-flex-vertical"
+          >
+            <div
+              class="ant-flex css-var-test-id ant-flex-align-center ant-flex-justify-space-between ant-flex-gap-small"
+            >
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <h5
+                  class="ant-typography css-var-test-id"
+                  style="margin: 0px;"
+                >
+                  clear
+                </h5>
+                <span
+                  class="ant-tag ant-tag-filled ant-tag-blue css-var-test-id"
+                >
+                  6.7.0
+                </span>
+              </div>
+              <div
+                class="ant-flex css-var-test-id ant-flex-align-center ant-flex-gap-small"
+              >
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-default ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="pushpin"
+                      class="anticon anticon-pushpin"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="pushpin"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M878.3 392.1L631.9 145.7c-6.5-6.5-15-9.7-23.5-9.7s-17 3.2-23.5 9.7L423.8 306.9c-12.2-1.4-24.5-2-36.8-2-73.2 0-146.4 24.1-206.5 72.3a33.23 33.23 0 00-2.7 49.4l181.7 181.7-215.4 215.2a15.8 15.8 0 00-4.6 9.8l-3.4 37.2c-.9 9.4 6.6 17.4 15.9 17.4.5 0 1 0 1.5-.1l37.2-3.4c3.7-.3 7.2-2 9.8-4.6l215.4-215.4 181.7 181.7c6.5 6.5 15 9.7 23.5 9.7 9.7 0 19.3-4.2 25.9-12.4 56.3-70.3 79.7-158.3 70.2-243.4l161.1-161.1c12.9-12.8 12.9-33.8 0-46.8zM666.2 549.3l-24.5 24.5 3.8 34.4a259.92 259.92 0 01-30.4 153.9L262 408.8c12.9-7.1 26.3-13.1 40.3-17.9 27.2-9.4 55.7-14.1 84.7-14.1 9.6 0 19.3.5 28.9 1.6l34.4 3.8 24.5-24.5L608.5 224 800 415.5 666.2 549.3z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="ant-btn css-var-test-id ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-sm ant-btn-icon-only"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-typography css-var-test-id"
+              style="margin: 0px; font-size: 12px;"
+            >
+              清除按钮元素，设置图标颜色、大小和交互样式
             </div>
           </div>
         </li>

--- a/components/input-number/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input-number/__tests__/__snapshots__/demo.test.tsx.snap
@@ -608,6 +608,429 @@ exports[`renders components/input-number/demo/addon.tsx correctly 1`] = `
 </div>
 `;
 
+exports[`renders components/input-number/demo/allow-clear.tsx correctly 1`] = `
+<div
+  class="ant-space ant-space-vertical ant-space-gap-row-small ant-space-gap-col-small css-var-test-id"
+>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+    >
+      <input
+        aria-valuenow="100"
+        autocomplete="off"
+        class="ant-input-number-input"
+        role="spinbutton"
+        step="1"
+        value="100"
+      />
+      <div
+        class="ant-input-number-suffix"
+      >
+        <button
+          aria-label="Clear"
+          class="ant-input-number-clear-icon"
+          type="button"
+        >
+          <span
+            aria-label="close-circle"
+            class="anticon anticon-close-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="close-circle"
+              fill="currentColor"
+              fill-rule="evenodd"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-input-number-actions"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Increase Value"
+          class="ant-input-number-action ant-input-number-action-up"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="up"
+            class="anticon anticon-up"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="up"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          aria-disabled="false"
+          aria-label="Decrease Value"
+          class="ant-input-number-action ant-input-number-action-down"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+    >
+      <input
+        aria-valuenow="0"
+        autocomplete="off"
+        class="ant-input-number-input"
+        role="spinbutton"
+        step="1"
+        value="0"
+      />
+      <div
+        class="ant-input-number-suffix"
+      >
+        <button
+          aria-label="Clear"
+          class="ant-input-number-clear-icon ant-input-number-clear-icon-has-suffix"
+          type="button"
+        >
+          <span
+            aria-label="close-circle"
+            class="anticon anticon-close-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="close-circle"
+              fill="currentColor"
+              fill-rule="evenodd"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+              />
+            </svg>
+          </span>
+        </button>
+        kg
+      </div>
+      <div
+        class="ant-input-number-actions"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Increase Value"
+          class="ant-input-number-action ant-input-number-action-up"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="up"
+            class="anticon anticon-up"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="up"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          aria-disabled="false"
+          aria-label="Decrease Value"
+          class="ant-input-number-action ant-input-number-action-down"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-input-number ant-input-number-mode-spinner css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+    >
+      <span
+        aria-disabled="false"
+        aria-label="Decrease Value"
+        class="ant-input-number-action ant-input-number-action-down"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="minus"
+          class="anticon anticon-minus"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="minus"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M872 474H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h720c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
+            />
+          </svg>
+        </span>
+      </span>
+      <input
+        aria-valuenow="0"
+        autocomplete="off"
+        class="ant-input-number-input"
+        role="spinbutton"
+        step="1"
+        value="0"
+      />
+      <div
+        class="ant-input-number-suffix"
+      >
+        <button
+          aria-label="Clear"
+          class="ant-input-number-clear-icon"
+          type="button"
+        >
+          <span
+            aria-label="close-circle"
+            class="anticon anticon-close-circle"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="close-circle"
+              fill="currentColor"
+              fill-rule="evenodd"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm127.98 274.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <span
+        aria-disabled="false"
+        aria-label="Increase Value"
+        class="ant-input-number-action ant-input-number-action-up"
+        role="button"
+        unselectable="on"
+      >
+        <span
+          aria-label="plus"
+          class="anticon anticon-plus"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="plus"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"
+            />
+            <path
+              d="M192 474h672q8 0 8 8v60q0 8-8 8H160q-8 0-8-8v-60q0-8 8-8z"
+            />
+          </svg>
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <div
+      class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+    >
+      <input
+        aria-valuenow="100"
+        autocomplete="off"
+        class="ant-input-number-input"
+        role="spinbutton"
+        step="1"
+        value="100"
+      />
+      <div
+        class="ant-input-number-suffix"
+      >
+        <button
+          aria-label="Clear"
+          class="ant-input-number-clear-icon"
+          type="button"
+        >
+          <span
+            aria-label="close-square"
+            class="anticon anticon-close-square"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="close-square"
+              fill="currentColor"
+              fill-rule="evenodd"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M880 112c17.7 0 32 14.3 32 32v736c0 17.7-14.3 32-32 32H144c-17.7 0-32-14.3-32-32V144c0-17.7 14.3-32 32-32zM639.98 338.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        class="ant-input-number-actions"
+      >
+        <span
+          aria-disabled="false"
+          aria-label="Increase Value"
+          class="ant-input-number-action ant-input-number-action-up"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="up"
+            class="anticon anticon-up"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="up"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+        <span
+          aria-disabled="false"
+          aria-label="Decrease Value"
+          class="ant-input-number-action ant-input-number-action-down"
+          role="button"
+          unselectable="on"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders components/input-number/demo/basic.tsx correctly 1`] = `
 <div
   class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"

--- a/components/input-number/__tests__/__snapshots__/demo.test.tsx.snap
+++ b/components/input-number/__tests__/__snapshots__/demo.test.tsx.snap
@@ -617,6 +617,7 @@ exports[`renders components/input-number/demo/allow-clear.tsx correctly 1`] = `
   >
     <div
       class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+      style="width:120px"
     >
       <input
         aria-valuenow="100"
@@ -721,6 +722,7 @@ exports[`renders components/input-number/demo/allow-clear.tsx correctly 1`] = `
   >
     <div
       class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+      style="width:120px"
     >
       <input
         aria-valuenow="0"
@@ -826,6 +828,7 @@ exports[`renders components/input-number/demo/allow-clear.tsx correctly 1`] = `
   >
     <div
       class="ant-input-number ant-input-number-mode-spinner css-var-test-id ant-input-number-css-var ant-input-number-outlined"
+      style="width:150px"
     >
       <span
         aria-disabled="false"
@@ -922,110 +925,6 @@ exports[`renders components/input-number/demo/allow-clear.tsx correctly 1`] = `
           </svg>
         </span>
       </span>
-    </div>
-  </div>
-  <div
-    class="ant-space-item"
-  >
-    <div
-      class="ant-input-number ant-input-number-mode-input css-var-test-id ant-input-number-css-var ant-input-number-outlined"
-    >
-      <input
-        aria-valuenow="100"
-        autocomplete="off"
-        class="ant-input-number-input"
-        role="spinbutton"
-        step="1"
-        value="100"
-      />
-      <div
-        class="ant-input-number-suffix"
-      >
-        <button
-          aria-label="Clear"
-          class="ant-input-number-clear-icon"
-          type="button"
-        >
-          <span
-            aria-label="close-square"
-            class="anticon anticon-close-square"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="close-square"
-              fill="currentColor"
-              fill-rule="evenodd"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M880 112c17.7 0 32 14.3 32 32v736c0 17.7-14.3 32-32 32H144c-17.7 0-32-14.3-32-32V144c0-17.7 14.3-32 32-32zM639.98 338.82h-.04l-.08.06L512 466.75 384.14 338.88c-.04-.05-.06-.06-.08-.06a.12.12 0 00-.07 0c-.03 0-.05.01-.09.05l-45.02 45.02a.2.2 0 00-.05.09.12.12 0 000 .07v.02a.27.27 0 00.06.06L466.75 512 338.88 639.86c-.05.04-.06.06-.06.08a.12.12 0 000 .07c0 .03.01.05.05.09l45.02 45.02a.2.2 0 00.09.05.12.12 0 00.07 0c.02 0 .04-.01.08-.05L512 557.25l127.86 127.87c.04.04.06.05.08.05a.12.12 0 00.07 0c.03 0 .05-.01.09-.05l45.02-45.02a.2.2 0 00.05-.09.12.12 0 000-.07v-.02a.27.27 0 00-.05-.06L557.25 512l127.87-127.86c.04-.04.05-.06.05-.08a.12.12 0 000-.07c0-.03-.01-.05-.05-.09l-45.02-45.02a.2.2 0 00-.09-.05.12.12 0 00-.07 0z"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-      <div
-        class="ant-input-number-actions"
-      >
-        <span
-          aria-disabled="false"
-          aria-label="Increase Value"
-          class="ant-input-number-action ant-input-number-action-up"
-          role="button"
-          unselectable="on"
-        >
-          <span
-            aria-label="up"
-            class="anticon anticon-up"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="up"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M890.5 755.3L537.9 269.2c-12.8-17.6-39-17.6-51.7 0L133.5 755.3A8 8 0 00140 768h75c5.1 0 9.9-2.5 12.9-6.6L512 369.8l284.1 391.6c3 4.1 7.8 6.6 12.9 6.6h75c6.5 0 10.3-7.4 6.5-12.7z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          aria-disabled="false"
-          aria-label="Decrease Value"
-          class="ant-input-number-action ant-input-number-action-down"
-          role="button"
-          unselectable="on"
-        >
-          <span
-            aria-label="down"
-            class="anticon anticon-down"
-            role="img"
-          >
-            <svg
-              aria-hidden="true"
-              data-icon="down"
-              fill="currentColor"
-              focusable="false"
-              height="1em"
-              viewBox="64 64 896 896"
-              width="1em"
-            >
-              <path
-                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-              />
-            </svg>
-          </span>
-        </span>
-      </div>
     </div>
   </div>
 </div>

--- a/components/input-number/__tests__/allow-clear.test.tsx
+++ b/components/input-number/__tests__/allow-clear.test.tsx
@@ -1,0 +1,342 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+
+import type { InputNumberProps } from '..';
+import InputNumber from '..';
+import { act, fireEvent, render } from '../../../tests/utils';
+import ConfigProvider from '../../config-provider';
+import type { FormInstance } from '../../form';
+import Form from '../../form';
+import deDE from '../../locale/de_DE';
+import zhCN from '../../locale/zh_CN';
+import Space from '../../space';
+
+describe('InputNumber allowClear', () => {
+  it.each([123, 0])('clears the uncontrolled value %s and notifies once', (defaultValue) => {
+    const onChange = jest.fn();
+    const onClear = jest.fn();
+    const { getByRole, container } = render(
+      <InputNumber allowClear defaultValue={defaultValue} onChange={onChange} onClear={onClear} />,
+    );
+    const input = getByRole('spinbutton');
+    const clear = getByRole('button', { name: 'Clear' });
+
+    expect(clear.querySelector('.anticon-close-circle')).toBeInTheDocument();
+    fireEvent.click(clear);
+
+    expect(input).toHaveValue('');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(onClear).toHaveBeenCalledTimes(1);
+    expect(clear).toBeDisabled();
+
+    fireEvent.mouseDown(container.querySelector('.ant-input-number-action-up')!);
+    fireEvent.mouseUp(container.querySelector('.ant-input-number-action-up')!);
+    expect(input).toHaveValue('1');
+  });
+
+  it('clears raw intermediate input when the numeric value is already empty', () => {
+    const onChange = jest.fn();
+    const onClear = jest.fn();
+    const { getByRole } = render(<InputNumber allowClear onChange={onChange} onClear={onClear} />);
+    const input = getByRole('spinbutton');
+
+    fireEvent.change(input, { target: { value: '-' } });
+    fireEvent.click(getByRole('button', { name: 'Clear' }));
+
+    expect(input).toHaveValue('');
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies without overriding a controlled value', () => {
+    const onChange = jest.fn();
+    const onClear = jest.fn();
+    const { getByRole } = render(
+      <InputNumber allowClear value={123} onChange={onChange} onClear={onClear} />,
+    );
+
+    fireEvent.click(getByRole('button', { name: 'Clear' }));
+
+    expect(getByRole('spinbutton')).toHaveValue('123');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears when the controlled parent accepts null', () => {
+    const Demo = () => {
+      const [value, setValue] = React.useState<number | null>(123);
+      return <InputNumber allowClear value={value} onChange={setValue} />;
+    };
+    const { getByRole } = render(<Demo />);
+
+    fireEvent.click(getByRole('button', { name: 'Clear' }));
+
+    expect(getByRole('spinbutton')).toHaveValue('');
+  });
+
+  it('preserves the null contract with stringMode and precision', () => {
+    const onChange = jest.fn();
+    const { getByRole } = render(
+      <InputNumber allowClear stringMode precision={2} defaultValue="1.23" onChange={onChange} />,
+    );
+
+    fireEvent.click(getByRole('button', { name: 'Clear' }));
+
+    expect(getByRole('spinbutton')).toHaveValue('');
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it.each<InputNumberProps>([
+    { disabled: true },
+    { readOnly: true },
+    { allowClear: { disabled: true } },
+  ])('keeps the clear action disabled with %j', (props) => {
+    const onChange = jest.fn();
+    const onClear = jest.fn();
+    const { getByRole } = render(
+      <InputNumber
+        allowClear
+        defaultValue={1}
+        styles={{ clear: { visibility: 'visible' } }}
+        onChange={onChange}
+        onClear={onClear}
+        {...props}
+      />,
+    );
+    const clear = getByRole('button', { name: 'Clear' });
+
+    expect(clear).toBeDisabled();
+    fireEvent.click(clear);
+    expect(getByRole('spinbutton')).toHaveValue('1');
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onClear).not.toHaveBeenCalled();
+  });
+
+  it('inherits the disabled state from ConfigProvider', () => {
+    const { container } = render(
+      <ConfigProvider componentDisabled>
+        <InputNumber allowClear defaultValue={1} />
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelector('.ant-input-number-clear-icon')).toBeDisabled();
+  });
+
+  it('preserves the value when allowClear is toggled', () => {
+    const { getByRole, queryByRole, rerender } = render(<InputNumber defaultValue={1} />);
+    const input = getByRole('spinbutton');
+    expect(queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+    fireEvent.change(input, { target: { value: '7' } });
+
+    rerender(<InputNumber allowClear defaultValue={1} />);
+    expect(input).toHaveValue('7');
+    rerender(<InputNumber allowClear={false} defaultValue={1} />);
+    expect(input).toHaveValue('7');
+    rerender(<InputNumber allowClear defaultValue={1} />);
+    fireEvent.click(getByRole('button', { name: 'Clear' }));
+    expect(input).toHaveValue('');
+  });
+
+  it('supports a custom icon and accessible label without clearing the suffix', () => {
+    const { getByRole, getByText } = render(
+      <ConfigProvider locale={zhCN}>
+        <InputNumber
+          allowClear={{
+            clearIcon: <span aria-label="Icon label">custom</span>,
+            label: 'Reset amount',
+          }}
+          defaultValue={1}
+          suffix="kg"
+        />
+      </ConfigProvider>,
+    );
+    const clear = getByRole('button', { name: 'Reset amount' });
+    expect(clear).toHaveTextContent('custom');
+
+    fireEvent.click(clear);
+
+    expect(getByText('kg')).toBeVisible();
+    expect(getByRole('spinbutton')).toHaveValue('');
+  });
+
+  it.each([
+    { locale: zhCN, label: zhCN.global!.clear! },
+    { locale: deDE, label: 'Clear' },
+  ])('uses the global clear label with locale $locale.locale', ({ locale, label }) => {
+    const { getByRole } = render(
+      <ConfigProvider locale={locale}>
+        <InputNumber allowClear defaultValue={1} />
+      </ConfigProvider>,
+    );
+
+    expect(getByRole('button', { name: label })).toBeInTheDocument();
+  });
+
+  it('merges ConfigProvider clear settings and supports an explicit opt-out', () => {
+    const Demo = ({ allowClear }: Pick<InputNumberProps, 'allowClear'>) => (
+      <ConfigProvider
+        inputNumber={{
+          allowClear: { clearIcon: 'context icon', label: 'Context clear', disabled: true },
+        }}
+      >
+        <InputNumber defaultValue={1} allowClear={allowClear} />
+      </ConfigProvider>
+    );
+    const { container, getByRole, rerender } = render(<Demo />);
+    expect(container.querySelector('.ant-input-number-clear-icon')).toBeDisabled();
+
+    rerender(<Demo allowClear={{ disabled: false }} />);
+    expect(getByRole('button', { name: 'Context clear' })).toHaveTextContent('context icon');
+    expect(getByRole('button', { name: 'Context clear' })).toBeEnabled();
+
+    rerender(
+      <Demo allowClear={{ disabled: false, clearIcon: 'local icon', label: 'Local clear' }} />,
+    );
+    expect(getByRole('button', { name: 'Local clear' })).toHaveTextContent('local icon');
+
+    rerender(<Demo allowClear={false} />);
+    expect(container.querySelector('.ant-input-number-clear-icon')).not.toBeInTheDocument();
+    expect(getByRole('spinbutton')).toHaveValue('1');
+  });
+
+  it('keeps focus and remains clickable inside the suffix', async () => {
+    const user = userEvent.setup();
+    const onBlur = jest.fn();
+    const { getByRole } = render(<InputNumber allowClear defaultValue={1} onBlur={onBlur} />);
+    const input = getByRole('spinbutton');
+    await user.click(input);
+    await user.click(getByRole('button', { name: 'Clear' }));
+
+    expect(input).toHaveFocus();
+    expect(input).toHaveValue('');
+    expect(onBlur).not.toHaveBeenCalled();
+  });
+
+  it.each(['{Enter}', '[Space]'])('clears with %s and returns focus to the input', async (keys) => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const onPressEnter = jest.fn();
+    const { getByRole } = render(
+      <InputNumber allowClear defaultValue={1} onChange={onChange} onPressEnter={onPressEnter} />,
+    );
+    const input = getByRole('spinbutton');
+    act(() => input.focus());
+    await user.tab();
+    expect(getByRole('button', { name: 'Clear' })).toHaveFocus();
+    await user.keyboard(keys);
+
+    expect(input).toHaveFocus();
+    expect(input).toHaveValue('');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(onPressEnter).not.toHaveBeenCalled();
+  });
+
+  it('lets Escape propagate without triggering a step or committing raw controlled input', () => {
+    const onKeyDown = jest.fn();
+    const onChange = jest.fn();
+    const onStep = jest.fn();
+    const { getByRole } = render(
+      <div onKeyDown={onKeyDown}>
+        <InputNumber allowClear value={1} onChange={onChange} onStep={onStep} />
+      </div>,
+    );
+    const input = getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '2' } });
+    onChange.mockClear();
+    const clear = getByRole('button', { name: 'Clear' });
+    act(() => clear.focus());
+
+    fireEvent.keyDown(clear, { key: 'ArrowUp' });
+    fireEvent.keyDown(clear, { key: 'Escape' });
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(onStep).not.toHaveBeenCalled();
+
+    fireEvent.click(clear);
+    expect(onChange.mock.calls).toEqual([[null]]);
+    expect(input).toHaveValue('1');
+    expect(input).toHaveFocus();
+  });
+
+  it('updates the Form field to null and preserves validation feedback', async () => {
+    const user = userEvent.setup();
+    const formRef = React.createRef<FormInstance>();
+    const { getByRole, container } = render(
+      <Form ref={formRef} initialValues={{ amount: 1 }}>
+        <Form.Item name="amount" label="Amount" hasFeedback validateStatus="success">
+          <InputNumber allowClear />
+        </Form.Item>
+      </Form>,
+    );
+
+    await user.click(getByRole('button', { name: 'Clear' }));
+
+    expect(formRef.current?.getFieldValue('amount')).toBeNull();
+    expect(getByRole('spinbutton', { name: 'Amount' })).toHaveValue('');
+    expect(container.querySelector('.ant-form-item-feedback-icon-success')).toBeVisible();
+  });
+
+  it('merges clear semantic classes and styles from ConfigProvider and props', () => {
+    const { getByRole } = render(
+      <ConfigProvider
+        inputNumber={{
+          allowClear: true,
+          classNames: { clear: 'context-clear' },
+          styles: { clear: { color: 'red', backgroundColor: 'yellow' } },
+        }}
+      >
+        <InputNumber
+          defaultValue={1}
+          classNames={({ props }) => ({ clear: props.allowClear ? 'local-clear' : '' })}
+          styles={{ clear: { color: 'blue' } }}
+        />
+      </ConfigProvider>,
+    );
+    const clear = getByRole('button', { name: 'Clear' });
+
+    expect(clear).toHaveClass('context-clear', 'local-clear');
+    expect(clear).toHaveStyle('color: rgb(0, 0, 255); background-color: rgb(255, 255, 0)');
+  });
+
+  it.each(['ltr', 'rtl'] as const)(
+    'reserves end padding for the spinner clear button in %s',
+    (direction) => {
+      const { getByRole } = render(
+        <ConfigProvider direction={direction}>
+          <InputNumber allowClear mode="spinner" defaultValue={1} />
+        </ConfigProvider>,
+      );
+      const clear = getByRole('button', { name: 'Clear' });
+
+      expect(getComputedStyle(clear.parentElement!).marginInlineEnd).toBe(
+        'var(--ant-input-number-input-padding-inline)',
+      );
+    },
+  );
+
+  it.each<InputNumberProps['variant']>(['outlined', 'filled', 'borderless', 'underlined'])(
+    'supports %s with RTL, compact sizing and spinner mode',
+    (variant) => {
+      const { container, getByRole, getByText } = render(
+        <ConfigProvider direction="rtl" componentSize="small">
+          <Space.Compact>
+            <InputNumber allowClear defaultValue={0} mode="spinner" suffix="kg" variant={variant} />
+          </Space.Compact>
+        </ConfigProvider>,
+      );
+
+      fireEvent.click(getByRole('button', { name: 'Clear' }));
+
+      expect(getByRole('spinbutton')).toHaveValue('');
+      expect(getByText('kg')).toBeVisible();
+      expect(container.querySelector('.ant-input-number')).toHaveClass(
+        `ant-input-number-${variant}`,
+        'ant-input-number-rtl',
+        'ant-input-number-sm',
+        'ant-input-number-mode-spinner',
+      );
+    },
+  );
+});

--- a/components/input-number/demo/_semantic.tsx
+++ b/components/input-number/demo/_semantic.tsx
@@ -13,6 +13,7 @@ const locales = {
     suffix: '后缀的包裹元素，设置flex布局、边距和过渡动画样式',
     action: '单个操作按钮元素，设置按钮的样式、悬浮效果和点击交互',
     actions: '操作元素，设置绝对定位、宽度、flex布局和数值调节按钮样式',
+    clear: '清除按钮元素，设置图标颜色、大小和交互样式',
   },
   en: {
     root: 'Root element, sets inline-block layout, width, border radius and reset styles',
@@ -23,6 +24,7 @@ const locales = {
       'Single action button element, sets button styling, hover effects and click interactions',
     actions:
       'Actions element, sets absolute positioning, width, flex layout and number adjustment button styles',
+    clear: 'Clear button element, sets icon color, size and interaction styles',
   },
 };
 
@@ -30,6 +32,7 @@ const Block: React.FC<InputNumberProps> = (props) => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
       <InputNumber
+        allowClear
         prefix="￥"
         suffix="RMB"
         defaultValue={100}
@@ -38,6 +41,7 @@ const Block: React.FC<InputNumberProps> = (props) => {
         {...props}
       />
       <InputNumber
+        allowClear
         defaultValue={100}
         style={{ width: 200 }}
         styles={{ actions: { opacity: 1, width: 24 }, suffix: { marginInlineEnd: 28 } }}
@@ -60,6 +64,7 @@ const App: React.FC = () => {
         { name: 'suffix', desc: locale.suffix },
         { name: 'actions', desc: locale.actions },
         { name: 'action', desc: locale.action },
+        { name: 'clear', desc: locale.clear, version: '6.7.0' },
       ]}
     >
       <Block />

--- a/components/input-number/demo/allow-clear.md
+++ b/components/input-number/demo/allow-clear.md
@@ -1,0 +1,7 @@
+## zh-CN
+
+点击清除图标清空数值，`onChange` 接收 `null`。支持自定义清除图标，值为 `0` 时也可以清空。
+
+## en-US
+
+Click the clear icon to empty the value. `onChange` receives `null`. Supports a custom clear icon and clearing `0`.

--- a/components/input-number/demo/allow-clear.tsx
+++ b/components/input-number/demo/allow-clear.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { CloseSquareFilled } from '@ant-design/icons';
+import { InputNumber, Space } from 'antd';
+
+const App: React.FC = () => (
+  <Space vertical>
+    <InputNumber allowClear defaultValue={100} />
+    <InputNumber allowClear defaultValue={0} suffix="kg" />
+    <InputNumber allowClear mode="spinner" defaultValue={0} />
+    <InputNumber allowClear={{ clearIcon: <CloseSquareFilled /> }} defaultValue={100} />
+  </Space>
+);
+
+export default App;

--- a/components/input-number/demo/allow-clear.tsx
+++ b/components/input-number/demo/allow-clear.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import { CloseSquareFilled } from '@ant-design/icons';
 import { InputNumber, Space } from 'antd';
 
 const App: React.FC = () => (
   <Space vertical>
-    <InputNumber allowClear defaultValue={100} />
-    <InputNumber allowClear defaultValue={0} suffix="kg" />
-    <InputNumber allowClear mode="spinner" defaultValue={0} />
-    <InputNumber allowClear={{ clearIcon: <CloseSquareFilled /> }} defaultValue={100} />
+    <InputNumber allowClear defaultValue={100} style={{ width: 120 }} />
+    <InputNumber allowClear defaultValue={0} suffix="kg" style={{ width: 120 }} />
+    <InputNumber allowClear mode="spinner" defaultValue={0} style={{ width: 150 }} />
   </Space>
 );
 

--- a/components/input-number/index.en-US.md
+++ b/components/input-number/index.en-US.md
@@ -20,6 +20,7 @@ When a numeric value needs to be provided.
 <code src="./demo/size.tsx">Sizes</code>
 <code src="./demo/addon.tsx" debug>Pre / Post tab</code>
 <code src="./demo/disabled.tsx">Disabled</code>
+<code src="./demo/allow-clear.tsx" version="6.7.0">Allow clear</code>
 <code src="./demo/digit.tsx">High precision decimals</code>
 <code src="./demo/formatter.tsx">Formatter</code>
 <code src="./demo/keyboard.tsx">Keyboard</code>
@@ -46,6 +47,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | --- | --- | --- | --- | --- | --- |
 | ~~addonAfter~~ | The label text displayed after (on the right side of) the input field, please use Space.Compact instead | ReactNode | - | 4.17.0 | × |
 | ~~addonBefore~~ | The label text displayed before (on the left side of) the input field, please use Space.Compact instead | ReactNode | - | 4.17.0 | × |
+| allowClear | Show a clear button. Supports a custom icon, disabled state, and accessible label. Clearing uses `null` | boolean \| { clearIcon?: ReactNode; disabled?: boolean; label?: string } | false | 6.7.0 | 6.7.0 |
 | changeOnBlur | Trigger `onChange` when blur. e.g. reset value in range by blur | boolean | true | 5.11.0 | × |
 | changeOnWheel | Allows control with mouse wheel | boolean | - | 5.14.0 | × |
 | classNames | Customize class for each semantic structure inside the component. Supports object or function. | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | 6.0.0 | 6.0.0 |
@@ -72,6 +74,7 @@ Common props ref：[Common props](/docs/react/common-props)
 | value | The current value of the component | number | - | - | × |
 | variant | Variants of Input | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 | 5.19.0 |
 | onChange | The callback triggered when the value is changed | function(value: number \| string \| null) | - | - | × |
+| onClear | Called when the clear button is activated | () => void | - | 6.7.0 | × |
 | onPressEnter | The callback function that is triggered when Enter key is pressed | function(e) | - | - | × |
 | onStep | The callback function that is triggered when click up or down buttons / Keyboard / Wheel | (value: number, info: { offset: number, type: 'up' \| 'down', emitter: 'handler' \| 'keydown' \| 'wheel' }) => void | - | - | × |
 | ~~bordered~~ | Whether has border style, please use `variant` instead | boolean | true | - | × |

--- a/components/input-number/index.tsx
+++ b/components/input-number/index.tsx
@@ -12,6 +12,7 @@ import type {
 import { clsx } from 'clsx';
 
 import ContextIsolator from '../_util/ContextIsolator';
+import { useAllowClear } from '../_util/hooks';
 import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { isPlainObject } from '../_util/is';
@@ -27,6 +28,7 @@ import useSize from '../config-provider/hooks/useSize';
 import type { SizeType } from '../config-provider/SizeContext';
 import { FormItemInputContext } from '../form/context';
 import useVariant from '../form/hooks/useVariants';
+import { useLocale } from '../locale';
 import SpaceAddon from '../space/Addon';
 import Compact, { useCompactItemContext } from '../space/Compact';
 import useStyle from './style';
@@ -38,6 +40,7 @@ export type InputNumberSemanticType = {
     suffix?: string;
     input?: string;
     actions?: string;
+    clear?: string;
   };
   styles?: {
     root?: React.CSSProperties;
@@ -45,6 +48,7 @@ export type InputNumberSemanticType = {
     suffix?: React.CSSProperties;
     input?: React.CSSProperties;
     actions?: React.CSSProperties;
+    clear?: React.CSSProperties;
   };
 };
 
@@ -126,6 +130,7 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
       addonAfter: _addonAfter,
       prefix,
       suffix,
+      allowClear,
       bordered,
       readOnly,
       status,
@@ -145,7 +150,23 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
       style: contextStyle,
       styles: contextStyles,
       classNames: contextClassNames,
+      allowClear: contextAllowClear,
     } = useComponentConfig('inputNumber');
+
+    // ====================== Clear =======================
+    const [locale] = useLocale('global');
+    const mergedAllowClear = useAllowClear({
+      allowClear,
+      contextAllowClear,
+      componentName: 'InputNumber',
+    });
+    const clearConfig = mergedAllowClear && {
+      ...(isPlainObject(mergedAllowClear) ? mergedAllowClear : {}),
+      label:
+        (isPlainObject(allowClear) ? allowClear.label : undefined) ??
+        (isPlainObject(contextAllowClear) ? contextAllowClear.label : undefined) ??
+        locale.clear,
+    };
 
     // ===================== Disabled =====================
     const disabled = React.useContext(DisabledContext);
@@ -188,6 +209,7 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
       size: mergedSize,
       disabled: mergedDisabled,
       controls: mergedControls,
+      allowClear: clearConfig,
     };
 
     const contextStyleRoot = useSemanticRootStyle(contextStyle);
@@ -231,6 +253,7 @@ const InternalInputNumber = React.forwardRef<RcInputNumberRef, InternalInputNumb
         controls={controlsTemp}
         prefix={prefix}
         suffix={suffixNode}
+        allowClear={clearConfig}
         classNames={mergedClassNames}
         styles={mergedStyles}
         {...others}

--- a/components/input-number/index.zh-CN.md
+++ b/components/input-number/index.zh-CN.md
@@ -21,6 +21,7 @@ demo:
 <code src="./demo/size.tsx">三种大小</code>
 <code src="./demo/addon.tsx" debug>前置/后置标签</code>
 <code src="./demo/disabled.tsx">不可用</code>
+<code src="./demo/allow-clear.tsx" version="6.7.0">带移除图标</code>
 <code src="./demo/digit.tsx">高精度小数</code>
 <code src="./demo/formatter.tsx">格式化展示</code>
 <code src="./demo/keyboard.tsx">键盘行为</code>
@@ -47,6 +48,7 @@ demo:
 | --- | --- | --- | --- | --- | --- |
 | ~~addonAfter~~ | 带标签的 input，设置后置标签，请使用 Space.Compact 替换 | ReactNode | - | 4.17.0 | × |
 | ~~addonBefore~~ | 带标签的 input，设置前置标签，请使用 Space.Compact 替换 | ReactNode | - | 4.17.0 | × |
+| allowClear | 显示清除按钮，支持自定义图标、禁用状态及无障碍标签。清空后的值为 `null` | boolean \| { clearIcon?: ReactNode; disabled?: boolean; label?: string } | false | 6.7.0 | 6.7.0 |
 | changeOnBlur | 是否在失去焦点时，触发 `onChange` 事件（例如值超出范围时，重新限制回范围并触发事件） | boolean | true | 5.11.0 | × |
 | changeOnWheel | 允许鼠标滚轮改变数值 | boolean | - | 5.14.0 | × |
 | classNames | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | Record<[SemanticDOM](#semantic-dom), string> \| (info: { props })=> Record<[SemanticDOM](#semantic-dom), string> | - | 6.0.0 | 6.0.0 |
@@ -73,6 +75,7 @@ demo:
 | value | 当前值 | number | - | - | × |
 | variant | 形态变体 | `outlined` \| `borderless` \| `filled` \| `underlined` | `outlined` | 5.13.0 \| `underlined`: 5.24.0 | 5.19.0 |
 | onChange | 变化回调 | function(value: number \| string \| null) | - | - | × |
+| onClear | 点击清除按钮时的回调 | () => void | - | 6.7.0 | × |
 | onPressEnter | 按下回车的回调 | function(e) | - | - | × |
 | onStep | 点击上下箭头、键盘、滚轮的回调 | (value: number, info: { offset: number, type: 'up' \| 'down', emitter: 'handler' \| 'keydown' \| 'wheel' }) => void | - | - | × |
 | ~~bordered~~ | 是否带边框，请使用 `variant` 替代 | boolean | true | - | × |

--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -1,7 +1,12 @@
 import type { CSSObject } from '@ant-design/cssinjs';
 import { unit } from '@ant-design/cssinjs';
 
-import { genBasicInputStyle, genPlaceholderStyle, initInputToken } from '../../input/style';
+import {
+  genAllowClearStyle,
+  genBasicInputStyle,
+  genPlaceholderStyle,
+  initInputToken,
+} from '../../input/style';
 import {
   genBorderlessStyle,
   genFilledStyle,
@@ -281,6 +286,10 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token) => {
             textAlign: 'center',
             paddingInline: varRef('input-padding-inline'),
           },
+
+          [`${componentCls}-suffix`]: {
+            marginInlineEnd: varRef('input-padding-inline'),
+          },
         },
       },
     },
@@ -315,6 +324,8 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token) => {
     // ==========================================================
     {
       [componentCls]: {
+        ...genAllowClearStyle(token),
+
         [`${componentCls}-prefix, ${componentCls}-suffix`]: {
           display: 'flex',
           flex: 'none',
@@ -331,11 +342,22 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token) => {
           height: '100%',
           marginInlineStart: inputAffixPadding,
           transition: `margin ${motionDurationMid}`,
+
+          [`${componentCls}-clear-icon`]: {
+            flex: 'none',
+            pointerEvents: 'auto',
+          },
         },
 
-        [`&:hover:not(${componentCls}-without-controls)`]: {
+        [`&-mode-input:not(${componentCls}-without-controls)`]: {
           [`${componentCls}-suffix`]: {
-            marginInlineEnd: token.handleWidth,
+            marginInlineEnd: token.handleVisibleWidth,
+          },
+
+          [`&:hover, &${componentCls}-focused`]: {
+            [`${componentCls}-suffix`]: {
+              marginInlineEnd: token.handleWidth,
+            },
           },
         },
       },

--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -388,7 +388,7 @@ export const genInputStyle: GenerateStyle<InputToken, CSSObject> = (token) => {
   };
 };
 
-const genAllowClearStyle: GenerateStyle<InputToken, CSSObject> = (token) => {
+export const genAllowClearStyle: GenerateStyle<InputToken, CSSObject> = (token) => {
   const { componentCls } = token;
   return {
     // ========================= Input =========================

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@rc-component/form": "~1.8.6",
     "@rc-component/image": "~1.10.0",
     "@rc-component/input": "~1.3.1",
-    "@rc-component/input-number": "~1.6.2",
+    "@rc-component/input-number": "~1.7.0",
     "@rc-component/listy": "~1.3.0",
     "@rc-component/mentions": "~1.12.0",
     "@rc-component/menu": "~1.5.0",

--- a/package.json
+++ b/package.json
@@ -343,7 +343,7 @@
     },
     {
       "path": "./dist/antd-with-locales.min.js",
-      "limit": "534 KiB",
+      "limit": "535 KiB",
       "gzip": true
     }
   ],


### PR DESCRIPTION
[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Closes #50885.

- Native implementation: [react-component/input-number#751](https://github.com/react-component/input-number/pull/751), merged and released in `@rc-component/input-number@1.7.0`.
- Related Ant Design proposal: #59004.

The earlier proposals [react-component/input-number#728](https://github.com/react-component/input-number/pull/728) and [react-component/input-number#729](https://github.com/react-component/input-number/pull/729) could also be closed as superseded by the merged rc implementation, if the maintainers agree.

### 💡 Background and Solution

Add `allowClear` and `onClear` to InputNumber using the native implementation released in `@rc-component/input-number@1.7.0`.

`allowClear` accepts a boolean or `{ clearIcon, disabled, label }`. It also supports ConfigProvider defaults and the `clear` semantic slot. The default icon and styles are shared with Input, and the accessible label uses the existing locale text.

```tsx
<InputNumber allowClear defaultValue={0} />
<InputNumber allowClear mode="spinner" defaultValue={100} />
```

Clearing stays inside rc's value update path: uncontrolled inputs are actually emptied, while controlled inputs emit `onChange(null)` without overriding `value`. The existing empty-value contract is preserved, with no `clearValue` API or extra numeric state in the wrapper.

The clear button works with `0`, respects disabled/read-only states, preserves keyboard and pointer focus, and has appropriate spacing beside the spinner controls in LTR and RTL.

Includes regression tests, English and Chinese API documentation, demos and semantic DOM updates. Targeted tests, visual checks, ESLint, Biome and TypeScript pass locally.

### 📝 Change Log

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | 🆕 Add `allowClear` and `onClear` to InputNumber, with custom clear icons, a disabled clear state, accessible labels and global clear configuration. |
| 🇨🇳 Chinese | 🆕 新增 InputNumber `allowClear` 和 `onClear`，支持自定义清除图标、禁用清除操作、无障碍标签及全局配置。 |
