### PR TITLE
fix(Table): preserve pagination semantic classNames and styles

### DIFF
--- a/components/table/InternalTable.tsx
+++ b/components/table/InternalTable.tsx
@@ -5,7 +5,13 @@ import { omit, pickAttrs } from '@rc-component/util';
 import { clsx } from 'clsx';
 
 import { useProxyImperativeHandle } from '../_util/hooks';
-import { useMergeSemantic, useSemanticRootStyle } from '../_util/hooks/useMergeSemantic';
+import {
+  mergeClassNames,
+  mergeStyles,
+  resolveStyleOrClass,
+  useMergeSemantic,
+  useSemanticRootStyle,
+} from '../_util/hooks/useMergeSemantic';
 import type { GenerateSemantic } from '../_util/hooks/useMergeSemantic/semanticType';
 import { isFunction, isNumber, isPlainObject } from '../_util/is';
 import type { Breakpoint } from '../_util/responsiveObserver';
@@ -531,6 +537,15 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     pagination,
   );
 
+  const paginationClassNames: TablePaginationConfig['classNames'] = (info) =>
+    mergeClassNames(
+      {},
+      mergedClassNames.pagination,
+      resolveStyleOrClass(mergedPagination.classNames, info),
+    );
+  const paginationStyles: TablePaginationConfig['styles'] = (info) =>
+    mergeStyles(resolveStyleOrClass(mergedPagination.styles, info), mergedStyles.pagination);
+
   changeEventInfo.pagination =
     pagination === false ? {} : getPaginationParam(mergedPagination, pagination);
 
@@ -630,8 +645,8 @@ const InternalTable = <RecordType extends AnyObject = AnyObject>(
     const renderPagination = (placement: 'start' | 'end' | 'center' = 'end') => (
       <Pagination
         {...mergedPagination}
-        classNames={mergedClassNames.pagination}
-        styles={mergedStyles.pagination}
+        classNames={paginationClassNames}
+        styles={paginationStyles}
         className={clsx(
           `${prefixCls}-pagination`,
           `${prefixCls}-pagination-${placement}`,

--- a/components/table/__tests__/semantic.test.tsx
+++ b/components/table/__tests__/semantic.test.tsx
@@ -209,6 +209,69 @@ describe('Table', () => {
     });
   });
 
+  it('should merge pagination classNames and styles', () => {
+    const { container } = render(
+      <Table
+        columns={[{ dataIndex: 'name' }]}
+        dataSource={[
+          { key: '1', name: 'Bamboo' },
+          { key: '2', name: 'Little' },
+        ]}
+        classNames={{
+          pagination: {
+            root: 'table-pagination-root',
+            item: 'table-pagination-item',
+          },
+        }}
+        styles={{
+          pagination: {
+            root: {
+              backgroundColor: 'rgb(0, 0, 255)',
+              color: 'rgb(0, 0, 0)',
+            },
+            item: {
+              backgroundColor: 'rgb(0, 255, 0)',
+              color: 'rgb(0, 0, 0)',
+            },
+          },
+        }}
+        pagination={{
+          pageSize: 1,
+          classNames: {
+            root: 'pagination-root',
+            item: 'pagination-item',
+          },
+          styles: {
+            root: {
+              color: 'rgb(255, 0, 0)',
+              borderTopWidth: '1px',
+            },
+            item: {
+              color: 'rgb(255, 165, 0)',
+              borderLeftWidth: '2px',
+            },
+          },
+        }}
+      />,
+    );
+
+    const paginationRoot = container.querySelector('.ant-pagination');
+    const paginationItem = container.querySelector('.ant-pagination-item');
+
+    expect(paginationRoot).toHaveClass('table-pagination-root', 'pagination-root');
+    expect(paginationRoot).toHaveStyle({
+      backgroundColor: 'rgb(0, 0, 255)',
+      color: 'rgb(0, 0, 0)',
+      borderTopWidth: '1px',
+    });
+    expect(paginationItem).toHaveClass('table-pagination-item', 'pagination-item');
+    expect(paginationItem).toHaveStyle({
+      backgroundColor: 'rgb(0, 255, 0)',
+      color: 'rgb(0, 0, 0)',
+      borderLeftWidth: '2px',
+    });
+  });
+
   it('should work with function classNames and styles', () => {
     const columns = [
       {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Table 会使用自身的语义化配置覆盖 `pagination.classNames` 和 `pagination.styles`，导致通过分页配置传入的 Pagination Semantic DOM 样式不生效。

本次改动合并两层语义化配置，同时保持 Table 顶层配置的既有优先级，并补充回归测试覆盖 `classNames`、`styles` 及冲突优先级。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Table ignoring pagination semantic `classNames` and `styles`. |
| 🇨🇳 中文 | 修复 Table 忽略分页器语义化 `classNames` 和 `styles` 配置的问题。 |
