### PR TITLE
docs: keep only dnd-kit in drag-and-drop recommendations

### DIFF
--- a/docs/react/recommendation.en-US.md
+++ b/docs/react/recommendation.en-US.md
@@ -15,7 +15,7 @@ title: Third-Party Libraries
 | React Form Library | [ProForm](https://procomponents.ant.design/components/form) [Formily](https://github.com/alibaba/formily) [react-hook-form](https://github.com/react-hook-form/react-hook-form) [formik](https://github.com/jaredpalmer/formik) |
 | Router | [react-router](https://github.com/remix-run/react-router) |
 | Layout | [react-grid-layout](https://github.com/react-grid-layout/react-grid-layout) [react-grid-system](https://github.com/sealninja/react-grid-system) [rc-dock](https://github.com/ticlo/rc-dock) |
-| Drag and drop | [dnd-kit](https://github.com/clauderic/dnd-kit) [react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd/) [react-dnd](https://github.com/react-dnd/react-dnd) |
+| Drag and drop | [dnd-kit](https://github.com/clauderic/dnd-kit) |
 | Code Editor | [react-codemirror2](https://github.com/scniro/react-codemirror2) [react-monaco-editor](https://github.com/react-monaco-editor/react-monaco-editor) |
 | Rich Text Editor | [react-quill](https://github.com/zenoamaro/react-quill) |
 | JSON Viewer | [react-json-view](https://github.com/mac-s-g/react-json-view) |

--- a/docs/react/recommendation.zh-CN.md
+++ b/docs/react/recommendation.zh-CN.md
@@ -15,7 +15,7 @@ title: 社区精选组件
 | 表单 | [ProForm](https://procomponents.ant.design/components/form) [Formily](https://github.com/alibaba/formily) [react-hook-form](https://github.com/react-hook-form/react-hook-form) [formik](https://github.com/jaredpalmer/formik) |
 | 路由 | [react-router](https://github.com/remix-run/react-router) |
 | 布局 | [react-grid-layout](https://github.com/react-grid-layout/react-grid-layout) [react-grid-system](https://github.com/sealninja/react-grid-system) [rc-dock](https://github.com/ticlo/rc-dock) |
-| 拖拽 | [dnd-kit](https://github.com/clauderic/dnd-kit) [react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd/) [react-dnd](https://github.com/react-dnd/react-dnd) |
+| 拖拽 | [dnd-kit](https://github.com/clauderic/dnd-kit) |
 | 代码编辑器 | [@uiw/react-codemirror](https://github.com/uiwjs/react-codemirror) [react-monaco-editor](https://github.com/react-monaco-editor/react-monaco-editor) |
 | 富文本编辑器 | [react-quill](https://github.com/zenoamaro/react-quill) |
 | JSON 编辑器 | [vanilla-jsoneditor](https://github.com/josdejong/svelte-jsoneditor) |


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 📝 站点、文档改进

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

react-beautiful-dnd 仓库已归档、停止维护，但「社区精选组件」文档的拖拽分类仍在推荐它。

经与协作者讨论（antd demo 中拖拽场景均使用 dnd-kit），决定拖拽分类仅保留 dnd-kit：在中英文两个文档页面的「拖拽 / Drag and drop」一行中移除 react-beautiful-dnd 和 react-dnd。
<img width="880" height="279" alt="image" src="https://github.com/user-attachments/assets/7749b514-37d0-476e-86ca-0000d628189c" />


纯文档改动，不涉及组件 API、交互与行为变化。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | 无需更新日志 |