### PR TITLE
ci: persist feature snapshots after automated merges

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -12,12 +12,20 @@ jobs:
   pr-check-ci:
     if: github.repository == 'ant-design/ant-design'
     permissions:
+      actions: write  # for dispatching the visual regression snapshot workflow
       checks: read  # for actions-cool/check-pr-ci to get check reference
       contents: write  # for actions-cool/check-pr-ci to merge PRs
       issues: write  # for actions-cool/check-pr-ci to update issues
       pull-requests: write  # for actions-cool/check-pr-ci to update PRs
     runs-on: ubuntu-latest
     steps:
+      - name: Get feature ref before auto merge
+        id: feature-before
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: echo "sha=$(gh api repos/$GH_REPO/git/ref/heads/feature --jq '.object.sha')" >> "$GITHUB_OUTPUT"
+
       - uses: actions-cool/check-pr-ci@0ae0a449b0b4a24d792befccee14931cc91caff9 # v1
         with:
           filter-label: BranchAutoMerge
@@ -30,3 +38,14 @@ jobs:
           success-merge: true
           merge-method: merge
           merge-title: 'chore: auto merge branches (#${number})'
+
+      - name: Persist feature snapshots after auto merge
+        env:
+          FEATURE_SHA_BEFORE: ${{ steps.feature-before.outputs.sha }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          feature_sha=$(gh api repos/$GH_REPO/git/ref/heads/feature --jq '.object.sha')
+          if [[ "$feature_sha" != "$FEATURE_SHA_BEFORE" ]]; then
+            gh workflow run visual-regression-persist-start.yml --repo "$GH_REPO" --ref feature
+          fi

--- a/.github/workflows/visual-regression-persist-finish.yml
+++ b/.github/workflows/visual-regression-persist-finish.yml
@@ -31,7 +31,7 @@ jobs:
           BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           if [[ "$REPO" == "ant-design/ant-design" && \
-                "$EVENT" == "push" && \
+                ( "$EVENT" == "push" || "$EVENT" == "workflow_dispatch" ) && \
                 ( "$BRANCH" == "master" || \
                   "$BRANCH" == "feature" || \
                   "$BRANCH" == "next" ) ]]; then

--- a/.github/workflows/visual-regression-persist-start.yml
+++ b/.github/workflows/visual-regression-persist-start.yml
@@ -8,6 +8,7 @@ on:
       - master
       - feature
       - next
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [x] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Related to #58217.

### 💡 需求背景和解决方案

由 `GITHUB_TOKEN` 自动合并 master 到 feature 时，产生的 push 不会触发快照持久化工作流，导致 feature 的视觉回归基线长期过期。

本 PR 在自动合并前后比较 feature SHA，仅当 feature 确实发生变化时，显式触发视觉快照工作流。同时允许持久化流程处理可信的 `workflow_dispatch` 事件，避免无变化时消耗额外截图资源。

验证：

- Workflow YAML 解析通过
- Prettier 检查通过
- `git diff --check` 通过
- feature SHA 未变化时确认跳过 dispatch

### 📝 更新日志

| 语言    | 更新描述     |
| ------- | ------------ |
| 🇺🇸 英文 | N/A          |
| 🇨🇳 中文 | 无需更新日志 |
