### PR TITLE
fix(Modal): preserve onCancel when cancel button has onClick

### DIFF
--- a/components/modal/__tests__/Modal.test.tsx
+++ b/components/modal/__tests__/Modal.test.tsx
@@ -65,6 +65,15 @@ describe('Modal', () => {
     expect(onCancel).toHaveBeenCalled();
   });
 
+  it('should trigger both onCancel and cancelButtonProps.onClick', () => {
+    const onCancel = jest.fn();
+    const onClick = jest.fn();
+    render(<Modal open onCancel={onCancel} cancelButtonProps={{ onClick }} />);
+    fireEvent.click(document.body.querySelectorAll('.ant-btn')[0]);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
   it('onCancel should be called when pressing ESC', () => {
     const onCancel = jest.fn();
     render(<Modal open onCancel={onCancel} />);

--- a/components/modal/components/NormalCancelBtn.tsx
+++ b/components/modal/components/NormalCancelBtn.tsx
@@ -12,13 +12,13 @@ export interface NormalCancelBtnProps extends Pick<ModalProps, 'cancelButtonProp
 const NormalCancelBtn: FC = () => {
   const { cancelButtonProps, cancelTextLocale, onCancel } = useContext(ModalContext);
 
-  const handleClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+  const onInternalClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
     onCancel?.(event);
     cancelButtonProps?.onClick?.(event);
   };
 
   return (
-    <Button {...cancelButtonProps} onClick={handleClick}>
+    <Button {...cancelButtonProps} onClick={onInternalClick}>
       {cancelTextLocale}
     </Button>
   );

--- a/components/modal/components/NormalCancelBtn.tsx
+++ b/components/modal/components/NormalCancelBtn.tsx
@@ -11,8 +11,14 @@ export interface NormalCancelBtnProps extends Pick<ModalProps, 'cancelButtonProp
 
 const NormalCancelBtn: FC = () => {
   const { cancelButtonProps, cancelTextLocale, onCancel } = useContext(ModalContext);
+
+  const handleClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+    onCancel?.(event);
+    cancelButtonProps?.onClick?.(event);
+  };
+
   return (
-    <Button onClick={onCancel} {...cancelButtonProps}>
+    <Button {...cancelButtonProps} onClick={handleClick}>
       {cancelTextLocale}
     </Button>
   );


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- [CodeSandbox 最小复现](https://codesandbox.io/p/sandbox/modal-de-cancelbuttonprops-onclick-hui-fu-gai-oncancel-vdjsyh?file=%2Fsrc%2FApp.tsx)

### 💡 需求背景和解决方案

Modal 同时配置 `onCancel` 与 `cancelButtonProps.onClick` 时，按钮的 `onClick` 会覆盖 Modal 的取消回调，导致依赖 `onCancel` 更新受控状态的弹窗无法关闭。

本次在默认取消按钮中合并执行两个回调，并增加回归测试。不涉及公开 API 变更。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Modal not triggering `onCancel` when `cancelButtonProps.onClick` is provided. |
| 🇨🇳 中文 | 修复 Modal 配置 `cancelButtonProps.onClick` 时不触发 `onCancel` 的问题。 |
