### PR TITLE
fix(Table): vertically center virtual cell content

### DIFF
--- a/components/table/style/virtual.ts
+++ b/components/table/style/virtual.ts
@@ -31,6 +31,10 @@ const genVirtualStyle: GenerateStyle<TableToken, CSSObject> = (token) => {
             display: 'flex',
             boxSizing: 'border-box',
             width: '100%',
+
+            [`> ${componentCls}-cell`]: {
+              alignContent: 'center',
+            },
           },
         },
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

close #53921

### 💡 需求背景和解决方案

Virtual Table 行高被较高内容撑开时，其他单元格内容会顶部对齐。

为虚拟行的直接单元格设置 `align-content: center`，恢复垂直居中，不改变现有 DOM 和内容布局。

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | 🐞 Fix Table virtual cells not vertically centering content. |
| 🇨🇳 中文 | 🐞 修复 Table 虚拟滚动单元格内容未垂直居中的问题。 |
