### PR TITLE
fix(Form): prevent vertical Form.Item controls from shrinking

### DIFF
--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -560,6 +560,7 @@ const genVerticalStyle: GenerateStyle<FormToken, CSSObject> = (token) => {
 
       [`${formItemCls}-control`]: {
         width: '100%',
+        flex: 'none',
       },
       [`> ${formItemCls}-row > ${formItemCls}-label,
         > ${formItemCls}-row > ${antCls}-col-24${formItemCls}-label,


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进

### 🔗 相关 Issue

fix #51626

### 💡 需求背景和解决方案

水平布局 Form 的后代样式会将 `flex: 1 1 0` 应用到内部使用 `layout="vertical"` 的 Form.Item control，导致其在纵向 flex 布局中高度被压缩。

为垂直布局的 Form.Item control 设置 `flex: none`，使控件恢复按内容计算高度。现有 `layout-multiple` demo 覆盖了相同的混合布局场景，其 image diff 属于预期的修复结果。

本地复现中，修复前 control 高度被压缩至 `1px`；修复后 Input 和编辑器区域分别恢复至约 `32px` 和 `142px`。

验证：

- Form 单元测试：106 passed，1 skipped
- ESLint：通过
- `git diff --check`：通过

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Form vertical Form.Item controls shrinking inside horizontal forms. |
| 🇨🇳 中文 | 🐞 修复 Form 在水平布局中嵌套的垂直 Form.Item 控件高度被压缩的问题。 |
