### PR TITLE
fix(ColorPicker): avoid mutating preset items

### DIFF
--- a/components/color-picker/__tests__/index.test.tsx
+++ b/components/color-picker/__tests__/index.test.tsx
@@ -259,6 +259,17 @@ describe('ColorPicker', () => {
     expect(handleColorChange).toHaveBeenCalledTimes(2);
   });
 
+  it('Should not mutate preset items', () => {
+    const preset: PresetsItem = {
+      label: 'Brand',
+      colors: ['#1677ff'],
+    };
+    Object.freeze(preset);
+
+    expect(() => render(<ColorPicker open presets={[preset]} />)).not.toThrow();
+    expect(preset.colors).toEqual(['#1677ff']);
+  });
+
   describe('preset collapsed', () => {
     const recommendedPreset: PresetsItem = {
       key: 'Recommended',

--- a/components/color-picker/components/ColorPresets.tsx
+++ b/components/color-picker/components/ColorPresets.tsx
@@ -19,10 +19,10 @@ interface ColorPresetsProps {
 }
 
 const genPresetColor = (list: PresetsItem[]) =>
-  list.map((value) => {
-    value.colors = value.colors.map(generateColor);
-    return value;
-  });
+  list.map((value) => ({
+    ...value,
+    colors: value.colors.map(generateColor),
+  }));
 
 export const isBright = (value: AggregationColor, bgColorToken: string) => {
   const { r, g, b, a } = value.toRgb();


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

[在线复现](https://codesandbox.io/p/sandbox/colorpicker-hui-xiu-gai-presets-xiang-bing-zai-dui-xiang-dong-jie-shi-beng-kui-2vvwww?file=%2Findex.tsx)

### 💡 需求背景和解决方案

ColorPicker 渲染预设颜色时会直接替换调用方传入的 `colors`。当预设项来自不可变状态或被冻结时，这会导致 `TypeError` 并使颜色面板无法渲染。

本次改为创建新的预设项并转换副本中的颜色，不再修改调用方数据。同时增加冻结预设项的回归测试。不涉及公开 API 或视觉变化。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | 🐞 Fix ColorPicker mutating preset items and crashing with frozen input. |
| 🇨🇳 中文 | 🐞 修复 ColorPicker 修改预设项并在传入冻结对象时崩溃的问题。 |
