### PR TITLE
fix(Modal): preserve falsy button text

### DIFF
--- a/components/modal/ConfirmDialog.tsx
+++ b/components/modal/ConfirmDialog.tsx
@@ -129,8 +129,11 @@ export const ConfirmContent: React.FC<
   const mergedLocale = staticLocale || locale;
 
   // ================== Locale Text ==================
-  const okTextLocale = okText || (mergedOkCancel ? mergedLocale?.okText : mergedLocale?.justOkText);
-  const cancelTextLocale = cancelText || mergedLocale?.cancelText;
+  const okTextLocale = fallbackProp(
+    okText,
+    mergedOkCancel ? mergedLocale?.okText : mergedLocale?.justOkText,
+  );
+  const cancelTextLocale = fallbackProp(cancelText, mergedLocale?.cancelText);
 
   // ================= Context Value =================
   const { closable } = restProps;

--- a/components/modal/__tests__/Modal.test.tsx
+++ b/components/modal/__tests__/Modal.test.tsx
@@ -86,6 +86,19 @@ describe('Modal', () => {
     expect(btns[btns.length - 1]).toHaveClass('ant-btn-dangerous');
   });
 
+  it.each([
+    { name: 'zero', value: 0, expected: '0' },
+    { name: 'empty string', value: '', expected: '' },
+    { name: 'false', value: false, expected: '' },
+    { name: 'null', value: null, expected: '' },
+  ])('support $name button text', ({ value, expected }) => {
+    render(<Modal cancelText={value} okText={value} open />);
+    const btns = document.body.querySelectorAll('.ant-modal-footer .ant-btn');
+
+    expect(btns[0].textContent).toBe(expected);
+    expect(btns[1].textContent).toBe(expected);
+  });
+
   it('mouse position', () => {
     const Demo = () => {
       const [open, setOpen] = React.useState(false);

--- a/components/modal/__tests__/confirm.test.tsx
+++ b/components/modal/__tests__/confirm.test.tsx
@@ -176,6 +176,14 @@ describe('Modal.confirm triggers callbacks correctly', () => {
     expect(onOk.mock.calls.length).toBe(1);
   });
 
+  it('support falsy button text', async () => {
+    await open({ cancelText: false, okText: 0 });
+    const btns = $$('.ant-modal-confirm-btns .ant-btn');
+
+    expect(btns[0].textContent).toBe('');
+    expect(btns[1].textContent).toBe('0');
+  });
+
   it('should allow Modal.confirm without onCancel been set', async () => {
     await open();
 

--- a/components/modal/__tests__/hook.test.tsx
+++ b/components/modal/__tests__/hook.test.tsx
@@ -87,6 +87,31 @@ describe('Modal.hook', () => {
     jest.useRealTimers();
   });
 
+  it('support falsy button text', async () => {
+    jest.useFakeTimers();
+
+    const Demo = () => {
+      const [modal, contextHolder] = Modal.useModal();
+
+      React.useEffect(() => {
+        const instance = modal.confirm({ cancelText: false, okText: 0 });
+        return () => instance.destroy();
+      }, []);
+
+      return <ConfigWarp>{contextHolder}</ConfigWarp>;
+    };
+
+    const { unmount } = render(<Demo />);
+    await waitFakeTimer();
+    const btns = document.body.querySelectorAll('.ant-modal-confirm-btns .ant-btn');
+
+    expect(btns[0].textContent).toBe('');
+    expect(btns[1].textContent).toBe('0');
+
+    unmount();
+    jest.useRealTimers();
+  });
+
   it('destroyAll works with contextHolder', () => {
     const modalTypes = ['info', 'success', 'warning', 'error'] as const;
 

--- a/components/modal/shared.tsx
+++ b/components/modal/shared.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import CloseOutlined from '@ant-design/icons/CloseOutlined';
 
+import fallbackProp from '../_util/fallbackProp';
 import { isFunction } from '../_util/is';
 import { DisabledContextProvider } from '../config-provider/DisabledContext';
 import { useLocale } from '../locale';
@@ -52,8 +53,8 @@ export const Footer: React.FC<
   const [locale] = useLocale('Modal', getConfirmLocale());
 
   // ================== Locale Text ==================
-  const okTextLocale: React.ReactNode = okText || locale?.okText;
-  const cancelTextLocale = cancelText || locale?.cancelText;
+  const okTextLocale: React.ReactNode = fallbackProp(okText, locale?.okText);
+  const cancelTextLocale = fallbackProp(cancelText, locale?.cancelText);
 
   const memoizedValue = React.useMemo<ModalContextProps>(() => {
     return {

--- a/components/modal/useModal/HookModal.tsx
+++ b/components/modal/useModal/HookModal.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import fallbackProp from '../../_util/fallbackProp';
 import { isFunction } from '../../_util/is';
 import { ConfigContext } from '../../config-provider';
 import defaultLocale from '../../locale/en_US';
@@ -68,11 +69,12 @@ const HookModal = React.forwardRef<HookModalRef, HookModalProps>((props, ref) =>
       close={close}
       open={open}
       afterClose={afterClose}
-      okText={
-        innerConfig.okText || (mergedOkCancel ? contextLocale?.okText : contextLocale?.justOkText)
-      }
+      okText={fallbackProp(
+        innerConfig.okText,
+        mergedOkCancel ? contextLocale?.okText : contextLocale?.justOkText,
+      )}
       direction={innerConfig.direction || direction}
-      cancelText={innerConfig.cancelText || contextLocale?.cancelText}
+      cancelText={fallbackProp(innerConfig.cancelText, contextLocale?.cancelText)}
       {...restProps}
     />
   );


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] ✅ 测试用例

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Modal 的 `okText` 和 `cancelText` 支持 `ReactNode`，但此前使用真假值判断回退到本地化默认文案，导致 `0`、空字符串、`false` 和 `null` 无法按配置渲染。

本次改为仅在属性为 `undefined` 时使用默认文案，并覆盖普通 Modal、静态方法和 `useModal` 三种调用方式。

本地已通过关联组件测试：18 个测试套件、1029 个测试用例及 503 个快照；Modal 图片测试 69 个用例通过。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Modal `okText` and `cancelText` incorrectly falling back to default text for falsy ReactNode values. |
| 🇨🇳 中文 | 修复 Modal 的 `okText` 和 `cancelText` 为假值 ReactNode 时被默认文案覆盖的问题。 |
