### PR TITLE
fix(Tree): handle undefined props and reset state when switching to uncontrolled mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "@rc-component/tabs": "~2.0.0",
     "@rc-component/tooltip": "~1.5.2",
     "@rc-component/tour": "~2.4.0",
-    "@rc-component/tree": "~1.5.0",
+    "@rc-component/tree": "~1.5.3",
     "@rc-component/tree-select": "~1.18.0",
     "@rc-component/trigger": "^3.10.1",
     "@rc-component/upload": "~1.1.1",


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1)

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

上游修复：https://github.com/react-component/tree/pull/1069

### 💡 需求背景和解决方案

将 `@rc-component/tree` 最低版本提升至 `~1.5.3`，确保 antd Tree 使用包含 `undefined` 非受控状态修复的版本。

修复显式传入 `undefined` 时被错误识别为受控状态的问题，并统一从受控切换至非受控时的状态重置行为。

本次仅升级 Tree，不修改 Cascader、TreeSelect 的依赖声明。

验证：Tree 的 11 个测试套件全部通过，116 个测试通过，10 个跳过，72 个快照通过。

### 📝 更新日志

| 语言 | 更新描述 |
| --- | --- |
| 🇺🇸 英文 | Fix Tree incorrectly treating explicitly passed `undefined` props as controlled and inconsistent state resets when switching to uncontrolled mode. |
| 🇨🇳 中文 | 修复 Tree 将显式传入的 `undefined` 属性误判为受控状态，以及切换至非受控模式时状态重置不一致的问题。 |