### PR TITLE
docs: improve initial HMR for component documentation

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -73,6 +73,9 @@ export default defineConfig({
   mfsu: false,
   mako: isCloudflarePages && ['Darwin', 'Linux'].includes(os.type()) ? {} : false,
   utoopack: {
+    devServer: {
+      dynamicHmrChunkLists: true,
+    },
     watch: {
       nodeModulesRegexes: ['rc-.*', '.*cssinjs.*', '@rc-component/.*'],
     },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE_CN.md?plain=1)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [x] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

No linked issue. Identified while profiling local component documentation development.

### 💡 Background and Solution

The first demo edit after starting the documentation dev server can be slow because the entry HMR chunk list includes dynamic pages that have not been opened. Enable `utoopack.devServer.dynamicHmrChunkLists` so dynamic chunks register their own HMR lists when loaded, reducing the scope of the initial update.

Prior local validation with dumi 2.4.49, Umi 4.7.5, and the npm native binary of @utoo/pack 1.5.6-alpha.3 measured the first Button demo text update at 58.8 seconds by default and 2.7 seconds with this option. These are single diagnostic samples from separate processes with cold native caches, not a repeated benchmark. The option does not eliminate eager site compilation during startup.

Validation:

- `biome check .dumirc.ts`
- `eslint .dumirc.ts`
- `git diff --check`
- Prior local browser smoke checks: demo text, Markdown body, and shared Button implementation updates applied without a full page reload; Button → Table → Button navigation retained the updated component.

The browser checks used ant-design commit `dba7fa41f46e51ade7621aba763ade9d73c5de29` with the same option enabled. Formatting and lint checks were rerun on this PR branch; browser checks were not repeated against the updated master base.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Speed up the first hot update when developing component documentation with utoopack. |
| 🇨🇳 Chinese | 提升使用 utoopack 开发组件文档时的首次热更新速度。 |
