### PR TITLE
ci: persist snapshots for all auto-merged branches

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -19,12 +19,16 @@ jobs:
       pull-requests: write  # for actions-cool/check-pr-ci to update PRs
     runs-on: ubuntu-latest
     steps:
-      - name: Get feature ref before auto merge
-        id: feature-before
+      - name: Get visual regression refs before auto merge
+        id: refs-before
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: echo "sha=$(gh api repos/$GH_REPO/git/ref/heads/feature --jq '.object.sha')" >> "$GITHUB_OUTPUT"
+        run: |
+          for branch in master feature next; do
+            sha=$(gh api repos/$GH_REPO/git/ref/heads/$branch --jq '.object.sha')
+            echo "$branch=$sha" >> "$GITHUB_OUTPUT"
+          done
 
       - uses: actions-cool/check-pr-ci@0ae0a449b0b4a24d792befccee14931cc91caff9 # v1
         with:
@@ -39,13 +43,23 @@ jobs:
           merge-method: merge
           merge-title: 'chore: auto merge branches (#${number})'
 
-      - name: Persist feature snapshots after auto merge
+      - name: Persist snapshots after auto merge
         env:
-          FEATURE_SHA_BEFORE: ${{ steps.feature-before.outputs.sha }}
+          MASTER_SHA_BEFORE: ${{ steps.refs-before.outputs.master }}
+          FEATURE_SHA_BEFORE: ${{ steps.refs-before.outputs.feature }}
+          NEXT_SHA_BEFORE: ${{ steps.refs-before.outputs.next }}
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          feature_sha=$(gh api repos/$GH_REPO/git/ref/heads/feature --jq '.object.sha')
-          if [[ "$feature_sha" != "$FEATURE_SHA_BEFORE" ]]; then
-            gh workflow run visual-regression-persist-start.yml --repo "$GH_REPO" --ref feature
-          fi
+          persist_if_changed() {
+            branch=$1
+            sha_before=$2
+            sha=$(gh api repos/$GH_REPO/git/ref/heads/$branch --jq '.object.sha')
+            if [[ "$sha" != "$sha_before" ]]; then
+              gh workflow run visual-regression-persist-start.yml --repo "$GH_REPO" --ref "$branch"
+            fi
+          }
+
+          persist_if_changed master "$MASTER_SHA_BEFORE"
+          persist_if_changed feature "$FEATURE_SHA_BEFORE"
+          persist_if_changed next "$NEXT_SHA_BEFORE"

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -26,7 +26,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           for branch in master feature next; do
-            sha=$(gh api repos/$GH_REPO/git/ref/heads/$branch --jq '.object.sha')
+            sha=$(gh api repos/$GH_REPO/git/matching-refs/heads/$branch --jq ".[] | select(.ref == \"refs/heads/$branch\") | .object.sha")
             echo "$branch=$sha" >> "$GITHUB_OUTPUT"
           done
 
@@ -54,8 +54,8 @@ jobs:
           persist_if_changed() {
             branch=$1
             sha_before=$2
-            sha=$(gh api repos/$GH_REPO/git/ref/heads/$branch --jq '.object.sha')
-            if [[ "$sha" != "$sha_before" ]]; then
+            sha=$(gh api repos/$GH_REPO/git/matching-refs/heads/$branch --jq ".[] | select(.ref == \"refs/heads/$branch\") | .object.sha")
+            if [[ -n "$sha_before" && -n "$sha" && "$sha" != "$sha_before" ]]; then
               gh workflow run visual-regression-persist-start.yml --repo "$GH_REPO" --ref "$branch"
             fi
           }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [x] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Follow-up to #59252.

Addresses the [Codex review feedback on #59256](https://github.com/ant-design/ant-design/pull/59256#discussion_r3964183875).

### 💡 Background and Solution

Branch auto-merges use `GITHUB_TOKEN`, so their pushes do not trigger the visual regression persistence workflow. #59252 compensated for this behavior, but only detected changes to `feature` and always dispatched that ref. Automated merges targeting `master` or `next` could therefore leave their visual regression baselines stale.

The auto-merge action can process multiple eligible pull requests in one scheduled run. This change records the SHA of `master`, `feature`, and `next` before auto-merge, compares all three refs afterward, and dispatches snapshot persistence only for the branches that changed.

Validation:

- Prettier check passed
- `git diff --check` passed
- Shell simulation confirmed that only changed refs are dispatched

### 📝 Change Log

| Language   | Changelog                    |
| ---------- | ---------------------------- |
| 🇺🇸 English | N/A (internal workflow only) |
| 🇨🇳 Chinese | N/A (internal workflow only) |
