### PR TITLE
fix: avoid border flash when switching from borderless variant

### DIFF
--- a/components/input-number/style/index.ts
+++ b/components/input-number/style/index.ts
@@ -103,20 +103,6 @@ const genInputNumberStyles: GenerateStyle<InputNumberToken> = (token) => {
         }),
         ...genBorderlessStyle(token),
 
-        // InputNumber 两层结构：borderless 补偿只加在内层 input 的 CSS 变量上，避免外层+内层双重 padding 导致高度异常
-        [`&${componentCls}-borderless`]: {
-          paddingBlock: 0,
-          [varName('input-padding-block')]: unit(token.calc(paddingBlock).add(lineWidth).equal()),
-        },
-        [`&${componentCls}-borderless${componentCls}-sm`]: {
-          paddingBlock: 0,
-          [varName('input-padding-block')]: unit(token.calc(paddingBlockSM).add(lineWidth).equal()),
-        },
-        [`&${componentCls}-borderless${componentCls}-lg`]: {
-          paddingBlock: 0,
-          [varName('input-padding-block')]: unit(token.calc(paddingBlockLG).add(lineWidth).equal()),
-        },
-
         // ========================= RTL ==========================
         '&-rtl': {
           direction: 'rtl',

--- a/components/input/style/variants.ts
+++ b/components/input/style/variants.ts
@@ -203,18 +203,8 @@ export const genBorderlessStyle = (token: InputToken, extraStyles?: CSSObject): 
   return {
     '&-borderless': {
       background: 'transparent',
-      border: 'none',
-      // Compensate for the removed border to maintain consistent height with other components
-      // (e.g. Select borderless) that keep a transparent border.
-      paddingBlock: token.calc(token.paddingBlock).add(token.lineWidth).equal(),
-
-      [`&${componentCls}-sm, &${componentCls}-affix-wrapper-sm`]: {
-        paddingBlock: token.calc(token.paddingBlockSM).add(token.lineWidth).equal(),
-      },
-
-      [`&${componentCls}-lg, &${componentCls}-affix-wrapper-lg`]: {
-        paddingBlock: token.calc(token.paddingBlockLG).add(token.lineWidth).equal(),
-      },
+      // Reserve border space for consistent control heights and a stable transition origin.
+      border: `${unit(token.lineWidth)} ${token.lineType} transparent`,
 
       '&:focus, &:focus-within': {
         outline: 'none',


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

N/A

### 💡 需求背景和解决方案

Form 的表单变体从 `borderless` 切换到其他形态时，Input 系列组件会短暂闪现深色边框。

<img width="660" height="820" alt="antd-form-variant" src="https://github.com/user-attachments/assets/8adda160-0681-4b74-9640-2d1e185a9c5f" />


这是因为 `borderless` 使用 `border: none`，而组件配置了边框过渡动画。切换形态时，浏览器会从默认的边框宽度和 `currentColor` 开始过渡，导致首帧出现深色边框。

本次调整使用 token 对应宽度的透明边框作为 `borderless` 的稳定过渡起点，并移除不再需要的 padding 补偿。该实现与 Select 的透明边框策略保持一致，同时维持 Input、带 prefix/suffix 的 Input、InputNumber 和 Select 在默认、小、大尺寸及自定义 `lineWidth` 下的高度对齐。
<img width="654" height="857" alt="antd-borderless-input2" src="https://github.com/user-attachments/assets/ac6db2ba-ec49-44d8-87e7-a3073feea5de" />


验证：

- 相关 Input 和 InputNumber 测试共 61 项通过
- ESLint 和提交检查通过
- Chromium 验证三档尺寸及 `lineWidth: 1`、`lineWidth: 3` 下控件高度保持一致
- https://github.com/ant-design/ant-design/issues/56609 和 https://github.com/ant-design/ant-design/issues/57135 验证通过

<img width="926" height="857" alt="antd-borderless-input-select" src="https://github.com/user-attachments/assets/51a437d2-7441-4e58-8375-ccfd8301e0b3" />


### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix Input, InputNumber, Mentions, and DatePicker flashing dark borders when switching from the `borderless` variant. |
| 🇨🇳 中文 | 🐞 修复 Input、InputNumber、Mentions 和 DatePicker 从 `borderless` 形态切换时闪现深色边框的问题。 |