### PR TITLE
demo: fix Tabs semantic popup highlighting

### DIFF
--- a/.dumi/theme/common/Markers.tsx
+++ b/.dumi/theme/common/Markers.tsx
@@ -23,6 +23,7 @@ const Markers: React.FC<MarkersProps> = (props) => {
 
   // ======================== Effect =========================
   React.useEffect(() => {
+    const canObserve = typeof IntersectionObserver !== 'undefined';
     const allElements = targetClassName
       ? Array.from(containerRef.current?.querySelectorAll<HTMLElement>(`.${targetClassName}`) || [])
       : [];
@@ -56,7 +57,7 @@ const Markers: React.FC<MarkersProps> = (props) => {
         top: rect.top - (containerRect.top || 0),
         width: rect.width,
         height: rect.height,
-        visible: isVisible(targetElement),
+        visible: !canObserve && isVisible(targetElement),
       };
     });
 
@@ -75,6 +76,48 @@ const Markers: React.FC<MarkersProps> = (props) => {
         },
       );
     });
+
+    if (!canObserve) {
+      return;
+    }
+
+    let destroyed = false;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (destroyed) {
+          return;
+        }
+
+        setRectList((prev) => {
+          const next = [...prev];
+
+          entries.forEach((entry) => {
+            const index = targetElements.indexOf(entry.target as HTMLElement);
+            if (index !== -1 && next[index]) {
+              next[index] = {
+                ...next[index],
+                visible:
+                  entry.isIntersecting &&
+                  entry.intersectionRatio > 0 &&
+                  isVisible(entry.target as HTMLElement),
+              };
+            }
+          });
+
+          return next;
+        });
+      },
+      { root: containerRef.current },
+    );
+
+    targetElements.forEach((element) => {
+      observer.observe(element);
+    });
+
+    return () => {
+      destroyed = true;
+      observer.disconnect();
+    };
   }, [containerRef, targetClassName]);
 
   // ======================== Render =========================

--- a/components/tabs/__tests__/__snapshots__/demo-semantic.test.tsx.snap
+++ b/components/tabs/__tests__/__snapshots__/demo-semantic.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`renders components/tabs/demo/_semantic.tsx correctly 1`] = `
     >
       <div
         class="ant-tabs ant-tabs-top ant-tabs-editable ant-tabs-card ant-tabs-editable-card semantic-mark-root css-var-test-id ant-tabs-css-var"
-        style="height: 220px; width: 100%;"
+        style="height: 220px; position: relative; width: 100%;"
       >
         <div
           aria-orientation="horizontal"
@@ -1329,7 +1329,7 @@ exports[`renders components/tabs/demo/_semantic.tsx correctly 1`] = `
               aria-controls="rc-tabs-test-more-popup"
               aria-expanded="false"
               aria-haspopup="listbox"
-              class="ant-tabs-nav-more"
+              class="ant-tabs-nav-more ant-tabs-dropdown-open"
               id="rc-tabs-test-more"
               style="visibility: hidden; order: 1;"
               type="button"
@@ -1354,6 +1354,23 @@ exports[`renders components/tabs/demo/_semantic.tsx correctly 1`] = `
                 </svg>
               </span>
             </button>
+            <div
+              class="ant-tabs-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up css-var-test-id ant-tabs-css-var semantic-mark-popup-root ant-tabs-dropdown-placement-topLeft"
+              style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; right: auto; bottom: auto; box-sizing: border-box; background: rgb(255, 255, 255);"
+            >
+              <ul
+                aria-label="expanded dropdown"
+                class="ant-tabs-dropdown-menu ant-tabs-dropdown-menu-root ant-tabs-dropdown-menu-vertical"
+                data-menu-list="true"
+                id="rc-tabs-test-more-popup"
+                role="listbox"
+                tabindex="-1"
+              />
+              <div
+                aria-hidden="true"
+                style="display: none;"
+              />
+            </div>
             <button
               aria-label="Add tab"
               class="ant-tabs-nav-add"

--- a/components/tabs/__tests__/semantic.test.tsx
+++ b/components/tabs/__tests__/semantic.test.tsx
@@ -35,9 +35,8 @@ describe('Tabs.Semantic', () => {
       <Tabs
         defaultActiveKey="1"
         type="editable-card"
-        // `more.visible` is spread over rc-tabs' own `visible`, so the popup mounts
-        // without having to fake element sizes to force tab overflow.
-        more={{ visible: true }}
+        // Open the more popup without having to fake element sizes to force tab overflow.
+        more={{ open: true }}
         styles={customStyles}
         classNames={customClassnames}
         items={Array.from({ length: 30 }, (_, i) => {

--- a/components/tabs/demo/_semantic.tsx
+++ b/components/tabs/demo/_semantic.tsx
@@ -39,7 +39,8 @@ const Block: React.FC<Readonly<TabsProps>> = (props) => {
       {...props}
       defaultActiveKey="1"
       type="editable-card"
-      style={{ height: 220, width: '100%' }}
+      style={{ height: 220, position: 'relative', width: '100%' }}
+      getPopupContainer={(triggerNode) => triggerNode.closest<HTMLElement>('.ant-tabs')!}
       styles={{
         popup: {
           root: { background: '#fff' },
@@ -75,7 +76,7 @@ const App: React.FC = () => {
         { name: 'popup.root', desc: locale['popup.root'] },
       ]}
     >
-      <Block />
+      <Block more={{ open: true, placement: 'topLeft' }} />
     </SemanticPreview>
   );
 };


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [x] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

close #59275

关联 #59221

### 💡 需求背景和解决方案

Tabs Semantic DOM 测试仍使用已经废弃的 `more.visible`，同时 Semantic DOM demo 未主动展示 more 下拉菜单。

本次将测试迁移至 `more.open`，并在 demo 中打开下拉菜单、设置 `topLeft` 弹出位置。弹出层改为挂载到 Tabs 根节点内，避免插入 `body` 后脱离 SemanticPreview 的查询范围，使 `popup.root` 的框选效果正常生效。

同步更新 Semantic DOM 测试快照。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | N/A |
| 🇨🇳 中文 | 无需更新日志 |